### PR TITLE
fix: pathlib.WindowsPath converts Win paths to lowercase

### DIFF
--- a/poetry/masonry/utils/include.py
+++ b/poetry/masonry/utils/include.py
@@ -2,6 +2,7 @@ from typing import List
 from typing import Optional
 
 from poetry.utils._compat import Path
+from poetry.utils._compat import glob
 
 
 class Include(object):
@@ -25,7 +26,7 @@ class Include(object):
         self._include = str(include)
         self._formats = formats
 
-        self._elements = sorted(list(self._base.glob(str(self._include))))
+        self._elements = sorted(list(self._glob_include()))
 
     @property
     def base(self):  # type: () -> Path
@@ -43,6 +44,12 @@ class Include(object):
         return len(self._elements) == 0
 
     def refresh(self):  # type: () -> Include
-        self._elements = sorted(list(self._base.glob(self._include)))
+        self._elements = sorted(list(self._glob_include()))
 
         return self
+
+    def _glob_include(self):
+        element_paths_string = list(
+            glob(str(self._base) + "/" + self._include, recursive=True)
+        )
+        return map(lambda path_string: Path(path_string), element_paths_string)

--- a/tests/masonry/utils/test_include.py
+++ b/tests/masonry/utils/test_include.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from tomlkit._compat import decode
+from tomlkit._utils import escape_string
+from tomlkit.items import String
+from tomlkit.items import StringType
+from tomlkit.items import Trivia
+
+from poetry.masonry.utils.include import Include
+from poetry.utils._compat import Path
+
+
+def test_include_elements():
+    def create_toml_string(value):
+        escaped = escape_string(value)
+
+        return String(StringType.SLB, decode(value), escaped, Trivia())
+
+    include = Include(
+        Path(__file__).parent / "fixtures" / "MyPackage", create_toml_string("Foo")
+    )
+
+    expected_path = Path(__file__).parent / Path("fixtures/MyPackage/Foo")
+
+    assert len(include.elements) == 1
+    assert include.elements[0] == expected_path


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Hi,

Poetry uses WindowsPath which, on Windows, unexpectedly converts file system paths to lowercase. As a result, I am not able to correctly import classes from packages built by Poetry on Windows.

**real Windows path:**
src/DbxDeploy/Logger/MyLogger.py

**path in package build by Poetry:**
src/dbxdeploy/Logger/MyLogger.py

See also: https://stackoverflow.com/questions/21173979/how-do-i-get-path-to-python-script-with-proper-case

Thank you for considering my fix