### PR TITLE
Short version command output

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -423,6 +423,10 @@ The new version should ideally be a valid semver string or a valid bump rule:
 `patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`.
 
 
+### Options
+* `--short (-s)`: Only print the version string without package name.
+
+
 ## export
 
 This command exports the lock file to other formats.

--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -1,4 +1,5 @@
-from cleo import argument, option
+from cleo import argument
+from cleo import option
 
 from .command import Command
 
@@ -19,11 +20,7 @@ class VersionCommand(Command):
         )
     ]
     options = [
-        option(
-            "short",
-            "s",
-            description="Only print the version without package name."
-        )
+        option("short", "s", description="Only print the version without package name.")
     ]
 
     help = """\
@@ -66,8 +63,12 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
             self.poetry.file.write(content)
         else:
             short = self.option("short")
-            msg = "" if short else "<comment>{}</> ".format(self.poetry.package.name)
-            self.line("{}<info>{}</>".format(msg, self.poetry.package.pretty_version))
+            package_name = (
+                "" if short else "<comment>{}</> ".format(self.poetry.package.name)
+            )
+            self.line(
+                "{}<info>{}</>".format(package_name, self.poetry.package.pretty_version)
+            )
 
     def increment_version(self, version, rule):
         from poetry.semver import Version

--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -1,4 +1,4 @@
-from cleo import argument
+from cleo import argument, option
 
 from .command import Command
 
@@ -16,6 +16,13 @@ class VersionCommand(Command):
             "version",
             "The version number or the rule to update the version.",
             optional=True,
+        )
+    ]
+    options = [
+        option(
+            "short",
+            "s",
+            description="Only print the version without package name."
         )
     ]
 
@@ -58,11 +65,9 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
 
             self.poetry.file.write(content)
         else:
-            self.line(
-                "<comment>{}</> <info>{}</>".format(
-                    self.poetry.package.name, self.poetry.package.pretty_version
-                )
-            )
+            short = self.option("short")
+            msg = "" if short else "<comment>{}</> ".format(self.poetry.package.name)
+            self.line("{}<info>{}</>".format(msg, self.poetry.package.pretty_version))
 
     def increment_version(self, version, rule):
         from poetry.semver import Version

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -45,3 +45,11 @@ def test_version_show(app):
     tester = CommandTester(command)
     tester.execute()
     assert "simple-project 1.2.3\n" == tester.io.fetch_output()
+
+
+@pytest.mark.parametrize("option", ["--short", "-s"])
+def test_version_show_short(app, option):
+    command = app.find("version")
+    tester = CommandTester(command)
+    tester.execute(option)
+    assert "1.2.3\n" == tester.io.fetch_output()


### PR DESCRIPTION
Implements #2036 by providing `--short/-s` as an option to `poetry version`

I am open to other names for the option.