### PR TITLE
Fix PEP440 compatible release (`~=`) handling

### DIFF
--- a/poetry/semver/__init__.py
+++ b/poetry/semver/__init__.py
@@ -76,14 +76,12 @@ def parse_single_constraint(constraint):  # type: (str) -> VersionConstraint
         version = Version.parse(m.group(1))
 
         if precision == 2:
-            low = version
             high = version.stable.next_major
         else:
-            low = Version(version.major, version.minor, version.patch)
             high = version.stable.next_minor
 
         return VersionRange(
-            low, high, include_min=True, always_include_max_prerelease=True
+            version, high, include_min=True, always_include_max_prerelease=True
         )
 
     # Caret range

--- a/tests/semver/test_main.py
+++ b/tests/semver/test_main.py
@@ -68,6 +68,7 @@ def test_parse_constraint_wildcard(input, constraint):
         ("~3.5", VersionRange(Version(3, 5, 0), Version(3, 6, 0), True)),
         ("~=3.5", VersionRange(Version(3, 5, 0), Version(4, 0, 0), True)),  # PEP 440
         ("~=3.5.3", VersionRange(Version(3, 5, 3), Version(3, 6, 0), True)),  # PEP 440
+        ("~=3.5.3rc1", VersionRange(Version(3, 5, 3, pre='rc1'), Version(3, 6, 0), True)),  # PEP 440
     ],
 )
 def test_parse_constraint_tilde(input, constraint):

--- a/tests/semver/test_main.py
+++ b/tests/semver/test_main.py
@@ -68,7 +68,10 @@ def test_parse_constraint_wildcard(input, constraint):
         ("~3.5", VersionRange(Version(3, 5, 0), Version(3, 6, 0), True)),
         ("~=3.5", VersionRange(Version(3, 5, 0), Version(4, 0, 0), True)),  # PEP 440
         ("~=3.5.3", VersionRange(Version(3, 5, 3), Version(3, 6, 0), True)),  # PEP 440
-        ("~=3.5.3rc1", VersionRange(Version(3, 5, 3, pre='rc1'), Version(3, 6, 0), True)),  # PEP 440
+        (
+            "~=3.5.3rc1",
+            VersionRange(Version(3, 5, 3, pre="rc1"), Version(3, 6, 0), True),
+        ),  # PEP 440
     ],
 )
 def test_parse_constraint_tilde(input, constraint):


### PR DESCRIPTION
PEP440 compatible release version range (`~=`) should have itself as a minimum value. Examples from [official doc](https://python.org/dev/peps/pep-0440/#compatible-release) (each pair is equivalent):

```
~=2.2
>=2.2, ==2.*

~=1.4.5
>=1.4.5, ==1.4.*

~=2.2.post3
>=2.2.post3, ==2.*

~=1.4.5a4
>=1.4.5a4, ==1.4.*
```

In every case, lower bound is exactly same as the input version including `rest` and `pre` but current behavior drop other than major, minor and patch. Current incorrect behavior was originally introduced 2 years ago by commit c55d55a8, where it tried to reset patch version to 0 for tilde expression, and hasn't been fixed by #1481, which only added up to patch version.

Closes #1150  

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
