### PR TITLE
fix (#2038): "Call" object has no attribute "id"

### DIFF
--- a/poetry/utils/setup_reader.py
+++ b/poetry/utils/setup_reader.py
@@ -183,6 +183,7 @@ class SetupReader(object):
             func = value.func
             if not (isinstance(func, ast.Name) and func.id == "setup") and not (
                 isinstance(func, ast.Attribute)
+                and hasattr(func.value, "id")
                 and func.value.id == "setuptools"
                 and func.attr == "setup"
             ):


### PR DESCRIPTION
We need to check if the attribute `id` is available before asking for it's value. Otherwise it results in an AttributeError.

Fixes: #2038