### PR TITLE
Add long_description_content_type to sdist setup kwargs

### DIFF
--- a/poetry/masonry/builders/sdist.py
+++ b/poetry/masonry/builders/sdist.py
@@ -176,6 +176,13 @@ class SdistBuilder(Builder):
 
             extra.append("'python_requires': {!r},".format(python_requires))
 
+        if self._meta.description_content_type:
+            extra.append(
+                "'long_description_content_type': {!r},".format(
+                    self._meta.description_content_type
+                )
+            )
+
         return encode(
             SETUP.format(
                 before="\n".join(before),

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -138,6 +138,7 @@ def test_make_setup():
             "pendulum>=1.4,<2.0"
         ]
     }
+    assert ns["setup_kwargs"]["long_description_content_type"] == "text/x-rst"
 
 
 def test_make_pkg_info(mocker):


### PR DESCRIPTION
This PR attempts to add the content type of long_description to setup.py kwargs when building sdists.

I noticed that the content type is included in the wheel metadata, but missing from the setup() call in sdist packages.

I did not update any documentation as part of this pull request, because I do not believe this is a change/feature requiring documentation, rather a minor bugfix.