### PR TITLE
fix(git): get commit sha of git commit from annotated tags

### DIFF
--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -229,9 +229,9 @@ class Git:
                 folder.as_posix(),
             ]
 
-        # git rev-list TAG --max-count=1 works with annotated and
-        # non-annotated tags.
-        args += ["rev-list", rev, "--max-count=1"]
+        # We need "^{commit}" to ensure that the commit SHA of the commit the
+        # tag points to is returned, even in the case of annotated tags.
+        args += ["rev-parse", rev + "^{commit}"]
 
         return self.run(*args)
 

--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -231,7 +231,7 @@ class Git:
 
         # git rev-list TAG --max-count=1 works with annotated and
         # non-annotated tags.
-        args += ["rev-list", rev, '--max-count=1']
+        args += ["rev-list", rev, "--max-count=1"]
 
         return self.run(*args)
 

--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -229,7 +229,9 @@ class Git:
                 folder.as_posix(),
             ]
 
-        args += ["rev-parse", rev]
+        # git rev-list TAG --max-count=1 works with annotated and
+        # non-annotated tags.
+        args += ["rev-list", rev, '--max-count=1']
 
         return self.run(*args)
 


### PR DESCRIPTION
# Description

This is an attempt to close #1916. I think all we need to do is make sure that the revision always points to the SHA of the commit in question and not the SHA of the tag object.
There is a question on stackoverflow [here](https://stackoverflow.com/questions/1862423/how-to-tell-which-commit-a-tag-points-to-in-git) about this, where a few solutions are listed.
I chose the command `git rev-list TAG --max-count=1`

# Testing and Documentation
I have tested this on a regular tag and annotated tag at the command line and they both pointed to the right corresponding commit hash. However, I have not tested this by running poetry itself.

For the tests, I am not sure how to test this other than generating a fake git repo and creating commits. Let me know if you would prefer that and I'll try to find out how to do it.
For the documentation, I left a comment by the call to explain the purpose of this command. It's not ideal, but I can't think of where else to put documentation.