### PR TITLE
Update README: add button to launch Poetry playground in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ ensuring you have the right stack everywhere.
 
 It supports Python 2.7 and 3.4+.
 
+You can quickly start playing with Poetry right in your browser:
+
+[![Try in browser](https://cdn.rawgit.com/rootnroll/library/assets/try.svg)](https://rootnroll.com/d/poetry/)
+
 ## Installation
 
 Poetry provides a custom installer that will install `poetry` isolated


### PR DESCRIPTION
Add the button to README to launch a Poetry playground and try it out right in the browser:
[![Try in browser](https://cdn.rawgit.com/rootnroll/library/assets/try.svg)](https://rootnroll.com/d/poetry/)

https://rootnroll.com is a standalone service for running cli playgrounds.

Source files used to create the Poetry playground: https://github.com/rootnroll/library/tree/master/poetry/
Automated build of the docker image: https://hub.docker.com/r/rootnroll/demo-poetry/