### PR TITLE
Prevent empty parentheses from appearing in lockfile marker

### DIFF
--- a/poetry/version/markers.py
+++ b/poetry/version/markers.py
@@ -499,7 +499,9 @@ class MultiMarker(BaseMarker):
     def __str__(self):
         elements = []
         for m in self._markers:
-            if isinstance(m, SingleMarker):
+            if m.is_any() or m.is_empty():
+                pass
+            elif isinstance(m, SingleMarker):
                 elements.append(str(m))
             elif isinstance(m, MultiMarker):
                 elements.append(str(m))

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -1,5 +1,7 @@
 from poetry.packages import Dependency
 from poetry.packages import Package
+from poetry.version.markers import MultiMarker
+from poetry.version.markers import SingleMarker
 
 
 def test_accepts():
@@ -101,6 +103,21 @@ def test_to_pep_508_in_extras():
         'or python_version >= "3.6" and python_version < "4.0"'
         ") "
         'and (extra == "foo" or extra == "bar")'
+    )
+
+
+def test_to_pep_508_without_extras():
+    dependency = Dependency("unicodedata2", ">=12.1.0")
+    dependency.marker = MultiMarker.of(
+        SingleMarker("python_version", "< 3.8"),
+        SingleMarker("platform_python_implementation", "!= PyPy"),
+        SingleMarker("extra", "== 'unicode'"),
+    )
+
+    result = dependency.to_pep_508(with_extras=False)
+    assert (
+        result
+        == 'unicodedata2 (>=12.1.0); python_version < "3.8" and platform_python_implementation != "PyPy"'
     )
 
 


### PR DESCRIPTION
Fixes #1728.
Fixes #1772.

Prior to this PR, an **extra** dependency of the form:

```
foo (>=x.y.z); (some_constraint) and extra == 'bar'
```

would be serialised to the lockfile as:

```
marker = "some_constraint and ()"
```

Per #1728, the lockfile parser crashes on this.

This PR fixes that.

So far as I can tell this needs to be fixed on the serialisation side - empty parentheses are not permitted by the [PEP 508 grammar](https://www.python.org/dev/peps/pep-0508/#grammar).

The fix is implemented by updating `MultiMarker.__str__` to filter out any/empty markers (which occur when `with_extras=False`), similarly to the existing behaviour of `MarkerUnion.__str__`.

I'd like to add more defensive test coverage for the various `MarkerXyz` classes, but I'll do that in a follow-up PR.

