### PR TITLE
Support using environment variables to configure username and passwords

### DIFF
--- a/poetry/utils/password_manager.py
+++ b/poetry/utils/password_manager.py
@@ -148,11 +148,19 @@ class PasswordManager:
         self._keyring.delete_password(name, "__token__")
 
     def get_http_auth(self, name):
+        username = self._config.get("http-basic.{}.username".format(name))
+        password = self._config.get("http-basic.{}.password".format(name))
         auth = self._config.get("http-basic.{}".format(name))
-        if not auth:
+
+        if not auth and not (username or password):
             return None
 
-        username, password = auth["username"], auth.get("password")
+        if not username:
+            username = auth['username']
+
+        if not password:
+            password = auth.get('password')
+
         if password is None:
             password = self._keyring.get_password(name, username)
 


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

As per #1871 you cannot configure HTTP basic auth using environment variables. This is a problem for a lot of use cases:

1. Docker - using build time secrets means you can inject the HTTP basic auth configuration as an environment and download packages from a private repository without including this information in the resulting container. That's harder to do if you execute `poetry config ...`.

2. User onboarding - many companies inject credentials into laptops as environment variables, and tools should be configured to work with those with a minimum of configuration. Simply having `POETRY_HTTP_BASIC_MY_INTERNAL_PYPI_USERNAME` and  `POETRY_HTTP_BASIC_MY_INTERNAL_PYPI_PASSWORD` should be sufficient.