### PR TITLE
Fix errors when using the --help option

### DIFF
--- a/poetry/console/config/application_config.py
+++ b/poetry/console/config/application_config.py
@@ -9,6 +9,7 @@ from clikit.api.event import PRE_HANDLE
 from clikit.api.event import PreHandleEvent
 from clikit.api.event import PreResolveEvent
 from clikit.api.event.event_dispatcher import EventDispatcher
+from clikit.api.exceptions import CliKitException
 from clikit.api.formatter import Style
 from clikit.api.io import Input
 from clikit.api.io import InputStream
@@ -101,7 +102,16 @@ class ApplicationConfig(BaseApplicationConfig):
         if args.has_option_token("-h") or args.has_option_token("--help"):
             from clikit.api.resolver import ResolvedCommand
 
-            resolved_command = self.command_resolver.resolve(args, application)
+            try:
+                resolved_command = self.command_resolver.resolve(args, application)
+            except CliKitException:
+                # We weren't able to resolve the command,
+                # due to a parse error most likely,
+                # so we fall back on the default behavior
+                return super(ApplicationConfig, self).resolve_help_command(
+                    event, event_name, dispatcher
+                )
+
             # If the current command is the run one, skip option
             # check and interpret them as part of the executed command
             if resolved_command.command.name == "run":


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR fixes the behavior of the `--help` option for some commands where it would cause an error. This was due to the fact that we were trying to resolve an incomplete command. Now if the command cannot be resolved we will fall back on the default CliKit behavior.

Fixes #1625 