### PR TITLE
Add constraint and version utils

### DIFF
--- a/poetry/semver/__init__.py
+++ b/poetry/semver/__init__.py
@@ -3,6 +3,7 @@ import re
 from .empty_constraint import EmptyConstraint
 from .patterns import BASIC_CONSTRAINT
 from .patterns import CARET_CONSTRAINT
+from .patterns import COMPLETE_VERSION
 from .patterns import TILDE_CONSTRAINT
 from .patterns import TILDE_PEP440_CONSTRAINT
 from .patterns import X_CONSTRAINT

--- a/poetry/semver/constraint_utils.py
+++ b/poetry/semver/constraint_utils.py
@@ -1,0 +1,42 @@
+"""
+Constraint utilities
+
+The focus of this module is any constraint support, but
+PEP-0440 support trumps everything else.
+
+With regard to SEM-VER compatibility, PEP-0440 is partially
+but not fully compatible with all the SEM-VER specs; see
+
+https://legacy.python.org/dev/peps/pep-0440/#semantic-versioning
+> Semantic versions containing a hyphen (pre-releases - clause 10) or
+> a plus sign (builds - clause 11) are not compatible with this PEP
+> and are not permitted in the public version field.
+"""
+
+from typing import List
+
+from poetry.semver import parse_single_constraint
+
+
+def is_constraint(value):  # type: (str) -> bool
+    """Check that a string is a single constraint
+
+    :param value: any string
+    :return: True if value is a constraint
+    """
+    try:
+        return bool(parse_single_constraint(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def sorted_constraints(values, reverse=False):  # type: (List[str], bool) -> List[str]
+    """Sort a list of single constraints (string);
+    discards any string that is not a constraint.
+
+    :param values: any strings
+    :param reverse: sort descending (reverse=True) or ascending (reverse=False)
+    :return: sorted values based on sort criteria for constraints
+    """
+    unsorted = (ver for ver in values if is_constraint(ver))
+    return sorted(unsorted, key=parse_single_constraint, reverse=reverse)

--- a/poetry/semver/version_utils.py
+++ b/poetry/semver/version_utils.py
@@ -1,0 +1,42 @@
+"""
+Version utilities
+
+The focus of this module is any version support, but
+PEP-0440 support trumps everything else.
+
+With regard to SEM-VER compatibility, PEP-0440 is partially
+but not fully compatible with all the SEM-VER specs; see
+
+https://legacy.python.org/dev/peps/pep-0440/#semantic-versioning
+> Semantic versions containing a hyphen (pre-releases - clause 10) or
+> a plus sign (builds - clause 11) are not compatible with this PEP
+> and are not permitted in the public version field.
+"""
+
+from typing import List
+
+from poetry.semver import Version
+
+
+def is_version(value):  # type: (str) -> bool
+    """Check that a string is a release version
+
+    :param value: any string
+    :return: True if value is a release version
+    """
+    try:
+        return bool(Version.parse(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def sorted_versions(values, reverse=False):  # type: (List[str], bool) -> List[str]
+    """Sort a list of release versions (string);
+    discards any string that is not a release version.
+
+    :param values: a list of strings
+    :param reverse: sort descending (reverse=True) or ascending (reverse=False)
+    :return: sorted values based on sort criteria for release versions
+    """
+    unsorted = (ver for ver in values if is_version(ver))
+    return sorted(unsorted, key=Version.parse, reverse=reverse)

--- a/tests/semver/test_constraint_utils.py
+++ b/tests/semver/test_constraint_utils.py
@@ -1,0 +1,62 @@
+import pytest
+
+import poetry.semver
+from poetry.semver.constraint_utils import is_constraint
+from poetry.semver.constraint_utils import sorted_constraints
+
+# TODO: test PEP-0440 vs. SEM-VER constraints
+
+
+# from test_main.py
+@pytest.mark.parametrize(
+    "constraint,result",
+    [
+        ("*", True),
+        ("*.*", True),
+        ("v*.*", True),
+        ("*.x.*", True),
+        ("x.X.x.*", True),
+        ("!=1.0.0", True),
+        (">1.0.0", True),
+        ("<1.2.3", True),
+        ("<=1.2.3", True),
+        (">=1.2.3", True),
+        ("=1.2.3", True),
+        ("1.2.3", True),
+        ("=1.0", True),
+        ("1.2.3b5", True),
+        (">= 1.2.3", True),
+        (">dev", True),
+        ("n.a.n", False),
+        ("hot-fix-666", False),
+    ],
+)
+def test_is_constraint(mocker, constraint, result):
+    # the full responsibility for validating all constraints lies with parse_single_constraint,
+    # this test just checks that it is called within `is_constraint` for a few examples.
+    parser = mocker.spy(poetry.semver.constraint_utils, name="parse_single_constraint")
+    assert is_constraint(constraint) == result
+    assert parser.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "unsorted, sorted_",
+    [
+        ([">1.2.3", "<=1.2.3"], ["<=1.2.3", ">1.2.3"]),
+        (["1.0.3", "1.0.2", "1.0.1"], ["1.0.1", "1.0.2", "1.0.3"]),
+        (
+            ["1.0.3", "1.0.2", "1.0.1", "n.a.n", "hot-fix-666"],
+            ["1.0.1", "1.0.2", "1.0.3"],
+        ),
+        (["10.0.3", "1.0.3", "n.a.n", "hot-fix-666"], ["1.0.3", "10.0.3"]),
+    ],
+)
+def test_sorted_constraints(mocker, unsorted, sorted_):
+    parser = mocker.spy(poetry.semver.constraint_utils, name="parse_single_constraint")
+    assert sorted_constraints(unsorted) == sorted_
+    # parser is called to (a) check is_constraint and (b) instantiate VersionConstraint for sort key
+    assert parser.call_count == (len(unsorted) + len(sorted_))
+    # test the reverse order
+    parser.reset_mock()
+    assert sorted_constraints(unsorted, reverse=True) == list(reversed(sorted_))
+    assert parser.call_count == (len(unsorted) + len(sorted_))

--- a/tests/semver/test_version_utils.py
+++ b/tests/semver/test_version_utils.py
@@ -1,0 +1,141 @@
+import random
+
+import pytest
+
+import poetry.semver
+from poetry.semver.version_utils import is_version
+from poetry.semver.version_utils import sorted_versions
+
+# semver sorted values, from
+# https://github.com/k-bx/python-semver/blob/master/test_semver.py
+SORTED_SEMVER = [
+    "1.0.0-alpha",
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.beta",
+    "1.0.0-beta",
+    "1.0.0-beta.2",
+    "1.0.0-beta.11",
+    "1.0.0-rc.1",
+    "1.0.0",
+    "1.0.0",
+    "2.0.0",
+]
+
+# current poetry behavior
+# - may not actually be PEP-0440
+# - depends on Version sort-behavior in this current implementation
+SORTED_VERSIONS = [
+    "1.0.0-alpha",
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.beta",
+    "1.0.0-beta",
+    "1.0.0-beta.2",
+    "1.0.0-beta.11",
+    "1.0.0-rc.1",
+    "1.0.0",
+    "1.0.0",
+    "2.0.0",
+]
+
+UNSORTED_VERSIONS = [
+    "1.0.0-alpha.beta",
+    "1.0.0-alpha",
+    "1.0.0-beta.2",
+    "1.0.0-alpha.1",
+    "1.0.0-beta.11",
+    "1.0.0-rc.1",
+    "2.0.0",
+    "1.0.0",
+    "1.0.0-beta",
+    "1.0.0",
+]
+
+
+# versions compatible with both PEP-0440 and SEM-VER
+@pytest.mark.parametrize(
+    "any_version,result",
+    [("2.0.0", True), ("1.0.0", True), ("n.a.n", False), ("hot-fix-666", False)],
+)
+def test_is_version(mocker, any_version, result):
+    parser = mocker.spy(poetry.semver.version.Version, name="parse")
+    assert is_version(any_version) == result
+    assert parser.call_count == 1
+
+
+# versions compatible with SEM-VER, excluded by PEP-0440
+# - uncomment parameters for TDD red->green
+# - TODO: add SEM-VER option to Version.parse? (or sub-class)
+@pytest.mark.parametrize(
+    "sem_version,result",
+    [
+        ("1.2.3-alpha.1.2+build.11.e0f985a", True),
+        ("2.0.0", True),
+        ("1.0.0", True),
+        ("1.0.0-alpha.1", True),
+        ("1.0.0-alpha", True),
+        ("1.0.0-alpha.beta", True),
+        ("1.0.0-rc.1", True),
+        ("1.0.0-beta.11", True),
+        ("1.0.0-beta.2", True),
+        ("1.0.0-beta", True),
+        # ("1.0.0.2", False),     # PEP-0440 OK, sem-ver not
+        # ("1.0.0.0rc2", False),  # PEP-0440 OK, sem-ver not
+        ("n.a.n", False),
+        ("hot-fix-666", False),
+    ],
+)
+def test_semver_is_version(mocker, sem_version, result):
+    parser = mocker.spy(poetry.semver.version.Version, name="parse")
+    assert is_version(sem_version) == result
+    assert parser.call_count == 1
+
+
+# versions compatible with PEP-0440, excluded by SEM-VER
+# - uncomment parameters for TDD red->green
+# - TODO: add PEP-0440 option to Version.parse? (or sub-class)
+@pytest.mark.parametrize(
+    "pep0440_version,result",
+    [
+        # ("1.2.3-alpha.1.2+build.11.e0f985a", False),
+        ("2.0.0", True),
+        ("1.0.0", True),
+        # ("1.0.0-alpha.1", False),
+        # ("1.0.0-alpha", False),
+        # ("1.0.0-alpha.beta", False),
+        # ("1.0.0-rc.1", False),
+        # ("1.0.0-beta.11", False),
+        # ("1.0.0-beta.2", False),
+        # ("1.0.0-beta", False),
+        ("1.0.0.2", True),  # PEP-0440 OK, sem-ver not
+        ("1.0.0.0rc2", True),  # PEP-0440 OK, sem-ver not
+        ("n.a.n", False),
+        ("hot-fix-666", False),
+    ],
+)
+def test_pep0440_is_version(mocker, pep0440_version, result):
+    parser = mocker.spy(poetry.semver.version.Version, name="parse")
+    assert is_version(pep0440_version) == result
+    assert parser.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "unsorted, sorted_",
+    [
+        # (UNSORTED_VERSIONS, SORTED_VERSIONS),  # fails - TODO: fix it?
+        (["1.0.3", "1.0.2", "1.0.1"], ["1.0.1", "1.0.2", "1.0.3"]),
+        (
+            ["1.0.3", "1.0.2", "1.0.1", "n.a.n", "hot-fix-666"],
+            ["1.0.1", "1.0.2", "1.0.3"],
+        ),
+        (["10.0.3", "1.0.3", "n.a.n", "hot-fix-666"], ["1.0.3", "10.0.3"]),
+    ],
+)
+def test_sorted_versions(mocker, unsorted, sorted_):
+    parser = mocker.spy(poetry.semver.version_utils.Version, name="parse")
+    assert sorted_versions(unsorted) == sorted_
+    # parser is called to (a) check is_version and (b) instantiate Version for sort key
+    assert parser.call_count == (len(unsorted) + len(sorted_))
+    # test the reverse order
+    parser.reset_mock()
+    assert sorted_versions(unsorted, reverse=True) == list(reversed(sorted_))
+    assert parser.call_count == (len(unsorted) + len(sorted_))


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
  - no docs required - internal utils only

Add constraint/version utils for boolean checks and sorting
- TODO notes about PEP-0440 vs. SEM-VER tests for TDD
- should be OPEN to adding PEP-0440 or SEM-VER config options down the road
- punting on PEP-0440 vs. SEM-VER implementations