### PR TITLE
Added settings.prepend-index.url configuration

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -14,7 +14,6 @@ poetry up
 
 calls `poetry update`.
 
-
 ## Global options
 
 * `--verbose (-v|vv|vvv)`: Increase the verbosity of messages: "-v" for normal output, "-vv" for more verbose output and "-vvv" for debug.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -31,6 +31,12 @@ Defaults to one of the following directories:
 - Windows: `C:\Users\<username>\AppData\Local\pypoetry\Cache/virtualenvs`
 - Unix:    `~/.cache/pypoetry/virtualenvs`
 
+### settings.prepend-index.url : string
+
+A repository url can be added to the set of indexes used by setting this
+configuration. It will be prepended and so preferred over other sources of
+packages.
+
 ### `repositories.<name>`: string
 
 Set a new alternative repository. See [Repositories](/docs/repositories/) for more information.

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -67,6 +67,7 @@ To remove a repository (repo is a short alias for repositories):
                 lambda val: str(Path(val)),
                 str(Path(CACHE_DIR) / "virtualenvs"),
             ),
+            "settings.prepend-index.url": (str, str, ""),
         }
 
         return unique_config_values

--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import os
 import shutil
 
 from typing import Dict
@@ -43,6 +44,16 @@ class Poetry:
 
         # Configure sources
         self._pool = Pool()
+
+        # add prepend index from poetry configuration
+        prepend_index_url = self._config.setting("settings.prepend-index.url")
+        if prepend_index_url:
+            self._pool.add_repository(
+                self.create_legacy_repository(
+                    {"name": "prepend-index", "url": prepend_index_url}
+                )
+            )
+
         for source in self._local_config.get("source", []):
             self._pool.add_repository(self.create_legacy_repository(source))
 

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -31,7 +31,8 @@ def test_list_displays_default_value_if_not_set(app, config):
 
     tester.execute("--list")
 
-    expected = """settings.virtualenvs.create = true
+    expected = """settings.prepend-index.url = ""
+settings.virtualenvs.create = true
 settings.virtualenvs.in-project = false
 settings.virtualenvs.path = "."
 repositories = {}
@@ -50,7 +51,8 @@ def test_list_displays_set_get_setting(app, config):
     command._settings_config = Config(config.file)
     tester.execute("--list")
 
-    expected = """settings.virtualenvs.create = false
+    expected = """settings.prepend-index.url = ""
+settings.virtualenvs.create = false
 settings.virtualenvs.in-project = false
 settings.virtualenvs.path = "."
 repositories = {}


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Added settings.prepend-index.url to add a repository url can be added to the set of indexes used by setting this configuration. It will be prepended and so preferred over other sources of packages.
