### PR TITLE
Make auth password optional

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -221,7 +221,9 @@ class LegacyRepository(PyPiRepository):
         return "{scheme}://{username}:{password}@{netloc}{path}".format(
             scheme=parsed.scheme,
             username=quote(self._auth.auth.username),
-            password=quote(self._auth.auth.password),
+            password=quote(self._auth.auth.password)
+            if self._auth.auth.password
+            else "",
             netloc=parsed.netloc,
             path=parsed.path,
         )

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -271,3 +271,10 @@ def test_username_password_special_chars():
     repo = MockRepository(auth=auth)
 
     assert "http://user%3A:p%40ssword@foo.bar" == repo.authenticated_url
+
+
+def test_username_without_password():
+    auth = Auth("http://foo.bar", "user:", None)
+    repo = MockRepository(auth=auth)
+
+    assert "http://user%3A:@foo.bar" == repo.authenticated_url


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

---

Some auths have no password, such as [Gemfury](https://gemfury.com/help/pypi-server/#repo-url). If there is no password in auth, quote function raises exception. So I fixed it to ignore password if it's `None` or empty.