### PR TITLE
Canonicalise virtual environment name

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -29,8 +29,8 @@ from poetry.utils._compat import Path
 from poetry.utils._compat import decode
 from poetry.utils._compat import encode
 from poetry.utils._compat import list_to_shell_command
-from poetry.utils.helpers import canonicalize_name
 from poetry.utils._compat import subprocess
+from poetry.utils.helpers import canonicalize_name
 from poetry.utils.toml_file import TomlFile
 from poetry.version.markers import BaseMarker
 

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -29,6 +29,7 @@ from poetry.utils._compat import Path
 from poetry.utils._compat import decode
 from poetry.utils._compat import encode
 from poetry.utils._compat import list_to_shell_command
+from poetry.utils.helpers import canonicalize_name
 from poetry.utils._compat import subprocess
 from poetry.utils.toml_file import TomlFile
 from poetry.version.markers import BaseMarker
@@ -691,7 +692,7 @@ class EnvManager(object):
 
     @classmethod
     def generate_env_name(cls, name, cwd):  # type: (str, str) -> str
-        name = name.lower()
+        name = canonicalize_name(name.lower())
         sanitized_name = re.sub(r'[ $`!*@"\\\r\n\t]', "_", name)[:42]
         h = hashlib.sha256(encode(cwd)).digest()
         h = base64.urlsafe_b64encode(h).decode()[:8]

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -678,6 +678,17 @@ def test_create_venv_does_not_try_to_find_compatible_versions_with_executable(
     assert 0 == m.call_count
 
 
+def test_venv_name_canonicalisation():
+    """Ensure that name canonicalisation does not cause venv name collisions
+    """
+    project_name_underscore = "simple_project"
+    project_name_dash = "simple-project"
+
+    assert EnvManager.generate_env_name(
+        project_name_underscore, str(project_name_underscore)
+    ) != EnvManager.generate_env_name(project_name_dash, str(project_name_dash))
+
+
 def test_create_venv_uses_patch_version_to_detect_compatibility(
     manager, poetry, config, mocker
 ):


### PR DESCRIPTION
poetry's in-memory package representation saves the package name in a canonicalised form (replace underscores with dashes).

When virtual environments are created [this form](https://github.com/sdispater/poetry/blob/5a2a3e62c0af2bd0150a2db1ca287d0f9bd653d4/poetry/packages/package.py#L37) is used [instead of the actual name](https://github.com/sdispater/poetry/blob/5a2a3e62c0af2bd0150a2db1ca287d0f9bd653d4/poetry/console/config/application_config.py#L88), while operations on the virtual environment are still performed with the base environment name. This fails if the environment name contains a character, that would normally be replaced during canonicalisation.

Fixes #1043 (potentially also #726)
