### PR TITLE
support git subfolder (#755)

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -212,7 +212,14 @@ poetry add git+https://github.com/sdispater/pendulum.git#develop
 poetry add git+https://github.com/sdispater/pendulum.git#2.0.5
 ```
 
-or make them point to a local directory or file:
+If the package is located within a subdirectory of a git dependency use:
+
+```bash
+poetry add "git+https://github.com/demo/project_in_subdirectory.git?subdirectory=pyproject-demo"
+poetry add "git+https://github.com/demo/project_in_subdirectory.git#develop?subdirectory=pyproject-demo"
+```
+
+You can also point to a local directory or file:
 
 ```bash
 poetry add ./my-package/

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -377,11 +377,17 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     if parsed.rev:
                         pair["rev"] = url.revision
 
+                    if parsed.subdirectory:
+                        pair["subdirectory"] = parsed.subdirectory
+
                     if extras:
                         pair["extras"] = extras
 
                     package = Provider.get_package_from_vcs(
-                        "git", url.url, reference=pair.get("rev")
+                        "git",
+                        url.url,
+                        reference=pair.get("rev"),
+                        subdirectory=parsed.subdirectory,
                     )
                     pair["name"] = package.name
                     result.append(pair)

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -11,9 +11,9 @@ from clikit.io import NullIO
 from poetry.repositories.pool import Pool
 from poetry.utils._compat import Path
 from poetry.utils._compat import encode
-from poetry.utils.cache import DownloadCache
 from poetry.utils.env import Env
 from poetry.utils.helpers import safe_rmtree
+from poetry.utils.temp import DownloadTmpDir
 
 from .base_installer import BaseInstaller
 
@@ -236,7 +236,9 @@ class PipInstaller(BaseInstaller):
         from poetry.vcs import Git
 
         src_dir = self._env.path / "src" / package.name
-        tmp_dir = Path(DownloadCache.mkcache(package.source_url, prefix="pypoetry-git"))
+        tmp_dir = Path(
+            DownloadTmpDir.mkcache(package.source_url, prefix="pypoetry-git")
+        )
 
         if src_dir.exists():
             safe_rmtree(str(src_dir))

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -11,6 +11,7 @@ from clikit.io import NullIO
 from poetry.repositories.pool import Pool
 from poetry.utils._compat import Path
 from poetry.utils._compat import encode
+from poetry.utils.cache import DownloadCache
 from poetry.utils.env import Env
 from poetry.utils.helpers import safe_rmtree
 
@@ -235,33 +236,21 @@ class PipInstaller(BaseInstaller):
         from poetry.vcs import Git
 
         src_dir = self._env.path / "src" / package.name
-        tmp_dir = Path(
-            tempfile.mkdtemp(
-                prefix="pypoetry-git-{}".format(
-                    package.source_url.split("/")[-1].rstrip(".git")
-                )
-            )
-        )
+        tmp_dir = Path(DownloadCache.mkcache(package.source_url, prefix="pypoetry-git"))
 
         if src_dir.exists():
             safe_rmtree(str(src_dir))
 
-        if tmp_dir.exists():
-            safe_rmtree(str(tmp_dir))
-
         src_dir.parent.mkdir(exist_ok=True)
 
-        try:
-            git = Git()
+        git = Git()
+
+        if not any(tmp_dir.glob("*")):
             git.clone(package.source_url, tmp_dir)
-            git.checkout(package.source_reference, tmp_dir)
 
-            shutil.copytree(str(tmp_dir / package.source_subdirectory), str(src_dir))
+        git.checkout(package.source_reference, tmp_dir)
 
-        except Exception:
-            raise
-        finally:
-            safe_rmtree(str(tmp_dir))
+        shutil.copytree(str(tmp_dir / package.source_subdirectory), str(src_dir))
 
         # Now we just need to install from the source directory
         pkg = Package(package.name, package.version)

--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -296,6 +296,10 @@
                     "type": "string",
                     "description": "The revision to checkout."
                 },
+                "subdirectory": {
+                    "type": "string",
+                    "description": "path relative to repositories root, where package is located"
+                },
                 "python": {
                     "type": "string",
                     "description": "The python versions for which the dependency should be installed."

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -145,6 +145,7 @@ class Locker(object):
                 package.source_type = info["source"].get("type", "")
                 package.source_url = info["source"]["url"]
                 package.source_reference = info["source"]["reference"]
+                package.source_subdirectory = info["source"].get("subdirectory", "")
 
             packages.add_package(package)
 
@@ -306,5 +307,8 @@ class Locker(object):
                 data["source"]["type"] = package.source_type
             if package.source_type == "directory":
                 data["develop"] = package.develop
+
+            if package.source_subdirectory:
+                data["source"]["subdirectory"] = package.source_subdirectory
 
         return data

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -64,6 +64,7 @@ class Package(object):
         self.source_type = ""
         self.source_reference = ""
         self.source_url = ""
+        self.source_subdirectory = ""
 
         self.requires = []
         self.dev_requires = []
@@ -299,6 +300,7 @@ class Package(object):
                     rev=constraint.get("rev", None),
                     category=category,
                     optional=optional,
+                    subdirectory=constraint.get("subdirectory", None),
                 )
             elif "file" in constraint:
                 file_path = Path(constraint["file"])

--- a/poetry/packages/vcs_dependency.py
+++ b/poetry/packages/vcs_dependency.py
@@ -1,5 +1,3 @@
-from poetry.vcs import git
-
 from .dependency import Dependency
 
 
@@ -16,7 +14,9 @@ class VCSDependency(Dependency):
         branch=None,
         tag=None,
         rev=None,
+        optional=False,
         category="main",
+        subdirectory=None,
         optional=False,
     ):
         self._vcs = vcs
@@ -29,6 +29,7 @@ class VCSDependency(Dependency):
         self._branch = branch
         self._tag = tag
         self._rev = rev
+        self._subdirectory = subdirectory
 
         super(VCSDependency, self).__init__(
             name, "*", category=category, optional=optional, allows_prereleases=True
@@ -53,6 +54,10 @@ class VCSDependency(Dependency):
     @property
     def rev(self):
         return self._rev
+
+    @property
+    def subdirectory(self):
+        return self._subdirectory
 
     @property
     def reference(self):  # type: () -> str
@@ -86,6 +91,9 @@ class VCSDependency(Dependency):
             requirement += " @ {}+ssh://{}@{}".format(
                 self._vcs, parsed_url.format(), self.reference
             )
+
+        if self.subdirectory:
+            requirement += "#subdirectory={}".format(self.subdirectory)
 
         return requirement
 

--- a/poetry/packages/vcs_dependency.py
+++ b/poetry/packages/vcs_dependency.py
@@ -1,3 +1,5 @@
+from poetry.vcs import git
+
 from .dependency import Dependency
 
 
@@ -17,7 +19,6 @@ class VCSDependency(Dependency):
         optional=False,
         category="main",
         subdirectory=None,
-        optional=False,
     ):
         self._vcs = vcs
         self._source = source

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -33,7 +33,6 @@ from poetry.utils._compat import PY35
 from poetry.utils._compat import OrderedDict
 from poetry.utils._compat import Path
 from poetry.utils._compat import urlparse
-from poetry.utils.cache import DownloadCache
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import EnvManager
 from poetry.utils.env import VirtualEnv
@@ -41,6 +40,7 @@ from poetry.utils.helpers import parse_requires
 from poetry.utils.helpers import temporary_directory
 from poetry.utils.inspector import Inspector
 from poetry.utils.setup_reader import SetupReader
+from poetry.utils.temp import DownloadTmpDir
 from poetry.utils.toml_file import TomlFile
 from poetry.vcs.git import Git
 from poetry.version.markers import MarkerUnion
@@ -186,7 +186,7 @@ class Provider:
         if vcs != "git":
             raise ValueError("Unsupported VCS dependency {}".format(vcs))
 
-        tmp_dir = Path(DownloadCache.mkcache(url, prefix="pypoetry-git"))
+        tmp_dir = Path(DownloadTmpDir.mkcache(url, prefix="pypoetry-git"))
 
         git = Git()
 

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -169,6 +169,7 @@ class Provider:
             dependency.source,
             dependency.reference,
             name=dependency.name,
+            subdirectory=dependency.subdirectory,
         )
 
         for extra in dependency.extras:
@@ -182,8 +183,8 @@ class Provider:
 
     @classmethod
     def get_package_from_vcs(
-        cls, vcs, url, reference=None, name=None
-    ):  # type: (str, str, Optional[str], Optional[str]) -> Package
+        cls, vcs, url, reference=None, name=None, subdirectory=None
+    ):  # type: (str, str, Optional[str], Optional[str], Optional[str]) -> Package
         if vcs != "git":
             raise ValueError("Unsupported VCS dependency {}".format(vcs))
 
@@ -201,7 +202,13 @@ class Provider:
 
             revision = git.rev_parse(reference, tmp_dir).strip()
 
-            package = cls.get_package_from_directory(tmp_dir, name=name)
+            if subdirectory is None:
+                package = cls.get_package_from_directory(tmp_dir, name=name)
+            else:
+                package = cls.get_package_from_directory(
+                    tmp_dir / subdirectory, name=name
+                )
+                package.source_subdirectory = Path(subdirectory).as_posix()
 
             package.source_type = "git"
             package.source_url = url

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -34,6 +34,7 @@ from poetry.utils._compat import PY35
 from poetry.utils._compat import OrderedDict
 from poetry.utils._compat import Path
 from poetry.utils._compat import urlparse
+from poetry.utils.cache import DownloadCache
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import EnvManager
 from poetry.utils.env import VirtualEnv
@@ -188,35 +189,29 @@ class Provider:
         if vcs != "git":
             raise ValueError("Unsupported VCS dependency {}".format(vcs))
 
-        tmp_dir = Path(
-            mkdtemp(prefix="pypoetry-git-{}".format(url.split("/")[-1].rstrip(".git")))
-        )
+        tmp_dir = Path(DownloadCache.mkcache(url, prefix="pypoetry-git"))
 
-        try:
-            git = Git()
+        git = Git()
+
+        if not any(tmp_dir.glob("*")):
             git.clone(url, tmp_dir)
-            if reference is not None:
-                git.checkout(reference, tmp_dir)
-            else:
-                reference = "HEAD"
 
-            revision = git.rev_parse(reference, tmp_dir).strip()
+        if reference is not None:
+            git.checkout(reference, tmp_dir)
+        else:
+            reference = "HEAD"
 
-            if subdirectory is None:
-                package = cls.get_package_from_directory(tmp_dir, name=name)
-            else:
-                package = cls.get_package_from_directory(
-                    tmp_dir / subdirectory, name=name
-                )
-                package.source_subdirectory = Path(subdirectory).as_posix()
+        revision = git.rev_parse(reference, tmp_dir).strip()
 
-            package.source_type = "git"
-            package.source_url = url
-            package.source_reference = revision
-        except Exception:
-            raise
-        finally:
-            safe_rmtree(str(tmp_dir))
+        if subdirectory is None:
+            package = cls.get_package_from_directory(tmp_dir, name=name)
+        else:
+            package = cls.get_package_from_directory(tmp_dir / subdirectory, name=name)
+            package.source_subdirectory = Path(subdirectory).as_posix()
+
+        package.source_type = "git"
+        package.source_url = url
+        package.source_reference = revision
 
         return package
 

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -5,7 +5,6 @@ import re
 import time
 
 from contextlib import contextmanager
-from tempfile import mkdtemp
 from typing import Any
 from typing import List
 from typing import Optional
@@ -39,7 +38,6 @@ from poetry.utils.env import EnvCommandError
 from poetry.utils.env import EnvManager
 from poetry.utils.env import VirtualEnv
 from poetry.utils.helpers import parse_requires
-from poetry.utils.helpers import safe_rmtree
 from poetry.utils.helpers import temporary_directory
 from poetry.utils.inspector import Inspector
 from poetry.utils.setup_reader import SetupReader
@@ -61,7 +59,6 @@ class Indicator(ProgressIndicator):
 
 
 class Provider:
-
     UNSAFE_PACKAGES = {"setuptools", "distribute", "pip"}
 
     def __init__(self, package, pool, io):  # type: (Package, Pool, Any) -> None

--- a/poetry/utils/cache.py
+++ b/poetry/utils/cache.py
@@ -1,0 +1,12 @@
+from tempfile import TemporaryDirectory
+
+
+class DownloadCache:
+    cache_dirs = {}
+
+    @classmethod
+    def mkcache(cls, source=None, suffix=None, prefix=None, dir=None):
+        if source not in cls.cache_dirs:
+            cls.cache_dirs[source] = TemporaryDirectory(suffix, prefix, dir)
+
+        return cls.cache_dirs[source].name

--- a/poetry/utils/cache.py
+++ b/poetry/utils/cache.py
@@ -20,7 +20,7 @@ class DownloadCache:
     cache_dirs = {}
 
     @classmethod
-    def mkcache(cls, source, suffix=None, prefix=None, dir=None):
+    def mkcache(cls, source, suffix="", prefix="", dir=""):
         if source not in cls.cache_dirs:
             cls.cache_dirs[source] = mkdtemp(suffix, prefix, dir)
 

--- a/poetry/utils/cache.py
+++ b/poetry/utils/cache.py
@@ -3,11 +3,17 @@ import shutil
 
 from tempfile import mkdtemp
 
+from poetry.utils._compat import Path
+
+
+def force_rm(action, name, exc):
+    Path(name).unlink()
+
 
 @atexit.register
 def cleanup_caches():
     for source, cache in DownloadCache.cache_dirs.items():
-        shutil.rmtree(cache)
+        shutil.rmtree(cache, onerror=force_rm)
 
 
 class DownloadCache:

--- a/poetry/utils/cache.py
+++ b/poetry/utils/cache.py
@@ -1,12 +1,21 @@
-from tempfile import TemporaryDirectory
+import atexit
+import shutil
+
+from tempfile import mkdtemp
+
+
+@atexit.register
+def cleanup_caches():
+    for source, cache in DownloadCache.cache_dirs.items():
+        shutil.rmtree(cache)
 
 
 class DownloadCache:
     cache_dirs = {}
 
     @classmethod
-    def mkcache(cls, source=None, suffix=None, prefix=None, dir=None):
+    def mkcache(cls, source, suffix=None, prefix=None, dir=None):
         if source not in cls.cache_dirs:
-            cls.cache_dirs[source] = TemporaryDirectory(suffix, prefix, dir)
+            cls.cache_dirs[source] = mkdtemp(suffix, prefix, dir)
 
-        return cls.cache_dirs[source].name
+        return cls.cache_dirs[source]

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -81,6 +81,9 @@ class Exporter(object):
                 line = "-e git+{}@{}#egg={}".format(
                     package.source_url, package.source_reference, package.name
                 )
+                if package.source_subdirectory:
+                    line += "?subdirectory={}".format(package.source_subdirectory)
+
             elif package.source_type in ["directory", "file", "url"]:
                 if package.source_type == "file":
                     dependency = FileDependency(package.name, Path(package.source_url))

--- a/poetry/utils/temp.py
+++ b/poetry/utils/temp.py
@@ -11,17 +11,17 @@ def force_rm(action, name, exc):
 
 
 @atexit.register
-def cleanup_caches():
-    for source, cache in DownloadCache.cache_dirs.items():
+def cleanup_tmp():
+    for source, cache in DownloadTmpDir.tmp_dirs.items():
         shutil.rmtree(cache, onerror=force_rm)
 
 
-class DownloadCache:
-    cache_dirs = {}
+class DownloadTmpDir:
+    tmp_dirs = {}
 
     @classmethod
     def mkcache(cls, source, suffix="", prefix="", dir=""):
-        if source not in cls.cache_dirs:
-            cls.cache_dirs[source] = mkdtemp(suffix, prefix, dir)
+        if source not in cls.tmp_dirs:
+            cls.tmp_dirs[source] = mkdtemp(suffix, prefix, dir)
 
-        return cls.cache_dirs[source]
+        return cls.tmp_dirs[source]

--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -14,7 +14,7 @@ pattern_formats = {
     "port": r"\d+",
     "path": r"[\w~.\-/\\]+",
     "name": r"[\w~.\-]+",
-    "rev": r"[^@#]+",
+    "rev": r"[^@#?]+",
     "subdir": r"[\w\-/\\]+",
 }
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -172,10 +172,8 @@ def test_add_git_constraint(app, repo, installer):
     repo.add_package(get_package("pendulum", "1.4.4"))
     repo.add_package(get_package("cleo", "0.6.5"))
 
-    tester.execute(
-        "git+https://github.com/demo/project_in_subdirectory.git?subdirectory=pyproject-demo"
-    )
-    pass
+    tester.execute("git+https://github.com/demo/demo.git")
+
     expected = """\
 
 Updating dependencies

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -172,8 +172,10 @@ def test_add_git_constraint(app, repo, installer):
     repo.add_package(get_package("pendulum", "1.4.4"))
     repo.add_package(get_package("cleo", "0.6.5"))
 
-    tester.execute("git+https://github.com/demo/demo.git")
-
+    tester.execute(
+        "git+https://github.com/demo/project_in_subdirectory.git?subdirectory=pyproject-demo"
+    )
+    pass
     expected = """\
 
 Updating dependencies
@@ -197,6 +199,25 @@ Package operations: 2 installs, 0 updates, 0 removals
     assert "demo" in content["dependencies"]
     assert content["dependencies"]["demo"] == {
         "git": "https://github.com/demo/demo.git"
+    }
+
+
+def test_add_git_constraint_with_subdir(app, repo, installer):
+    command = app.find("add")
+    tester = CommandTester(command)
+
+    tester.execute(
+        "git+https://github.com/demo/project_in_subdirectory.git?subdirectory=pyproject-demo"
+    )
+
+    assert len(installer.installs) == 1
+
+    content = app.poetry.file.read()["tool"]["poetry"]
+
+    assert "demo" in content["dependencies"]
+    assert content["dependencies"]["demo"] == {
+        "git": "https://github.com/demo/project_in_subdirectory.git",
+        "subdirectory": "pyproject-demo",
     }
 
 

--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from cleo.testers import CommandTester
+
+from ..conftest import Path
+
+
+fixtures_dir = Path(__file__).parent.parent.parent / "fixtures"
+
+
+def test_export_with_vcs_subdirectory(app_project):
+    project = fixtures_dir / "project_with_git_subdirectory_dependency"
+    app = app_project(project)
+
+    command = app.find("lock")
+    tester = CommandTester(command)
+    tester.execute()
+
+    assert app.poetry.locker.lock.exists()
+
+    with app.poetry.locker.lock.open(encoding="utf-8") as f:
+        content = f.read()
+    expected = """\
+[[package]]
+category = "main"
+description = ""
+name = "demo"
+optional = false
+python-versions = "~2.7 || ^3.4"
+version = "0.1.2"
+
+[package.source]
+reference = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+subdirectory = "pyproject-demo"
+type = "git"
+url = "https://github.com/demo/project_in_subdirectory.git"
+[metadata]
+content-hash = "1394d1b3da3a2a62939852f9b1671ad0b6a7dbb0c2e9f1017a0df9b30c8b151d"
+python-versions = "~2.7 || ^3.4"
+
+[metadata.files]
+demo = []
+"""
+    assert content == expected

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import pytest
 
@@ -189,3 +190,22 @@ def app(poetry):
 @pytest.fixture
 def app_tester(app):
     return ApplicationTester(app)
+
+
+@pytest.fixture
+def app_project(repo, tmp_dir):
+    def create_app(project):
+        shutil.copy(project / "pyproject.toml", Path(tmp_dir))
+        p = Factory().create_poetry(Path(tmp_dir))
+
+        locker = Locker(p.locker.lock.path, p.locker._local_config)
+        locker.write()
+        p.set_locker(locker)
+
+        pool = Pool()
+        pool.add_repository(repo)
+        p.set_pool(pool)
+
+        return Application(p)
+
+    return create_app

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -195,7 +195,7 @@ def app_tester(app):
 @pytest.fixture
 def app_project(repo, tmp_dir):
     def create_app(project):
-        shutil.copy(project / "pyproject.toml", Path(tmp_dir))
+        shutil.copy(str(project / "pyproject.toml"), tmp_dir)
         p = Factory().create_poetry(Path(tmp_dir))
 
         locker = Locker(p.locker.lock.path, p.locker._local_config)

--- a/tests/fixtures/git/github.com/demo/project_in_subdirectory/pyproject-demo/pyproject.toml
+++ b/tests/fixtures/git/github.com/demo/project_in_subdirectory/pyproject-demo/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "demo"
+version = "0.1.2"
+description = "Some description."
+authors = [
+    "Sébastien Eustace <sebastien@eustace.io>"
+]
+license = "MIT"
+
+# Requirements
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.4"
+pendulum = '^1.4'
+
+[tool.poetry.dev-dependencies]

--- a/tests/fixtures/git/github.com/demo/project_in_subdirectory/pyproject-demo/pyproject.toml
+++ b/tests/fixtures/git/github.com/demo/project_in_subdirectory/pyproject-demo/pyproject.toml
@@ -10,6 +10,5 @@ license = "MIT"
 # Requirements
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.4"
-pendulum = '^1.4'
 
 [tool.poetry.dev-dependencies]

--- a/tests/fixtures/project_with_git_subdirectory_dependency/pyproject.toml
+++ b/tests/fixtures/project_with_git_subdirectory_dependency/pyproject.toml
@@ -1,0 +1,35 @@
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "Some description."
+authors = [
+    "Sébastien Eustace <sebastien@eustace.io>"
+]
+license = "MIT"
+
+homepage = "https://python-poetry.org"
+repository = "https://github.com/python-poetry/poetry"
+documentation = "https://python-poetry.org/docs"
+
+keywords = ["packaging", "dependency", "poetry"]
+
+classifiers = [
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Libraries :: Python Modules"
+]
+
+# Requirements
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.4"
+demo = { git = "https://github.com/demo/project_in_subdirectory.git", rev = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24", subdirectory="pyproject-demo" }
+
+
+[tool.poetry.dev-dependencies]
+
+
+[tool.poetry.scripts]
+my-script = "my_package:main"
+
+
+[tool.poetry.plugins."blogtool.parsers"]
+".rst" = "some_module::SomeClass"

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import pytest
 
 from poetry.packages import Package
+from poetry.packages import VCSDependency
 
 
 def test_package_authors():
@@ -37,3 +38,18 @@ def test_package_add_dependency_vcs_category_default_main():
         "poetry", constraint={"git": "https://github.com/python-poetry/poetry.git"}
     )
     assert dependency.category == "main"
+
+
+def test_package_add_dependency_vcs__with_subdirectory():
+    package = Package("foo", "0.1.0")
+
+    dependency = package.add_dependency(
+        "poetry",
+        constraint={
+            "git": "https://github.com/demo/project_in_subdirectory.git",
+            "subdirectory": "mypackage",
+        },
+    )
+    assert dependency.source == "https://github.com/demo/project_in_subdirectory.git"
+    assert dependency.subdirectory == "mypackage"
+    assert isinstance(dependency, VCSDependency)

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -61,6 +61,19 @@ def test_to_pep_508_in_extras():
     assert expected == dependency.to_pep_508()
 
 
+def test_to_pep_508_with_subdirectory():
+    dependency = VCSDependency(
+        "poetry",
+        "git",
+        "https://github.com/python-poetry/poetry.git",
+        subdirectory="mypackage",
+    )
+
+    expected = "poetry @ git+https://github.com/python-poetry/poetry.git@master#subdirectory=mypackage"
+
+    assert expected == dependency.to_pep_508()
+
+
 @pytest.mark.parametrize("category", ["main", "dev"])
 def test_category(category):
     dependency = VCSDependency(

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -128,6 +128,19 @@ def test_search_for_vcs_read_setup_raises_error_if_no_version(provider, mocker):
         provider.search_for_vcs(dependency)
 
 
+def test_search_for_vcs_with_subdirectory(provider):
+    dependency = VCSDependency(
+        "demo",
+        "git",
+        "https://github.com/demo/project_in_subdirectory.git",
+        subdirectory="pyproject-demo",
+    )
+    package = provider.search_for_vcs(dependency)[0]
+
+    assert package.name == "demo"
+    assert package.version.text == "0.1.2"
+
+
 @pytest.mark.parametrize("directory", ["demo", "non-canonical-name"])
 def test_search_for_directory_setup_egg_info(provider, directory):
     dependency = DirectoryDependency(

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -10,15 +10,15 @@ from poetry.vcs.git import ParsedUrl
     [
         (
             "git+ssh://user@hostname:project.git#commit",
-            GitUrl("user@hostname:project.git", "commit"),
+            GitUrl("user@hostname:project.git", "commit", None),
         ),
         (
             "git+http://user@hostname/project/blah.git@commit",
-            GitUrl("http://user@hostname/project/blah.git", "commit"),
+            GitUrl("http://user@hostname/project/blah.git", "commit", None),
         ),
         (
             "git+https://user@hostname/project/blah.git",
-            GitUrl("https://user@hostname/project/blah.git", None),
+            GitUrl("https://user@hostname/project/blah.git", None, None),
         ),
         (
             "git+https://user@hostname/project~_-.foo/blah~_-.bar.git",
@@ -26,54 +26,74 @@ from poetry.vcs.git import ParsedUrl
         ),
         (
             "git+https://user@hostname:project/blah.git",
-            GitUrl("https://user@hostname/project/blah.git", None),
+            GitUrl("https://user@hostname/project/blah.git", None, None),
         ),
         (
             "git+ssh://git@github.com:sdispater/poetry.git#v1.0.27",
-            GitUrl("git@github.com:sdispater/poetry.git", "v1.0.27"),
+            GitUrl("git@github.com:sdispater/poetry.git", "v1.0.27", None),
         ),
         (
             "git+ssh://git@github.com:/sdispater/poetry.git",
-            GitUrl("git@github.com:/sdispater/poetry.git", None),
+            GitUrl("git@github.com:/sdispater/poetry.git", None, None),
         ),
-        ("git+ssh://git@github.com:org/repo", GitUrl("git@github.com:org/repo", None),),
+        (
+            "git+ssh://git@github.com:org/repo",
+            GitUrl("git@github.com:org/repo", None, None),
+        ),
         (
             "git+ssh://git@github.com/org/repo",
-            GitUrl("ssh://git@github.com/org/repo", None),
+            GitUrl("ssh://git@github.com/org/repo", None, None),
         ),
-        ("git+ssh://foo:22/some/path", GitUrl("ssh://foo:22/some/path", None)),
-        ("git@github.com:org/repo", GitUrl("git@github.com:org/repo", None)),
+        ("git+ssh://foo:22/some/path", GitUrl("ssh://foo:22/some/path", None, None)),
+        ("git@github.com:org/repo", GitUrl("git@github.com:org/repo", None, None)),
         (
             "git+https://github.com/sdispater/pendulum",
-            GitUrl("https://github.com/sdispater/pendulum", None),
+            GitUrl("https://github.com/sdispater/pendulum", None, None),
         ),
         (
             "git+https://github.com/sdispater/pendulum#7a018f2d075b03a73409e8356f9b29c9ad4ea2c5",
             GitUrl(
                 "https://github.com/sdispater/pendulum",
                 "7a018f2d075b03a73409e8356f9b29c9ad4ea2c5",
+                None,
             ),
         ),
         (
             "git+ssh://git@git.example.com:b/b.git#v1.0.0",
-            GitUrl("git@git.example.com:b/b.git", "v1.0.0"),
+            GitUrl("git@git.example.com:b/b.git", "v1.0.0", None),
         ),
         (
             "git+ssh://git@github.com:sdispater/pendulum.git#foo/bar",
-            GitUrl("git@github.com:sdispater/pendulum.git", "foo/bar"),
+            GitUrl("git@github.com:sdispater/pendulum.git", "foo/bar", None),
         ),
-        ("git+file:///foo/bar.git", GitUrl("file:///foo/bar.git", None)),
+        ("git+file:///foo/bar.git", GitUrl("file:///foo/bar.git", None, None)),
         (
             "git+file://C:\\Users\\hello\\testing.git#zkat/windows-files",
-            GitUrl("file://C:\\Users\\hello\\testing.git", "zkat/windows-files"),
+            GitUrl("file://C:\\Users\\hello\\testing.git", "zkat/windows-files", None),
         ),
         (
             "git+https://git.example.com/sdispater/project/my_repo.git",
-            GitUrl("https://git.example.com/sdispater/project/my_repo.git", None),
+            GitUrl("https://git.example.com/sdispater/project/my_repo.git", None, None),
         ),
         (
             "git+ssh://git@git.example.com:sdispater/project/my_repo.git",
-            GitUrl("git@git.example.com:sdispater/project/my_repo.git", None),
+            GitUrl("git@git.example.com:sdispater/project/my_repo.git", None, None),
+        ),
+        (
+            "git+https://git.example.com/sdispater/project/my_repo.git?subdirectory=path/to/package",
+            GitUrl(
+                "https://git.example.com/sdispater/project/my_repo.git",
+                None,
+                "path/to/package",
+            ),
+        ),
+        (
+            "git+ssh://git@git.example.com:sdispater/project/my_repo.git?subdirectory=path/to/package",
+            GitUrl(
+                "git@git.example.com:sdispater/project/my_repo.git",
+                None,
+                "path/to/package",
+            ),
         ),
     ],
 )
@@ -87,19 +107,40 @@ def test_normalize_url(url, normalized):
         (
             "git+ssh://user@hostname:project.git#commit",
             ParsedUrl(
-                "ssh", "hostname", ":project.git", "user", None, "project", "commit"
+                "ssh",
+                "hostname",
+                ":project.git",
+                "user",
+                None,
+                "project",
+                "commit",
+                None,
             ),
         ),
         (
             "git+http://user@hostname/project/blah.git@commit",
             ParsedUrl(
-                "http", "hostname", "/project/blah.git", "user", None, "blah", "commit"
+                "http",
+                "hostname",
+                "/project/blah.git",
+                "user",
+                None,
+                "blah",
+                "commit",
+                None,
             ),
         ),
         (
             "git+https://user@hostname/project/blah.git",
             ParsedUrl(
-                "https", "hostname", "/project/blah.git", "user", None, "blah", None
+                "https",
+                "hostname",
+                "/project/blah.git",
+                "user",
+                None,
+                "blah",
+                None,
+                None,
             ),
         ),
         (
@@ -117,7 +158,14 @@ def test_normalize_url(url, normalized):
         (
             "git+https://user@hostname:project/blah.git",
             ParsedUrl(
-                "https", "hostname", ":project/blah.git", "user", None, "blah", None
+                "https",
+                "hostname",
+                ":project/blah.git",
+                "user",
+                None,
+                "blah",
+                None,
+                None,
             ),
         ),
         (
@@ -130,6 +178,7 @@ def test_normalize_url(url, normalized):
                 None,
                 "poetry",
                 "v1.0.27",
+                None,
             ),
         ),
         (
@@ -142,23 +191,28 @@ def test_normalize_url(url, normalized):
                 None,
                 "poetry",
                 None,
+                None,
             ),
         ),
         (
             "git+ssh://git@github.com:org/repo",
-            ParsedUrl("ssh", "github.com", ":org/repo", "git", None, "repo", None),
+            ParsedUrl(
+                "ssh", "github.com", ":org/repo", "git", None, "repo", None, None
+            ),
         ),
         (
             "git+ssh://git@github.com/org/repo",
-            ParsedUrl("ssh", "github.com", "/org/repo", "git", None, "repo", None),
+            ParsedUrl(
+                "ssh", "github.com", "/org/repo", "git", None, "repo", None, None
+            ),
         ),
         (
             "git+ssh://foo:22/some/path",
-            ParsedUrl("ssh", "foo", "/some/path", None, "22", "path", None),
+            ParsedUrl("ssh", "foo", "/some/path", None, "22", "path", None, None),
         ),
         (
             "git@github.com:org/repo",
-            ParsedUrl(None, "github.com", ":org/repo", "git", None, "repo", None),
+            ParsedUrl(None, "github.com", ":org/repo", "git", None, "repo", None, None),
         ),
         (
             "git+https://github.com/sdispater/pendulum",
@@ -169,6 +223,7 @@ def test_normalize_url(url, normalized):
                 None,
                 None,
                 "pendulum",
+                None,
                 None,
             ),
         ),
@@ -182,11 +237,14 @@ def test_normalize_url(url, normalized):
                 None,
                 "pendulum",
                 "7a018f2d075b03a73409e8356f9b29c9ad4ea2c5",
+                None,
             ),
         ),
         (
             "git+ssh://git@git.example.com:b/b.git#v1.0.0",
-            ParsedUrl("ssh", "git.example.com", ":b/b.git", "git", None, "b", "v1.0.0"),
+            ParsedUrl(
+                "ssh", "git.example.com", ":b/b.git", "git", None, "b", "v1.0.0", None
+            ),
         ),
         (
             "git+ssh://git@github.com:sdispater/pendulum.git#foo/bar",
@@ -198,11 +256,12 @@ def test_normalize_url(url, normalized):
                 None,
                 "pendulum",
                 "foo/bar",
+                None,
             ),
         ),
         (
             "git+file:///foo/bar.git",
-            ParsedUrl("file", None, "/foo/bar.git", None, None, "bar", None),
+            ParsedUrl("file", None, "/foo/bar.git", None, None, "bar", None, None),
         ),
         (
             "git+file://C:\\Users\\hello\\testing.git#zkat/windows-files",
@@ -214,6 +273,7 @@ def test_normalize_url(url, normalized):
                 None,
                 "testing",
                 "zkat/windows-files",
+                None,
             ),
         ),
         (
@@ -225,6 +285,7 @@ def test_normalize_url(url, normalized):
                 None,
                 None,
                 "my_repo",
+                None,
                 None,
             ),
         ),
@@ -238,6 +299,33 @@ def test_normalize_url(url, normalized):
                 None,
                 "my_repo",
                 None,
+                None,
+            ),
+        ),
+        (
+            "git+https://git.example.com/sdispater/project/my_repo.git?subdirectory=path/to/package",
+            ParsedUrl(
+                "https",
+                "git.example.com",
+                "/sdispater/project/my_repo.git",
+                None,
+                None,
+                "my_repo",
+                None,
+                "path/to/package",
+            ),
+        ),
+        (
+            "git+ssh://git@git.example.com:sdispater/project/my_repo.git?subdirectory=path/to/package",
+            ParsedUrl(
+                "ssh",
+                "git.example.com",
+                ":sdispater/project/my_repo.git",
+                "git",
+                None,
+                "my_repo",
+                None,
+                "path/to/package",
             ),
         ),
     ],
@@ -252,6 +340,7 @@ def test_parse_url(url, parsed):
     assert parsed.rev == result.rev
     assert parsed.url == result.url
     assert parsed.user == result.user
+    assert parsed.subdirectory == result.subdirectory
 
 
 def test_parse_url_should_fail():

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -95,6 +95,22 @@ from poetry.vcs.git import ParsedUrl
                 "path/to/package",
             ),
         ),
+        (
+            "git+https://git.example.com/sdispater/project/my_repo.git#dev?subdirectory=path/to/package",
+            GitUrl(
+                "https://git.example.com/sdispater/project/my_repo.git",
+                "dev",
+                "path/to/package",
+            ),
+        ),
+        (
+            "git+ssh://git@git.example.com:sdispater/project/my_repo.git#dev?subdirectory=path/to/package",
+            GitUrl(
+                "git@git.example.com:sdispater/project/my_repo.git",
+                "dev",
+                "path/to/package",
+            ),
+        ),
     ],
 )
 def test_normalize_url(url, normalized):
@@ -325,6 +341,32 @@ def test_normalize_url(url, normalized):
                 None,
                 "my_repo",
                 None,
+                "path/to/package",
+            ),
+        ),
+        (
+            "git+https://git.example.com/sdispater/project/my_repo.git#dev?subdirectory=path/to/package",
+            ParsedUrl(
+                "https",
+                "git.example.com",
+                "/sdispater/project/my_repo.git",
+                None,
+                None,
+                "my_repo",
+                "dev",
+                "path/to/package",
+            ),
+        ),
+        (
+            "git+ssh://git@git.example.com:sdispater/project/my_repo.git#dev?subdirectory=path/to/package",
+            ParsedUrl(
+                "ssh",
+                "git.example.com",
+                ":sdispater/project/my_repo.git",
+                "git",
+                None,
+                "my_repo",
+                "dev",
                 "path/to/package",
             ),
         ),

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -22,7 +22,7 @@ from poetry.vcs.git import ParsedUrl
         ),
         (
             "git+https://user@hostname/project~_-.foo/blah~_-.bar.git",
-            GitUrl("https://user@hostname/project~_-.foo/blah~_-.bar.git", None),
+            GitUrl("https://user@hostname/project~_-.foo/blah~_-.bar.git", None, None),
         ),
         (
             "git+https://user@hostname:project/blah.git",
@@ -168,6 +168,7 @@ def test_normalize_url(url, normalized):
                 "user",
                 None,
                 "blah~_-.bar",
+                None,
                 None,
             ),
         ),


### PR DESCRIPTION
This PR implements the possibility to add git dependencies, where the package is located within a subdirectory  of the repository.

The path to the subdirectory can be specified as follows:

```
poetry add "git+https://github.com/demo/project_in_subdirectory.git?subdirectory=pyproject-demo"
```

Where `pyproject-demo` is a subfolder relative to the root after checkout the repository. This can be combined with the revision tag:

```
poetry add "git+https://github.com/demo/project_in_subdirectory.git#dev?subdirectory=pyproject-demo"
```

To specify the subdir in the `pyproject.toml` a new argument `subdirectory` was introduced:

```
mypackage = {git = "https://github.com/demo/project_in_subdirectory.git", rev = "dev", subdirectory = "pyproject-demo"}
```

To implement this feature is was necessary  to checkout the repository first to a temporary folder and copy the desired folder to it's destination. For this a new `DownloadTmpDir` class was implemented, which avoids downloading from the same git source multiple times, during run time.

I would like to get some feed back from people, who can test this on a real world use case. Especially if this all works as expected.

Implements: #755 

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
