### PR TITLE
Add --no-freeze option to poetry export

### DIFF
--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -23,6 +23,7 @@ class ExportCommand(Command):
             multiple=True,
         ),
         option("with-credentials", None, "Include credentials for extra indices."),
+        option("no-freeze", None, "Do not freeze version"),
     ]
 
     def handle(self):
@@ -65,4 +66,5 @@ class ExportCommand(Command):
             dev=self.option("dev"),
             extras=self.option("extras"),
             with_credentials=self.option("with-credentials"),
+            no_freeze=self.option("no-freeze"),
         )

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -32,7 +32,8 @@ class Exporter(object):
         dev=False,
         extras=None,
         with_credentials=False,
-    ):  # type: (str, Path, Union[IO, str], bool, bool, bool) -> None
+        no_freeze=False,
+    ):  # type: (str, Path, Union[IO, str], bool, bool, bool, bool) -> None
         if fmt not in self.ACCEPTED_FORMATS:
             raise ValueError("Invalid export format: {}".format(fmt))
 
@@ -43,6 +44,7 @@ class Exporter(object):
             dev=dev,
             extras=extras,
             with_credentials=with_credentials,
+            no_freeze=no_freeze,
         )
 
     def _export_requirements_txt(
@@ -53,6 +55,7 @@ class Exporter(object):
         dev=False,
         extras=None,
         with_credentials=False,
+        no_freeze=False,
     ):  # type: (Path, Union[IO, str], bool, bool, bool) -> None
         indexes = set()
         content = ""
@@ -96,6 +99,9 @@ class Exporter(object):
                 line = "{}".format(package.source_url)
                 if package.develop and package.source_type == "directory":
                     line = "-e " + line
+            elif no_freeze:
+                dependency = package.to_dependency()
+                line = package.name
             else:
                 dependency = package.to_dependency()
                 line = "{}=={}".format(package.name, package.version)

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from textwrap import dedent
+
 import pytest
 
 from cleo.testers import CommandTester
@@ -90,9 +92,11 @@ def test_export_exports_requirements_txt_file_locks_if_no_lock_file(app, repo):
 
     assert app.poetry.locker.lock.exists()
 
-    expected = """\
-foo==1.0.0
-"""
+    expected = dedent(
+        """
+        foo==1.0.0
+        """
+    ).lstrip()
 
     assert expected == content
     assert "The lock file does not exist. Locking." in tester.io.fetch_output()
@@ -121,9 +125,11 @@ def test_export_exports_requirements_txt_uses_lock_file(app, repo):
 
     assert app.poetry.locker.lock.exists()
 
-    expected = """\
-foo==1.0.0
-"""
+    expected = dedent(
+        """
+        foo==1.0.0
+        """
+    ).lstrip()
 
     assert expected == content
     assert "The lock file does not exist. Locking." not in tester.io.fetch_output()
@@ -161,9 +167,11 @@ def test_export_prints_to_stdout_by_default(app, repo):
 
     tester.execute("--format requirements.txt")
 
-    expected = """\
-foo==1.0.0
-"""
+    expected = dedent(
+        """
+        foo==1.0.0
+        """
+    ).lstrip()
 
     assert expected == tester.io.fetch_output()
 
@@ -183,9 +191,60 @@ def test_export_includes_extras_by_flag(app, repo):
 
     tester.execute("--format requirements.txt --extras feature_bar")
 
-    expected = """\
-bar==1.1.0
-foo==1.0.0
-"""
+    expected = dedent(
+        """
+        bar==1.1.0
+        foo==1.0.0
+        """
+    ).lstrip()
+
+    assert expected == tester.io.fetch_output()
+
+
+def test_export_no_freeze(app, repo):
+    repo.add_package(get_package("foo", "1.0.0"))
+    repo.add_package(get_package("bar", "1.1.0"))
+
+    command = app.find("lock")
+    tester = CommandTester(command)
+    tester.execute()
+
+    assert app.poetry.locker.lock.exists()
+
+    command = app.find("export")
+    tester = CommandTester(command)
+
+    tester.execute("--format requirements.txt --no-freeze")
+
+    expected = dedent(
+        """
+        foo
+        """
+    ).lstrip()
+
+    assert expected == tester.io.fetch_output()
+
+
+def test_export_no_freeze_and_extra(app, repo):
+    repo.add_package(get_package("foo", "1.0.0"))
+    repo.add_package(get_package("bar", "1.1.0"))
+
+    command = app.find("lock")
+    tester = CommandTester(command)
+    tester.execute()
+
+    assert app.poetry.locker.lock.exists()
+
+    command = app.find("export")
+    tester = CommandTester(command)
+
+    tester.execute("--format requirements.txt --extras feature_bar --no-freeze")
+
+    expected = dedent(
+        """
+        bar
+        foo
+        """
+    ).lstrip()
 
     assert expected == tester.io.fetch_output()


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Hi. This is my fist little submission.
This PR provides a solution for #2009. This allows to generate a `requirements.txt` without frozen version in it, so that user can keep `requirements.txt` when building a setuptools package using for example PBR.