### PR TITLE
fix: RunCommand calling scripts with incorrect executable path

### DIFF
--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -24,7 +24,7 @@ class RunCommand(EnvCommand):
         # running program. To make calling Poetry scripts through RunCommand
         # match this behavior, we must set `sys.argv[0]` to be the full path of
         # the executable.
-        full_path_args = args.copy()
+        full_path_args = list(args)
         full_path_args[0] = self.env._bin(full_path_args[0])
 
         if isinstance(script, dict):

--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -20,6 +20,13 @@ class RunCommand(EnvCommand):
         return self.env.execute(*args)
 
     def run_script(self, script, args):
+        # Calling `sys.argv` should run the same program as the currently
+        # running program. To make calling Poetry scripts through RunCommand
+        # match this behavior, we must set `sys.argv[0]` to be the full path of
+        # the executable.
+        full_path_args = args.copy()
+        full_path_args[0] = self.env._bin(full_path_args[0])
+
         if isinstance(script, dict):
             script = script["callable"]
 
@@ -34,7 +41,7 @@ class RunCommand(EnvCommand):
             "from importlib import import_module; "
             "sys.argv = {!r}; {}"
             "import_module('{}').{}()\"".format(
-                args, src_in_sys_path, module, callable_
+                full_path_args, src_in_sys_path, module, callable_
             )
         ]
 

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -18,7 +18,9 @@ def test_run_script_sets_argv(app):
 
     command = app.find("run")
     command._env = Env.get()
+    # fake the existence of our script
     command._env._bin = mock_foo
+    # we don't want to run anything
     command._env.run = mock_run
     res = command.run_script("cli:cli", ["foogit", "status"])
     expected = dict(

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -1,0 +1,32 @@
+import pytest
+
+from poetry.console.commands import RunCommand
+from poetry.utils.env import Env
+
+
+def test_run_script_sets_argv(app):
+    """
+    If RunCommand calls a script defined in pyproject.toml, sys.argv[0] should
+    be set to the full path of the script.
+    """
+
+    def mock_foo(bin):
+        return "/full/path/to/" + bin
+
+    def mock_run(*args, **kwargs):
+        return dict(args=args, kwargs=kwargs)
+
+    command = app.find("run")
+    command._env = Env.get()
+    command._env._bin = mock_foo
+    command._env.run = mock_run
+    res = command.run_script("cli:cli", ["foogit", "status"])
+    expected = dict(
+        args=(
+            "python",
+            "-c",
+            "\"import sys; from importlib import import_module; sys.argv = ['/full/path/to/foogit', 'status']; import_module('cli').cli()\"",
+        ),
+        kwargs={"call": True, "shell": True},
+    )
+    assert res == expected


### PR DESCRIPTION
Fixes GH-965

Calling `sys.argv` should run the same program as the currently running program. To make calling Poetry scripts through RunCommand match this behavior, we must set `sys.argv[0]` to be the full path of the executable.

This change makes the behavior of calling a script through `poetry run` the same as calling a script directly from the .venv/bin.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
