### PR TITLE
Suggested fix for Issue #59

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -198,8 +198,8 @@ class Installer:
             dist = os.path.join(dir, 'dist')
             print('  - Getting dependencies')
             self.call(
-                self.CURRENT_PYTHON, '-m', 'pip', 'install', '--install-option="--prefix="',
-                'poetry=={}'.format(version), '--target', dist
+                self.CURRENT_PYTHON, '-m', 'pip', 'install', 'poetry=={}'.format(version),
+                '--target', dist
             )
 
             print('  - Vendorizing dependencies')
@@ -245,7 +245,6 @@ class Installer:
 
             self.call(
                 self.CURRENT_PYTHON, '-m', 'pip', 'install',
-                '--install-option="--prefix="',
                 '--upgrade',
                 '--no-deps',
                 os.path.join(dir, 'poetry-{}-{}.whl'.format(version, tag))


### PR DESCRIPTION
Use `sys.executable` to get the location of the version of Python running `get-poetry.py`.