### PR TITLE
Ignore dependency if not needed

### DIFF
--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -1887,3 +1887,19 @@ def test_solver_does_not_fail_with_locked_git_and_non_git_dependencies(
             {"job": "install", "package": git_package, "skipped": True},
         ],
     )
+
+
+def test_ignore_python_constraint_no_overlap_dependencies(solver, repo, package):
+    pytest = get_package("demo", "1.0.0")
+    pytest.add_dependency("configparser", {"version": "^1.2.3", "python": "<3.2"})
+
+    package.add_dependency("demo", {"version": "^1.0.0", "python": "^3.6"})
+
+    repo.add_package(pytest)
+    repo.add_package(get_package("configparser", "1.2.3"))
+
+    ops = solver.solve()
+
+    check_solver_result(
+        ops, [{"job": "install", "package": pytest}],
+    )


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Closes #1782 
This bug affects the basic dev flow and bites me often. When a dependency is marked as required on older Python versions, it should be ignored if the parent constraint has no overlap with it.
