### PR TITLE
get-poetry.py: Use correct python when installed with non-default python

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -208,7 +208,9 @@ if __name__ == "__main__":
     from poetry.console import main
 
     main()
-""".format(python=os.path.basename(sys.executable))
+""".format(
+    python=os.path.basename(sys.executable)
+)
 
 BAT = u('@echo off\r\npython "{poetry_bin}" %*\r\n')
 

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -194,7 +194,7 @@ POETRY_LIB = os.path.join(POETRY_HOME, "lib")
 POETRY_LIB_BACKUP = os.path.join(POETRY_HOME, "lib-backup")
 
 
-BIN = """#!/usr/bin/env python
+BIN = """#!/usr/bin/env {python}
 # -*- coding: utf-8 -*-
 import glob
 import sys
@@ -208,7 +208,7 @@ if __name__ == "__main__":
     from poetry.console import main
 
     main()
-"""
+""".format(python=os.path.basename(sys.executable))
 
 BAT = u('@echo off\r\npython "{poetry_bin}" %*\r\n')
 


### PR DESCRIPTION
On CentOS 6, `/usr/bin/env python` is Python 2.6. This results in poetry being unusable since 2.7 is required. Poetry should still work when an alternative Python is used to install it. That is, you should be able to run `python2.7 get-poetry.py` and end up with a usable installation of poetry.

This will use the python executable used to run get-poetry.py in the shebang, ensuring that a valid python is used.

NOTE: I didn't see a place to add tests for this, the "installation" dir seems to refer to installing python packages using poetry, not installing poetry itself via `get-poetry.py`. Any help in this respect would be much appreciated.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
