### PR TITLE
Fix non-compliant Git URL matching

### DIFF
--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -12,8 +12,8 @@ pattern_formats = {
     "user": r"[a-zA-Z0-9_.-]+",
     "resource": r"[a-zA-Z0-9_.-]+",
     "port": r"\d+",
-    "path": r"[\w\-/\\]+",
-    "name": r"[\w\-]+",
+    "path": r"[\w~.\-/\\]+",
+    "name": r"[\w~.\-]+",
     "rev": r"[^@#]+",
 }
 

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -21,6 +21,10 @@ from poetry.vcs.git import ParsedUrl
             GitUrl("https://user@hostname/project/blah.git", None),
         ),
         (
+            "git+https://user@hostname/project~_-.foo/blah~_-.bar.git",
+            GitUrl("https://user@hostname/project~_-.foo/blah~_-.bar.git", None),
+        ),
+        (
             "git+https://user@hostname:project/blah.git",
             GitUrl("https://user@hostname/project/blah.git", None),
         ),
@@ -96,6 +100,18 @@ def test_normalize_url(url, normalized):
             "git+https://user@hostname/project/blah.git",
             ParsedUrl(
                 "https", "hostname", "/project/blah.git", "user", None, "blah", None
+            ),
+        ),
+        (
+            "git+https://user@hostname/project~_-.foo/blah~_-.bar.git",
+            ParsedUrl(
+                "https",
+                "hostname",
+                "/project~_-.foo/blah~_-.bar.git",
+                "user",
+                None,
+                "blah~_-.bar",
+                None,
             ),
         ),
         (


### PR DESCRIPTION
[RFC 3986 § 2.3](https://tools.ietf.org/html/rfc3986#section-2.3) permits more characters in a URL than were matched. This corrects that, though there may be other deficiencies. This was a regression from v1.0.2, where at least “.” was matched without error.

Specifically, this had failed for us upon upgrading to v1.0.3 for a Git URL whose path contained akin to “foo.bar.git”.