### PR TITLE
fix: correct parsing of wheel version with regex.

### DIFF
--- a/poetry/packages/__init__.py
+++ b/poetry/packages/__init__.py
@@ -2,6 +2,7 @@ import os
 import re
 
 from poetry.semver import Version
+from poetry.utils.patterns import wheel_file_re
 from poetry.version.requirements import Requirement
 
 from .dependency import Dependency
@@ -70,7 +71,7 @@ def dependency_from_pep_508(name):
             link = Link(path_to_url(os.path.normpath(os.path.abspath(link.path))))
         # wheel file
         if link.is_wheel:
-            m = re.match(r"^(?P<namever>(?P<name>.+?)-(?P<ver>\d.*?))", link.filename)
+            m = wheel_file_re.match(link.filename)
             if not m:
                 raise ValueError("Invalid wheel name: {}".format(link.filename))
 

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -191,3 +191,14 @@ def test_dependency_from_pep_508_with_url():
     assert "django-utils" == dep.name
     assert dep.is_url()
     assert "https://example.com/django-utils-1.0.0.tar.gz" == dep.url
+
+
+def test_dependency_from_pep_508_with_wheel_url():
+    name = (
+        "example_wheel @ https://example.com/example_wheel-14.0.2-py2.py3-none-any.whl"
+    )
+
+    dep = dependency_from_pep_508(name)
+
+    assert "example-wheel" == dep.name
+    assert str(dep.constraint) == "14.0.2"


### PR DESCRIPTION
The previous regexp was only taking the first integer of the version number,
this presented problems when the major version number reached double digits.

Poetry would determine that the version of the dependency is '1', rather than,
ie: '14'. This caused failures to solve versions.

Detailed description of issue in bug report that I filed here: https://github.com/python-poetry/poetry/issues/1931

This fixes the issue for me and allows `poetry update` to correctly solve versions when a wheel file is referenced with a version >=10.

Unrelated to the specifics of this bug, but I noticed that when parsing a url to a wheel it does not return a `URLDependency` like non-wheel based urls but a `Dependency` instance. Therefore `dep.is_url()` returns `False` and the dependency only contains the name and parsed version as the constraint, the url itself is discarded. I'm not sure if this is intended or not?

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. _not appropriate_