### PR TITLE
init: change dev dependency prompt

### DIFF
--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -165,8 +165,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         dev_requirements = {}
 
         question = (
-            "Would you like to define your dev dependencies"
-            " (require-dev) interactively"
+            "Would you like to define your development dependencies interactively?"
         )
         if self.confirm(question, True):
             if not help_displayed:


### PR DESCRIPTION
A very simple fix, continuation for #1221. It seems that words `require` and `require-dev` have come from another package manager, and these words don't make much sense in Poetry. The prompt for main deps has been already patched with #1221, I've just done the same for dev deps.