### PR TITLE
Revert "create PEP508 compliant dependency string for directory and file dependencies (#1796)"

### DIFF
--- a/poetry/packages/directory_dependency.py
+++ b/poetry/packages/directory_dependency.py
@@ -74,17 +74,6 @@ class DirectoryDependency(Dependency):
     def develop(self):
         return self._develop
 
-    @property
-    def base_pep_508_name(self):  # type: () -> str
-        requirement = self.pretty_name
-
-        if self.extras:
-            requirement += "[{}]".format(",".join(self.extras))
-
-        requirement += " @ {}".format(self._path)
-
-        return requirement
-
     def supports_poetry(self):
         return self._supports_poetry
 

--- a/poetry/packages/file_dependency.py
+++ b/poetry/packages/file_dependency.py
@@ -49,17 +49,6 @@ class FileDependency(Dependency):
     def full_path(self):
         return self._full_path.resolve()
 
-    @property
-    def base_pep_508_name(self):  # type: () -> str
-        requirement = self.pretty_name
-
-        if self.extras:
-            requirement += "[{}]".format(",".join(self.extras))
-
-        requirement += " @ {}".format(self._path)
-
-        return requirement
-
     def is_file(self):
         return True
 

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -8,24 +8,12 @@ from poetry.utils.env import EnvCommandError
 from poetry.utils.env import MockEnv as BaseMockEnv
 
 
-fixtures_dir = Path(__file__).parent.parent / "fixtures"
-DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "demo"
-
-
 class MockEnv(BaseMockEnv):
     def run(self, bin, *args):
         raise EnvCommandError(CalledProcessError(1, "python", output=""))
 
 
-def test_directory_dependency():
-    dependency = DirectoryDependency("simple_project", fixtures_dir / "simple_project")
-
-    assert dependency.pretty_name == "simple_project"
-    assert dependency.develop
-    assert dependency.path == fixtures_dir / "simple_project"
-    assert dependency.base_pep_508_name == "simple_project @ {}".format(
-        fixtures_dir / "simple_project"
-    )
+DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "demo"
 
 
 def test_directory_dependency_must_exist():

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -7,16 +7,6 @@ from poetry.utils._compat import Path
 DIST_PATH = Path(__file__).parent.parent / "fixtures" / "distributions"
 
 
-def test_file_dependency():
-    dependency = FileDependency("demo", DIST_PATH / "demo-0.1.0.tar.gz")
-
-    assert dependency.pretty_name == "demo"
-    assert dependency.path == DIST_PATH / "demo-0.1.0.tar.gz"
-    assert dependency.base_pep_508_name == "demo @ {}".format(
-        DIST_PATH / "demo-0.1.0.tar.gz"
-    )
-
-
 def test_file_dependency_wrong_path():
     with pytest.raises(ValueError):
         FileDependency("demo", DIST_PATH / "demo-0.2.0.tar.gz")


### PR DESCRIPTION
This reverts commit 10e471a0e6a916acd4b6b1bf5362a0d7054ebc04.

## Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

#1796 is causing errors when directory and file dependencies are present in the `pyproject.toml`
 file. This is caused by the PEP-508 compliant dependency strings being added to the generated `setup.py` file which is not currently supported.