### PR TITLE
force recreation of venv if it is not sane (#286)

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -612,7 +612,7 @@ class EnvManager(object):
             if force:
                 if not env.is_sane():
                     io.write_line(
-                        "<warning>virtualenv found in {} seems to be broken. </warning>".format(
+                        "<warning>The virtual environment found in {} seems to be broken.</warning>".format(
                             env.path
                         )
                     )

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -475,6 +475,11 @@ class EnvManager(object):
         env = self.get(reload=True)
 
         if not env.is_sane():
+            io.write_line(
+                "<warning>Environment found in {} seems to be broken. Forcing recreation.</warning>".format(
+                    env.path
+                )
+            )
             force = True
 
         if env.is_venv() and not force:

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -473,6 +473,10 @@ class EnvManager(object):
 
         cwd = self._poetry.file.parent
         env = self.get(reload=True)
+
+        if not env.is_sane():
+            force = True
+
         if env.is_venv() and not force:
             # Already inside a virtualenv.
             return env

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -475,11 +475,6 @@ class EnvManager(object):
         env = self.get(reload=True)
 
         if not env.is_sane():
-            io.write_line(
-                "<warning>Environment found in {} seems to be broken. Forcing recreation.</warning>".format(
-                    env.path
-                )
-            )
             force = True
 
         if env.is_venv() and not force:
@@ -615,6 +610,12 @@ class EnvManager(object):
             self.build_venv(str(venv), executable=executable)
         else:
             if force:
+                if not env.is_sane():
+                    io.write_line(
+                        "<warning>virtualenv found in {} seems to be broken. </warning>".format(
+                            env.path
+                        )
+                    )
                 io.write_line(
                     "Recreating virtualenv <c1>{}</> in {}".format(name, str(venv))
                 )


### PR DESCRIPTION
With this PR a virtual environment is recreated if it's not sane, meaning the python and pip executable is not found within the venv path.

I'm not sure how to write a test for it. If it's necessary, please give me a hint :)

Fixes: #286

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

