### PR TITLE
Fix downloading packages from Simplepypi

### DIFF
--- a/poetry/utils/inspector.py
+++ b/poetry/utils/inspector.py
@@ -127,7 +127,7 @@ class Inspector:
                 gz = GzipFile(str(file_path))
                 suffix = ".tar.gz"
 
-            tar = tarfile.TarFile(str(file_path), fileobj=gz)
+            tar = tarfile.open(str(file_path))
 
         try:
             tar.extractall(os.path.join(str(file_path.parent), "unpacked"))

--- a/poetry/utils/inspector.py
+++ b/poetry/utils/inspector.py
@@ -114,17 +114,14 @@ class Inspector:
         # Still not dependencies found
         # So, we unpack and introspect
         suffix = file_path.suffix
-        gz = None
         if suffix == ".zip":
             tar = zipfile.ZipFile(str(file_path))
         else:
             if suffix == ".bz2":
-                gz = BZ2File(str(file_path))
                 suffixes = file_path.suffixes
                 if len(suffixes) > 1 and suffixes[-2] == ".tar":
                     suffix = ".tar.bz2"
             else:
-                gz = GzipFile(str(file_path))
                 suffix = ".tar.gz"
 
             tar = tarfile.open(str(file_path))
@@ -132,9 +129,6 @@ class Inspector:
         try:
             tar.extractall(os.path.join(str(file_path.parent), "unpacked"))
         finally:
-            if gz:
-                gz.close()
-
             tar.close()
 
         unpacked = file_path.parent / "unpacked"

--- a/poetry/utils/inspector.py
+++ b/poetry/utils/inspector.py
@@ -3,8 +3,6 @@ import os
 import tarfile
 import zipfile
 
-from bz2 import BZ2File
-from gzip import GzipFile
 from typing import Dict
 from typing import List
 from typing import Union


### PR DESCRIPTION
Hi! Submiting a small PR to fix issue breaking fetching packages from simplepypi repositories.

The reason is that simplepypi returns http header 'Content-encoding: gzip' and requests automatically decompresses these files (see http://docs.python-requests.org/en/master/user/quickstart/#raw-response-content). So the resulted file is not "gzipped" but only "tarred" and an exception is raised. This is described in https://github.com/python-poetry/poetry/issues/517
