### PR TITLE
[bugfix] use ssh scheme to avoid VenvCommandError w/ `poetry add --git`

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -112,8 +112,13 @@ class PipInstaller(BaseInstaller):
             return req
 
         if package.source_type == "git":
+            url = (
+                "ssh://" + package.source_url.replace(":", "/")
+                if package.source_url.startswith("git@")
+                else package.source_url
+            )
             return "git+{}@{}#egg={}".format(
-                package.source_url, package.source_reference, package.name
+                url, package.source_reference, package.name
             )
 
         return "{}=={}".format(package.name, package.version)


### PR DESCRIPTION
This will avoid the following error when installing from private git repositories that expect to use the `ssh` url scheme i.e. `git@github.com:sdispater/poetry.git`

Without this patch, you'll often get the following error when installing from private git repos:
```
poetry add project --git git@github.com:user/project.git
...
[VenvCommandError]                                                                                                                                         
Command ['pip', 'install', '--no-deps', 'git+git@github.com:user/project.git@6ee26eca2a5f7f449cd894bda5e47d02daad4059#egg=project'] errored with the following output:   
Invalid requirement: 'git+git@github.com:user/project.git@6ee26eca2a5f7f449cd894bda5e47d02daad4059#egg=project'                                                          
It looks like a path. File 'git+git@github.com:user/project.git@6ee26eca2a5f7f449cd894bda5e47d02daad4059#egg=project' does not exist.
```
---

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

---

I checked `Updated documentation` since this PR doesn't affect poetry's API in any way; it's just a bug fix.

I didn't add a test only because I'm not sure how best to do so. I tested this manually on my own machine to solve the problem I was having