### PR TITLE
Fix missing URL source option for multi-constraint dependencies

### DIFF
--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -460,6 +460,9 @@
                     },
                     {
                         "$ref": "#/definitions/path-dependency"
+                    },
+                    {
+                        "$ref": "#/definitions/url-dependency"
                     }
                 ]
             }

--- a/tests/fixtures/project_with_multi_constraint_types_dependency/pyproject.toml
+++ b/tests/fixtures/project_with_multi_constraint_types_dependency/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "project-with-multi-constraint-types-dependency"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+packages = [
+    {include = "project"}
+]
+
+[tool.poetry.dependencies]
+python = "*"
+demo = [
+    { git = "https://github.com/demo/demo.git", rev = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24", python = "<3.4" },
+    { path = "../distributions/demo-0.1.0-py2.py3-none-any.whl", python = "~3.5" },
+    { url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl", python = "^3.6" },
+]
+
+[tool.poetry.dev-dependencies]

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -202,6 +202,21 @@ def test_make_pkg_info_multi_constraints_dependency():
     ]
 
 
+def test_make_pkg_info_multi_constraint_types_dependency():
+    poetry = Factory().create_poetry(
+        Path(__file__).parent.parent.parent
+        / "fixtures"
+        / "project_with_multi_constraint_types_dependency"
+    )
+
+    builder = SdistBuilder(poetry, NullEnv(), NullIO())
+    pkg_info = builder.build_pkg_info()
+    p = Parser()
+    parsed = p.parsestr(to_str(pkg_info))
+
+    assert "Requires-Dist" in parsed
+
+
 def test_find_packages():
     poetry = Factory().create_poetry(project("complete"))
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -142,6 +142,16 @@ def test_create_poetry_with_multi_constraints_dependency():
     assert len(package.requires) == 2
 
 
+def test_create_poetry_with_multi_constraint_types_dependency():
+    poetry = Factory().create_poetry(
+        fixtures_dir / "project_with_multi_constraint_types_dependency"
+    )
+
+    package = poetry.package
+
+    assert len(package.requires) == 3
+
+
 def test_poetry_with_default_source():
     poetry = Factory().create_poetry(fixtures_dir / "with_default_source")
 


### PR DESCRIPTION
Updated the schema to allow URL sources in multi-constraint dependencies. Looks like a minor oversight when url-dependencies were added in #1260.

- [x] Added **tests** for changed code.
- [x] ~Updated **documentation** for changed code.~ _N/A_

