### PR TITLE
Lazy Keyring intialization for PasswordManager

### DIFF
--- a/poetry/utils/password_manager.py
+++ b/poetry/utils/password_manager.py
@@ -117,35 +117,40 @@ class KeyRing:
 class PasswordManager:
     def __init__(self, config):
         self._config = config
-        self._keyring = KeyRing("poetry-repository")
-        if not self._keyring.is_available():
-            logger.warning("Using a plaintext file to store and retrieve credentials")
+        self._keyring = None
 
     @property
     def keyring(self):
+        if self._keyring is None:
+            self._keyring = KeyRing("poetry-repository")
+            if not self._keyring.is_available():
+                logger.warning(
+                    "Using a plaintext file to store and retrieve credentials"
+                )
+
         return self._keyring
 
     def set_pypi_token(self, name, token):
-        if not self._keyring.is_available():
+        if not self.keyring.is_available():
             self._config.auth_config_source.add_property(
                 "pypi-token.{}".format(name), token
             )
         else:
-            self._keyring.set_password(name, "__token__", token)
+            self.keyring.set_password(name, "__token__", token)
 
     def get_pypi_token(self, name):
-        if not self._keyring.is_available():
+        if not self.keyring.is_available():
             return self._config.get("pypi-token.{}".format(name))
 
-        return self._keyring.get_password(name, "__token__")
+        return self.keyring.get_password(name, "__token__")
 
     def delete_pypi_token(self, name):
-        if not self._keyring.is_available():
+        if not self.keyring.is_available():
             return self._config.auth_config_source.remove_property(
                 "pypi-token.{}".format(name)
             )
 
-        self._keyring.delete_password(name, "__token__")
+        self.keyring.delete_password(name, "__token__")
 
     def get_http_auth(self, name):
         auth = self._config.get("http-basic.{}".format(name))
@@ -154,7 +159,7 @@ class PasswordManager:
 
         username, password = auth["username"], auth.get("password")
         if password is None:
-            password = self._keyring.get_password(name, username)
+            password = self.keyring.get_password(name, username)
 
         return {
             "username": username,
@@ -164,10 +169,10 @@ class PasswordManager:
     def set_http_password(self, name, username, password):
         auth = {"username": username}
 
-        if not self._keyring.is_available():
+        if not self.keyring.is_available():
             auth["password"] = password
         else:
-            self._keyring.set_password(name, username, password)
+            self.keyring.set_password(name, username, password)
 
         self._config.auth_config_source.add_property("http-basic.{}".format(name), auth)
 
@@ -177,7 +182,7 @@ class PasswordManager:
             return
 
         try:
-            self._keyring.delete_password(name, auth["username"])
+            self.keyring.delete_password(name, auth["username"])
         except KeyRingError:
             pass
 


### PR DESCRIPTION
When one specify a source in the `pyproject.toml`, a PasswordManager instance is initialized in the factory function, in order to extract the Basic Auth credentials from the config. While this is fine, this had the undesirable effect to instantiate the Keyring, even when it's not needed.

I had two concerns with this:
- I don't have a keyring on my system, so every Poetry command was printing a warning. I don't really want this warning unless I'm doing stuff related to credentials, like `poetry publish`
- Initializing the keyring adds a small delay to Poetry startup. A very rough estimation on my computer tells me it's about 50 to 100ms, it might be more on slower systems.

Another solution would be to make the parsing of parts of the configuration lazy, so that we don't lead the sources if we don't need to. But that's way more intrusive & bug prone.