### PR TITLE
create PEP508 compliant dependency string for directory and file dependencies

### DIFF
--- a/poetry/packages/directory_dependency.py
+++ b/poetry/packages/directory_dependency.py
@@ -74,6 +74,17 @@ class DirectoryDependency(Dependency):
     def develop(self):
         return self._develop
 
+    @property
+    def base_pep_508_name(self):  # type: () -> str
+        requirement = self.pretty_name
+
+        if self.extras:
+            requirement += "[{}]".format(",".join(self.extras))
+
+        requirement += " @ {}".format(self._path)
+
+        return requirement
+
     def supports_poetry(self):
         return self._supports_poetry
 

--- a/poetry/packages/file_dependency.py
+++ b/poetry/packages/file_dependency.py
@@ -49,6 +49,17 @@ class FileDependency(Dependency):
     def full_path(self):
         return self._full_path.resolve()
 
+    @property
+    def base_pep_508_name(self):  # type: () -> str
+        requirement = self.pretty_name
+
+        if self.extras:
+            requirement += "[{}]".format(",".join(self.extras))
+
+        requirement += " @ {}".format(self._path)
+
+        return requirement
+
     def is_file(self):
         return True
 

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -7,6 +7,7 @@ from poetry.utils._compat import Path
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import MockEnv as BaseMockEnv
 
+
 fixtures_dir = Path(__file__).parent.parent / "fixtures"
 DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "demo"
 
@@ -22,7 +23,9 @@ def test_directory_dependency():
     assert dependency.pretty_name == "simple_project"
     assert dependency.develop
     assert dependency.path == fixtures_dir / "simple_project"
-    assert dependency.base_pep_508_name == "simple_project @ {}".format(fixtures_dir / "simple_project")
+    assert dependency.base_pep_508_name == "simple_project @ {}".format(
+        fixtures_dir / "simple_project"
+    )
 
 
 def test_directory_dependency_must_exist():

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -7,13 +7,22 @@ from poetry.utils._compat import Path
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import MockEnv as BaseMockEnv
 
+fixtures_dir = Path(__file__).parent.parent / "fixtures"
+DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "demo"
+
 
 class MockEnv(BaseMockEnv):
     def run(self, bin, *args):
         raise EnvCommandError(CalledProcessError(1, "python", output=""))
 
 
-DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "demo"
+def test_directory_dependency():
+    dependency = DirectoryDependency("simple_project", fixtures_dir / "simple_project")
+
+    assert dependency.pretty_name == "simple_project"
+    assert dependency.develop
+    assert dependency.path == fixtures_dir / "simple_project"
+    assert dependency.base_pep_508_name == "simple_project @ {}".format(fixtures_dir / "simple_project")
 
 
 def test_directory_dependency_must_exist():

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -3,6 +3,7 @@ import pytest
 from poetry.packages import FileDependency
 from poetry.utils._compat import Path
 
+
 DIST_PATH = Path(__file__).parent.parent / "fixtures" / "distributions"
 
 
@@ -11,7 +12,9 @@ def test_file_dependency():
 
     assert dependency.pretty_name == "demo"
     assert dependency.path == DIST_PATH / "demo-0.1.0.tar.gz"
-    assert dependency.base_pep_508_name == "demo @ {}".format(DIST_PATH / "demo-0.1.0.tar.gz")
+    assert dependency.base_pep_508_name == "demo @ {}".format(
+        DIST_PATH / "demo-0.1.0.tar.gz"
+    )
 
 
 def test_file_dependency_wrong_path():

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -3,8 +3,15 @@ import pytest
 from poetry.packages import FileDependency
 from poetry.utils._compat import Path
 
-
 DIST_PATH = Path(__file__).parent.parent / "fixtures" / "distributions"
+
+
+def test_file_dependency():
+    dependency = FileDependency("demo", DIST_PATH / "demo-0.1.0.tar.gz")
+
+    assert dependency.pretty_name == "demo"
+    assert dependency.path == DIST_PATH / "demo-0.1.0.tar.gz"
+    assert dependency.base_pep_508_name == "demo @ {}".format(DIST_PATH / "demo-0.1.0.tar.gz")
 
 
 def test_file_dependency_wrong_path():


### PR DESCRIPTION
With this PR directory and file dependencies return PEP508 compliant dependency strings.

Until now for these type of dependencies only the package name was returned.

Depending on how the discussion [here](https://discuss.python.org/t/what-is-the-correct-interpretation-of-path-based-pep-508-uri-reference/2815) ends, this might resolve #1689 as well.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
