### PR TITLE
Make Poetry respect XDG variables on macOS

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -4,11 +4,11 @@ Poetry can be configured via the `config` command ([see more about its usage her
 or directly in the `config.toml` file that will be automatically be created when you first run that command.
 This file can typically be found in one of the following directories:
 
-- macOS:   `~/Library/Application Support/pypoetry`
-- Windows: `C:\Users\<username>\AppData\Roaming\pypoetry`
-
-For Unix, we follow the XDG spec and support `$XDG_CONFIG_HOME`.
-That means, by default `~/.config/pypoetry`.
+- Windows: `C:\Users\<username>\AppData\Roaming\pypoetry`;
+- macOS:   If you have the `$XDG_CONFIG_HOME` set, Poetry will follow the XDG
+           spec, otherwise `~/Library/Application Support/pypoetry` is used;
+- Unix:    Follow the XDG spec and support `$XDG_CONFIG_HOME`. That means, by
+           default `~/.config/pypoetry`;
 
 ## Local configuration
 
@@ -98,9 +98,11 @@ The path to the cache directory used by Poetry.
 
 Defaults to one of the following directories:
 
-- macOS:   `~/Library/Caches/pypoetry`
-- Windows: `C:\Users\<username>\AppData\Local\pypoetry\Cache`
-- Unix:    `~/.cache/pypoetry`
+- Windows: `C:\Users\<username>\AppData\Local\pypoetry\Cache`;
+- macOS:   If you have the `$XDG_CACHE_HOME` set, Poetry will follow the XDG
+           spec, otherwise `~/Library/Caches/pypoetry` is used;
+- Unix:    Follow the XDG spec and support `$XDG_CACHE_HOME`. That means, by
+           default `~/.cache/pypoetry`;
 
 ### `virtualenvs.create`: boolean
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -31,7 +31,9 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poet
     Python version and use it to [create virtualenvs](/docs/basic-usage/#poetry-and-virtualenvs) accordingly.
 
 The installer installs the `poetry` tool to Poetry's `bin` directory.
-On Unix it is located at `$HOME/.poetry/bin` and on Windows at `%USERPROFILE%\.poetry\bin`.
+On Unix based systems (including macOS) it is located at `$POETRY_HOME/bin`,
+at `$XDG_OPT_HOME/poetry/bin`, or at `$HOME/.poetry/bin` (if `$POETRY_HOME`
+nor `$XDG_OPT_HOME` are defined), and on Windows at `%USERPROFILE%\.poetry\bin`.
 
 This directory will be in your `$PATH` environment variable,
 which means you can run them from the shell without further configuration.

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -190,7 +190,14 @@ def expanduser(path):
 
 
 HOME = expanduser("~")
-POETRY_HOME = os.environ.get("POETRY_HOME") or os.path.join(HOME, ".poetry")
+POETRY_HOME = os.environ.get("POETRY_HOME")
+if not POETRY_HOME:
+    POETRY_HOME = os.environ.get("XDG_OPT_HOME")
+    if POETRY_HOME:
+        POETRY_HOME = os.path.join(POETRY_HOME, "poetry")
+    else:
+        POETRY_HOME = os.path.join(HOME, ".poetry")
+
 POETRY_BIN = os.path.join(POETRY_HOME, "bin")
 POETRY_ENV = os.path.join(POETRY_HOME, "env")
 POETRY_LIB = os.path.join(POETRY_HOME, "lib")

--- a/poetry.lock
+++ b/poetry.lock
@@ -42,6 +42,19 @@ tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.i
 
 [[package]]
 category = "dev"
+description = "Backport of functools.lru_cache"
+marker = "python_version < \"3.2\""
+name = "backports.functools-lru-cache"
+optional = false
+python-versions = ">=2.6"
+version = "1.6.1"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov"]
+
+[[package]]
+category = "dev"
 description = "The uncompromising code formatter."
 marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "black"
@@ -67,10 +80,10 @@ description = "httplib2 caching for requests"
 name = "cachecontrol"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.12.5"
+version = "0.12.6"
 
 [package.dependencies]
-msgpack = "*"
+msgpack = ">=0.5.2"
 requests = "*"
 
 [package.dependencies.lockfile]
@@ -176,7 +189,7 @@ version = ">=3.6,<4.0"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
+marker = "sys_platform == \"win32\" and python_version == \"3.4\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -185,7 +198,7 @@ version = "0.4.1"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
+marker = "sys_platform == \"win32\" and python_version != \"3.4\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -220,6 +233,17 @@ name = "coverage"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
 version = "4.5.4"
+
+[[package]]
+category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.0.1"
+
+[package.extras]
+toml = ["toml"]
 
 [[package]]
 category = "main"
@@ -352,7 +376,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.8"
+version = "1.4.9"
 
 [package.extras]
 license = ["editdistance"]
@@ -414,6 +438,29 @@ name = "ipaddress"
 optional = false
 python-versions = "*"
 version = "1.0.23"
+
+[[package]]
+category = "dev"
+description = "A Python utility / library to sort Python imports."
+name = "isort"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "4.3.21"
+
+[package.dependencies]
+[package.dependencies."backports.functools-lru-cache"]
+python = "<3.2"
+version = "*"
+
+[package.dependencies.futures]
+python = "<3.2"
+version = "*"
+
+[package.extras]
+pipfile = ["pipreqs", "requirementslib"]
+pyproject = ["toml"]
+requirements = ["pipreqs", "pip-api"]
+xdg_home = ["appdirs (>=1.4.0)"]
 
 [[package]]
 category = "main"
@@ -698,8 +745,8 @@ description = "Utility library for gitignore style pattern matching of file path
 marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "pathspec"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.6.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.7.0"
 
 [[package]]
 category = "dev"
@@ -814,7 +861,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.0"
+version = "1.8.1"
 
 [[package]]
 category = "main"
@@ -877,7 +924,7 @@ description = "Extension pack for Python Markdown."
 name = "pymdown-extensions"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
-version = "6.2"
+version = "6.2.1"
 
 [package.dependencies]
 Markdown = ">=3.0.1"
@@ -889,7 +936,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.5"
+version = "2.4.6"
 
 [[package]]
 category = "main"
@@ -908,17 +955,24 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "4.6.7"
+version = "4.6.8"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
 attrs = ">=17.4.0"
-colorama = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.5.0"
 six = ">=1.10.0"
 wcwidth = "*"
+
+[[package.dependencies.colorama]]
+python = "<3.4.0 || >=3.5.0"
+version = "*"
+
+[[package.dependencies.colorama]]
+python = ">=3.4,<3.5"
+version = "<=0.4.1"
 
 [[package.dependencies.more-itertools]]
 python = "<2.8"
@@ -1013,7 +1067,7 @@ marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2019.12.9"
+version = "2019.12.20"
 
 [[package]]
 category = "main"
@@ -1278,7 +1332,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "16.7.8"
+version = "16.7.9"
 
 [package.extras]
 docs = ["sphinx (>=1.8.0,<2)", "towncrier (>=18.5.0)", "sphinx-rtd-theme (>=0.4.2,<1)"]
@@ -1316,7 +1370,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "35feeab2d2e9415a82f714a41962c442ea8b302f0e8365c10ee188f31603684a"
+content-hash = "0673cf135c64916427ff8b043beda8145679f733b75b6a17a0171f98389b1e96"
 python-versions = "~2.7 || ^3.4"
 
 [metadata.files]
@@ -1336,12 +1390,17 @@ attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
+"backports.functools-lru-cache" = [
+    {file = "backports.functools_lru_cache-1.6.1-py2.py3-none-any.whl", hash = "sha256:0bada4c2f8a43d533e4ecb7a12214d9420e66eb206d54bf2d682581ca4b80848"},
+    {file = "backports.functools_lru_cache-1.6.1.tar.gz", hash = "sha256:8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a"},
+]
 black = [
     {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
     {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
 ]
 cachecontrol = [
-    {file = "CacheControl-0.12.5.tar.gz", hash = "sha256:cef77effdf51b43178f6a2d3b787e3734f98ade253fa3187f3bb7315aaa42ff7"},
+    {file = "CacheControl-0.12.6-py2.py3-none-any.whl", hash = "sha256:10d056fa27f8563a271b345207402a6dcce8efab7e5b377e270329c62471b10d"},
+    {file = "CacheControl-0.12.6.tar.gz", hash = "sha256:be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8"},
 ]
 cachy = [
     {file = "cachy-0.3.0-py2.py3-none-any.whl", hash = "sha256:338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7"},
@@ -1380,6 +1439,7 @@ cffi = [
     {file = "cffi-1.13.2-cp37-cp37m-win32.whl", hash = "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e"},
     {file = "cffi-1.13.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a"},
     {file = "cffi-1.13.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d"},
+    {file = "cffi-1.13.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3"},
     {file = "cffi-1.13.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db"},
     {file = "cffi-1.13.2-cp38-cp38-win32.whl", hash = "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506"},
     {file = "cffi-1.13.2-cp38-cp38-win_amd64.whl", hash = "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba"},
@@ -1452,6 +1512,37 @@ coverage = [
     {file = "coverage-4.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351"},
     {file = "coverage-4.5.4-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5"},
     {file = "coverage-4.5.4.tar.gz", hash = "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c"},
+    {file = "coverage-5.0.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:c90bda74e16bcd03861b09b1d37c0a4158feda5d5a036bb2d6e58de6ff65793e"},
+    {file = "coverage-5.0.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bb3d29df5d07d5399d58a394d0ef50adf303ab4fbf66dfd25b9ef258effcb692"},
+    {file = "coverage-5.0.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:1ca43dbd739c0fc30b0a3637a003a0d2c7edc1dd618359d58cc1e211742f8bd1"},
+    {file = "coverage-5.0.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:591506e088901bdc25620c37aec885e82cc896528f28c57e113751e3471fc314"},
+    {file = "coverage-5.0.1-cp27-cp27m-win32.whl", hash = "sha256:a50b0888d8a021a3342d36a6086501e30de7d840ab68fca44913e97d14487dc1"},
+    {file = "coverage-5.0.1-cp27-cp27m-win_amd64.whl", hash = "sha256:c792d3707a86c01c02607ae74364854220fb3e82735f631cd0a345dea6b4cee5"},
+    {file = "coverage-5.0.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:f425f50a6dd807cb9043d15a4fcfba3b5874a54d9587ccbb748899f70dc18c47"},
+    {file = "coverage-5.0.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:25b8f60b5c7da71e64c18888f3067d5b6f1334b9681876b2fb41eea26de881ae"},
+    {file = "coverage-5.0.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7362a7f829feda10c7265b553455de596b83d1623b3d436b6d3c51c688c57bf6"},
+    {file = "coverage-5.0.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:fcd4459fe35a400b8f416bc57906862693c9f88b66dc925e7f2a933e77f6b18b"},
+    {file = "coverage-5.0.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:40fbfd6b044c9db13aeec1daf5887d322c710d811f944011757526ef6e323fd9"},
+    {file = "coverage-5.0.1-cp35-cp35m-win32.whl", hash = "sha256:7f2675750c50151f806070ec11258edf4c328340916c53bac0adbc465abd6b1e"},
+    {file = "coverage-5.0.1-cp35-cp35m-win_amd64.whl", hash = "sha256:24bcfa86fd9ce86b73a8368383c39d919c497a06eebb888b6f0c12f13e920b1a"},
+    {file = "coverage-5.0.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:eeafb646f374988c22c8e6da5ab9fb81367ecfe81c70c292623373d2a021b1a1"},
+    {file = "coverage-5.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:2ca2cd5264e84b2cafc73f0045437f70c6378c0d7dbcddc9ee3fe192c1e29e5d"},
+    {file = "coverage-5.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2cc707fc9aad2592fc686d63ef72dc0031fc98b6fb921d2f5395d9ab84fbc3ef"},
+    {file = "coverage-5.0.1-cp36-cp36m-win32.whl", hash = "sha256:04b961862334687549eb91cd5178a6fbe977ad365bddc7c60f2227f2f9880cf4"},
+    {file = "coverage-5.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:232f0b52a5b978288f0bbc282a6c03fe48cd19a04202df44309919c142b3bb9c"},
+    {file = "coverage-5.0.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:cfce79ce41cc1a1dc7fc85bb41eeeb32d34a4cf39a645c717c0550287e30ff06"},
+    {file = "coverage-5.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c9c6a1d1190c0b75ec7c0f339088309952b82ae8d67a79ff1319eb4e749b96"},
+    {file = "coverage-5.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1cbb88b34187bdb841f2599770b7e6ff8e259dc3bb64fc7893acf44998acf5f8"},
+    {file = "coverage-5.0.1-cp37-cp37m-win32.whl", hash = "sha256:ff3936dd5feaefb4f91c8c1f50a06c588b5dc69fba4f7d9c79a6617ad80bb7df"},
+    {file = "coverage-5.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:65bead1ac8c8930cf92a1ccaedcce19a57298547d5d1db5c9d4d068a0675c38b"},
+    {file = "coverage-5.0.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:348630edea485f4228233c2f310a598abf8afa5f8c716c02a9698089687b6085"},
+    {file = "coverage-5.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:960d7f42277391e8b1c0b0ae427a214e1b31a1278de6b73f8807b20c2e913bba"},
+    {file = "coverage-5.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0101888bd1592a20ccadae081ba10e8b204d20235d18d05c6f7d5e904a38fc10"},
+    {file = "coverage-5.0.1-cp38-cp38m-win32.whl", hash = "sha256:c0fff2733f7c2950f58a4fd09b5db257b00c6fec57bf3f68c5bae004d804b407"},
+    {file = "coverage-5.0.1-cp38-cp38m-win_amd64.whl", hash = "sha256:5f622f19abda4e934938e24f1d67599249abc201844933a6f01aaa8663094489"},
+    {file = "coverage-5.0.1-cp39-cp39m-win32.whl", hash = "sha256:2714160a63da18aed9340c70ed514973971ee7e665e6b336917ff4cca81a25b1"},
+    {file = "coverage-5.0.1-cp39-cp39m-win_amd64.whl", hash = "sha256:b7dbc5e8c39ea3ad3db22715f1b5401cd698a621218680c6daf42c2f9d36e205"},
+    {file = "coverage-5.0.1.tar.gz", hash = "sha256:5ac71bba1e07eab403b082c4428f868c1c9e26a21041436b4905c4c3d4e49b08"},
 ]
 cryptography = [
     {file = "cryptography-2.8-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"},
@@ -1513,8 +1604,8 @@ httpretty = [
     {file = "httpretty-0.9.7.tar.gz", hash = "sha256:66216f26b9d2c52e81808f3e674a6fb65d4bf719721394a1a9be926177e55fbe"},
 ]
 identify = [
-    {file = "identify-1.4.8-py2.py3-none-any.whl", hash = "sha256:9e7521e9abeaede4d2d1092a106e418c65ddf6b3182b43930bcb3c8cfb974488"},
-    {file = "identify-1.4.8.tar.gz", hash = "sha256:7782115794ec28b011702815d9f5e532244560cd2bf0789c4f09381d43befd90"},
+    {file = "identify-1.4.9-py2.py3-none-any.whl", hash = "sha256:72e9c4ed3bc713c7045b762b0d2e2115c572b85abfc1f4604f5a4fd4c6642b71"},
+    {file = "identify-1.4.9.tar.gz", hash = "sha256:6f44e637caa40d1b4cb37f6ed3b262ede74901d28b1cc5b1fc07360871edd65d"},
 ]
 idna = [
     {file = "idna-2.8-py2.py3-none-any.whl", hash = "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"},
@@ -1531,6 +1622,10 @@ importlib-resources = [
 ipaddress = [
     {file = "ipaddress-1.0.23-py2.py3-none-any.whl", hash = "sha256:6e0f4a39e66cb5bb9a137b00276a2eff74f93b71dcbdad6f10ff7df9d3557fcc"},
     {file = "ipaddress-1.0.23.tar.gz", hash = "sha256:b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2"},
+]
+isort = [
+    {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
+    {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
 jeepney = [
     {file = "jeepney-0.4.1-py3-none-any.whl", hash = "sha256:f6a3f93464a0cf052f4e87da3c8b3ed1e27696758fb9739c63d3a74d9a1b6774"},
@@ -1653,7 +1748,8 @@ pathlib2 = [
     {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
 ]
 pathspec = [
-    {file = "pathspec-0.6.0.tar.gz", hash = "sha256:e285ccc8b0785beadd4c18e5708b12bb8fcf529a1e61215b3feff1d1e559ea5c"},
+    {file = "pathspec-0.7.0-py2.py3-none-any.whl", hash = "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424"},
+    {file = "pathspec-0.7.0.tar.gz", hash = "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"},
 ]
 pep562 = [
     {file = "pep562-1.0-py2.py3-none-any.whl", hash = "sha256:d2a48b178ebf5f8dd31709cc26a19808ef794561fa2fe50ea01ea2bad4d667ef"},
@@ -1682,8 +1778,8 @@ ptyprocess = [
     {file = "ptyprocess-0.6.0.tar.gz", hash = "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"},
 ]
 py = [
-    {file = "py-1.8.0-py2.py3-none-any.whl", hash = "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa"},
-    {file = "py-1.8.0.tar.gz", hash = "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"},
+    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
+    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
 ]
 pycparser = [
     {file = "pycparser-2.19.tar.gz", hash = "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"},
@@ -1705,19 +1801,19 @@ pylev = [
 pymdown-extensions = [
     {file = "pymdown-extensions-6.0.tar.gz", hash = "sha256:6cf0cf36b5a03b291ace22dc2f320f4789ce56fbdb6635a3be5fadbf5d7694dd"},
     {file = "pymdown_extensions-6.0-py2.py3-none-any.whl", hash = "sha256:25b0a7967fa697b5035e23340a48594e3e93acb10b06d74574218ace3347d1df"},
-    {file = "pymdown-extensions-6.2.tar.gz", hash = "sha256:27953f071d37b63d418738f75d847d824c0e4430e93f085cfdd9f8dc08a8c5c3"},
-    {file = "pymdown_extensions-6.2-py2.py3-none-any.whl", hash = "sha256:328b9e114925729e0789558a94325be8e7ca9e0323ed2a2b705d9bc1de4d2716"},
+    {file = "pymdown-extensions-6.2.1.tar.gz", hash = "sha256:3bbe6048275f8a0d13a0fe44e0ea201e67268aa7bb40c2544eef16abbf168f7b"},
+    {file = "pymdown_extensions-6.2.1-py2.py3-none-any.whl", hash = "sha256:dce5e17b93be0572322b7d06c9a13c13a9d98694d6468277911d50ca87d26f29"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.5-py2.py3-none-any.whl", hash = "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f"},
-    {file = "pyparsing-2.4.5.tar.gz", hash = "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"},
+    {file = "pyparsing-2.4.6-py2.py3-none-any.whl", hash = "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"},
+    {file = "pyparsing-2.4.6.tar.gz", hash = "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.14.11.tar.gz", hash = "sha256:3ca82748918eb65e2d89f222b702277099aca77e34843c5eb9d52451173970e2"},
 ]
 pytest = [
-    {file = "pytest-4.6.7-py2.py3-none-any.whl", hash = "sha256:65e92898fb5b61d0a1d7319c3e6dcf97e599e331cfdc2b27f20c0d87ece19239"},
-    {file = "pytest-4.6.7.tar.gz", hash = "sha256:9ea149066f566c943d3122f4b1cf1b577cab73189d11f490b54703fa5fa9df50"},
+    {file = "pytest-4.6.8-py2.py3-none-any.whl", hash = "sha256:f8447ebf8fd3d362868a5d3f43a9df786dfdfe9608843bd9002a2d47a104808f"},
+    {file = "pytest-4.6.8.tar.gz", hash = "sha256:6192875be8af57b694b7c4904e909680102befcb99e610ef3d9f786952f795aa"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
@@ -1749,17 +1845,27 @@ pyyaml = [
     {file = "PyYAML-5.2.tar.gz", hash = "sha256:c0ee8eca2c582d29c3c2ec6e2c4f703d1b7f1fb10bc72317355a746057e7346c"},
 ]
 regex = [
-    {file = "regex-2019.12.9-cp27-none-win32.whl", hash = "sha256:40b7d1291a56897927e08bb973f8c186c2feb14c7f708bfe7aaee09483e85a20"},
-    {file = "regex-2019.12.9-cp27-none-win_amd64.whl", hash = "sha256:c203c9ee755e9656d0af8fab82754d5a664ebaf707b3f883c7eff6a3dd5151cf"},
-    {file = "regex-2019.12.9-cp35-none-win32.whl", hash = "sha256:719978a9145d59fc78509ea1d1bb74243f93583ef2a34dcc5623cf8118ae9726"},
-    {file = "regex-2019.12.9-cp35-none-win_amd64.whl", hash = "sha256:75cf3796f89f75f83207a5c6a6e14eaf57e0369ef0ffff8e22bf36bbcfa0f1de"},
-    {file = "regex-2019.12.9-cp36-none-win32.whl", hash = "sha256:3dbd8333fd2ebd50977ac8747385a73aa1f546eb6b16fcd83d274470fe11f243"},
-    {file = "regex-2019.12.9-cp36-none-win_amd64.whl", hash = "sha256:ad9e3c7260809c0d1ded100269f78ea0217c0704f1eaaf40a382008461848b45"},
-    {file = "regex-2019.12.9-cp37-none-win32.whl", hash = "sha256:91235c98283d2bddf1a588f0fbc2da8afa37959294bbd18b76297bdf316ba4d6"},
-    {file = "regex-2019.12.9-cp37-none-win_amd64.whl", hash = "sha256:aaffd68c4c1ed891366d5c390081f4bf6337595e76a157baf453603d8e53fbcb"},
-    {file = "regex-2019.12.9-cp38-none-win32.whl", hash = "sha256:e865bc508e316a3a09d36c8621596e6599a203bc54f1cd41020a127ccdac468a"},
-    {file = "regex-2019.12.9-cp38-none-win_amd64.whl", hash = "sha256:77396cf80be8b2a35db863cca4c1a902d88ceeb183adab328b81184e71a5eafe"},
-    {file = "regex-2019.12.9.tar.gz", hash = "sha256:77a3799152951d6d14ae5720ca162c97c64f85d4755da585418eac216b736cad"},
+    {file = "regex-2019.12.20-cp27-cp27m-win32.whl", hash = "sha256:7bbbdbada3078dc360d4692a9b28479f569db7fc7f304b668787afc9feb38ec8"},
+    {file = "regex-2019.12.20-cp27-cp27m-win_amd64.whl", hash = "sha256:a83049eb717ae828ced9cf607845929efcb086a001fc8af93ff15c50012a5716"},
+    {file = "regex-2019.12.20-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:27d1bd20d334f50b7ef078eba0f0756a640fd25f5f1708d3b5bed18a5d6bced9"},
+    {file = "regex-2019.12.20-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1768cf42a78a11dae63152685e7a1d90af7a8d71d2d4f6d2387edea53a9e0588"},
+    {file = "regex-2019.12.20-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:4850c78b53acf664a6578bba0e9ebeaf2807bb476c14ec7e0f936f2015133cae"},
+    {file = "regex-2019.12.20-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:78b3712ec529b2a71731fbb10b907b54d9c53a17ca589b42a578bc1e9a2c82ea"},
+    {file = "regex-2019.12.20-cp36-cp36m-win32.whl", hash = "sha256:8d9ef7f6c403e35e73b7fc3cde9f6decdc43b1cb2ff8d058c53b9084bfcb553e"},
+    {file = "regex-2019.12.20-cp36-cp36m-win_amd64.whl", hash = "sha256:faad39fdbe2c2ccda9846cd21581063086330efafa47d87afea4073a08128656"},
+    {file = "regex-2019.12.20-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:adc35d38952e688535980ae2109cad3a109520033642e759f987cf47fe278aa1"},
+    {file = "regex-2019.12.20-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ef0b828a7e22e58e06a1cceddba7b4665c6af8afeb22a0d8083001330572c147"},
+    {file = "regex-2019.12.20-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:0e6cf1e747f383f52a0964452658c04300a9a01e8a89c55ea22813931b580aa8"},
+    {file = "regex-2019.12.20-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:032fdcc03406e1a6485ec09b826eac78732943840c4b29e503b789716f051d8d"},
+    {file = "regex-2019.12.20-cp37-cp37m-win32.whl", hash = "sha256:77ae8d926f38700432807ba293d768ba9e7652df0cbe76df2843b12f80f68885"},
+    {file = "regex-2019.12.20-cp37-cp37m-win_amd64.whl", hash = "sha256:c29a77ad4463f71a506515d9ec3a899ed026b4b015bf43245c919ff36275444b"},
+    {file = "regex-2019.12.20-cp38-cp38-manylinux1_i686.whl", hash = "sha256:57eacd38a5ec40ed7b19a968a9d01c0d977bda55664210be713e750dd7b33540"},
+    {file = "regex-2019.12.20-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:724eb24b92fc5fdc1501a1b4df44a68b9c1dda171c8ef8736799e903fb100f63"},
+    {file = "regex-2019.12.20-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d508875793efdf6bab3d47850df8f40d4040ae9928d9d80864c1768d6aeaf8e3"},
+    {file = "regex-2019.12.20-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:cfd31b3300fefa5eecb2fe596c6dee1b91b3a05ece9d5cfd2631afebf6c6fadd"},
+    {file = "regex-2019.12.20-cp38-cp38-win32.whl", hash = "sha256:29b20f66f2e044aafba86ecf10a84e611b4667643c42baa004247f5dfef4f90b"},
+    {file = "regex-2019.12.20-cp38-cp38-win_amd64.whl", hash = "sha256:d3ee0b035816e0520fac928de31b6572106f0d75597f6fa3206969a02baba06f"},
+    {file = "regex-2019.12.20.tar.gz", hash = "sha256:106e25a841921d8259dcef2a42786caae35bc750fb996f830065b3dfaa67b77e"},
 ]
 requests = [
     {file = "requests-2.21.0-py2.py3-none-any.whl", hash = "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"},
@@ -1869,8 +1975,8 @@ urllib3 = [
     {file = "urllib3-1.25.7.tar.gz", hash = "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"},
 ]
 virtualenv = [
-    {file = "virtualenv-16.7.8-py2.py3-none-any.whl", hash = "sha256:b57776b44f91511866594e477dd10e76a6eb44439cdd7f06dcd30ba4c5bd854f"},
-    {file = "virtualenv-16.7.8.tar.gz", hash = "sha256:116655188441670978117d0ebb6451eb6a7526f9ae0796cc0dee6bd7356909b0"},
+    {file = "virtualenv-16.7.9-py2.py3-none-any.whl", hash = "sha256:55059a7a676e4e19498f1aad09b8313a38fcc0cdbe4fdddc0e9b06946d21b4bb"},
+    {file = "virtualenv-16.7.9.tar.gz", hash = "sha256:0d62c70883c0342d59c11d0ddac0d954d0431321a41ab20851facf2b222598f3"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.7-py2.py3-none-any.whl", hash = "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"},

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -36,12 +36,9 @@ class SelfUpdateCommand(Command):
 
     @property
     def home(self):
-        from poetry.utils._compat import Path
-        from poetry.utils.appdirs import expanduser
+        from poetry.utils.appdirs import poetry_home_dir
 
-        home = Path(expanduser("~"))
-
-        return home / ".poetry"
+        return poetry_home_dir()
 
     @property
     def lib(self):

--- a/poetry/utils/appdirs.py
+++ b/poetry/utils/appdirs.py
@@ -21,6 +21,34 @@ def expanduser(path):
     return expanded
 
 
+def poetry_home_dir():
+    r"""
+    Return full path to the Poetry's installation dir.
+
+    Typical user cache directories are:
+         macOS:      In $POETRY_HOME, in $XDG_OPT_HOME, or in
+                     ~/.poetry. Whichever is found first.
+         Unix:       In $POETRY_HOME, in $XDG_OPT_HOME, or in
+                     ~/.poetry. Whichever is found first.
+         Windows:    C:\Users\<username>\AppData\Local\<AppName>\Cache
+
+    Unfortunately, XDG does not define a variable for system unbound packages.
+    Due to this, we use the variable $XDG_OPT_HOME to find the best place
+    to install Poetry (this is usually set to ~/.local/opt).
+
+    The fallback place to install Poetry is "~/.poetry" (on Windows this is
+    equivalent to "%USERPROFILE%/.poetry".)
+    """
+    home = os.getenv("POETRY_HOME")
+    if not home:
+        home = os.getenv("XDG_OPT_HOME")
+        if home:
+            home = os.path.join(home, "poetry")
+        else:
+            home = os.path.join(expanduser("~"), ".poetry")
+    return home
+
+
 def user_cache_dir(appname):
     r"""
     Return full path to the user-specific cache dir for this application.
@@ -28,7 +56,8 @@ def user_cache_dir(appname):
         "appname" is the name of application.
 
     Typical user cache directories are:
-        macOS:      ~/Library/Caches/<AppName>
+        macOS:      $XDG_CACHE_HOME/<AppName> if $XDG_CACHE_HOME is defined,
+                    or in ~/Library/Caches/<AppName> otherwise.
         Unix:       ~/.cache/<AppName> (XDG default)
         Windows:    C:\Users\<username>\AppData\Local\<AppName>\Cache
 
@@ -48,15 +77,12 @@ def user_cache_dir(appname):
 
         # Add our app name and Cache directory to it
         path = os.path.join(path, appname, "Cache")
-    elif sys.platform == "darwin":
-        # Get the base path
-        path = expanduser("~/Library/Caches")
-
-        # Add our app name to it
-        path = os.path.join(path, appname)
     else:
         # Get the base path
-        path = os.getenv("XDG_CACHE_HOME", expanduser("~/.cache"))
+        path = os.getenv(
+            "XDG_CACHE_HOME",
+            expanduser("~/Library/Caches" if sys.platform == "darwin" else expanduser("~/.cache")),
+        )
 
         # Add our app name to it
         path = os.path.join(path, appname)
@@ -78,9 +104,12 @@ def user_data_dir(appname, roaming=False):
             for a discussion of issues.
 
     Typical user data directories are:
-        macOS:                  ~/Library/Application Support/<AppName>
-        Unix:                   ~/.local/share/<AppName>    # or in
-                                $XDG_DATA_HOME, if defined
+        macOS:                  ~/Library/Application Support/<AppName> or
+                                in $XDG_DATA_HOME/<AppName>, if $XDG_DATA_HOME
+                                is defined
+        Unix:                   ~/.local/share/<AppName> or in
+                                $XDG_DATA_HOME/<AppName>, if $XDG_DATA_HOME
+                                is defined
         Win XP (not roaming):   C:\Documents and Settings\<username>\ ...
                                 ...Application Data\<AppName>
         Win XP (roaming):       C:\Documents and Settings\<username>\Local ...
@@ -92,15 +121,16 @@ def user_data_dir(appname, roaming=False):
     That means, by default "~/.local/share/<AppName>".
     """
     if WINDOWS:
-        const = roaming and "CSIDL_APPDATA" or "CSIDL_LOCAL_APPDATA"
+        const = "CSIDL_APPDATA" if roaming else "CSIDL_LOCAL_APPDATA"
         path = os.path.join(os.path.normpath(_get_win_folder(const)), appname)
-    elif sys.platform == "darwin":
-        path = os.path.join(expanduser("~/Library/Application Support/"), appname)
     else:
-        path = os.path.join(
-            os.getenv("XDG_DATA_HOME", expanduser("~/.local/share")), appname
+        datadir = os.getenv(
+            "XDG_DATA_HOME",
+            expanduser("~/Library/Application Support")
+            if sys.platform == "darwin"
+            else expanduser("~/.local/share"),
         )
-
+        path = os.path.join(datadir, appname,) if appname else datadir
     return path
 
 
@@ -117,8 +147,10 @@ def user_config_dir(appname, roaming=True):
             for a discussion of issues.
 
     Typical user data directories are:
-        macOS:                  same as user_data_dir
-        Unix:                   ~/.config/<AppName>
+        macOS:                  same as user_data_dir or in
+                                $XDG_DATA_HOME/<AppName>, if
+                                $XDG_DATA_HOME is defined
+        Unix:                   ~/.config/<AppName> (XDG default)
         Win *:                  same as user_data_dir
 
     For Unix, we follow the XDG spec and support $XDG_CONFIG_HOME.
@@ -126,11 +158,16 @@ def user_config_dir(appname, roaming=True):
     """
     if WINDOWS:
         path = user_data_dir(appname, roaming=roaming)
-    elif sys.platform == "darwin":
-        path = user_data_dir(appname)
     else:
-        path = os.getenv("XDG_CONFIG_HOME", expanduser("~/.config"))
-        path = os.path.join(path, appname)
+        path = os.path.join(
+            os.getenv(
+                "XDG_CONFIG_HOME",
+                user_data_dir(None)
+                if sys.platform == "darwin"
+                else expanduser("~/.config"),
+            ),
+            appname,
+        )
 
     return path
 
@@ -143,7 +180,9 @@ def site_config_dirs(appname):
         "appname" is the name of application.
 
     Typical user config directories are:
-        macOS:      /Library/Application Support/<AppName>/
+        macOS:      /Library/Application Support/<AppName>/ or
+                    $XDG_CONFIG_DIRS[i]/<AppName>/ for each value in
+                    $XDG_CONFIG_DIRS
         Unix:       /etc or $XDG_CONFIG_DIRS[i]/<AppName>/ for each value in
                     $XDG_CONFIG_DIRS
         Win XP:     C:\Documents and Settings\All Users\Application ...
@@ -156,11 +195,15 @@ def site_config_dirs(appname):
     if WINDOWS:
         path = os.path.normpath(_get_win_folder("CSIDL_COMMON_APPDATA"))
         pathlist = [os.path.join(path, appname)]
-    elif sys.platform == "darwin":
-        pathlist = [os.path.join("/Library/Application Support", appname)]
     else:
         # try looking in $XDG_CONFIG_DIRS
-        xdg_config_dirs = os.getenv("XDG_CONFIG_DIRS", "/etc/xdg")
+        xdg_config_dirs = os.getenv(
+            "XDG_CONFIG_DIRS",
+            expanduser("~/Library/Application Support")
+            if sys.platform == "darwin"
+            else "/etc/xdg",
+        )
+
         if xdg_config_dirs:
             pathlist = [
                 os.path.join(expanduser(x), appname)
@@ -169,8 +212,9 @@ def site_config_dirs(appname):
         else:
             pathlist = []
 
-        # always look in /etc directly as well
-        pathlist.append("/etc")
+        if sys.platform != "darwin":
+            # always look in /etc directly as well
+            pathlist.append("/etc")
 
     return pathlist
 

--- a/poetry/utils/appdirs.py
+++ b/poetry/utils/appdirs.py
@@ -81,7 +81,11 @@ def user_cache_dir(appname):
         # Get the base path
         path = os.getenv(
             "XDG_CACHE_HOME",
-            expanduser("~/Library/Caches" if sys.platform == "darwin" else expanduser("~/.cache")),
+            expanduser(
+                "~/Library/Caches"
+                if sys.platform == "darwin"
+                else expanduser("~/.cache")
+            ),
         )
 
         # Add our app name to it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ subprocess32 = { version = "^3.5", python = "~2.7 || ~3.4" }
 importlib-metadata = {version = "^0.23", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
+isort = "^4.3.21"
 pytest = "^4.1"
 pytest-cov = "^2.5"
 mkdocs = { version = "^1.0", python = "~2.7.9 || ^3.4" }

--- a/tests/utils/test_appdirs.py
+++ b/tests/utils/test_appdirs.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+from os import path
+
+import pytest
+
+from poetry.utils import appdirs
+
+
+windows = pytest.mark.skipif(
+    not (sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt")),
+    reason="tests that check Windows only behavior",
+)
+
+macos = pytest.mark.skipif(
+    sys.platform != "darwin", reason="tests that check macOS only behavior"
+)
+
+unix = pytest.mark.skipif(
+    sys.platform.startswith("win")
+    or (sys.platform == "cli" and os.name == "nt")
+    or sys.platform == "darwin",
+    reason="tests that check Unix type behavior",
+)
+
+macos_and_unix = pytest.mark.skipif(
+    sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt"),
+    reason="tests that check either Unix or macOS behavior",
+)
+
+
+@macos_and_unix
+def test_poetry_home_defined_by_env_var():
+    crazy_dir = path.join(os.environ["HOME"], "my_crazy_dir")
+    os.environ["POETRY_HOME"] = crazy_dir
+    assert appdirs.poetry_home_dir() == crazy_dir
+    del os.environ["POETRY_HOME"]
+
+
+@macos_and_unix
+def test_poetry_home_defined_by_xdg():
+    xdg_package_home = path.join(os.environ["HOME"], ".local", "opt")
+    poetry_home = path.join(xdg_package_home, "poetry")
+    os.environ["XDG_OPT_HOME"] = xdg_package_home
+    assert appdirs.poetry_home_dir() == poetry_home
+    del os.environ["XDG_OPT_HOME"]
+
+
+@macos_and_unix
+def test_poetry_home_fallback_default():
+    poetry_home = path.join(os.environ["HOME"], ".poetry")
+    assert appdirs.poetry_home_dir() == poetry_home
+
+
+@macos_and_unix
+def test_user_cache_dir_xdg_set():
+    xdg_cache_home = path.join(os.environ["HOME"], ".local", "var", "cache")
+    poetry_cache = path.join(xdg_cache_home, "poetry")
+    os.environ["XDG_CACHE_HOME"] = xdg_cache_home
+    assert appdirs.user_cache_dir("poetry") == poetry_cache
+    del os.environ["XDG_CACHE_HOME"]
+
+
+@macos
+def test_user_cache_dir_macos_default():
+    poetry_cache = path.join(appdirs.expanduser("~/Library/Caches"), "poetry")
+    if "XDG_CACHE_HOME" in os.environ:
+        del os.environ["XDG_CACHE_HOME"]
+    assert appdirs.user_cache_dir("poetry") == poetry_cache
+
+
+@unix
+def test_user_cache_dir_unix_default():
+    poetry_cache = path.join(appdirs.expanduser("~/.cache"), "poetry")
+    if "XDG_CACHE_HOME" in os.environ:
+        del os.environ["XDG_CACHE_HOME"]
+    assert appdirs.user_cache_dir("poetry") == poetry_cache
+
+
+@macos_and_unix
+def test_user_data_dir_xdg_set():
+    xdg_data_home = path.join(os.environ["HOME"], ".local", "crazy_path", "data")
+    poetry_data = path.join(xdg_data_home, "poetry")
+    os.environ["XDG_DATA_HOME"] = xdg_data_home
+    assert appdirs.user_data_dir("poetry") == poetry_data
+    del os.environ["XDG_DATA_HOME"]
+
+
+@macos
+def test_user_data_dir_macos_default():
+    poetry_data = path.join(
+        appdirs.expanduser("~/Library/Application Support"), "poetry"
+    )
+    if "XDG_DATA_HOME" in os.environ:
+        del os.environ["XDG_DATA_HOME"]
+    assert appdirs.user_data_dir("poetry") == poetry_data
+
+
+@unix
+def test_user_data_dir_unix_default():
+    poetry_data = path.join(appdirs.expanduser("~/.local/share"), "poetry")
+    if "XDG_DATA_HOME" in os.environ:
+        del os.environ["XDG_DATA_HOME"]
+    assert appdirs.user_data_dir("poetry") == poetry_data
+
+
+@macos_and_unix
+def test_user_config_dir_xdg_set():
+    xdg_config_home = path.join(os.environ["HOME"], ".local", "crazy_path", "data")
+    poetry_config = path.join(xdg_config_home, "poetry")
+    os.environ["XDG_CONFIG_HOME"] = xdg_config_home
+    assert appdirs.user_config_dir("poetry") == poetry_config
+    del os.environ["XDG_CONFIG_HOME"]
+
+
+@macos
+def test_user_config_dir_macos_default():
+    poetry_data = path.join(
+        appdirs.expanduser("~/Library/Application Support"), "poetry"
+    )
+    if "XDG_CONFIG_HOME" in os.environ:
+        del os.environ["XDG_CONFIG_HOME"]
+    assert appdirs.user_config_dir("poetry") == poetry_data
+
+
+@unix
+def test_user_config_dir_unix_default():
+    poetry_data = path.join(appdirs.expanduser("~/.config"), "poetry")
+    if "XDG_CONFIG_HOME" in os.environ:
+        del os.environ["XDG_CONFIG_HOME"]
+    assert appdirs.user_config_dir("poetry") == poetry_data
+
+
+@macos
+def test_site_config_dirs_xdg_set_macos():
+    site_config_dirs = [
+        appdirs.expanduser("~/.local/config.d"),
+        appdirs.expanduser("~/.config/others.d"),
+    ]
+    os.environ["XDG_CONFIG_DIRS"] = os.pathsep.join(site_config_dirs)
+
+    for expected, actual in zip(
+        [path.join(x, "poetry") for x in site_config_dirs],
+        appdirs.site_config_dirs("poetry"),
+    ):
+        assert expected == actual
+
+    del os.environ["XDG_CONFIG_DIRS"]
+
+
+@macos
+def test_site_config_dirs_macos_default():
+    site_config_dirs = [
+        path.join(appdirs.expanduser("~/Library/Application Support"), "poetry")
+    ]
+    if "XDG_CONFIG_DIRS" in os.environ:
+        del os.environ["XDG_CONFIG_DIRS"]
+    for expected, actual in zip(site_config_dirs, appdirs.site_config_dirs("poetry")):
+        assert expected == actual
+
+
+@unix
+def test_site_config_dirs_xdg_set_unix():
+    site_config_dirs = [
+        appdirs.expanduser("~/.local/config.d"),
+        appdirs.expanduser("~/.config/others.d"),
+    ]
+    os.environ["XDG_CONFIG_DIRS"] = os.pathsep.join(site_config_dirs)
+    site_config_dirs.append("/etc")
+
+    for expected, actual in zip(
+        [path.join(x, "poetry") for x in site_config_dirs],
+        appdirs.site_config_dirs("poetry"),
+    ):
+        assert expected == actual
+
+    del os.environ["XDG_CONFIG_DIRS"]
+
+
+@unix
+def test_site_config_dirs_unix_default():
+    site_config_dirs = ["/etc/xdg/poetry", "/etc/poetry"]
+    if "XDG_CONFIG_DIRS" in os.environ:
+        del os.environ["XDG_CONFIG_DIRS"]
+    for expected, actual in zip(site_config_dirs, appdirs.site_config_dirs("poetry")):
+        assert expected == actual

--- a/tests/utils/test_appdirs.py
+++ b/tests/utils/test_appdirs.py
@@ -164,6 +164,7 @@ def test_site_config_dirs_macos_default():
 
 @unix
 def test_site_config_dirs_xdg_set_unix():
+    unix_extra_dir = "/etc"
     site_config_dirs = [
         appdirs.expanduser("~/.local/config.d"),
         appdirs.expanduser("~/.config/others.d"),
@@ -172,7 +173,10 @@ def test_site_config_dirs_xdg_set_unix():
     site_config_dirs.append("/etc")
 
     for expected, actual in zip(
-        [path.join(x, "poetry") for x in site_config_dirs],
+        [
+            path.join(x, "poetry") if x != unix_extra_dir else x
+            for x in site_config_dirs
+        ],
         appdirs.site_config_dirs("poetry"),
     ):
         assert expected == actual
@@ -182,7 +186,7 @@ def test_site_config_dirs_xdg_set_unix():
 
 @unix
 def test_site_config_dirs_unix_default():
-    site_config_dirs = ["/etc/xdg/poetry", "/etc/poetry"]
+    site_config_dirs = ["/etc/xdg/poetry", "/etc"]
     if "XDG_CONFIG_DIRS" in os.environ:
         del os.environ["XDG_CONFIG_DIRS"]
     for expected, actual in zip(site_config_dirs, appdirs.site_config_dirs("poetry")):


### PR DESCRIPTION
## Changes Description

Since macOS is a Unix system, there is no reason to not allow Poetry to
use the XDG variables to install and maintain itself.

Resolves: [1239](https://github.com/python-poetry/poetry/issues/1239)

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
