### PR TITLE
sdist builder - include long description content type

### DIFF
--- a/poetry/masonry/builders/sdist.py
+++ b/poetry/masonry/builders/sdist.py
@@ -30,6 +30,7 @@ setup_kwargs = {{
     'version': {version!r},
     'description': {description!r},
     'long_description': {long_description!r},
+    'long_description_content_type': {long_description_content_type!r},
     'author': {author!r},
     'author_email': {author_email!r},
     'maintainer': {maintainer!r},
@@ -185,6 +186,9 @@ class SdistBuilder(Builder):
                 version=to_str(self._meta.version),
                 description=to_str(self._meta.summary),
                 long_description=to_str(self._meta.description),
+                long_description_content_type=to_str(
+                    self._meta.description_content_type
+                ),
                 author=to_str(self._meta.author),
                 author_email=to_str(self._meta.author_email),
                 maintainer=to_str(self._meta.maintainer),

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -126,6 +126,7 @@ def test_make_setup():
         "my_package.sub_pkg2",
         "my_package.sub_pkg3",
     ]
+    assert ns["setup_kwargs"]["long_description_content_type"] == "text/x-rst"
     assert ns["install_requires"] == ["cachy[msgpack]>=0.2.0,<0.3.0", "cleo>=0.6,<0.7"]
     assert ns["entry_points"] == {
         "console_scripts": [


### PR DESCRIPTION
minor change to include long description content type for sdist builder masonry along with test.

I was using a variant of the script here https://github.com/python-poetry/poetry/issues/761#issuecomment-568229920 to generate setup.py for compatibility with existing users while we transition to poetry.
