### PR TITLE
Pass the prompt to rename virtual enviornments

### DIFF
--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -16,7 +16,7 @@ from poetry.utils.toml_file import TomlFile
 CWD = Path(__file__).parent.parent / "fixtures" / "simple_project"
 
 
-def build_venv(path, executable=None):
+def build_venv(path, executable=None, prompt=None):
     os.mkdir(path)
 
 
@@ -61,7 +61,9 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(app, tmp_dir, m
     )
 
     m.assert_called_with(
-        os.path.join(tmp_dir, "{}-py3.7".format(venv_name)), executable="python3.7"
+        os.path.join(tmp_dir, "{}-py3.7".format(venv_name)),
+        executable="python3.7",
+        prompt="{}-py3.7".format(venv_name),
     )
 
     envs_file = TomlFile(Path(tmp_dir) / "envs.toml")

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -80,7 +80,7 @@ def test_env_get_in_project_venv(manager, poetry):
     shutil.rmtree(str(venv.path))
 
 
-def build_venv(path, executable=None):
+def build_venv(path, executable=None, prompt=None):
     os.mkdir(path)
 
 
@@ -122,7 +122,9 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     venv_name = EnvManager.generate_env_name("simple-project", str(poetry.file.parent))
 
     m.assert_called_with(
-        os.path.join(tmp_dir, "{}-py3.7".format(venv_name)), executable="python3.7"
+        os.path.join(tmp_dir, "{}-py3.7".format(venv_name)),
+        executable="python3.7",
+        prompt="{}-py3.7".format(venv_name),
     )
 
     envs_file = TomlFile(Path(tmp_dir) / "envs.toml")
@@ -240,7 +242,9 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     env = manager.activate("python3.6", NullIO())
 
     m.assert_called_with(
-        os.path.join(tmp_dir, "{}-py3.6".format(venv_name)), executable="python3.6"
+        os.path.join(tmp_dir, "{}-py3.6".format(venv_name)),
+        executable="python3.6",
+        prompt="{}-py3.6".format(venv_name),
     )
 
     assert envs_file.exists()
@@ -292,7 +296,9 @@ def test_activate_activates_recreates_for_different_patch(
     env = manager.activate("python3.7", NullIO())
 
     build_venv_m.assert_called_with(
-        os.path.join(tmp_dir, "{}-py3.7".format(venv_name)), executable="python3.7"
+        os.path.join(tmp_dir, "{}-py3.7".format(venv_name)),
+        executable="python3.7",
+        prompt="{}-py3.7".format(venv_name),
     )
     remove_venv_m.assert_called_with(
         os.path.join(tmp_dir, "{}-py3.7".format(venv_name))
@@ -581,7 +587,9 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
     manager.create_venv(NullIO())
 
     m.assert_called_with(
-        str(Path("/foo/virtualenvs/{}-py3.7".format(venv_name))), executable="python3"
+        str(Path("/foo/virtualenvs/{}-py3.7".format(venv_name))),
+        executable="python3",
+        prompt="{}-py3.7".format(venv_name),
     )
 
 
@@ -605,7 +613,9 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     manager.create_venv(NullIO())
 
     m.assert_called_with(
-        str(Path("/foo/virtualenvs/{}-py3.8".format(venv_name))), executable="python3.8"
+        str(Path("/foo/virtualenvs/{}-py3.8".format(venv_name))),
+        executable="python3.8",
+        prompt="{}-py3.8".format(venv_name),
     )
 
 


### PR DESCRIPTION
resolves #1403

the prompt term was added to venv in python 3.6 allowing you to rename what is shown on the prompt when you are in the shell. This fixes a very annoying issue of if you are working with virtual environments stored in project roots you always see (.venv). 

I still need to fix up the unit tests as the ones breaking are because of unexpected arguments that I will adjust.

The inspect module is available in python 3.4+ so there shouldn't breaking in this change as there is already a failover for python 2.7.

Tested manually against 3.5.8, 3.7.3 and 3.8.0

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://poetry.eustace.io/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
