### PR TITLE
Make Poetry executable use python3 from path if >= 3.5

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -197,8 +197,23 @@ POETRY_LIB = os.path.join(POETRY_HOME, "lib")
 POETRY_LIB_BACKUP = os.path.join(POETRY_HOME, "lib-backup")
 
 
-BIN = """#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+BIN = """#!/bin/sh
+# This script is bilingual.
+# The first part is POSIX shell, and the second part Python.
+""\":"
+check_version() {
+    version=$( ($1 --version  2>&1 | cut -d ' ' -f2) || echo '0.0.0')
+    maj=$(echo $version | cut -d '.' -f1)
+    min=$(echo $version | cut -d '.' -f2)
+    [ $maj -ge 3 ] && [ $min -ge 5 ] && return 0
+    return 1
+}
+
+check_version python && exec python $0 "$@"
+check_version python3 && exec python3 $0 "$@"
+exec python $0 "$@"
+":""\"
+
 import glob
 import sys
 import os


### PR DESCRIPTION
Currently SetupReader only works with Python versions >=3.5 -- but on some versions of Ubuntu and Debian, Poetry may run under Python 2, even when Python 3 is available.

On some distributions /usr/bin/python is still Python 2 by default and /usr/bin/python3 is Python 3. pyenv follows a similar convention, shimming both the python and python3 executables.

This patch changes the poetry executable to first use the python executable, if it is >= 3.5, then use the python3 executable, if it is >= 3.5, and otherwise fall back to whichever version is available under python.