### PR TITLE
fix: removed hint for uninstall poetry, after installation.

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -226,6 +226,9 @@ It will add the `poetry` command to {poetry}'s bin directory, located at:
 {poetry_home_bin}
 
 {platform_msg}
+
+You can uninstall at any time with by executing this script with the --uninstall option,
+and these changes will be reverted.
 """
 
 PRE_UNINSTALL_MESSAGE = """# We are sorry to see you go!

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -227,7 +227,7 @@ It will add the `poetry` command to {poetry}'s bin directory, located at:
 
 {platform_msg}
 
-You can uninstall at any time with by executing this script with the --uninstall option,
+You can uninstall at any time by executing this script with the --uninstall option,
 and these changes will be reverted.
 """
 

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -226,10 +226,6 @@ It will add the `poetry` command to {poetry}'s bin directory, located at:
 {poetry_home_bin}
 
 {platform_msg}
-
-You can uninstall at any time with `poetry self uninstall`,
-or by executing this script with the --uninstall option,
-and these changes will be reverted.
 """
 
 PRE_UNINSTALL_MESSAGE = """# We are sorry to see you go!


### PR DESCRIPTION
As discussed in https://github.com/python-poetry/poetry/pull/1722#issuecomment-565346594 this PR remove the hint about uninstalling poetry, because this is not fully implemented yet.