### PR TITLE
get_vcs starts searching git folder from tmp dir instead of project (#1946)

### DIFF
--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -75,7 +75,9 @@ class Builder(object):
     @lru_cache(maxsize=None)
     def find_excluded_files(self):  # type: () -> Set[str]
         # Checking VCS
-        vcs = get_vcs(self._path)
+        vcs = get_vcs(
+            self._original_path if hasattr(self, "_original_path") else self._path
+        )
         if not vcs:
             vcs_ignored_files = set()
         else:

--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -44,6 +44,7 @@ class Builder(object):
         self._io = io
         self._package = poetry.package
         self._path = poetry.file.parent
+        self._original_path = self._path
 
         packages = []
         for p in self._package.packages:
@@ -75,9 +76,7 @@ class Builder(object):
     @lru_cache(maxsize=None)
     def find_excluded_files(self):  # type: () -> Set[str]
         # Checking VCS
-        vcs = get_vcs(
-            self._original_path if hasattr(self, "_original_path") else self._path
-        )
+        vcs = get_vcs(self._original_path)
         if not vcs:
             vcs_ignored_files = set()
         else:

--- a/poetry/vcs/__init__.py
+++ b/poetry/vcs/__init__.py
@@ -8,6 +8,7 @@ from .git import Git
 
 
 def get_vcs(directory):  # type: (Path) -> Git
+    working_dir = Path.cwd()
     os.chdir(str(directory))
 
     try:
@@ -17,8 +18,11 @@ def get_vcs(directory):  # type: (Path) -> Git
             )
         ).strip()
 
-        return Git(Path(git_dir))
+        vcs = Git(Path(git_dir))
 
     except subprocess.CalledProcessError:
+        vcs = None
+    finally:
+        os.chdir(str(working_dir))
 
-        return
+    return vcs

--- a/poetry/vcs/__init__.py
+++ b/poetry/vcs/__init__.py
@@ -9,7 +9,7 @@ from .git import Git
 
 def get_vcs(directory):  # type: (Path) -> Git
     working_dir = Path.cwd()
-    os.chdir(str(directory))
+    os.chdir(str(directory.resolve()))
 
     try:
         git_dir = decode(


### PR DESCRIPTION
At the moment, when building sdist and wheel the wheel is created from the unpacked sdist in a tmp dir. When trying to find the excluded file by git it starts searching the `.git` folder from this tmp dir instead of the original path.

This PR fixes this.

Furthermore `git rev-parse --show-toplevel` is used to get the git's root folder instead of finding a folder called `.git`. This should be more reliable.

I have no idea how to test this. So any help would be useful :)

Fixes: #1946 

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
