### PR TITLE
fix (setup_reader): parse arguments when setuptools.setup() is used (#1761)

### DIFF
--- a/poetry/utils/setup_reader.py
+++ b/poetry/utils/setup_reader.py
@@ -181,10 +181,11 @@ class SetupReader(object):
                 continue
 
             func = value.func
-            if not isinstance(func, ast.Name):
-                continue
-
-            if func.id != "setup":
+            if not (isinstance(func, ast.Name) and func.id == "setup") and not (
+                isinstance(func, ast.Attribute)
+                and func.value.id == "setuptools"
+                and func.attr == "setup"
+            ):
                 continue
 
             return value, elements

--- a/tests/utils/fixtures/setups/setuptools_setup/setup.py
+++ b/tests/utils/fixtures/setups/setuptools_setup/setup.py
@@ -8,5 +8,4 @@ setuptools.setup(
     description="Just a description",
     url="https://example.org",
     packages=setuptools.find_packages(),
-
 )

--- a/tests/utils/fixtures/setups/setuptools_setup/setup.py
+++ b/tests/utils/fixtures/setups/setuptools_setup/setup.py
@@ -1,0 +1,12 @@
+import setuptools
+
+setuptools.setup(
+    name="my_package",
+    version="0.1.2",
+    author="John Doe",
+    author_email="john@example.orh",
+    description="Just a description",
+    url="https://example.org",
+    packages=setuptools.find_packages(),
+
+)

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -168,6 +168,7 @@ def test_setup_reader_read_extras_require_with_variables(setup):
     assert expected_python_requires == result["python_requires"]
 
 
+@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_setup_reader_setuptools(setup):
     result = SetupReader.read_from_directory(setup("setuptools_setup"))
 

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -166,3 +166,13 @@ def test_setup_reader_read_extras_require_with_variables(setup):
     assert expected_install_requires == result["install_requires"]
     assert expected_extras_require == result["extras_require"]
     assert expected_python_requires == result["python_requires"]
+
+
+def test_setup_reader_setuptools(setup):
+    result = SetupReader.read_from_directory(setup("setuptools_setup"))
+
+    expected_name = "my_package"
+    expected_version = "0.1.2"
+
+    assert expected_name == result["name"]
+    assert expected_version == result["version"]


### PR DESCRIPTION
At the moment the parser expect that the setup method in `setup.py` is called with `setup()` only and will fail if `setuptools.setup()` is used instead. This PR fixes it.

Fixes: #1761 

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.

