### PR TITLE
[WIP] Use packaging and compare PEP-0440 vs. SEM-VER vs. legacy etc

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -14,7 +14,7 @@ marker = "python_version >= \"2.7\" and python_version < \"2.8\" and (sys_platfo
 name = "asn1crypto"
 optional = false
 python-versions = "*"
-version = "0.24.0"
+version = "1.0.1"
 
 [[package]]
 category = "dev"
@@ -41,12 +41,7 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.1.0"
-
-[package.extras]
-dev = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface", "sphinx", "pre-commit"]
-docs = ["sphinx", "zope.interface"]
-tests = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface"]
+version = "19.2.0"
 
 [[package]]
 category = "dev"
@@ -63,9 +58,6 @@ attrs = ">=18.1.0"
 click = ">=6.5"
 toml = ">=0.9.4"
 
-[package.extras]
-d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
-
 [[package]]
 category = "main"
 description = "httplib2 caching for requests"
@@ -75,16 +67,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.12.5"
 
 [package.dependencies]
+lockfile = ">=0.9"
 msgpack = "*"
 requests = "*"
-
-[package.dependencies.lockfile]
-optional = true
-version = ">=0.9"
-
-[package.extras]
-filecache = ["lockfile (>=0.9)"]
-redis = ["redis (>=2.10.5)"]
 
 [[package]]
 category = "main"
@@ -93,11 +78,6 @@ name = "cachy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.3.0"
-
-[package.extras]
-memcached = ["python-memcached (>=1.59,<2.0)"]
-msgpack = ["msgpack-python (>=0.5,<0.6)"]
-redis = ["redis (>=3.3.6,<4.0.0)"]
 
 [[package]]
 category = "main"
@@ -196,18 +176,14 @@ optional = false
 python-versions = ">=2.6"
 version = "4.0.2"
 
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2)", "pytest-flake8", "pytest-black-multipy"]
-
 [[package]]
 category = "dev"
 description = "Backports and enhancements for the contextlib module"
 marker = "python_version < \"3\""
 name = "contextlib2"
 optional = false
-python-versions = "*"
-version = "0.5.5"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.6.0"
 
 [[package]]
 category = "dev"
@@ -238,13 +214,6 @@ version = "*"
 [package.dependencies.ipaddress]
 python = "<3"
 version = "*"
-
-[package.extras]
-docs = ["sphinx (>=1.6.5,<1.8.0 || >1.8.0)", "sphinx-rtd-theme"]
-docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
-idna = ["idna (>=2.1)"]
-pep8test = ["flake8", "flake8-import-order", "pep8-naming"]
-test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
 
 [[package]]
 category = "main"
@@ -325,13 +294,6 @@ version = "1.0.1"
 six = ">=1.9"
 webencodings = "*"
 
-[package.extras]
-all = ["genshi", "chardet (>=2.2)", "datrie", "lxml"]
-chardet = ["chardet (>=2.2)"]
-datrie = ["datrie"]
-genshi = ["genshi"]
-lxml = ["lxml"]
-
 [[package]]
 category = "dev"
 description = "HTTP client mock for Python"
@@ -350,9 +312,6 @@ name = "identify"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.4.7"
-
-[package.extras]
-license = ["editdistance"]
 
 [[package]]
 category = "main"
@@ -380,10 +339,6 @@ version = ">=3.5"
 [package.dependencies.contextlib2]
 python = "<3"
 version = "*"
-
-[package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "importlib-resources"]
 
 [[package]]
 category = "dev"
@@ -421,23 +376,17 @@ optional = false
 python-versions = ">=3.5"
 version = "0.4.1"
 
-[package.extras]
-dev = ["testpath"]
-
 [[package]]
 category = "dev"
-description = "A small but fast and easy to use stand-alone template engine written in pure python."
+description = "A very fast and expressive template engine."
 marker = "python_version >= \"2.7.9\" and python_version < \"2.8.0\" or python_version >= \"3.4\" and python_version < \"4.0\""
 name = "jinja2"
 optional = false
 python-versions = "*"
-version = "2.10.1"
+version = "2.10.3"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
-
-[package.extras]
-i18n = ["Babel (>=0.8)"]
 
 [[package]]
 category = "main"
@@ -457,9 +406,6 @@ six = ">=1.11.0"
 python = "<3"
 version = "*"
 
-[package.extras]
-format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
-
 [[package]]
 category = "main"
 description = "Store and access your passwords safely."
@@ -477,10 +423,6 @@ pywin32-ctypes = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1"
 python = "<3.5"
 version = "<3"
 
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs", "pytest-flake8"]
-
 [[package]]
 category = "main"
 description = "Store and access your passwords safely."
@@ -494,10 +436,6 @@ version = "19.2.0"
 entrypoints = "*"
 pywin32-ctypes = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1"
 secretstorage = "*"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs", "pytest-flake8", "pytest-black-multipy"]
 
 [[package]]
 category = "dev"
@@ -539,9 +477,6 @@ version = "3.1.1"
 
 [package.dependencies]
 setuptools = ">=36"
-
-[package.extras]
-testing = ["coverage", "pyyaml"]
 
 [[package]]
 category = "dev"
@@ -585,11 +520,6 @@ six = "*"
 python = "<3.3"
 version = ">=1"
 
-[package.extras]
-build = ["twine", "wheel", "blurb"]
-docs = ["sphinx"]
-test = ["pytest", "pytest-cov"]
-
 [[package]]
 category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
@@ -626,7 +556,7 @@ python-versions = "*"
 version = "1.3.3"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
@@ -652,7 +582,7 @@ marker = "python_version >= \"2.7\" and python_version < \"2.8\" or python_versi
 name = "pathlib2"
 optional = false
 python-versions = "*"
-version = "2.3.4"
+version = "2.3.5"
 
 [package.dependencies]
 six = "*"
@@ -688,9 +618,6 @@ optional = false
 python-versions = "*"
 version = "1.5.0.1"
 
-[package.extras]
-testing = ["nose", "coverage"]
-
 [[package]]
 category = "dev"
 description = "plugin and hook calling mechanisms for python"
@@ -703,9 +630,6 @@ version = "0.13.0"
 [package.dependencies.importlib-metadata]
 python = "<3.8"
 version = ">=0.12"
-
-[package.extras]
-dev = ["pre-commit", "tox"]
 
 [[package]]
 category = "dev"
@@ -871,23 +795,17 @@ version = ">=1.0"
 python = "<3.6"
 version = ">=2.2.0"
 
-[package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "nose", "requests", "mock"]
-
 [[package]]
 category = "dev"
 description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.7.1"
+version = "2.8.1"
 
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=3.6"
-
-[package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
 
 [[package]]
 category = "dev"
@@ -895,7 +813,7 @@ description = "Thin-wrapper around the mock package for easier use with py.test"
 name = "pytest-mock"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.10.4"
+version = "1.11.1"
 
 [package.dependencies]
 pytest = ">=2.7"
@@ -903,9 +821,6 @@ pytest = ">=2.7"
 [package.dependencies.mock]
 python = "<3.0"
 version = "*"
-
-[package.extras]
-dev = ["pre-commit", "tox"]
 
 [[package]]
 category = "dev"
@@ -951,10 +866,6 @@ chardet = ">=3.0.2,<3.1.0"
 idna = ">=2.5,<2.9"
 urllib3 = ">=1.21.1,<1.25"
 
-[package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
-
 [[package]]
 category = "main"
 description = "Python HTTP for Humans."
@@ -968,10 +879,6 @@ certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<3.1.0"
 idna = ">=2.5,<2.9"
 urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
-
-[package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
 category = "main"
@@ -1004,9 +911,6 @@ version = "2.3.1"
 
 [package.dependencies]
 cryptography = "*"
-
-[package.extras]
-dbus-python = ["dbus-python"]
 
 [[package]]
 category = "main"
@@ -1068,7 +972,7 @@ description = "Style preserving TOML library"
 name = "tomlkit"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.5.5"
+version = "0.5.7"
 
 [package.dependencies]
 [package.dependencies.enum34]
@@ -1122,10 +1026,6 @@ virtualenv = ">=14.0.0"
 python = "<3.8"
 version = ">=0.12,<1"
 
-[package.extras]
-docs = ["sphinx (>=2.0.0,<3)", "towncrier (>=18.5.0)", "pygments-github-lexers (>=0.0.5)", "sphinxcontrib-autoprogram (>=0.1.5)"]
-testing = ["freezegun (>=0.3.11,<1)", "pathlib2 (>=2.3.3,<3)", "pytest (>=4.0.0,<6)", "pytest-cov (>=2.5.1,<3)", "pytest-mock (>=1.10.0,<2)", "pytest-xdist (>=1.22.2,<2)", "pytest-randomly (>=1.2.3,<2)", "flaky (>=3.4.0,<4)", "psutil (>=5.6.1,<6)"]
-
 [[package]]
 category = "main"
 description = "Type Hints for Python"
@@ -1143,22 +1043,13 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
 version = "1.24.3"
 
-[package.extras]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
-
 [[package]]
 category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-version = "1.25.5"
-
-[package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+version = "1.25.6"
 
 [[package]]
 category = "main"
@@ -1167,10 +1058,6 @@ name = "virtualenv"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "16.7.5"
-
-[package.extras]
-docs = ["sphinx (>=1.8.0,<2)", "towncrier (>=18.5.0)", "sphinx-rtd-theme (>=0.4.2,<1)"]
-testing = ["pytest (>=4.0.0,<5)", "coverage (>=4.5.0,<5)", "pytest-timeout (>=1.3.0,<2)", "six (>=1.10.0,<2)", "pytest-xdist", "pytest-localserver", "pypiserver", "mock", "xonsh"]
 
 [[package]]
 category = "dev"
@@ -1199,20 +1086,16 @@ version = "0.6.0"
 [package.dependencies]
 more-itertools = "*"
 
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pathlib2", "contextlib2", "unittest2"]
-
 [metadata]
-content-hash = "fef0a14e6eed6d3fd20670fe4c048b1f17bc12a08a8b8a5482dfcff6f569cb1d"
+content-hash = "e04130e91a8bcf0cb910934e6911318cc4bd559fea30a9655007e64c7e628986"
 python-versions = "~2.7 || ^3.4"
 
 [metadata.hashes]
 appdirs = ["9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92", "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"]
-asn1crypto = ["2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87", "9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"]
+asn1crypto = ["0b199f211ae690df3db4fd6c1c4ff976497fb1da689193e368eedbadc53d9292", "bca90060bd995c3f62c4433168eab407e44bdbdb567b3f3a396a676c1a4c4a3f"]
 "aspy.yaml" = ["463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc", "e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"]
 atomicwrites = ["03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4", "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"]
-attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"]
+attrs = ["ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2", "f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"]
 black = ["09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf", "68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"]
 cachecontrol = ["cef77effdf51b43178f6a2d3b787e3734f98ade253fa3187f3bb7315aaa42ff7"]
 cachy = ["186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1", "338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7"]
@@ -1225,7 +1108,7 @@ click = ["2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13", "5b
 clikit = ["229d259b9ec7adb6ce668aed70059ff79058b22794b958c178c50ece6ade5871", "b5034efd4dadb65e71544f978c70628dc56df4b0b47b0e6a7e521347dfc07fdf"]
 colorama = ["05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d", "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"]
 configparser = ["254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c", "c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"]
-contextlib2 = ["509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48", "f5260a6e679d2ff42ec91ec5252f4eeffdcf21053db9113bd0a8e4d953769c00"]
+contextlib2 = ["7197aa736777caac513dbd800944c209a49765bf1979b12b037dce0277077ed3", "9d2c67f18c1f9b6db1b46317f7f784aa82789d2ee5dea5d9c0f0f2a764eb862e"]
 coverage = ["08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6", "0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650", "141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5", "19e4df788a0581238e9390c85a7a09af39c7b539b29f25c89209e6c3e371270d", "23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351", "245388cda02af78276b479f299bbf3783ef0a6a6273037d7c60dc73b8d8d7755", "331cb5115673a20fb131dadd22f5bcaf7677ef758741312bee4937d71a14b2ef", "386e2e4090f0bc5df274e720105c342263423e77ee8826002dcffe0c9533dbca", "3a794ce50daee01c74a494919d5ebdc23d58873747fa0e288318728533a3e1ca", "60851187677b24c6085248f0a0b9b98d49cba7ecc7ec60ba6b9d2e5574ac1ee9", "63a9a5fc43b58735f65ed63d2cf43508f462dc49857da70b8980ad78d41d52fc", "6b62544bb68106e3f00b21c8930e83e584fdca005d4fffd29bb39fb3ffa03cb5", "6ba744056423ef8d450cf627289166da65903885272055fb4b5e113137cfa14f", "7494b0b0274c5072bddbfd5b4a6c6f18fbbe1ab1d22a41e99cd2d00c8f96ecfe", "826f32b9547c8091679ff292a82aca9c7b9650f9fda3e2ca6bf2ac905b7ce888", "93715dffbcd0678057f947f496484e906bf9509f5c1c38fc9ba3922893cda5f5", "9a334d6c83dfeadae576b4d633a71620d40d1c379129d587faa42ee3e2a85cce", "af7ed8a8aa6957aac47b4268631fa1df984643f07ef00acd374e456364b373f5", "bf0a7aed7f5521c7ca67febd57db473af4762b9622254291fbcbb8cd0ba5e33e", "bf1ef9eb901113a9805287e090452c05547578eaab1b62e4ad456fcc049a9b7e", "c0afd27bc0e307a1ffc04ca5ec010a290e49e3afbe841c5cafc5c5a80ecd81c9", "dd579709a87092c6dbee09d1b7cfa81831040705ffa12a1b248935274aee0437", "df6712284b2e44a065097846488f66840445eb987eb81b3cc6e4149e7b6982e1", "e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c", "e2ede7c1d45e65e209d6093b762e98e8318ddeff95317d07a27a2140b80cfd24", "e4ef9c164eb55123c62411f5936b5c2e521b12356037b6e1c2617cef45523d47", "eca2b7343524e7ba246cab8ff00cab47a2d6d54ada3b02772e908a45675722e2", "eee64c616adeff7db37cc37da4180a3a5b6177f5c46b187894e633f088fb5b28", "ef824cad1f980d27f26166f86856efe11eff9912c4fed97d3804820d43fa550c", "efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7", "fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0", "ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"]
 cryptography = ["24b61e5fcb506424d3ec4e18bca995833839bf13c59fc43e530e488f28d46b8c", "25dd1581a183e9e7a806fe0543f485103232f940fcfc301db65e630512cce643", "3452bba7c21c69f2df772762be0066c7ed5dc65df494a1d53a58b683a83e1216", "41a0be220dd1ed9e998f5891948306eb8c812b512dc398e5a01846d855050799", "5751d8a11b956fbfa314f6553d186b94aa70fdb03d8a4d4f1c82dcacf0cbe28a", "5f61c7d749048fa6e3322258b4263463bfccefecb0dd731b6561cb617a1d9bb9", "72e24c521fa2106f19623a3851e9f89ddfdeb9ac63871c7643790f872a305dfc", "7b97ae6ef5cba2e3bb14256625423413d5ce8d1abb91d4f29b6d1a081da765f8", "961e886d8a3590fd2c723cf07be14e2a91cf53c25f02435c04d39e90780e3b53", "96d8473848e984184b6728e2c9d391482008646276c3ff084a1bd89e15ff53a1", "ae536da50c7ad1e002c3eee101871d93abdc90d9c5f651818450a0d3af718609", "b0db0cecf396033abb4a93c95d1602f268b3a68bb0a9cc06a7cff587bb9a7292", "cfee9164954c186b191b91d4193989ca994703b2fff406f71cf454a2d3c7327e", "e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6", "f27d93f0139a3c056172ebb5d4f9056e770fdf0206c2f422ff2ebbad142e09ed", "f57b76e46a58b63d1c6375017f4564a28f19a5ca912691fd2e4261b3414b618d"]
 entrypoints = ["589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19", "c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"]
@@ -1243,7 +1126,7 @@ importlib-metadata = ["aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25
 importlib-resources = ["6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b", "d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"]
 ipaddress = ["64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794", "b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"]
 jeepney = ["13806f91a96e9b2623fd2a81b950d763ee471454aafd9eb6d75dbe7afce428fb", "f6a3f93464a0cf052f4e87da3c8b3ed1e27696758fb9739c63d3a74d9a1b6774"]
-jinja2 = ["065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013", "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"]
+jinja2 = ["74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f", "9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"]
 jsonschema = ["5f9c0a719ca2ce14c5de2fd350a64fd2d13e8539db29836a86adc990bb1a068f", "8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d"]
 keyring = ["67d6cc0132bd77922725fae9f18366bb314fd8f95ff4d323a4df41890a96a838", "7b29ebfcf8678c4da531b2478a912eea01e80007e5ddca9ee0c7038cb3489ec6", "91037ccaf0c9a112a76f7740e4a416b9457a69b66c2799421581bee710a974b3", "f5bb20ea6c57c2360daf0c591931c9ea0d7660a8d9e32ca84d63273f131ea605"]
 livereload = ["78d55f2c268a8823ba499305dcac64e28ddeb9a92571e12d543cd304faf5817b", "89254f78d7529d7ea0a3417d224c34287ebfe266b05e67e51facaf82c27f0f66"]
@@ -1253,11 +1136,11 @@ markupsafe = ["00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"
 mkdocs = ["17d34329aad75d5de604b9ed4e31df3a4d235afefdc46ce7b1964fddb2e1e939", "8cc8b38325456b9e942c981a209eaeb1e9f3f77b493ad755bfef889b9c8d356a"]
 mock = ["83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3", "d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"]
 more-itertools = ["38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4", "c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc", "fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9", "409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832", "92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"]
-msgpack = ["0cc7ca04e575ba34fea7cfcd76039f55def570e6950e4155a4174368142c8e1b", "187794cd1eb73acccd528247e3565f6760bd842d7dc299241f830024a7dd5610", "1904b7cb65342d0998b75908304a03cb004c63ef31e16c8c43fee6b989d7f0d7", "24149a75643aeaa81ece4259084d11b792308a6cf74e796cbb35def94c89a25a", "30b88c47e0cdb6062daed88ca283b0d84fa0d2ad6c273aa0788152a1c643e408", "355f7fd0f90134229eaeefaee3cf42e0afc8518e8f3cd4b25f541a7104dcb8f9", "4abdb88a9b67e64810fb54b0c24a1fd76b12297b4f7a1467d85a14dd8367191a", "757bd71a9b89e4f1db0622af4436d403e742506dbea978eba566815dc65ec895", "76df51492bc6fa6cc8b65d09efdb67cbba3cbfe55004c3afc81352af92b4a43c", "774f5edc3475917cd95fe593e625d23d8580f9b48b570d8853d06cac171cd170", "8a3ada8401736df2bf497f65589293a86c56e197a80ae7634ec2c3150a2f5082", "a06efd0482a1942aad209a6c18321b5e22d64eb531ea20af138b28172d8f35ba", "b8b4bd3dafc7b92608ae5462add1c8cc881851c2d4f5d8977fdea5b081d17f21", "c6e5024fc0cdf7f83b6624850309ddd7e06c48a75fa0d1c5173de4d93300eb19", "db7ff14abc73577b0bcbcf73ecff97d3580ecaa0fc8724babce21fdf3fe08ef6", "dedf54d72d9e7b6d043c244c8213fe2b8bbfe66874b9a65b39c4cc892dd99dd4", "ea3c2f859346fcd55fc46e96885301d9c2f7a36d453f5d8f2967840efa1e1830", "f0f47bafe9c9b8ed03e19a100a743662dd8c6d0135e684feea720a0d0046d116"]
+msgpack = ["0cc7ca04e575ba34fea7cfcd76039f55def570e6950e4155a4174368142c8e1b", "187794cd1eb73acccd528247e3565f6760bd842d7dc299241f830024a7dd5610", "1904b7cb65342d0998b75908304a03cb004c63ef31e16c8c43fee6b989d7f0d7", "229a0ccdc39e9b6c6d1033cd8aecd9c296823b6c87f0de3943c59b8bc7c64bee", "24149a75643aeaa81ece4259084d11b792308a6cf74e796cbb35def94c89a25a", "30b88c47e0cdb6062daed88ca283b0d84fa0d2ad6c273aa0788152a1c643e408", "32fea0ea3cd1ef820286863a6202dcfd62a539b8ec3edcbdff76068a8c2cc6ce", "355f7fd0f90134229eaeefaee3cf42e0afc8518e8f3cd4b25f541a7104dcb8f9", "4abdb88a9b67e64810fb54b0c24a1fd76b12297b4f7a1467d85a14dd8367191a", "757bd71a9b89e4f1db0622af4436d403e742506dbea978eba566815dc65ec895", "76df51492bc6fa6cc8b65d09efdb67cbba3cbfe55004c3afc81352af92b4a43c", "774f5edc3475917cd95fe593e625d23d8580f9b48b570d8853d06cac171cd170", "8a3ada8401736df2bf497f65589293a86c56e197a80ae7634ec2c3150a2f5082", "a06efd0482a1942aad209a6c18321b5e22d64eb531ea20af138b28172d8f35ba", "b24afc52e18dccc8c175de07c1d680bdf315844566f4952b5bedb908894bec79", "b8b4bd3dafc7b92608ae5462add1c8cc881851c2d4f5d8977fdea5b081d17f21", "c6e5024fc0cdf7f83b6624850309ddd7e06c48a75fa0d1c5173de4d93300eb19", "db7ff14abc73577b0bcbcf73ecff97d3580ecaa0fc8724babce21fdf3fe08ef6", "dedf54d72d9e7b6d043c244c8213fe2b8bbfe66874b9a65b39c4cc892dd99dd4", "ea3c2f859346fcd55fc46e96885301d9c2f7a36d453f5d8f2967840efa1e1830", "f0f47bafe9c9b8ed03e19a100a743662dd8c6d0135e684feea720a0d0046d116"]
 nodeenv = ["ad8259494cf1c9034539f6cced78a1da4840a4b157e23640bc4a0c0546b0cb7a"]
 packaging = ["28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47", "d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"]
 pastel = ["a904e1659512cc9880a028f66de77cc813a4c32f7ceb68725cbc8afad57ef7ef", "bf3b1901b2442ea0d8ab9a390594e5b0c9584709d543a3113506fe8b28cbace3"]
-pathlib2 = ["2156525d6576d21c4dcaddfa427fae887ef89a7a9de5cbfe0728b3aafa78427e", "446014523bb9be5c28128c4d2a10ad6bb60769e78bd85658fe44a450674e0ef8"]
+pathlib2 = ["0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db", "6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"]
 pep562 = ["58cb1cc9ee63d93e62b4905a50357618d526d289919814bea1f0da8f53b79395", "d2a48b178ebf5f8dd31709cc26a19808ef794561fa2fe50ea01ea2bad4d667ef"]
 pexpect = ["2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1", "9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"]
 pkginfo = ["7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb", "a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32"]
@@ -1273,8 +1156,8 @@ pymdown-extensions = ["25b0a7967fa697b5035e23340a48594e3e93acb10b06d74574218ace3
 pyparsing = ["6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80", "d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"]
 pyrsistent = ["3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2"]
 pytest = ["8fc39199bdda3d9d025d3b1f4eb99a192c20828030ea7c9a0d2840721de7d347", "d100a02770f665f5dcf7e3f08202db29857fee6d15f34c942be0a511f39814f0"]
-pytest-cov = ["2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6", "e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"]
-pytest-mock = ["43ce4e9dd5074993e7c021bb1c22cbb5363e612a2b5a76bc6d956775b10758b7", "5bf5771b1db93beac965a7347dc81c675ec4090cb841e49d9d34637a25c30568"]
+pytest-cov = ["cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b", "cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"]
+pytest-mock = ["34520283d459cdf1d0dbb58a132df804697f1b966ecedf808bbf3d255af8f659", "f1ab8aefe795204efe7a015900296d1719e7bf0f4a0558d71e8599da1d1309d0"]
 pytest-sugar = ["26cf8289fe10880cbbc130bd77398c4e6a8b936d8393b116a5c16121d95ab283", "fcd87a74b2bce5386d244b49ad60549bfbc4602527797fac167da147983f58ab"]
 pywin32-ctypes = ["24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942", "9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"]
 pyyaml = ["0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9", "01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4", "5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8", "5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696", "7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34", "7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9", "87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73", "9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299", "a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b", "b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae", "b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681", "bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41", "f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"]
@@ -1287,11 +1170,11 @@ six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a
 subprocess32 = ["88e37c1aac5388df41cc8a8456bb49ebffd321a3ad4d70358e3518176de3a56b", "eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d"]
 termcolor = ["1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"]
 toml = ["229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c", "235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e", "f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"]
-tomlkit = ["a8d806f3a453c2d292afe97918398354e405b93919e2e68771a3fd0a90e89576", "c6b0c11b85e888c12330c7605d43c1446aa148cd421163f90ca46ea813f2c336"]
+tomlkit = ["6c1c8af5d98468e9d2b07db2060ae2bc6fe204bda7f32f46a6255b50fe78a71c", "c4e657ec7a92aedc05202c068099ca530100aacb7dfadd100f2e8e5fd40302a1"]
 tornado = ["0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d", "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409", "732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f", "8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f", "8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5", "d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb", "e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444", "349884248c36801afa19e342a77cc4458caca694b0eda633f5878e458a44cb2c", "398e0d35e086ba38a0427c3b37f4337327231942e731edaa6e9fd1865bbd6f60", "4e73ef678b1a859f0cb29e1d895526a20ea64b5ffd510a2307b5998c7df24281", "559bce3d31484b665259f50cd94c5c28b961b09315ccd838f284687245f416e5", "abbe53a39734ef4aba061fca54e30c6b4639d3e1f59653f0da37a0003de148c7", "c845db36ba616912074c5b1ee897f8e0124df269468f25e4fe21fe72f6edd7a9", "c9399267c926a4e7c418baa5cbe91c7d1cf362d505a1ef898fde44a07c9dd8a5"]
 tox = ["0bc216b6a2e6afe764476b4a07edf2c1dab99ed82bb146a1130b2e828f5bff5e", "c4f6b319c20ba4913dbfe71ebfd14ff95d1853c4231493608182f66e566ecfe1"]
 typing = ["91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23", "c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36", "f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"]
-urllib3 = ["2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4", "a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb", "2f3eadfea5d92bc7899e75b5968410b749a054b492d5a6379c1344a1481bc2cb", "9c6c593cb28f52075016307fc26b0a0f8e82bc7d1ff19aaaa959b91710a56c47"]
+urllib3 = ["2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4", "a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb", "3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398", "9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"]
 virtualenv = ["680af46846662bb38c5504b78bad9ed9e4f3ba2d54f54ba42494fdf94337fe30", "f78d81b62d3147396ac33fc9d77579ddc42cc2a98dd9ea38886f616b33bc7fb2"]
 wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]
 webencodings = ["a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"]

--- a/poetry/semver/__init__.py
+++ b/poetry/semver/__init__.py
@@ -3,6 +3,7 @@ import re
 from .empty_constraint import EmptyConstraint
 from .patterns import BASIC_CONSTRAINT
 from .patterns import CARET_CONSTRAINT
+from .patterns import COMPLETE_VERSION
 from .patterns import TILDE_CONSTRAINT
 from .patterns import TILDE_PEP440_CONSTRAINT
 from .patterns import X_CONSTRAINT

--- a/poetry/semver/constraint_utils.py
+++ b/poetry/semver/constraint_utils.py
@@ -1,0 +1,42 @@
+"""
+Constraint utilities
+
+The focus of this module is any constraint support, but
+PEP-0440 support trumps everything else.
+
+With regard to SEM-VER compatibility, PEP-0440 is partially
+but not fully compatible with all the SEM-VER specs; see
+
+https://legacy.python.org/dev/peps/pep-0440/#semantic-versioning
+> Semantic versions containing a hyphen (pre-releases - clause 10) or
+> a plus sign (builds - clause 11) are not compatible with this PEP
+> and are not permitted in the public version field.
+"""
+
+from typing import List
+
+from poetry.semver import parse_single_constraint
+
+
+def is_constraint(value):  # type: (str) -> bool
+    """Check that a string is a single constraint
+
+    :param value: any string
+    :return: True if value is a constraint
+    """
+    try:
+        return bool(parse_single_constraint(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def sorted_constraints(values, reverse=False):  # type: (List[str], bool) -> List[str]
+    """Sort a list of single constraints (string);
+    discards any string that is not a constraint.
+
+    :param values: any strings
+    :param reverse: sort descending (reverse=True) or ascending (reverse=False)
+    :return: sorted values based on sort criteria
+    """
+    unsorted = (ver for ver in values if is_constraint(ver))
+    return sorted(unsorted, key=parse_single_constraint, reverse=reverse)

--- a/poetry/semver/version_utils.py
+++ b/poetry/semver/version_utils.py
@@ -1,0 +1,145 @@
+"""
+Version utilities
+
+The focus of this module is any version support, but
+PEP-0440 support trumps everything else.
+
+With regard to SEM-VER compatibility, PEP-0440 is partially
+but not fully compatible with all the SEM-VER specs; see
+
+https://legacy.python.org/dev/peps/pep-0440/#semantic-versioning
+> Semantic versions containing a hyphen (pre-releases - clause 10) or
+> a plus sign (builds - clause 11) are not compatible with this PEP
+> and are not permitted in the public version field.
+"""
+
+from typing import List
+
+from poetry.semver import Version
+from packaging import version as pep440_version
+
+
+def is_version(value):  # type: (str) -> bool
+    """Check that a string is a release version
+
+    :param value: any string
+    :return: True if value is a release version
+    """
+    try:
+        return bool(Version.parse(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def sorted_versions(values, reverse=False):  # type: (List[str], bool) -> List[str]
+    """Sort a list of release versions (string);
+    discards any string that is not a release version.
+
+    :param values: a list of strings
+    :param reverse: sort descending (reverse=True) or ascending (reverse=False)
+    :return: sorted values based on sort criteria for release versions
+    """
+    unsorted = (ver for ver in values if is_version(ver))
+    return sorted(unsorted, key=Version.parse, reverse=reverse)
+
+
+def is_package_version(value):  # type: (str) -> bool
+    """Check that a string is a PEP-0440 release version
+    (or a legacy version).
+
+    :param value: any string
+    :return: True if value is a PEP-0440 or legacy version
+    """
+    try:
+
+        ver = pep440_version.parse(value)
+        if isinstance(ver, pep440_version.Version):
+            return True
+        elif isinstance(ver, pep440_version.LegacyVersion):
+            return True
+        else:
+            return False
+    except (pep440_version.InvalidVersion, TypeError, ValueError):
+        return False
+
+
+def sorted_package_versions(
+    values, reverse=False
+):  # type: (List[str], bool) -> List[str]
+    """Sort a list of PEP-0440 release versions (string);
+    discards any string that is not a PEP-0440 or legacy version.
+
+    :param values: a list of strings
+    :param reverse: sort descending (reverse=True) or ascending (reverse=False)
+    :return: sorted values based on sort criteria for PEP-0440 and legacy versions
+    """
+    unsorted = (ver for ver in values if is_package_version(ver))
+    return sorted(unsorted, key=pep440_version.parse, reverse=reverse)
+
+
+def is_pep440_version(value):  # type: (str) -> bool
+    """Check that a string is a PEP-0440 release version
+    (or a legacy version).
+
+    :param value: any string
+    :return: True if value is a PEP-0440 version
+    """
+    try:
+
+        ver = pep440_version.parse(value)
+        if isinstance(ver, pep440_version.LegacyVersion):
+            return False
+        elif isinstance(ver, pep440_version.Version):
+            return True
+        else:
+            return False
+    except (pep440_version.InvalidVersion, TypeError, ValueError):
+        return False
+
+
+def sorted_pep440_versions(
+    values, reverse=False
+):  # type: (List[str], bool) -> List[str]
+    """Sort a list of PEP-0440 release versions (string);
+    discards any string that is not a PEP-0440 release version
+    (or a legacy version).
+
+    :param values: a list of strings
+    :param reverse: sort descending (reverse=True) or ascending (reverse=False)
+    :return: sorted values based on sort criteria for PEP-0440 release versions
+    """
+    unsorted = (ver for ver in values if is_pep440_version(ver))
+    return sorted(unsorted, key=pep440_version.parse, reverse=reverse)
+
+
+def is_legacy_version(value):  # type: (str) -> bool
+    """Check that a string is a legacy version.
+
+    :param value: any string
+    :return: True if value is a legacy version
+    """
+    try:
+
+        ver = pep440_version.parse(value)
+        if isinstance(ver, pep440_version.LegacyVersion):
+            return True
+        elif isinstance(ver, pep440_version.Version):
+            return False
+        else:
+            return False
+    except (pep440_version.InvalidVersion, TypeError, ValueError):
+        return False
+
+
+def sorted_legacy_versions(
+    values, reverse=False
+):  # type: (List[str], bool) -> List[str]
+    """Sort a list of legacy versions (string);
+    discards any string that is not a legacy version.
+
+    :param values: a list of strings
+    :param reverse: sort descending (reverse=True) or ascending (reverse=False)
+    :return: sorted values based on sort criteria for legacy release versions
+    """
+    unsorted = (ver for ver in values if is_legacy_version(ver))
+    return sorted(unsorted, key=pep440_version.parse, reverse=reverse)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ jsonschema = "^3.0a3"
 pyrsistent = "^0.14.2"
 pyparsing = "^2.2"
 cachecontrol = { version = "^0.12.4", extras = ["filecache"] }
+packaging = "^19.1"
 pkginfo = "^1.4"
 html5lib = "^1.0"
 shellingham = "^1.1"

--- a/tests/semver/test_constraint_utils.py
+++ b/tests/semver/test_constraint_utils.py
@@ -1,0 +1,62 @@
+import pytest
+
+import poetry.semver
+from poetry.semver.constraint_utils import is_constraint
+from poetry.semver.constraint_utils import sorted_constraints
+
+# TODO: test PEP-0440 vs. SEM-VER constraints
+
+
+# from test_main.py
+@pytest.mark.parametrize(
+    "constraint,result",
+    [
+        ("*", True),
+        ("*.*", True),
+        ("v*.*", True),
+        ("*.x.*", True),
+        ("x.X.x.*", True),
+        ("!=1.0.0", True),
+        (">1.0.0", True),
+        ("<1.2.3", True),
+        ("<=1.2.3", True),
+        (">=1.2.3", True),
+        ("=1.2.3", True),
+        ("1.2.3", True),
+        ("=1.0", True),
+        ("1.2.3b5", True),
+        (">= 1.2.3", True),
+        (">dev", True),
+        ("n.a.n", False),
+        ("hot-fix-666", False),
+    ],
+)
+def test_is_constraint(mocker, constraint, result):
+    # the full responsibility for validating all constraints lies with parse_single_constraint,
+    # this test just checks that it is called within `is_constraint` for a few examples.
+    parser = mocker.spy(poetry.semver.constraint_utils, name="parse_single_constraint")
+    assert is_constraint(constraint) == result
+    assert parser.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "unsorted, sorted_",
+    [
+        ([">1.2.3", "<=1.2.3"], ["<=1.2.3", ">1.2.3"]),
+        (["1.0.3", "1.0.2", "1.0.1"], ["1.0.1", "1.0.2", "1.0.3"]),
+        (
+            ["1.0.3", "1.0.2", "1.0.1", "n.a.n", "hot-fix-666"],
+            ["1.0.1", "1.0.2", "1.0.3"],
+        ),
+        (["10.0.3", "1.0.3", "n.a.n", "hot-fix-666"], ["1.0.3", "10.0.3"]),
+    ],
+)
+def test_sorted_constraints(mocker, unsorted, sorted_):
+    parser = mocker.spy(poetry.semver.constraint_utils, name="parse_single_constraint")
+    assert sorted_constraints(unsorted) == sorted_
+    # parser is called to (a) check is_constraint and (b) instantiate VersionConstraint for sort key
+    assert parser.call_count == (len(unsorted) + len(sorted_))
+    # test the reverse order
+    parser.reset_mock()
+    assert sorted_constraints(unsorted, reverse=True) == list(reversed(sorted_))
+    assert parser.call_count == (len(unsorted) + len(sorted_))

--- a/tests/semver/test_version_utils.py
+++ b/tests/semver/test_version_utils.py
@@ -1,0 +1,176 @@
+import random
+
+import pytest
+
+import poetry.semver
+from poetry.semver.version_utils import is_legacy_version
+from poetry.semver.version_utils import is_pep440_version
+from poetry.semver.version_utils import is_version
+from poetry.semver.version_utils import sorted_versions
+
+# semver sorted values, from
+# https://github.com/k-bx/python-semver/blob/master/test_semver.py
+SORTED_SEMVER = [
+    "1.0.0-alpha",
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.beta",
+    "1.0.0-beta",
+    "1.0.0-beta.2",
+    "1.0.0-beta.11",
+    "1.0.0-rc.1",
+    "1.0.0",
+    "1.0.0",
+    "2.0.0",
+]
+
+# current poetry behavior
+# - may not actually be PEP-0440
+# - depends on Version sort-behavior in this current implementation
+SORTED_VERSIONS = [
+    "1.0.0-alpha",
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.beta",
+    "1.0.0-beta",
+    "1.0.0-beta.2",
+    "1.0.0-beta.11",
+    "1.0.0-rc.1",
+    "1.0.0",
+    "1.0.0",
+    "2.0.0",
+]
+
+UNSORTED_VERSIONS = [
+    "1.0.0-alpha.beta",
+    "1.0.0-alpha",
+    "1.0.0-beta.2",
+    "1.0.0-alpha.1",
+    "1.0.0-beta.11",
+    "1.0.0-rc.1",
+    "2.0.0",
+    "1.0.0",
+    "1.0.0-beta",
+    "1.0.0",
+]
+
+
+# versions compatible with both PEP-0440 and SEM-VER
+@pytest.mark.parametrize(
+    "any_version,result",
+    [("2.0.0", True), ("1.0.0", True), ("n.a.n", False), ("hot-fix-666", False)],
+)
+def test_is_version(mocker, any_version, result):
+    parser = mocker.spy(poetry.semver.version.Version, name="parse")
+    assert is_version(any_version) == result
+    assert parser.call_count == 1
+
+
+# versions compatible with SEM-VER, excluded by PEP-0440
+# - uncomment parameters for TDD red->green
+# - TODO: add SEM-VER option to Version.parse? (or sub-class)
+@pytest.mark.parametrize(
+    "sem_version,result",
+    [
+        ("1.2.3-alpha.1.2+build.11.e0f985a", True),
+        ("2.0.0", True),
+        ("1.0.0", True),
+        ("1.0.0-alpha.1", True),
+        ("1.0.0-alpha", True),
+        ("1.0.0-alpha.beta", True),
+        ("1.0.0-rc.1", True),
+        ("1.0.0-beta.11", True),
+        ("1.0.0-beta.2", True),
+        ("1.0.0-beta", True),
+        # ("1.0.0.2", False),     # PEP-0440 OK, sem-ver not
+        # ("1.0.0.0rc2", False),  # PEP-0440 OK, sem-ver not
+        ("n.a.n", False),
+        ("hot-fix-666", False),
+    ],
+)
+def test_semver_is_version(mocker, sem_version, result):
+    parser = mocker.spy(poetry.semver.version.Version, name="parse")
+    assert is_version(sem_version) == result
+    assert parser.call_count == 1
+
+
+# versions compatible with PEP-0440 (not legacy versions), excluded by SEM-VER
+# the packaging.version implementation seems to interpret SEM-VER versions and
+# cast them into a PEP-0440 form, e.g. "1.0.0-alpha.1" -> "1.0.0a1"
+@pytest.mark.parametrize(
+    "pep0440_version,result",
+    [
+        ("1.2.3-alpha.1.2+build.11.e0f985a", False),  # sem-ver / legacy
+        ("2.0.0", True),  # all OK
+        ("1.0.0", True),  # all OK
+        ("1.0.0-alpha.1", True),  # sem-ver converted to PEP-0440 "1.0.0a1"
+        ("1.0.0-alpha", True),  # sem-ver converted to PEP-0440 "1.0.0a0"
+        ("1.0.0-alpha.beta", False),  # sem-ver / LegacyVersion
+        ("1.0.0-rc.1", True),  # sem-ver converted to PEP-0440 "1.0.0rc1"
+        ("1.0.0-beta.11", True),  # sem-ver converted to PEP-0440 "1.0.0b11"
+        ("1.0.0-beta.2", True),  # sem-ver converted to PEP-0440 "1.0.0b2"
+        ("1.0.0-beta", True),  # sem-ver converted to PEP-0440 "1.0.0b0"
+        ("1.0.0.2", True),  # PEP-0440 OK, sem-ver not
+        ("1.0.0.0rc2", True),  # PEP-0440 OK, sem-ver not
+        ("n.a.n", False),  # LegacyVersion (huh?)
+        ("hot-fix-666", False),  # LegacyVersion (huh?)
+    ],
+)
+def test_is_pep0440_version(mocker, pep0440_version, result):
+    parser = mocker.spy(poetry.semver.version_utils.pep440_version, name="parse")
+    assert is_pep440_version(pep0440_version) == result
+    assert parser.call_count == 1
+
+
+# legacy versions (incompatible with PEP-0440) - ? relationship to SEM-VER
+@pytest.mark.parametrize(
+    "legacy_version,result",
+    [
+        ("1.2.3-alpha.1.2+build.11.e0f985a", True),  # sem-ver / legacy
+        ("2.0.0", False),  # all OK
+        ("1.0.0", False),  # all OK
+        ("1.0.0-alpha.1", False),  # sem-ver converted to PEP-0440 "1.0.0a1"
+        ("1.0.0-alpha", False),  # sem-ver converted to PEP-0440 "1.0.0a0"
+        ("1.0.0-alpha.beta", True),  # sem-ver / LegacyVersion
+        ("1.0.0-rc.1", False),  # sem-ver converted to PEP-0440 "1.0.0rc1"
+        ("1.0.0-beta.11", False),  # sem-ver converted to PEP-0440 "1.0.0b11"
+        ("1.0.0-beta.2", False),  # sem-ver converted to PEP-0440 "1.0.0b2"
+        ("1.0.0-beta", False),  # sem-ver converted to PEP-0440 "1.0.0b0"
+        ("1.0.0.2", False),  # PEP-0440 OK, sem-ver not
+        ("1.0.0.0rc2", False),  # PEP-0440 OK, sem-ver not
+        ("n.a.n", True),  # LegacyVersion (huh?)
+        ("hot-fix-666", True),  # LegacyVersion (huh?)
+        ("french toast", True),  # LegacyVersion (huh?)
+    ],
+)
+def test_is_legacy_version(mocker, legacy_version, result):
+    parser = mocker.spy(poetry.semver.version_utils.pep440_version, name="parse")
+    assert is_legacy_version(legacy_version) == result
+    assert parser.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "unsorted, sorted_",
+    [
+        # (UNSORTED_VERSIONS, SORTED_VERSIONS),  # fails - TODO: fix it?
+        (["1.0.3", "1.0.2", "1.0.1"], ["1.0.1", "1.0.2", "1.0.3"]),
+        (
+            ["1.0.3", "1.0.2", "1.0.1", "n.a.n", "hot-fix-666"],
+            ["1.0.1", "1.0.2", "1.0.3"],
+        ),
+        (["10.0.3", "1.0.3", "n.a.n", "hot-fix-666"], ["1.0.3", "10.0.3"]),
+    ],
+)
+def test_sorted_versions(mocker, unsorted, sorted_):
+    parser = mocker.spy(poetry.semver.version_utils.Version, name="parse")
+    assert sorted_versions(unsorted) == sorted_
+    # parser is called to (a) check is_version and (b) instantiate Version for sort key
+    assert parser.call_count == (len(unsorted) + len(sorted_))
+    # test the reverse order
+    parser.reset_mock()
+    assert sorted_versions(unsorted, reverse=True) == list(reversed(sorted_))
+    assert parser.call_count == (len(unsorted) + len(sorted_))
+
+
+# TODO: sorted-pep440
+# TODO: sorted-legacy
+# TODO: sorted-packaging
+# TODO: sorted-sem-ver


### PR DESCRIPTION
WIP to explore variants of version formatting and regex patterns in several version conventions and how they relate to poetry version and constraint tools
- sem-ver
- PEP-0440
- poetry

This may never get merged, but it's worth throwing it up for the curious.  I might need to revise one or more other PRs in the light of looking closer at these version standards.  There is no intention in this to apply a specific versioning system on poetry (AFAIK, PEP-0440 is the only thing that poetry is _supposed_ to implement and support).

### TODO
- related to similar PRs #1268 and #1375 
  - probably rebase this on #1268 and/or collapse that into this (although it stands on it own)
- closer analysis of the poetry version class API vs. the packaging version API
- What does conda do to handle many various version standards?
  - PEP-0440 should apply to python packages, but what about things like rasterio that wrap c++ libs where those c++ libs could use a different versioning format?

### checklist
- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
  - don't know if it needs any (yet)