### PR TITLE
Fixed default cache-dir path

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -100,7 +100,7 @@ Defaults to one of the following directories:
 
 - macOS:   `~/Library/Caches/pypoetry`
 - Windows: `C:\Users\<username>\AppData\Local\pypoetry\Cache`
-- Unix:    `~/.cache/pypoetry/virtualenvs`
+- Unix:    `~/.cache/pypoetry`
 
 ### `virtualenvs.create`: boolean
 


### PR DESCRIPTION
Typo in `cache-dir` setting. It has `virtualenvs.path` value in documentation.