### PR TITLE
Detect python version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry
       run: |
-        python get-poetry.py --preview -y
+        python get-poetry.py --preview -y --python-binary $(which python)
         source $HOME/.poetry/env
     - name: Install dependencies
       run: |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ pip install --user poetry
 Be aware, however, that it will also install poetry's dependencies
 which might cause conflicts.
 
+If you want to manually specify the Python interpreter used by Poetry, you can do:
+
+```bash
+python get-poetry.py --python-binary /usr/bin/python3
+```
+
 ## Updating `poetry`
 
 Updating poetry to the latest stable version is as simple as calling the `self:update` command.


### PR DESCRIPTION
This PR allows users to manually specify the Python interpreter to use when installing Poetry. If one is not passed, it will try to find a `python3` executable on the PATH, and otherwise default to the `python` executable. This is an implementation as discussed with @brycedrennan in #1042. 
