### PR TITLE
Provide hints when an invalid license id is input

### DIFF
--- a/tests/spdx/test_main.py
+++ b/tests/spdx/test_main.py
@@ -41,3 +41,38 @@ def test_license_by_id_with_full_name():
 def test_license_by_id_invalid():
     with pytest.raises(ValueError):
         license_by_id("invalid")
+
+
+def test_license_by_id_invalid_gpl():
+    with pytest.raises(ValueError) as exc_info:
+        license_by_id("gpl")
+
+    assert "Did you mean" in str(exc_info.value)
+    assert " GPL-3.0-only" in str(exc_info.value)
+    assert " AGPL-3.0-only" not in str(exc_info.value)
+
+
+def test_license_by_id_invalid_agpl():
+    with pytest.raises(ValueError) as exc_info:
+        license_by_id("agpl")
+
+    assert "Did you mean" in str(exc_info.value)
+    assert " GPL-3.0-only" not in str(exc_info.value)
+    assert " AGPL-3.0-only" in str(exc_info.value)
+
+
+def test_license_by_id_invalid_agpl_versioned():
+    with pytest.raises(ValueError) as exc_info:
+        license_by_id("gnu agpl v3+")
+
+    assert "Did you mean" in str(exc_info.value)
+    assert " GPL-3.0-only" not in str(exc_info.value)
+    assert " AGPL-3.0-only" in str(exc_info.value)
+
+
+def test_license_by_id_invalid_unpopular():
+    with pytest.raises(ValueError) as exc_info:
+        license_by_id("not-a-well-known-license")
+
+    assert "spdx.org" in str(exc_info.value)
+    assert "Did you mean" not in str(exc_info.value)


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [n/a?] Updated **documentation** for changed code.

Currently, the `poetry new`/`init` license field can be a little opaque to new users -- here is the actual output from my first time using poetry a few hours ago:

```
This command will guide you through creating your pyproject.toml config.

Package name [projects]: attoate  
Version [0.1.0]: 
Description []: 
Author [Jamie McClymont <jamie@kwiius.com>, n to skip]: 
License []: GPLv3+ 
 Invalid license id: GPLv3+ 
License []: help
 Invalid license id: help 
License []: ?
 Invalid license id: ? 
License []: gpl-3-or-later
 Invalid license id: gpl-3-or-later 
License []: ?
 Invalid license id: ? 

-------- Some googling later --------

License []: GPL-3.0-or-later
```

This PR improves the error message to show a link to the SPDX license list, and in common cases, a best-effort guess at which license ids you might be looking for. For example:

```
invalid license id: some-wacky-license
Poetry uses SPDX license identifiers: https://spdx.org/licenses/
```

Or, if a common license id is recognised:

```
Invalid license id: that one from the apache web server
Poetry uses SPDX license identifiers: https://spdx.org/licenses/
Did you mean one of the following?
 * Apache-1.0
 * Apache-1.1
 * Apache-2.0
```

I'm not a python dev (as evidenced by the fact I didn't know what a license id was :P), feedback is welcome :)