### PR TITLE
fix: Add information about valid export formats to help page

### DIFF
--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -11,7 +11,12 @@ class ExportCommand(Command):
     description = "Exports the lock file to alternative formats."
 
     options = [
-        option("format", "f", "Format to export to.", flag=False),
+        option(
+            "format",
+            "f",
+            "Format to export to. Currently, only requirements.txt is supported.",
+            flag=False,
+        ),
         option("output", "o", "The name of the output file.", flag=False),
         option("without-hashes", None, "Exclude hashes from the exported file."),
         option("dev", None, "Include development dependencies."),


### PR DESCRIPTION
Add missing information about valid export formats to help page.

Fixes: #1640 

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.