### PR TITLE
fix (git.py): git url's can now contain longer path names (#1746)

### DIFF
--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -9,24 +9,24 @@ from poetry.utils._compat import decode
 
 PATTERNS = [
     re.compile(
-        r"^(git\+)?"
-        r"(?P<protocol>https?|git|ssh|rsync|file)://"
-        r"(?:(?P<user>.+)@)*"
-        r"(?P<resource>[a-z0-9_.-]*)"
-        r"(:?P<port>[\d]+)?"
-        r"(?P<pathname>[:/]((?P<owner>[\w\-]+)/)?"
-        r"((?P<name>[\w\-.]+?)(\.git|/)?)?)"
-        r"([@#](?P<rev>[^@#]+))?"
-        r"$"
-    ),
-    re.compile(
         r"(git\+)?"
         r"((?P<protocol>\w+)://)"
         r"((?P<user>\w+)@)?"
         r"(?P<resource>[\w.\-]+)"
         r"(:(?P<port>\d+))?"
         r"(?P<pathname>(/(?P<owner>\w+)/)"
-        r"(/?(?P<name>[\w\-]+)(\.git|/)?)?)"
+        r"((?P<projects>([\w\-/]+)/)?(?P<name>[\w\-]+)(\.git|/)?)?)"
+        r"([@#](?P<rev>[^@#]+))?"
+        r"$"
+    ),
+    re.compile(
+        r"^(git\+)?"
+        r"(?P<protocol>https?|git|ssh|rsync|file)://"
+        r"(?:(?P<user>.+)@)*"
+        r"(?P<resource>[a-z0-9_.-]*)"
+        r"(:?P<port>[\d]+)?"
+        r"(?P<pathname>[:/]((?P<owner>[\w\-]+)/(?P<projects>([\w\-/]+)/)?)?"
+        r"((?P<name>[\w\-.]+?)(\.git|/)?)?)"
         r"([@#](?P<rev>[^@#]+))?"
         r"$"
     ),
@@ -34,7 +34,7 @@ PATTERNS = [
         r"^(?:(?P<user>.+)@)*"
         r"(?P<resource>[a-z0-9_.-]*)[:]*"
         r"(?P<port>[\d]+)?"
-        r"(?P<pathname>/?(?P<owner>.+)/(?P<name>.+).git)"
+        r"(?P<pathname>/?(?P<owner>.+)/(?P<projects>([\w\-/]+)/)?(?P<name>.+).git)"
         r"([@#](?P<rev>[^@#]+))?"
         r"$"
     ),
@@ -43,6 +43,7 @@ PATTERNS = [
         r"(?P<resource>[\w.\-]+)"
         r"[:/]{1,2}"
         r"(?P<pathname>((?P<owner>\w+)/)?"
+        r"(?P<projects>([\w\-/]+)/)?"
         r"((?P<name>[\w\-]+)(\.git|/)?)?)"
         r"([@#](?P<rev>[^@#]+))?"
         r"$"

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -62,6 +62,14 @@ from poetry.vcs.git import GitUrl
             "git+file://C:\\Users\\hello\\testing.git#zkat/windows-files",
             GitUrl("file://C:\\Users\\hello\\testing.git", "zkat/windows-files"),
         ),
+        (
+            "git+https://git.example.com/sdispater/project/my_repo.git",
+            GitUrl("https://git.example.com/sdispater/project/my_repo.git", None),
+        ),
+        (
+            "git+ssh://git@git.example.com:sdispater/project/my_repo.git",
+            GitUrl("git@git.example.com:sdispater/project/my_repo.git", None),
+        ),
     ],
 )
 def test_normalize_url(url, normalized):


### PR DESCRIPTION
git url's can now contain longer path names, e.g. projects like in gitlab.

Fixes: #1746 

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
