### PR TITLE
directory dependency - resolve relative paths

### DIFF
--- a/poetry/packages/directory_dependency.py
+++ b/poetry/packages/directory_dependency.py
@@ -32,6 +32,8 @@ class DirectoryDependency(Dependency):
         if self._base and not self._path.is_absolute():
             self._full_path = self._base / self._path
 
+        self._full_path = self._full_path.resolve()
+
         if not self._full_path.exists():
             raise ValueError("Directory {} does not exist".format(self._path))
 

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -1,3 +1,5 @@
+import os
+
 from subprocess import CalledProcessError
 
 import pytest
@@ -19,3 +21,25 @@ DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "
 def test_directory_dependency_must_exist():
     with pytest.raises(ValueError):
         DirectoryDependency("demo", DIST_PATH / "invalid")
+
+
+def test_directory_relative_path():
+    assert (
+        DirectoryDependency(
+            "demo",
+            Path(
+                os.path.sep.join(
+                    [
+                        str(Path(__file__).parent),
+                        "..",
+                        "fixtures",
+                        "git",
+                        "github.com",
+                        "demo",
+                        "demo",
+                    ]
+                )
+            ),
+        ).full_path
+        == DIST_PATH / "demo"
+    )


### PR DESCRIPTION
addresses #2046  by resolving relative references in directory paths, with this build --format=wheel and build --format=sdist both work, albeit with an unconstrained dep name in generated PKG-INFO.

# Pull Request Check List

- [ x ] Added **tests** for changed code.

