### PR TITLE
Fix rmtree failures on Windows (#1031)

### DIFF
--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -37,19 +37,22 @@ def temporary_directory(*args, **kwargs):
     robust_rmtree(name)
 
 
-def robust_rmtree(path, max_retries=3):
+def robust_rmtree(path):
     """Robustly tries to delete paths.
 
     Retries several times if an OSError occurs.
     If the final attempt fails, the Exception is propagated
     to the caller.
     """
-    for i in range(max_retries - 1):
+    timeout = 0.001
+    while timeout < 2:
         try:
             shutil.rmtree(path)
             return  # Only hits this on success
         except OSError:
-            time.sleep(2)
+            # Increase the timeout and try again
+            time.sleep(timeout)
+            timeout *= 2
 
     # Final attempt, pass any Exceptions up to caller.
     shutil.rmtree(path)


### PR DESCRIPTION
Fixes https://github.com/sdispater/poetry/issues/1031

-------

- [x] Added **tests** for changed code. (N/A)
- [x] Updated **documentation** for changed code. (N/A)

Existing tests cover the code change + no need for documentation.

If you **really** want a test that attempts to simulate the flaky behavior for windows I can try to write one, but I can't see any sensible way to do that. So potentially change `robust_rmtree` to a private function to indicate no need for direct testing.

---------

Avoid the use of `TemporaryDirectory`, instead manually dealing with temporary files to allow custom cleanup.

Retrying `shutil.rmtree` multiple times avoids the removal race conditions found in Windows causing:

1. Irrelevant errors when other failures cause removal delays
2. Failures during arbitrary installs caused by antivirus software
