### PR TITLE
Update pip to defined versions after creating a new venv [feature]

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -698,7 +698,8 @@ class EnvManager(object):
             "pip",
             "install",
             "--upgrade",
-            "pip>={},<={}".format(PIP_VERSION_MIN, PIP_VERSION_MAX),
+            '"pip>={},<={}"'.format(PIP_VERSION_MIN, PIP_VERSION_MAX),
+            shell=True,
         )
 
     def remove_venv(self, path):  # type: (str) -> None

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -11,6 +11,7 @@ from poetry.factory import Factory
 from poetry.semver import Version
 from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import Path
+from poetry.utils.env import PIP_VERSION_MAX
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import EnvManager
 from poetry.utils.env import NoCompatiblePythonVersionFound
@@ -573,6 +574,11 @@ def test_run_with_input_non_zero_return(tmp_dir, tmp_venv):
         tmp_venv.run("python", "-", input_=ERRORING_SCRIPT)
 
     assert processError.value.e.returncode == 1
+
+
+def test_env_pip_version(tmp_dir, tmp_venv):
+    venv_pip_version = tmp_venv.run("pip", "-V", shell=True)
+    assert venv_pip_version.split()[:2] == ["pip", PIP_VERSION_MAX]
 
 
 def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_ones_first(


### PR DESCRIPTION
Until now, a new venv created with poetry would have an undefined pip version (for example, in my setup it's pip 18.1). This could be problematic, as older pip versions are not compatible with some packages (manylinux2010/2014 packages - for example, tensorflow 2), and might have security risks. On the other hand, future pip versions might introduce API changes that will prevent poetry from working.

This code forces new venvs to update their pip to a version from a defined range of versions. Updating pip happens just after the venv creation (and not each time before package installation). This will allow users to manually change it if the need arises.

Code is loosely based on https://github.com/python-poetry/poetry/pull/740

I know that the need for internet connectivity in venv creation might be an issue, but I was not sure how to tackle it, and I wanted to get feedback on this code first.

### Closes:
closes #732 (partially - this PR does not install setuptools)
closes #1661
closes #1962
closes #1651

### Pull Request Check List
- [x] Added **tests** for changed code.
Tests were passing in my setup, but might need tweaking to pass with different setups (i.e. python 3.4)
- [x] Updated **documentation** for changed code.
No relevant documentation found, but I did my best to add relevant comments. 
Should I update the changelog?
