### PR TITLE
Fix handling of forward slashes and url encoding in credentials

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -51,10 +51,10 @@ except ImportError:
 
 
 try:
-    from urllib.parse import quote, unquote
+    from urllib.parse import quote
 
 except ImportError:
-    from urllib import quote, unquote
+    from urllib import quote
 
 
 with warnings.catch_warnings():
@@ -221,8 +221,8 @@ class LegacyRepository(PyPiRepository):
 
         return "{scheme}://{username}:{password}@{netloc}{path}".format(
             scheme=parsed.scheme,
-            username=quote(unquote(self._auth.auth.username), safe=""),
-            password=quote(unquote(self._auth.auth.password), safe=""),
+            username=quote(self._auth.auth.username, safe=""),
+            password=quote(self._auth.auth.password, safe=""),
             netloc=parsed.netloc,
             path=parsed.path,
         )

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -51,9 +51,10 @@ except ImportError:
 
 
 try:
-    from urllib.parse import quote
+    from urllib.parse import quote, unquote
+
 except ImportError:
-    from urllib import quote
+    from urllib import quote, unquote
 
 
 with warnings.catch_warnings():
@@ -220,8 +221,8 @@ class LegacyRepository(PyPiRepository):
 
         return "{scheme}://{username}:{password}@{netloc}{path}".format(
             scheme=parsed.scheme,
-            username=quote(self._auth.auth.username),
-            password=quote(self._auth.auth.password),
+            username=quote(unquote(self._auth.auth.username), safe=""),
+            password=quote(unquote(self._auth.auth.password), safe=""),
             netloc=parsed.netloc,
             path=parsed.path,
         )

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -267,7 +267,7 @@ def test_get_package_retrieves_packages_with_no_hashes():
 
 
 def test_username_password_special_chars():
-    auth = Auth("http://foo.bar", "user:", "p@ssword")
+    auth = Auth("http://foo.bar", "user:", "/%2Fp@ssword")
     repo = MockRepository(auth=auth)
 
-    assert "http://user%3A:p%40ssword@foo.bar" == repo.authenticated_url
+    assert "http://user%3A:%2F%2Fp%40ssword@foo.bar" == repo.authenticated_url

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -270,4 +270,4 @@ def test_username_password_special_chars():
     auth = Auth("http://foo.bar", "user:", "/%2Fp@ssword")
     repo = MockRepository(auth=auth)
 
-    assert "http://user%3A:%2F%2Fp%40ssword@foo.bar" == repo.authenticated_url
+    assert "http://user%3A:%2F%252Fp%40ssword@foo.bar" == repo.authenticated_url


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

## Problem
- Credentials containing `/` do not urlencode it, since `quote()` passes the `safe='/'` by default 

## Solution
- Pass `safe=''` so that `/` is encoded properly