### PR TITLE
Set the virtualenv directory name via configuration

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -22,6 +22,11 @@ Defaults to `true`.
 Create the virtualenv inside the project's root directory.
 Defaults to `false`.
 
+### `settings.virtualenvs.name`: string
+
+The name of the virtualenv folder that will be created.
+Defaults to `.venv`.
+
 ### `settings.virtualenvs.path`: string
 
 Directory where virtualenvs will be created.

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -161,13 +161,15 @@ class Env(object):
         in_venv = os.environ.get("VIRTUAL_ENV") is not None
 
         if not in_venv:
+            config = Config.create("config.toml")
+
             # Checking if a local virtualenv exists
-            if (cwd / ".venv").exists():
-                venv = cwd / ".venv"
+            venv_name = config.setting("settings.virtualenvs.name", ".venv")
+            if (cwd / venv_name).exists():
+                venv = cwd / venv_name
 
                 return VirtualEnv(venv)
 
-            config = Config.create("config.toml")
             create_venv = config.setting("settings.virtualenvs.create", True)
 
             if not create_venv:
@@ -216,8 +218,9 @@ class Env(object):
         root_venv = config.setting("settings.virtualenvs.in-project")
 
         venv_path = config.setting("settings.virtualenvs.path")
+        venv_name = config.setting("settings.virtualenvs.name")
         if root_venv:
-            venv_path = cwd / ".venv"
+            venv_path = cwd / venv_name
         elif venv_path is None:
             venv_path = Path(CACHE_DIR) / "virtualenvs"
         else:


### PR DESCRIPTION
This is to solve a use case I came across when working within a Docker container while mounting a volume from my local machine. Local machine is running OSX, container is running Alpine. My local has the .venv folder in the application directory so that VS Code can use it for autocompletion, however if that folder exists Poetry will fail to even `in-project` and `create` are both set to `false` (a virtualenv is not required within the isolated container).

An alternative solution would be to move the `create_venv` section above the check for a local virtualenv, however I felt this was more flexible.