### PR TITLE
Properly propagate dependency markers

### DIFF
--- a/poetry/packages/dependency.py
+++ b/poetry/packages/dependency.py
@@ -55,6 +55,7 @@ class Dependency(object):
         self._python_constraint = parse_constraint("*")
         self._transitive_python_versions = None
         self._transitive_python_constraint = None
+        self._transitive_marker = None
 
         self._extras = []
         self._in_extras = []
@@ -116,6 +117,17 @@ class Dependency(object):
     def transitive_python_versions(self, value):
         self._transitive_python_versions = value
         self._transitive_python_constraint = parse_constraint(value)
+
+    @property
+    def transitive_marker(self):
+        if self._transitive_marker is None:
+            return self.marker
+
+        return self._transitive_marker
+
+    @transitive_marker.setter
+    def transitive_marker(self, value):
+        self._transitive_marker = value
 
     @property
     def python_constraint(self):

--- a/poetry/puzzle/solver.py
+++ b/poetry/puzzle/solver.py
@@ -225,7 +225,7 @@ class Solver:
             intersection = (
                 previous["marker"]
                 .without_extras()
-                .intersect(previous_dep.marker.without_extras())
+                .intersect(previous_dep.transitive_marker.without_extras())
             )
             intersection = intersection.intersect(package.marker.without_extras())
 

--- a/poetry/version/markers.py
+++ b/poetry/version/markers.py
@@ -175,6 +175,12 @@ class BaseMarker(object):
     def without_extras(self):  # type: () -> BaseMarker
         raise NotImplementedError()
 
+    def exclude(self, marker_name):  # type: (str) -> BaseMarker
+        raise NotImplementedError()
+
+    def only(self, marker_name):  # type: (str) -> BaseMarker
+        raise NotImplementedError()
+
     def __repr__(self):
         return "<{} {}>".format(self.__class__.__name__, str(self))
 
@@ -196,6 +202,12 @@ class AnyMarker(BaseMarker):
         return True
 
     def without_extras(self):
+        return self
+
+    def exclude(self, marker_name):  # type: (str) -> AnyMarker
+        return self
+
+    def only(self, marker_name):  # type: (str) -> AnyMarker
         return self
 
     def __str__(self):
@@ -231,6 +243,12 @@ class EmptyMarker(BaseMarker):
         return False
 
     def without_extras(self):
+        return self
+
+    def exclude(self, marker_name):  # type: (str) -> EmptyMarker
+        return self
+
+    def only(self, marker_name):  # type: (str) -> EmptyMarker
         return self
 
     def __str__(self):
@@ -361,8 +379,17 @@ class SingleMarker(BaseMarker):
         return self._constraint.allows(self._parser(environment[self._name]))
 
     def without_extras(self):
-        if self.name == "extra":
+        return self.exclude("extra")
+
+    def exclude(self, marker_name):  # type: (str) -> BaseMarker
+        if self.name == marker_name:
             return AnyMarker()
+
+        return self
+
+    def only(self, marker_name):  # type: (str) -> BaseMarker
+        if self.name != marker_name:
+            return EmptyMarker()
 
         return self
 
@@ -410,7 +437,7 @@ class MultiMarker(BaseMarker):
         markers = _flatten_markers(markers, MultiMarker)
 
         for marker in markers:
-            if marker in new_markers or marker.is_empty():
+            if marker in new_markers:
                 continue
 
             if isinstance(marker, SingleMarker):
@@ -426,11 +453,9 @@ class MultiMarker(BaseMarker):
                     intersection = mark.constraint.intersect(marker.constraint)
                     if intersection == mark.constraint:
                         intersected = True
-                        break
                     elif intersection == marker.constraint:
                         new_markers[i] = marker
                         intersected = True
-                        break
                     elif intersection.is_empty():
                         return EmptyMarker()
 
@@ -439,8 +464,11 @@ class MultiMarker(BaseMarker):
 
             new_markers.append(marker)
 
-        if not new_markers:
+        if any(m.is_empty() for m in new_markers) or not new_markers:
             return EmptyMarker()
+
+        if len(new_markers) == 1 and new_markers[0].is_any():
+            return AnyMarker()
 
         return MultiMarker(*new_markers)
 
@@ -473,10 +501,32 @@ class MultiMarker(BaseMarker):
         return True
 
     def without_extras(self):
+        return self.exclude("extra")
+
+    def exclude(self, marker_name):  # type: (str) -> BaseMarker
         new_markers = []
 
         for m in self._markers:
-            marker = m.without_extras()
+            if isinstance(m, SingleMarker) and m.name == marker_name:
+                # The marker is not relevant since it must be excluded
+                continue
+
+            marker = m.exclude(marker_name)
+
+            if not marker.is_empty():
+                new_markers.append(marker)
+
+        return self.of(*new_markers)
+
+    def only(self, marker_name):  # type: (str) -> BaseMarker
+        new_markers = []
+
+        for m in self._markers:
+            if isinstance(m, SingleMarker) and m.name != marker_name:
+                # The marker is not relevant since it's not one we want
+                continue
+
+            marker = m.only(marker_name)
 
             if not marker.is_empty():
                 new_markers.append(marker)
@@ -550,7 +600,7 @@ class MarkerUnion(BaseMarker):
 
             markers.append(marker)
 
-        if len(markers) == 1 and markers[0].is_any():
+        if any(m.is_any() for m in markers):
             return AnyMarker()
 
         return MarkerUnion(*markers)
@@ -604,15 +654,37 @@ class MarkerUnion(BaseMarker):
         return False
 
     def without_extras(self):
+        return self.exclude("extra")
+
+    def exclude(self, marker_name):  # type: (str) -> BaseMarker
         new_markers = []
 
         for m in self._markers:
-            marker = m.without_extras()
+            if isinstance(m, SingleMarker) and m.name == marker_name:
+                # The marker is not relevant since it must be excluded
+                continue
+
+            marker = m.exclude(marker_name)
 
             if not marker.is_empty():
                 new_markers.append(marker)
 
-        return MarkerUnion(*new_markers)
+        return self.of(*new_markers)
+
+    def only(self, marker_name):  # type: (str) -> BaseMarker
+        new_markers = []
+
+        for m in self._markers:
+            if isinstance(m, SingleMarker) and m.name != marker_name:
+                # The marker is not relevant since it's not one we want
+                continue
+
+            marker = m.only(marker_name)
+
+            if not marker.is_empty():
+                new_markers.append(marker)
+
+        return self.of(*new_markers)
 
     def __eq__(self, other):
         if not isinstance(other, MarkerUnion):

--- a/tests/installation/fixtures/with-duplicate-dependencies-update.test
+++ b/tests/installation/fixtures/with-duplicate-dependencies-update.test
@@ -23,6 +23,7 @@ C = "1.5"
 [[package]]
 name = "C"
 version = "1.5"
+marker = "python_version >= \"2.7\""
 description = ""
 category = "main"
 optional = false

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1183,8 +1183,8 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
                     "checksum": [],
                     "dependencies": {
                         "B": [
-                            {"version": "^1.0", "python": "<4.0"},
-                            {"version": "^2.0", "python": ">=4.0"},
+                            {"version": "^1.0", "python": "<2.7"},
+                            {"version": "^2.0", "python": ">=2.7"},
                         ]
                     },
                 },
@@ -1197,7 +1197,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
                     "python-versions": "*",
                     "checksum": [],
                     "dependencies": {"C": "1.2"},
-                    "requirements": {"python": "<4.0"},
+                    "requirements": {"python": "<2.7"},
                 },
                 {
                     "name": "B",
@@ -1208,7 +1208,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
                     "python-versions": "*",
                     "checksum": [],
                     "dependencies": {"C": "1.5"},
-                    "requirements": {"python": ">=4.0"},
+                    "requirements": {"python": ">=2.7"},
                 },
                 {
                     "name": "C",

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -310,6 +310,24 @@ def test_marker_union_intersect_marker_union():
     )
 
 
+def test_marker_union_intersect_marker_union_drops_unnecessary_markers():
+    m = parse_marker(
+        'python_version >= "2.7" and python_version < "2.8" '
+        'or python_version >= "3.4" and python_version < "4.0"'
+    )
+    m2 = parse_marker(
+        'python_version >= "2.7" and python_version < "2.8" '
+        'or python_version >= "3.4" and python_version < "4.0"'
+    )
+
+    intersection = m.intersect(m2)
+    expected = (
+        'python_version >= "2.7" and python_version < "2.8" '
+        'or python_version >= "3.4" and python_version < "4.0"'
+    )
+    assert expected == str(intersection)
+
+
 def test_marker_union_intersect_multi_marker():
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
@@ -479,3 +497,110 @@ def test_parse_version_like_markers(marker, env):
     m = parse_marker(marker)
 
     assert m.validate(env)
+
+
+@pytest.mark.parametrize(
+    "marker, expected",
+    [
+        ('python_version >= "3.6"', 'python_version >= "3.6"'),
+        ('python_version >= "3.6" and extra == "foo"', 'python_version >= "3.6"'),
+        (
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar")',
+            'python_version >= "3.6"',
+        ),
+        (
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or implementation_name == "pypy"',
+            'python_version >= "3.6" or implementation_name == "pypy"',
+        ),
+        (
+            'python_version >= "3.6" and extra == "foo" or implementation_name == "pypy" and extra == "bar"',
+            'python_version >= "3.6" or implementation_name == "pypy"',
+        ),
+        (
+            'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
+            'python_version >= "3.6" or implementation_name == "pypy"',
+        ),
+    ],
+)
+def test_without_extras(marker, expected):
+    m = parse_marker(marker)
+
+    assert expected == str(m.without_extras())
+
+
+@pytest.mark.parametrize(
+    "marker, excluded, expected",
+    [
+        ('python_version >= "3.6"', "implementation_name", 'python_version >= "3.6"'),
+        ('python_version >= "3.6"', "python_version", "*"),
+        (
+            'python_version >= "3.6" and extra == "foo"',
+            "extra",
+            'python_version >= "3.6"',
+        ),
+        (
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar")',
+            "python_version",
+            '(extra == "foo" or extra == "bar")',
+        ),
+        (
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or implementation_name == "pypy"',
+            "python_version",
+            '(extra == "foo" or extra == "bar") or implementation_name == "pypy"',
+        ),
+        (
+            'python_version >= "3.6" and extra == "foo" or implementation_name == "pypy" and extra == "bar"',
+            "implementation_name",
+            'python_version >= "3.6" and extra == "foo" or extra == "bar"',
+        ),
+        (
+            'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
+            "implementation_name",
+            'python_version >= "3.6" or extra == "foo" or extra == "bar"',
+        ),
+    ],
+)
+def test_exclude(marker, excluded, expected):
+    m = parse_marker(marker)
+
+    if expected == "*":
+        assert m.exclude(excluded).is_any()
+    else:
+        assert expected == str(m.exclude(excluded))
+
+
+@pytest.mark.parametrize(
+    "marker, only, expected",
+    [
+        ('python_version >= "3.6"', "python_version", 'python_version >= "3.6"'),
+        (
+            'python_version >= "3.6" and extra == "foo"',
+            "python_version",
+            'python_version >= "3.6"',
+        ),
+        (
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar")',
+            "extra",
+            '(extra == "foo" or extra == "bar")',
+        ),
+        (
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or implementation_name == "pypy"',
+            "implementation_name",
+            'implementation_name == "pypy"',
+        ),
+        (
+            'python_version >= "3.6" and extra == "foo" or implementation_name == "pypy" and extra == "bar"',
+            "implementation_name",
+            'implementation_name == "pypy"',
+        ),
+        (
+            'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
+            "implementation_name",
+            'implementation_name == "pypy"',
+        ),
+    ],
+)
+def test_only(marker, only, expected):
+    m = parse_marker(marker)
+
+    assert expected == str(m.only(only))


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR fixes the propagation of environment markers for dependencies. Before this change, the environment markers where not properly propagated which could cause false reports of incompatibilities. For instance, if you had the `black` dependency with the `python_version >= '3.6' and implementation_name != 'pypy'` environment marker, the resolution would fail with the following message:

```
[SolverProblemError]
The current project's Python requirement (~2.7 || ^3.4) is not compatible with some of the required packages Python requirement:
  - black requires Python >=3.6

Because no versions of black match >19.10b0,<20.0
 and black (19.10b0) requires Python >=3.6, black is forbidden.
So, because my-package depends on black (^19.10b0), version solving failed.
```

This is obviously wrong since we specified `python_version >= '3.6'` but the marker was lost during the resolution.

I took this opportunity to improve the way we handle markers to avoid producing markers that are obviously wrong or that can't be satisfied.