### PR TITLE
fix: use correct badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ensuring you have the right stack everywhere.
 
 It supports Python 2.7 and 3.4+.
 
-![Tests Status](https://github.com/python-poetry/poetry/workflows/Tests/badge.svg)
+[![Tests Status](https://github.com/python-poetry/poetry/workflows/Tests/badge.svg?branch=master&event=push)](https://github.com/python-poetry/poetry/actions?query=workflow%3ATests+branch%3Amaster+event%3Apush)
 
 The [complete documentation](https://python-poetry.org/docs/) is available on the [official website](https://python-poetry.org).
 


### PR DESCRIPTION
Noticed that the README status badge was incorrectly showing tests as failing even though the latest commits to master were passing.

I've updated the badge so that its filtered to only commits in the master branch and also added a link to the corresponding workflows page.
