### PR TITLE
Add support for setup.py as an export format

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -433,7 +433,7 @@ poetry export -f requirements.txt > requirements.txt
 
 !!!note
 
-    Only the `requirements.txt` format is currently supported.
+    Only the `requirements.txt` and `setup.py` format is currently supported.
 
 ### Options
 

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -13,16 +13,22 @@ class ExportCommand(Command):
     options = [
         option("format", "f", "Format to export to.", flag=False),
         option("output", "o", "The name of the output file.", flag=False),
-        option("without-hashes", None, "Exclude hashes from the exported file."),
-        option("dev", None, "Include development dependencies."),
+        option(
+            "without-hashes", None, "Exclude hashes from the exported file if used."
+        ),
+        option("dev", None, "Include development dependencies if configurable."),
         option(
             "extras",
             "E",
-            "Extra sets of dependencies to include.",
+            "Extra sets of dependencies to include if configurable.",
             flag=False,
             multiple=True,
         ),
-        option("with-credentials", None, "Include credentials for extra indices."),
+        option(
+            "with-credentials",
+            None,
+            "Include credentials for extra indices if format supports indices.",
+        ),
     ]
 
     def handle(self):

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -1,7 +1,10 @@
+from typing import Any
 from typing import Union
 
 from clikit.api.io import IO
 
+from poetry.io.null_io import NullIO
+from poetry.masonry.builders import SdistBuilder
 from poetry.packages.directory_dependency import DirectoryDependency
 from poetry.packages.file_dependency import FileDependency
 from poetry.packages.url_dependency import URLDependency
@@ -9,6 +12,7 @@ from poetry.packages.vcs_dependency import VCSDependency
 from poetry.poetry import Poetry
 from poetry.utils._compat import Path
 from poetry.utils._compat import decode
+from poetry.utils.env import NullEnv
 
 
 class Exporter(object):
@@ -16,7 +20,7 @@ class Exporter(object):
     Exporter class to export a lock file to alternative formats.
     """
 
-    ACCEPTED_FORMATS = ("requirements.txt",)
+    ACCEPTED_FORMATS = ("requirements.txt", "setup.py")
     ALLOWED_HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
 
     def __init__(self, poetry):  # type: (Poetry) -> None
@@ -161,6 +165,13 @@ class Exporter(object):
 
             content = indexes_header + "\n" + content
 
+        self._output(content, cwd, output)
+
+    def _export_setup_py(
+        self, cwd, output, *_, **__
+    ):  # type: (Path, Union[IO, str], Any, Any) -> None
+        builder = SdistBuilder(self._poetry, NullEnv(), NullIO())
+        content = decode(builder.build_setup())
         self._output(content, cwd, output)
 
     def _output(


### PR DESCRIPTION
This change introduces `setup.py` as a valid export format.

Resolves: #761

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
