### PR TITLE
Fix how repository credentials are retrieved from env vars

### DIFF
--- a/poetry/utils/password_manager.py
+++ b/poetry/utils/password_manager.py
@@ -155,11 +155,14 @@ class PasswordManager:
     def get_http_auth(self, name):
         auth = self._config.get("http-basic.{}".format(name))
         if not auth:
-            return None
-
-        username, password = auth["username"], auth.get("password")
-        if password is None:
-            password = self.keyring.get_password(name, username)
+            username = self._config.get("http-basic.{}.username".format(name))
+            password = self._config.get("http-basic.{}.password".format(name))
+            if not username and not password:
+                return None
+        else:
+            username, password = auth["username"], auth.get("password")
+            if password is None:
+                password = self.keyring.get_password(name, username)
 
         return {
             "username": username,

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from keyring.backend import KeyringBackend
@@ -208,3 +210,17 @@ def test_keyring_with_chainer_backend_and_not_compatible_only_should_be_unavaila
     key_ring = KeyRing("poetry")
 
     assert not key_ring.is_available()
+
+
+def test_get_http_auth_from_environment_variables(
+    environ, config, mock_available_backend
+):
+    os.environ["POETRY_HTTP_BASIC_FOO_USERNAME"] = "bar"
+    os.environ["POETRY_HTTP_BASIC_FOO_PASSWORD"] = "baz"
+
+    manager = PasswordManager(config)
+
+    auth = manager.get_http_auth("foo")
+
+    assert "bar" == auth["username"]
+    assert "baz" == auth["password"]


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR fixes the issue where repository credentials were not retrieve from the environment variables as documented here: https://python-poetry.org/docs/repositories/#configuring-credentials

Fixes #1807 