### PR TITLE
If target package is lower version, call it out as a downgrade

### DIFF
--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -344,7 +344,8 @@ class Installer:
 
         if self._execute_operations or self.is_dry_run():
             self._io.write_line(
-                "  - Updating <info>{}</> (<comment>{}</> -> <comment>{}</>)".format(
+                "  - {} <info>{}</> (<comment>{}</> -> <comment>{}</>)".format(
+                    "Updating" if source.version < target.version else "Downgrading",
                     target.pretty_name,
                     source.full_pretty_version,
                     target.full_pretty_version,

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -716,6 +716,36 @@ Package operations: 1 install, 0 updates, 0 removals
     assert content["dependencies"]["foo"] == "^1.1.2"
 
 
+def test_add_existing_package_with_lower_exact_version_displays_as_downgrade(
+    app, repo, installer, installed
+):
+    content = app.poetry.file.read()
+    content["tool"]["poetry"]["dependencies"]["foo"] = "^1.2.0"
+    app.poetry.file.write(content)
+    command = app.find("add")
+    tester = CommandTester(command)
+
+    installed.add_package(get_package("foo", "1.2.0"))
+    repo.add_package(get_package("foo", "1.1.2"))
+
+    tester.execute("foo==1.1.2")
+
+    expected = """\
+
+Updating dependencies
+Resolving dependencies...
+
+Writing lock file
+
+
+Package operations: 0 installs, 1 update, 0 removals
+
+  - Downgrading foo (1.2.0 -> 1.1.2)
+"""
+
+    assert expected in tester.io.fetch_output()
+
+
 def test_add_chooses_prerelease_if_only_prereleases_are_available(app, repo, installer):
     command = app.find("add")
     tester = CommandTester(command)


### PR DESCRIPTION
Fixes #1394 

As per the example in the description of that issue: 
```sh
$ poetry add "Django==2.1.12"

Updating dependencies
Resolving dependencies... (8.0s)

Writing lock file


Package operations: 0 installs, 1 update, 1 removal

  - Downgrading django (2.2.5 -> 2.1.12)
  - Removing sqlparse (0.3.0)
$
```

This is a very simplistic implementation of the fix, and very superficial. Things to note:
* There are no tests; I couldn't find any tests encompassing the strings which are output
* The `Package operations` still list an update
* I did not modify the `Update` operation, so its str and repr methods still say `Update`/`Updating`.

I considered taking a bit more of a holistic approach to this, but as my brain went further down that path, I realized it would likely result in a new operation type and possibly even a new command.