### PR TITLE
Fix bugs where VCS dev-dependencies are `poetry install/show` even in --no-dev

### DIFF
--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -298,6 +298,7 @@ class Package(object):
                     tag=constraint.get("tag", None),
                     rev=constraint.get("rev", None),
                     optional=optional,
+                    category=category,
                 )
             elif "file" in constraint:
                 file_path = Path(constraint["file"])

--- a/poetry/packages/vcs_dependency.py
+++ b/poetry/packages/vcs_dependency.py
@@ -7,7 +7,15 @@ class VCSDependency(Dependency):
     """
 
     def __init__(
-        self, name, vcs, source, branch=None, tag=None, rev=None, optional=False
+        self,
+        name,
+        vcs,
+        source,
+        branch=None,
+        tag=None,
+        rev=None,
+        optional=False,
+        **kwargs
     ):
         self._vcs = vcs
         self._source = source
@@ -21,7 +29,7 @@ class VCSDependency(Dependency):
         self._rev = rev
 
         super(VCSDependency, self).__init__(
-            name, "*", optional=optional, allows_prereleases=True
+            name, "*", optional=optional, allows_prereleases=True, **kwargs
         )
 
     @property

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -986,6 +986,30 @@ def test_solver_can_resolve_git_dependencies_with_ref(solver, repo, package, ref
     assert op.package.source_reference.startswith("9cf87a2")
 
 
+def test_solver_marks_git_dev_dependencies_as_dev(solver, repo, package):
+    pendulum = get_package("pendulum", "2.0.3")
+    cleo = get_package("cleo", "1.0.0")
+    repo.add_package(pendulum)
+    repo.add_package(cleo)
+
+    package.add_dependency(
+        "demo", {"git": "https://github.com/demo/demo.git"}, category="dev"
+    )
+
+    ops = solver.solve()
+
+    check_solver_result(
+        ops,
+        [
+            {"job": "install", "package": pendulum},
+            {"job": "install", "package": get_package("demo", "0.1.2")},
+        ],
+    )
+
+    assert ops[0].package.category == "dev"
+    assert ops[1].package.category == "dev"
+
+
 def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requirement_is_compatible(
     solver, repo, package
 ):


### PR DESCRIPTION
Fixes https://github.com/sdispater/poetry/issues/599.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code. (partially)
- [ ] Updated **documentation** for changed code. (i think this changes code to match intended/documented behavior)

I added a "test that solver marks git dev-dependencies as dev".

I did not add a test that "solver marks dev-dependencies with lists of version conditions as dev".

- I haven't used "lists of dependencies" in my own projects yet. (I just tried using Git dependencies today.)
- `tests/puzzle/test_solver.py` doesn't hit either of 2 breakpoints in poetry.py `if isinstance(constraint, list):`.
- `tests/test_poetry.py` `test_poetry_with_multi_constraints_dependency()` references directory `tests/fixtures/project_with_multi_constraints_dependency` and hits that above branch (but not the path with dev-dependencies). But it doesn't call `solver.solve()`.

Where would that test go? Do I create a new directory fixture, or do I copy the general form of `tests/puzzle/test_solver.py`?

------

oops why are the tests failing? i swear it works on my machine... ~~i think i've been living in a cozy and exclusively python 3.6 environment for too long~~

Do I edit `VCSDependency.__init__()` and put **kwargs after allows_prereleases=True? Force push?