### PR TITLE
get-poetry.py now allows users to opt-out of PATH modifications

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -962,8 +962,8 @@ def main():
         preview=args.preview or string_to_bool(os.getenv("POETRY_PREVIEW", "0")),
         force=args.force,
         accept_all=args.accept_all
-                   or string_to_bool(os.getenv("POETRY_ACCEPT", "0"))
-                   or not is_interactive(),
+        or string_to_bool(os.getenv("POETRY_ACCEPT", "0"))
+        or not is_interactive(),
         modify_path=not args.no_modify_path,
         base_url=base_url,
     )


### PR DESCRIPTION
I could not find any tests/ docs for `get-poetry.py` but I am happy to update them if someone can point me in the right direction.

This change is intended to maintain backwards compatibility with the existing behavior, that said I think it might be worth reconsidering the default behavior. I will open a separate issue about that :)

This is related to #898. 

# Changelog

**[cb2c081] get-poetry.py now allows users to opt-out of PATH modifications**
The previous logic only allows a user to opt-out of PATH changes IFF
running from an interactive installation (e.g. an installation with a
shell). This change...

1. Adds a flag `--no-modify-path` that allows a user to opt out of path
   mangling from non-interactive installs.
2. Adds a confirmation prompt for interactive installs so that users
   have the opportunity to bail from the installation if they wish.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
