### PR TITLE
Fix SetupReader crashing on a nested function call.

### DIFF
--- a/poetry/utils/setup_reader.py
+++ b/poetry/utils/setup_reader.py
@@ -183,6 +183,7 @@ class SetupReader(object):
             func = value.func
             if not (isinstance(func, ast.Name) and func.id == "setup") and not (
                 isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
                 and hasattr(func.value, "id")
                 and func.value.id == "setuptools"
                 and func.attr == "setup"

--- a/tests/utils/fixtures/setups/graphene/setup.py
+++ b/tests/utils/fixtures/setups/graphene/setup.py
@@ -1,0 +1,86 @@
+import ast
+import codecs
+import re
+import sys
+
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
+
+_version_re = re.compile(r"VERSION\s+=\s+(.*)")
+
+with open("graphene/__init__.py", "rb") as f:
+    version = ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
+
+path_copy = sys.path[:]
+
+sys.path.append("graphene")
+try:
+    from pyutils.version import get_version
+
+    version = get_version(version)
+except Exception:
+    version = ".".join([str(v) for v in version])
+
+sys.path[:] = path_copy
+
+
+class PyTest(TestCommand):
+    user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
+
+tests_require = [
+    "pytest",
+    "pytest-benchmark",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-asyncio",
+    "snapshottest",
+    "coveralls",
+    "promise",
+    "six",
+    "mock",
+    "pytz",
+    "iso8601",
+]
+
+setup(
+    name="graphene",
+    version="3.0.2",
+    description="GraphQL Framework for Python",
+    long_description=codecs.open(
+        "README.rst", "r", encoding="ascii", errors="replace"
+    ).read(),
+    url="https://github.com/graphql-python/graphene",
+    author="Syrus Akbary",
+    author_email="me@syrusakbary.com",
+    license="MIT",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    keywords="api graphql protocol rest relay graphene",
+    packages=find_packages(exclude=["tests", "tests.*", "examples"]),
+    install_requires=["graphql-core>=3.0.0a0,<4", "aniso8601>=6,<8",],
+    tests_require=tests_require,
+    extras_require={"test": tests_require},
+    cmdclass={"test": PyTest},
+)

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -98,6 +98,37 @@ def test_setup_reader_read_sub_level_setup_call_with_direct_types(setup):
     assert result["python_requires"] is None
 
 
+@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
+def test_setup_reader_allow_nested_calls(setup):
+    result = SetupReader.read_from_directory(setup("graphene"))
+
+    expected_name = "graphene"
+    expected_version = "3.0.2"
+    expected_install_requires = ["graphql-core>=3.0.0a0,<4", "aniso8601>=6,<8"]
+    expected_extras_require = {
+        "test": [
+            "pytest",
+            "pytest-benchmark",
+            "pytest-cov",
+            "pytest-mock",
+            "pytest-asyncio",
+            "snapshottest",
+            "coveralls",
+            "promise",
+            "six",
+            "mock",
+            "pytz",
+            "iso8601",
+        ]
+    }
+
+    assert expected_name == result["name"]
+    assert expected_version == result["version"]
+    assert expected_install_requires == result["install_requires"]
+    assert expected_extras_require == result["extras_require"]
+    assert result["python_requires"] is None
+
+
 def test_setup_reader_read_setup_cfg(setup):
     result = SetupReader.read_from_directory(setup("with-setup-cfg"))
 


### PR DESCRIPTION
When SetupReader encountered a call such as `sys.path.append()`, it crashed, trying to read the `path` ast.Attribute value as a ast.Name. `graphene` is a package where this occurred in the wild.


# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!