### PR TITLE
Fix export git dependencies with `-e ` only if develop mode is on

### DIFF
--- a/docs/docs/dependency-specification.md
+++ b/docs/docs/dependency-specification.md
@@ -103,6 +103,15 @@ flask = { git = "https://github.com/pallets/flask.git", rev = "38eb5d3b" }
 numpy = { git = "https://github.com/numpy/numpy.git", tag = "v0.13.2" }
 ```
 
+In some cases you may also want to install the dependency in non-editable mode.
+This can be achieved by setting `develop` key to `false`.
+
+```toml
+[tool.poetry.dependencies]
+requests = { git = "https://github.com/kennethreitz/requests.git", tag = "v2.22.0", develop = false }
+```
+
+
 ## `path` dependencies
 
 To depend on a library located in a local directory or file,

--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -326,6 +326,10 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "develop": {
+                    "type": "boolean",
+                    "description": "Whether to install the dependency in development mode."
                 }
             }
         },

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -308,4 +308,7 @@ class Locker(object):
             if package.source_type == "directory":
                 data["develop"] = package.develop
 
+        if package.source_type == "git":
+            data["develop"] = package.develop
+
         return data

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -89,6 +89,7 @@ class Locker(object):
             package.description = info.get("description", "")
             package.category = info["category"]
             package.optional = info["optional"]
+            package.develop = info.get("develop", package.develop)
             if "hashes" in lock_data["metadata"]:
                 # Old lock so we create dummy files from the hashes
                 package.files = [

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -299,6 +299,7 @@ class Package(object):
                     rev=constraint.get("rev", None),
                     category=category,
                     optional=optional,
+                    develop=constraint.get("develop", True),
                 )
             elif "file" in constraint:
                 file_path = Path(constraint["file"])

--- a/poetry/packages/vcs_dependency.py
+++ b/poetry/packages/vcs_dependency.py
@@ -18,6 +18,7 @@ class VCSDependency(Dependency):
         rev=None,
         category="main",
         optional=False,
+        develop=True,  # type: bool
     ):
         self._vcs = vcs
         self._source = source
@@ -29,6 +30,7 @@ class VCSDependency(Dependency):
         self._branch = branch
         self._tag = tag
         self._rev = rev
+        self._develop = develop
 
         super(VCSDependency, self).__init__(
             name, "*", category=category, optional=optional, allows_prereleases=True
@@ -94,3 +96,7 @@ class VCSDependency(Dependency):
 
     def accepts_prereleases(self):  # type: () -> bool
         return True
+
+    @property
+    def develop(self):  # type: () -> bool
+        return self._develop

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -169,6 +169,7 @@ class Provider:
             dependency.source,
             dependency.reference,
             name=dependency.name,
+            develop=dependency.develop,
         )
 
         for extra in dependency.extras:
@@ -182,7 +183,7 @@ class Provider:
 
     @classmethod
     def get_package_from_vcs(
-        cls, vcs, url, reference=None, name=None
+        cls, vcs, url, reference=None, name=None, develop=True
     ):  # type: (str, str, Optional[str], Optional[str]) -> Package
         if vcs != "git":
             raise ValueError("Unsupported VCS dependency {}".format(vcs))
@@ -206,6 +207,7 @@ class Provider:
             package.source_type = "git"
             package.source_url = url
             package.source_reference = revision
+            package.develop = develop
         except Exception:
             raise
         finally:

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -78,9 +78,11 @@ class Exporter(object):
                     package.source_reference,
                 )
                 dependency.marker = package.marker
-                line = "-e git+{}@{}#egg={}".format(
+                line = "git+{}@{}#egg={}".format(
                     package.source_url, package.source_reference, package.name
                 )
+                if package.develop:
+                    line = "-e " + line
             elif package.source_type in ["directory", "file", "url"]:
                 if package.source_type == "file":
                     dependency = FileDependency(package.name, Path(package.source_url))

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -492,6 +492,47 @@ def test_exporter_can_export_requirements_txt_with_git_packages_and_markers(
     assert expected == content
 
 
+def test_exporter_can_export_requirements_txt_with_git_packages_develop_false(
+    tmp_dir, poetry
+):
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "develop": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "git",
+                        "url": "https://github.com/foo/foo.git",
+                        "reference": "123456",
+                    },
+                }
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo": []},
+            },
+        }
+    )
+    exporter = Exporter(poetry)
+
+    exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
+
+    with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """\
+git+https://github.com/foo/foo.git@123456#egg=foo
+"""
+
+    assert expected == content
+
+
 def test_exporter_can_export_requirements_txt_with_directory_packages(tmp_dir, poetry):
     poetry.locker.mock_lock_data(
         {


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [X] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Currently `pip_installer` behaves differently than `export`.
If `develop` is `False` it doesn't add `-e ` to requirement.
But `export` always adds `-e ` to requirement.

see https://github.com/python-poetry/poetry/blob/develop/tests/installation/test_pip_installer.py#L65

This patch updates the `export` behavior so it matches the behavior of `pip_installer`.

closes: #1816 