### PR TITLE
Add option to version command to output version number only

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -422,6 +422,9 @@ bump rule is provided.
 The new version should ideally be a valid semver string or a valid bump rule:
 `patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`.
 
+## Options
+
+* `--short (-s)`: Output the version number only.
 
 ## export
 

--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -1,4 +1,4 @@
-from cleo import argument
+from cleo import argument, option
 
 from .command import Command
 
@@ -18,6 +18,7 @@ class VersionCommand(Command):
             optional=True,
         )
     ]
+    options = [option("short", "s", "Output the version number only")]
 
     help = """\
 The version command shows the current version of the project or bumps the version of 
@@ -58,11 +59,14 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
 
             self.poetry.file.write(content)
         else:
-            self.line(
-                "Project (<comment>{}</>) version is <info>{}</>".format(
-                    self.poetry.package.name, self.poetry.package.pretty_version
+            if self.option("short"):
+                self.line("{}".format(self.poetry.package.pretty_version))
+            else:
+                self.line(
+                    "Project (<comment>{}</>) version is <info>{}</>".format(
+                        self.poetry.package.name, self.poetry.package.pretty_version
+                    )
                 )
-            )
 
     def increment_version(self, version, rule):
         from poetry.semver import Version

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -44,3 +44,10 @@ def test_version_show(app):
     tester = CommandTester(command)
     tester.execute()
     assert "Project (simple-project) version is 1.2.3\n" == tester.io.fetch_output()
+
+
+def test_short_version_show(app):
+    command = app.find("version")
+    tester = CommandTester(command)
+    tester.execute("--short")
+    assert "1.2.3\n" == tester.io.fetch_output()


### PR DESCRIPTION
Adds option to version command to output version number only. 

Resolves: https://github.com/sdispater/poetry/issues/1407
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
