### PR TITLE
get-poetry.py fallback to standard executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poet
 
 Alternatively, you can download the `get-poetry.py` file and execute it separately.
 
+The setup script must be able to find one of following executables in your shell's path environment:
+
+- `python` (which can be a py3 or py2 interpreter)
+- `python3`
+- `py.exe -3` (Windows)
+- `py.exe -2` (Windows)
+
 If you want to install prerelease versions, you can do so by passing `--preview` to `get-poetry.py`:
 
 ```bash

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -591,7 +591,7 @@ class Installer:
 
         for executable in allowed_executables:
             try:
-                subprocess.check_call(executable + "--version", shell=True)
+                subprocess.check_call(executable + " --version", shell=True)
             except subprocess.CalledProcessError:
                 continue
 

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -590,6 +590,7 @@ class Installer:
         if WINDOWS:
             allowed_executables += ["py.exe -3", "py.exe -2"]
 
+        # \d in regex ensures we can convert to int later
         version_matcher = re.compile(r"^Python (?P<major>\d+)\.(?P<minor>\d+)\..+$")
         fallback = None
         for executable in allowed_executables:
@@ -601,10 +602,11 @@ class Installer:
                 continue
 
             match = version_matcher.match(raw_version.strip())
-            if match and int(match.groupdict()["major"]) >= 3:
+            if match and tuple(map(int, match.groups())) >= (3, 5):
+                # favor the first py3.5+ executable we can find.
                 return executable
             if fallback is None:
-                # keep this one as the fallback; it was the first valid exec we found.
+                # keep this one as the fallback; it was the first valid executable we found.
                 fallback = executable
 
         if fallback is None:

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -602,8 +602,8 @@ class Installer:
                 continue
 
             match = version_matcher.match(raw_version.strip())
-            if match and tuple(map(int, match.groups())) >= (3, 5):
-                # favor the first py3.5+ executable we can find.
+            if match and tuple(map(int, match.groups())) >= (3, 0):
+                # favor the first py3 executable we can find.
                 return executable
             if fallback is None:
                 # keep this one as the fallback; it was the first valid executable we found.


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

I wasn't sure how to spin new tests here; I believe the get-poetry.py script isn't part of the test suite, is that possible?

This makes the installation more flexible by allowing `python3` on linux (when `python` cannot be found; typical in a lot of 2 -> 3 migration scenarios).

On windows, we add some basic support for [PEP 397](https://www.python.org/dev/peps/pep-0397/) by leveraging the `py.exe` launcher. Since Windows uses the .bat file to launch the .py file, I removed the shebang from the windows launcher so that we don't end up writing `/usr/bin/env py.exe -3` :sweat_smile: 

fixes #1877