### PR TITLE
Removing setecho(False) for all shells

### DIFF
--- a/poetry/utils/shell.py
+++ b/poetry/utils/shell.py
@@ -58,9 +58,6 @@ class Shell:
                 self._path, ["-i"], dimensions=(terminal.height, terminal.width)
             )
 
-        if not self._name == "bash":
-            c.setecho(False)
-
         activate_script = self._get_activate_script()
         bin_dir = "Scripts" if WINDOWS else "bin"
         activate_path = env.path / bin_dir / activate_script

--- a/poetry/utils/shell.py
+++ b/poetry/utils/shell.py
@@ -58,6 +58,9 @@ class Shell:
                 self._path, ["-i"], dimensions=(terminal.height, terminal.width)
             )
 
+        if self._name == "zsh":
+            c.setecho(False)
+
         activate_script = self._get_activate_script()
         bin_dir = "Scripts" if WINDOWS else "bin"
         activate_path = env.path / bin_dir / activate_script


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Intended to fix #1672. It appears to me that the only thing that the `setecho(False)` line does is prevent a double echo of the `/bin/activate` command in `zsh`.

## Example outputs

Example outputs from various shells. Note that the only things actually typed here are the initial `poetry shell` and the final `exit`:

### `fish`
```console
$ poetry shell
Spawning shell within <REDACTED>/.venv
$ source <REDACTED>/.venv/bin/activate.fish
$ exit
```

### `bash`
```console
bash-3.2$ poetry shell
Spawning shell within <REDACTED>/.venv

The default interactive shell is now zsh.
To update your account to use zsh, please run `chsh -s /bin/zsh`.
For more details, please visit https://support.apple.com/kb/HT208050.
bash-3.2$ . <REDACTED>/.venv/bin/activate
(.venv) bash-3.2$ exit
```

### `zsh`
```console
% poetry shell
Spawning shell within <REDACTED>/.venv
. <REDACTED>/.venv/bin/activate
% . <REDACTED>/.venv/bin/activate
(.venv) % exit
```