### PR TITLE
get_requires_for_build_wheel must return additional build requirements and not dependencies (#1689)

### DIFF
--- a/poetry/masonry/api.py
+++ b/poetry/masonry/api.py
@@ -20,13 +20,14 @@ log = logging.getLogger(__name__)
 
 def get_requires_for_build_wheel(config_settings=None):
     """
-    Returns a list of requirements for building, as strings
+    Returns an additional list of requirements for building, as PEP508 strings,
+    above and beyond those specified in the pyproject.toml file.
+
+    This implementation is optional. At the moment it only returns an empty list, which would be the same as if
+    not define. So this is just for completeness for future implementation.
     """
-    poetry = Factory().create_poetry(Path("."))
 
-    main, _ = SdistBuilder.convert_dependencies(poetry.package, poetry.package.requires)
-
-    return main
+    return []
 
 
 # For now, we require all dependencies to build either a wheel or an sdist.

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -28,15 +28,15 @@ fixtures = os.path.join(os.path.dirname(__file__), "builders", "fixtures")
 
 
 def test_get_requires_for_build_wheel():
-    expected = ["cleo>=0.6.0,<0.7.0", "cachy[msgpack]>=0.2.0,<0.3.0"]
+    expected = []
     with cwd(os.path.join(fixtures, "complete")):
-        api.get_requires_for_build_wheel() == expected
+        assert api.get_requires_for_build_wheel() == expected
 
 
 def test_get_requires_for_build_sdist():
-    expected = ["cleo>=0.6.0,<0.7.0", "cachy[msgpack]>=0.2.0,<0.3.0"]
+    expected = []
     with cwd(os.path.join(fixtures, "complete")):
-        api.get_requires_for_build_sdist() == expected
+        assert api.get_requires_for_build_sdist() == expected
 
 
 def test_build_wheel():


### PR DESCRIPTION
At the moment `get_requires_for_build_wheel` and `get_requires_for_build_sdist` returns the dependencies of the packages. This is wrong. According to PEP517 they should return additional requirements, not listed in the `pyproject.toml`, needed to build the package. 

The implementation of this methods is optional. If not implemented the default value is treated as an empty list. For completeness I would keep these method for maybe future implementation, but for now they return just an empty list.

Fixes: #1689

Thanks to @wakemaster39 for providing the correct input for this solution :+1: 

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
