### PR TITLE
Fixed typo

### DIFF
--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -7,7 +7,7 @@ class VersionCommand(Command):
 
     name = "version"
     description = (
-        "Shows the version of the project or bumps it when a valid"
+        "Shows the version of the project or bumps it when a valid "
         "bump rule is provided."
     )
 


### PR DESCRIPTION
Without this fix the helptext shows as:
```
  version                Shows the version of the project or bumps it when a validbump rule is provided.
```
