### PR TITLE
Fix poetry run command evaluates quotes

### DIFF
--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -44,7 +44,9 @@ class RunCommand(EnvCommand):
             "import sys; "
             "from importlib import import_module; "
             "sys.argv = {!r}; {}"
-            "import_module('{}').{}()".format(fixed_args, src_in_sys_path, module, callable_)
+            "import_module('{}').{}()".format(
+                fixed_args, src_in_sys_path, module, callable_
+            )
         ]
 
         return self.env.execute(*cmd)
@@ -61,4 +63,4 @@ class RunCommand(EnvCommand):
         return module
 
     def __fix_args_quotation_mark(self, args):
-        return str(args).replace('"', '\\"').replace("'", "\'")
+        return str(args).replace('"', '\\"').replace("'", "'")

--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -35,7 +35,9 @@ class RunCommand(EnvCommand):
 
         module, callable_ = script.split(":")
 
-        src_in_sys_path = "sys.path.append('src'); " if self._module.is_in_src() else ""
+        src_in_sys_path = "sys.path.append('src'); " if self._module.is_in_src(
+        ) else ""
+        fixed_args = self.__fix_args_quotation_mark(args)
 
         cmd = ["python", "-c"]
 
@@ -43,7 +45,7 @@ class RunCommand(EnvCommand):
             "import sys; "
             "from importlib import import_module; "
             "sys.argv = {!r}; {}"
-            "import_module('{}').{}()".format(args, src_in_sys_path, module, callable_)
+            "import_module('{}').{}()".format(fixed_args, src_in_sys_path, module, callable_)
         ]
 
         return self.env.execute(*cmd)
@@ -58,3 +60,6 @@ class RunCommand(EnvCommand):
         module = Module(package.name, path.as_posix(), package.packages)
 
         return module
+
+    def __fix_args_quotation_mark(self, args):
+        return str(args).replace('"', '\\"').replace("'", "\'")

--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -35,8 +35,7 @@ class RunCommand(EnvCommand):
 
         module, callable_ = script.split(":")
 
-        src_in_sys_path = "sys.path.append('src'); " if self._module.is_in_src(
-        ) else ""
+        src_in_sys_path = "sys.path.append('src'); " if self._module.is_in_src() else ""
         fixed_args = self.__fix_args_quotation_mark(args)
 
         cmd = ["python", "-c"]


### PR DESCRIPTION
I can't make a test case. Because a command test is hard for me.
 But I tested my self for these cases `'"bar"'`, `"'bar'"`. And it works well.
This is my first PR in Open Source. So, Please tell me what more work I have to do on this issue 😄

Resolved #1302 

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
