### PR TITLE
Use install_egg_info as backup to create egg for old distutils packages

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -329,7 +329,11 @@ class Provider:
                 with temporary_directory() as tmp_dir:
                     EnvManager.build_venv(tmp_dir)
                     venv = VirtualEnv(Path(tmp_dir), Path(tmp_dir))
-                    venv.run("python", "setup.py", "egg_info")
+                    try:
+                        venv.run("python", "setup.py", "egg_info")
+                    except EnvCommandError:
+                        # Try a backup for old distutils based packages
+                        venv.run("python", "setup.py", "install_egg_info", "-d", ".")
             except EnvCommandError:
                 result = SetupReader.read_from_directory(directory)
                 if not result["name"]:


### PR DESCRIPTION
For old distutils based packages setup.py egg_info will not create an egg_info, and so we must fall back to SetupReader. This doesn't work on Python < 3.5 so it would be nice to get an egg_info if possible. It appears that some versions of distutils allow us to get an egg_info using install_egg_info. This patch just adds that as an extra backup before resorting to SetupReader.