### PR TITLE
Fix #1791: Load repository URL from config

### DIFF
--- a/poetry/masonry/publishing/publisher.py
+++ b/poetry/masonry/publishing/publisher.py
@@ -49,15 +49,13 @@ class Publisher:
             repository_name = "pypi"
         else:
             # Retrieving config information
-            repository = self._poetry.config.get(
-                "repositories.{}".format(repository_name)
+            url = self._poetry.config.get(
+                "repositories.{}.url".format(repository_name)
             )
-            if repository is None:
+            if url is None:
                 raise RuntimeError(
                     "Repository {} is not defined".format(repository_name)
                 )
-
-            url = repository["url"]
 
         if not (username and password):
             # Check if we have a token first

--- a/poetry/masonry/publishing/publisher.py
+++ b/poetry/masonry/publishing/publisher.py
@@ -49,9 +49,7 @@ class Publisher:
             repository_name = "pypi"
         else:
             # Retrieving config information
-            url = self._poetry.config.get(
-                "repositories.{}.url".format(repository_name)
-            )
+            url = self._poetry.config.get("repositories.{}.url".format(repository_name))
             if url is None:
                 raise RuntimeError(
                     "Repository {} is not defined".format(repository_name)


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] ~Added **tests** for changed code.~
- [ ] ~Updated **documentation** for changed code.~

This PR fixes the issue where the repository URL wasn't being retrieved from the environment variables as documented here: https://python-poetry.org/docs/configuration/#using-environment-variables

Fixes #1791 
