### PR TITLE
Improve detection of installed packages

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -96,7 +96,12 @@ class PipInstaller(BaseInstaller):
 
             self.run(*args)
 
-    def update(self, _, target):
+    def update(self, package, target):
+        if package.source_type != target.source_type:
+            # If the source type has changed, we remove the current
+            # package to avoid perpetual updates in some cases
+            self.remove(package)
+
         self.install(target, update=True)
 
     def remove(self, package):

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -703,6 +703,7 @@ class Env(object):
 
         self._marker_env = None
         self._pip_version = None
+        self._site_packages = None
 
     @property
     def path(self):  # type: () -> Path
@@ -758,20 +759,25 @@ class Env(object):
 
     @property
     def site_packages(self):  # type: () -> Path
-        # It seems that PyPy3 virtual environments
-        # have their site-packages directory at the root
-        if self._path.joinpath("site-packages").exists():
-            return self._path.joinpath("site-packages")
+        if self._site_packages is None:
+            site_packages = []
+            dist_packages = []
+            for entry in self.sys_path:
+                entry = Path(entry)
+                if entry.name == "site-packages":
+                    site_packages.append(entry)
+                elif entry.name == "dist-packages":
+                    dist_packages.append(entry)
 
-        if self._is_windows:
-            return self._path / "Lib" / "site-packages"
+            if not site_packages and not dist_packages:
+                raise RuntimeError("Unable to find the site-packages directory")
 
-        return (
-            self._path
-            / "lib"
-            / "python{}.{}".format(*self.version_info[:2])
-            / "site-packages"
-        )
+            if site_packages:
+                self._site_packages = site_packages[0]
+            else:
+                self._site_packages = dist_packages[0]
+
+        return self._site_packages
 
     @property
     def sys_path(self):  # type: () -> List[str]
@@ -1114,6 +1120,7 @@ class MockEnv(NullEnv):
         os_name="posix",
         is_venv=False,
         pip_version="19.1",
+        sys_path=None,
         **kwargs
     ):
         super(MockEnv, self).__init__(**kwargs)
@@ -1124,6 +1131,7 @@ class MockEnv(NullEnv):
         self._os_name = os_name
         self._is_venv = is_venv
         self._pip_version = Version.parse(pip_version)
+        self._sys_path = sys_path
 
     @property
     def version_info(self):  # type: () -> Tuple[int]
@@ -1144,6 +1152,13 @@ class MockEnv(NullEnv):
     @property
     def pip_version(self):
         return self._pip_version
+
+    @property
+    def sys_path(self):
+        if self._sys_path is None:
+            return super(MockEnv, self).sys_path
+
+        return self._sys_path
 
     def is_venv(self):  # type: () -> bool
         return self._is_venv

--- a/tests/masonry/builders/test_editable.py
+++ b/tests/masonry/builders/test_editable.py
@@ -17,8 +17,7 @@ fixtures_dir = Path(__file__).parent / "fixtures"
 def test_build_should_delegate_to_pip_for_non_pure_python_packages(tmp_dir, mocker):
     move = mocker.patch("shutil.move")
     tmp_dir = Path(tmp_dir)
-    env = MockEnv(path=tmp_dir, pip_version="18.1", execute=False)
-    env.site_packages.mkdir(parents=True)
+    env = MockEnv(path=tmp_dir, pip_version="18.1", execute=False, sys_path=[])
     module_path = fixtures_dir / "extended"
 
     builder = EditableBuilder(Factory().create_poetry(module_path), env, NullIO())
@@ -33,8 +32,7 @@ def test_build_should_delegate_to_pip_for_non_pure_python_packages(tmp_dir, mock
 def test_build_should_temporarily_remove_the_pyproject_file(tmp_dir, mocker):
     move = mocker.patch("shutil.move")
     tmp_dir = Path(tmp_dir)
-    env = MockEnv(path=tmp_dir, pip_version="19.1", execute=False)
-    env.site_packages.mkdir(parents=True)
+    env = MockEnv(path=tmp_dir, pip_version="19.1", execute=False, sys_path=[])
     module_path = fixtures_dir / "extended"
 
     builder = EditableBuilder(Factory().create_poetry(module_path), env, NullIO())


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

In version 1.0.0, we changed the way the installed packages are detected to improve the detection of the type of packages (directory vs git dependencies for instance). However, this introduced issues where Poetry always reinstalled the packages because it was detecting the wrong type of package or because it was not retrieving it from the correct directory. This PR should fix most of these issues.

Fixes #1711
Fixes #1612 
