### PR TITLE
cli export - show valid formats on err

### DIFF
--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -29,7 +29,11 @@ class ExportCommand(Command):
         fmt = self.option("format")
 
         if fmt not in Exporter.ACCEPTED_FORMATS:
-            raise ValueError("Invalid export format: {}".format(fmt))
+            raise ValueError(
+                "Invalid export format: {} valid formats: {}".format(
+                    fmt, ", ".join(Exporter.ACCEPTED_FORMATS)
+                )
+            )
 
         output = self.option("output")
 


### PR DESCRIPTION
if a user passes in a bad value, tell them what the possible good values are. the valid ones aren't in --help for the command, rather than making them find the website docs or read the source, just tell them.

Resolves: #1893