### PR TITLE
fix: don't export local file dependency as editable (#897)

### DIFF
--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -94,7 +94,7 @@ class Exporter(object):
                 dependency.marker = package.marker
 
                 line = "{}".format(package.source_url)
-                if package.develop:
+                if package.develop and package.source_type in ["directory", "url"]:
                     line = "-e " + line
             else:
                 dependency = package.to_dependency()

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -94,7 +94,7 @@ class Exporter(object):
                 dependency.marker = package.marker
 
                 line = "{}".format(package.source_url)
-                if package.develop and package.source_type in ["directory", "url"]:
+                if package.develop and package.source_type == "directory":
                     line = "-e " + line
             else:
                 dependency = package.to_dependency()

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -603,7 +603,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages(tmp_dir, poetry
         content = f.read()
 
     expected = """\
--e tests/fixtures/distributions/demo-0.1.0.tar.gz
+tests/fixtures/distributions/demo-0.1.0.tar.gz
 """
 
     assert expected == content
@@ -644,7 +644,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
         content = f.read()
 
     expected = """\
--e tests/fixtures/distributions/demo-0.1.0.tar.gz; python_version < "3.7"
+tests/fixtures/distributions/demo-0.1.0.tar.gz; python_version < "3.7"
 """
 
     assert expected == content


### PR DESCRIPTION
At the moment local file dependencies are export as editable. This is not valid.

Fixes: #897

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
