### PR TITLE
Make sdist determinisitic by setting gzip mtime to 0

### DIFF
--- a/poetry/masonry/builders/sdist.py
+++ b/poetry/masonry/builders/sdist.py
@@ -58,7 +58,7 @@ class SdistBuilder(Builder):
         target = target_dir / "{}-{}.tar.gz".format(
             self._package.pretty_name, self._meta.version
         )
-        gz = GzipFile(target.as_posix(), mode="wb")
+        gz = GzipFile(target.as_posix(), mode="wb", mtime=0)
         tar = tarfile.TarFile(
             target.as_posix(), mode="w", fileobj=gz, format=tarfile.PAX_FORMAT
         )

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import ast
+import gzip
 import shutil
 import tarfile
 
@@ -473,3 +474,18 @@ def test_proper_python_requires_if_three_digits_precision_version_specified():
     parsed = p.parsestr(to_str(pkg_info))
 
     assert parsed["Requires-Python"] == "==2.7.15"
+
+
+def test_sdist_mtime_zero():
+    poetry = Poetry.create(project("module1"))
+
+    builder = SdistBuilder(poetry, NullEnv(), NullIO())
+    builder.build()
+
+    sdist = fixtures_dir / "module1" / "dist" / "module1-0.1.tar.gz"
+
+    assert sdist.exists()
+
+    with gzip.open(str(sdist), "rb") as gz:
+        gz.read(100)
+        assert gz.mtime == 0


### PR DESCRIPTION
A GZip file contains a timestamp with it's last modification time. This timestamp by default is the current time which will make `poetry build` produce non-deterministic sdist archives. To make sdist archives deterministic, this timestamp must be set to a fixed time. So this PR sets that time to 0.

- [x] Added **tests** for changed code.
- (N/A) Updated **documentation** for changed code.