### PR TITLE
fix: don't exclude files that are explicit included in wheel (#1336)

### DIFF
--- a/poetry/masonry/builders/wheel.py
+++ b/poetry/masonry/builders/wheel.py
@@ -153,7 +153,9 @@ class WheelBuilder(Builder):
                 else:
                     rel_file = file.relative_to(self._path)
 
-                if self.is_excluded(rel_file.as_posix()):
+                if self.is_excluded(rel_file.as_posix()) and isinstance(
+                    include, PackageInclude
+                ):
                     continue
 
                 if file.suffix == ".pyc":

--- a/tests/masonry/builders/fixtures/exclude_nested_data_toml/pyproject.toml
+++ b/tests/masonry/builders/fixtures/exclude_nested_data_toml/pyproject.toml
@@ -10,6 +10,7 @@ license = "MIT"
 readme = "README.rst"
 
 exclude = ["**/data/", "**/*/item*"]
+include = ["my_package/data/data2.txt"]
 
 homepage = "https://python-poetry.org/"
 repository = "https://github.com/python-poetry/poetry"

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -436,6 +436,7 @@ def test_src_excluded_nested_data():
         assert "my-package-1.2.3/my_package/data/sub_data/data2.txt" not in names
         assert "my-package-1.2.3/my_package/data/sub_data/data3.txt" not in names
         assert "my-package-1.2.3/my_package/data/data1.txt" not in names
+        assert "my-package-1.2.3/my_package/data/data2.txt" in names
         assert "my-package-1.2.3/my_package/puplic/publicdata.txt" in names
         assert "my-package-1.2.3/my_package/public/item1/itemdata1.txt" not in names
         assert (

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -93,6 +93,7 @@ def test_wheel_excluded_nested_data():
         assert "my_package/data/sub_data/data2.txt" not in z.namelist()
         assert "my_package/data/sub_data/data3.txt" not in z.namelist()
         assert "my_package/data/data1.txt" not in z.namelist()
+        assert "my_package/data/data2.txt" in z.namelist()
         assert "my_package/puplic/publicdata.txt" in z.namelist()
         assert "my_package/public/item1/itemdata1.txt" not in z.namelist()
         assert "my_package/public/item1/subitem/subitemdata.txt" not in z.namelist()


### PR DESCRIPTION
Explicit included files wasn't included in wheels if in excluding rule was there. This PR fixes it.

Fixes: #1336

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.
