### PR TITLE
Added support for repositories in global config and global default repository

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -395,15 +395,11 @@ poetry check
 
 ## search
 
-This command searches for packages on a remote index.
+This command searches for package(s) in all global repositories and local repositories (if poetry is invoked inside the project folder).
 
 ```bash
 poetry search requests pendulum
 ```
-
-### Options
-
-* `--only-name (-N)`: Search only in name.
 
 ## lock
 

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -18,7 +18,6 @@ from poetry.utils._compat import Path
 from poetry.utils._compat import urlparse
 
 from .command import Command
-from .env_command import EnvCommand
 
 
 class InitCommand(Command):
@@ -224,7 +223,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     package = self.ask("\nAdd a package:")
                     continue
 
-                matches = self._get_pool().search(constraint["name"])
+                matches = self.poetry.pool.search(constraint["name"])
 
                 if not matches:
                     self.line("<error>Unable to find package</error>")
@@ -330,7 +329,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
     ):  # type: (...) -> Tuple[str, str]
         from poetry.version.version_selector import VersionSelector
 
-        selector = VersionSelector(self._get_pool())
+        selector = VersionSelector(self.poetry.pool)
         package = selector.find_best_candidate(
             name, required_version, allow_prereleases=allow_prereleases, source=source
         )
@@ -463,8 +462,9 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         return result
 
+    @staticmethod
     def _format_requirements(
-        self, requirements
+        requirements,
     ):  # type: (List[Dict[str, str]]) -> Dict[str, Union[str, Dict[str, str]]]
         requires = {}
         for requirement in requirements:
@@ -480,7 +480,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         return requires
 
-    def _validate_author(self, author, default):
+    @staticmethod
+    def _validate_author(author, default):
         from poetry.packages.package import AUTHOR_REGEX
 
         author = author or default
@@ -497,23 +498,11 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         return author
 
-    def _validate_license(self, license):
+    @staticmethod
+    def _validate_license(license):
         from poetry.spdx import license_by_id
 
         if license:
             license_by_id(license)
 
         return license
-
-    def _get_pool(self):
-        from poetry.repositories import Pool
-        from poetry.repositories.pypi_repository import PyPiRepository
-
-        if isinstance(self, EnvCommand):
-            return self.poetry.pool
-
-        if self._pool is None:
-            self._pool = Pool()
-            self._pool.add_repository(PyPiRepository())
-
-        return self._pool

--- a/poetry/console/commands/search.py
+++ b/poetry/console/commands/search.py
@@ -8,20 +8,19 @@ class SearchCommand(Command):
     name = "search"
     description = "Searches for packages on remote repositories."
 
-    arguments = [argument("tokens", "The tokens to search for.", multiple=True)]
+    arguments = [argument("name", "The package names to search for.", multiple=True)]
 
     def handle(self):
-        from poetry.repositories.pypi_repository import PyPiRepository
+        packages = self.argument("name")
+        for name in packages:
+            results = self.poetry.pool.search(name)
+            for result in results:
+                self.line("")
+                name = "<info>{}</>".format(result.name)
 
-        results = PyPiRepository().search(self.argument("tokens"))
+                name += " (<comment>{}</>)".format(result.version)
 
-        for result in results:
-            self.line("")
-            name = "<info>{}</>".format(result.name)
+                self.line(name)
 
-            name += " (<comment>{}</>)".format(result.version)
-
-            self.line(name)
-
-            if result.description:
-                self.line(" {}".format(result.description))
+                if result.description:
+                    self.line(" {}".format(result.description))

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -53,7 +53,6 @@ class SelfUpdateCommand(Command):
 
     def handle(self):
         from poetry.__version__ import __version__
-        from poetry.repositories.pypi_repository import PyPiRepository
         from poetry.semver import Version
         from poetry.utils._compat import Path
 
@@ -70,8 +69,7 @@ class SelfUpdateCommand(Command):
         if not version:
             version = ">=" + __version__
 
-        repo = PyPiRepository(fallback=False)
-        packages = repo.find_packages(
+        packages = self.poetry.pool.find_packages(
             "poetry", version, allow_prereleases=self.option("preview")
         )
         if not packages:

--- a/tests/console/commands/debug/test_resolve.py
+++ b/tests/console/commands/debug/test_resolve.py
@@ -3,8 +3,8 @@ from cleo.testers import CommandTester
 from tests.helpers import get_package
 
 
-def test_debug_resolve_gives_resolution_results(app, repo):
-    command = app.find("debug resolve")
+def test_debug_resolve_gives_resolution_results(app_with_mocked_repo, repo):
+    command = app_with_mocked_repo.find("debug resolve")
     tester = CommandTester(command)
 
     cachy2 = get_package("cachy", "0.2.0")
@@ -28,8 +28,10 @@ cachy          0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_debug_resolve_tree_option_gives_the_dependency_tree(app, repo):
-    command = app.find("debug resolve")
+def test_debug_resolve_tree_option_gives_the_dependency_tree(
+    app_with_mocked_repo, repo
+):
+    command = app_with_mocked_repo.find("debug resolve")
     tester = CommandTester(command)
 
     cachy2 = get_package("cachy", "0.2.0")
@@ -53,11 +55,11 @@ cachy 0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_debug_resolve_git_dependency(app, repo):
+def test_debug_resolve_git_dependency(app_with_mocked_repo, repo):
     repo.add_package(get_package("pendulum", "2.0.3"))
     repo.add_package(get_package("cleo", "0.6.5"))
 
-    command = app.find("debug resolve")
+    command = app_with_mocked_repo.find("debug resolve")
     tester = CommandTester(command)
 
     tester.execute("git+https://github.com/demo/demo.git")

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -45,11 +45,11 @@ python = "~2.7 || ^3.6"
     assert expected in tester.io.fetch_output()
 
 
-def test_interactive_with_dependencies(app, repo, mocker, poetry):
+def test_interactive_with_dependencies(app_with_mocked_repo, repo, mocker, poetry):
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
 
-    command = app.find("init")
+    command = app_with_mocked_repo.find("init")
     command._pool = poetry.pool
 
     mocker.patch("poetry.utils._compat.Path.open")
@@ -137,11 +137,11 @@ python = "^{python}"
     assert expected in tester.io.fetch_output()
 
 
-def test_interactive_with_git_dependencies(app, repo, mocker, poetry):
+def test_interactive_with_git_dependencies(app_with_mocked_repo, repo, mocker, poetry):
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
 
-    command = app.find("init")
+    command = app_with_mocked_repo.find("init")
     command._pool = poetry.pool
 
     mocker.patch("poetry.utils._compat.Path.open")
@@ -187,11 +187,13 @@ pytest = "^3.6.0"
     assert expected in tester.io.fetch_output()
 
 
-def test_interactive_with_git_dependencies_with_reference(app, repo, mocker, poetry):
+def test_interactive_with_git_dependencies_with_reference(
+    app_with_mocked_repo, repo, mocker, poetry
+):
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
 
-    command = app.find("init")
+    command = app_with_mocked_repo.find("init")
     command._pool = poetry.pool
 
     mocker.patch("poetry.utils._compat.Path.open")
@@ -237,11 +239,13 @@ pytest = "^3.6.0"
     assert expected in tester.io.fetch_output()
 
 
-def test_interactive_with_git_dependencies_and_other_name(app, repo, mocker, poetry):
+def test_interactive_with_git_dependencies_and_other_name(
+    app_with_mocked_repo, repo, mocker, poetry
+):
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
 
-    command = app.find("init")
+    command = app_with_mocked_repo.find("init")
     command._pool = poetry.pool
 
     mocker.patch("poetry.utils._compat.Path.open")
@@ -287,11 +291,13 @@ pytest = "^3.6.0"
     assert expected in tester.io.fetch_output()
 
 
-def test_interactive_with_directory_dependency(app, repo, mocker, poetry):
+def test_interactive_with_directory_dependency(
+    app_with_mocked_repo, repo, mocker, poetry
+):
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
 
-    command = app.find("init")
+    command = app_with_mocked_repo.find("init")
     command._pool = poetry.pool
 
     mocker.patch("poetry.utils._compat.Path.open")
@@ -338,12 +344,12 @@ pytest = "^3.6.0"
 
 
 def test_interactive_with_directory_dependency_and_other_name(
-    app, repo, mocker, poetry
+    app_with_mocked_repo, repo, mocker, poetry
 ):
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
 
-    command = app.find("init")
+    command = app_with_mocked_repo.find("init")
     command._pool = poetry.pool
 
     mocker.patch("poetry.utils._compat.Path.open")
@@ -389,11 +395,11 @@ pytest = "^3.6.0"
     assert expected in tester.io.fetch_output()
 
 
-def test_interactive_with_file_dependency(app, repo, mocker, poetry):
+def test_interactive_with_file_dependency(app_with_mocked_repo, repo, mocker, poetry):
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
 
-    command = app.find("init")
+    command = app_with_mocked_repo.find("init")
     command._pool = poetry.pool
 
     mocker.patch("poetry.utils._compat.Path.open")

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -187,8 +187,8 @@ def test_show_basic_with_not_installed_packages_decorated(app, poetry, installed
     assert expected == tester.io.fetch_output()
 
 
-def test_show_latest_non_decorated(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_latest_non_decorated(app_with_mocked_repo, poetry, installed, repo):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -252,8 +252,8 @@ pendulum 2.0.0 2.0.1 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_latest_decorated(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_latest_decorated(app_with_mocked_repo, poetry, installed, repo):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -318,8 +318,8 @@ def test_show_latest_decorated(app, poetry, installed, repo):
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_outdated(app_with_mocked_repo, poetry, installed, repo):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -379,8 +379,10 @@ cachy 0.1.0 0.2.0 Cachy package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated_with_only_up_to_date_packages(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_outdated_with_only_up_to_date_packages(
+    app_with_mocked_repo, poetry, installed, repo
+):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_020 = get_package("cachy", "0.2.0")
@@ -419,8 +421,10 @@ def test_show_outdated_with_only_up_to_date_packages(app, poetry, installed, rep
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated_has_prerelease_but_not_allowed(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_outdated_has_prerelease_but_not_allowed(
+    app_with_mocked_repo, poetry, installed, repo
+):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -485,8 +489,10 @@ cachy 0.1.0 0.2.0 Cachy package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated_has_prerelease_and_allowed(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_outdated_has_prerelease_and_allowed(
+    app_with_mocked_repo, poetry, installed, repo
+):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010dev = get_package("cachy", "0.1.0.dev1")
@@ -551,8 +557,8 @@ cachy 0.1.0.dev1 0.3.0.dev123 Cachy package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated_formatting(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_outdated_formatting(app_with_mocked_repo, poetry, installed, repo):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -617,8 +623,10 @@ pendulum 2.0.0 2.0.1 Pendulum package
 
 
 @pytest.mark.parametrize("project_directory", ["project_with_local_dependencies"])
-def test_show_outdated_local_dependencies(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_outdated_local_dependencies(
+    app_with_mocked_repo, poetry, installed, repo
+):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -719,8 +727,10 @@ my-package 0.1.1 ../project_with_setup 0.1.2 ../project_with_setup
 
 
 @pytest.mark.parametrize("project_directory", ["project_with_git_dev_dependency"])
-def test_show_outdated_git_dev_dependency(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_outdated_git_dev_dependency(
+    app_with_mocked_repo, poetry, installed, repo
+):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -801,8 +811,10 @@ demo  0.1.1 9cf87a2 0.1.2 9cf87a2 Demo package
 
 
 @pytest.mark.parametrize("project_directory", ["project_with_git_dev_dependency"])
-def test_show_outdated_no_dev_git_dev_dependency(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_outdated_no_dev_git_dev_dependency(
+    app_with_mocked_repo, poetry, installed, repo
+):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -881,8 +893,8 @@ cachy 0.1.0 0.2.0 Cachy package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_hides_incompatible_package(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_hides_incompatible_package(app_with_mocked_repo, poetry, installed, repo):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -936,8 +948,10 @@ pendulum 2.0.0 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_all_shows_incompatible_package(app, poetry, installed, repo):
-    command = app.find("show")
+def test_show_all_shows_incompatible_package(
+    app_with_mocked_repo, poetry, installed, repo
+):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -992,8 +1006,10 @@ pendulum  2.0.0 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_non_dev_with_basic_installed_packages(app, poetry, installed):
-    command = app.find("show")
+def test_show_non_dev_with_basic_installed_packages(
+    app_with_mocked_repo, poetry, installed
+):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -1063,8 +1079,8 @@ pendulum 2.0.0 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_tree(app, poetry, installed):
-    command = app.find("show")
+def test_show_tree(app_with_mocked_repo, poetry, installed):
+    command = app_with_mocked_repo.find("show")
     tester = CommandTester(command)
 
     poetry.package.add_dependency("cachy", "^0.2.0")

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -84,6 +84,15 @@ class Locker(BaseLocker):
         self._lock_data = data
 
 
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR", fixtures_dir / "poetry_global_config_empty"
+    )
+
+
 @pytest.fixture()
 def package():
     p = ProjectPackage("root", "1.0")
@@ -679,7 +688,7 @@ def test_run_installs_with_local_file(installer, locker, repo, package):
     assert len(installer.installer.installs) == 2
 
 
-def test_run_installs_wheel_with_no_requires_dist(installer, locker, repo, package):
+def test_run_installs_wheel_with_no_requires_dist(installer, locker, package):
     file_path = (
         fixtures_dir / "wheel_with_no_requires_dist/demo-0.1.0-py2.py3-none-any.whl"
     )
@@ -695,7 +704,7 @@ def test_run_installs_wheel_with_no_requires_dist(installer, locker, repo, packa
 
 
 def test_run_installs_with_local_poetry_directory_and_extras(
-    installer, locker, repo, package, tmpdir
+    installer, locker, repo, package
 ):
     file_path = fixtures_dir / "project_with_extras"
     package.add_dependency(
@@ -714,7 +723,7 @@ def test_run_installs_with_local_poetry_directory_and_extras(
 
 
 def test_run_installs_with_local_poetry_directory_transitive(
-    installer, locker, repo, package, tmpdir
+    installer, locker, repo, package
 ):
     file_path = (
         fixtures_dir / "directory/project_with_transitive_directory_dependencies/"
@@ -736,7 +745,7 @@ def test_run_installs_with_local_poetry_directory_transitive(
 
 
 def test_run_installs_with_local_poetry_file_transitive(
-    installer, locker, repo, package, tmpdir
+    installer, locker, repo, package
 ):
     file_path = fixtures_dir / "directory/project_with_transitive_file_dependencies/"
     package.add_dependency(
@@ -755,9 +764,7 @@ def test_run_installs_with_local_poetry_file_transitive(
     assert len(installer.installer.installs) == 3
 
 
-def test_run_installs_with_local_setuptools_directory(
-    installer, locker, repo, package, tmpdir
-):
+def test_run_installs_with_local_setuptools_directory(installer, locker, repo, package):
     file_path = fixtures_dir / "project_with_setup/"
     package.add_dependency("my-package", {"path": str(file_path)})
 
@@ -1278,7 +1285,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
     "This is not working at the moment due to limitations in the resolver"
 )
 def test_installer_test_solver_finds_compatible_package_for_dependency_python_not_fully_compatible_with_package_python(
-    installer, locker, repo, package, installed
+    installer, locker, repo, package
 ):
     package.python_versions = "~2.7 || ^3.4"
     package.add_dependency("A", {"version": "^1.0", "python": "^3.5"})
@@ -1352,7 +1359,7 @@ def test_installer_required_extras_should_not_be_removed_when_updating_single_de
 
 
 def test_installer_required_extras_should_not_be_removed_when_updating_single_dependency_pypi_repository(
-    locker, repo, package, installed, env, mocker
+    locker, package, installed, env, mocker
 ):
     mocker.patch("sys.platform", "darwin")
 
@@ -1389,9 +1396,7 @@ def test_installer_required_extras_should_not_be_removed_when_updating_single_de
     assert len(installer.installer.removals) == 0
 
 
-def test_installer_required_extras_should_be_installed(
-    locker, repo, package, installed, env, mocker
-):
+def test_installer_required_extras_should_be_installed(locker, package, installed, env):
     pool = Pool()
     pool.add_repository(MockRepository())
 

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -1,12 +1,24 @@
 # -*- coding: utf-8 -*-
 from email.parser import Parser
 
+import pytest
+
 from clikit.io import NullIO
 
 from poetry.factory import Factory
 from poetry.masonry.builders.builder import Builder
 from poetry.utils._compat import Path
 from poetry.utils.env import NullEnv
+
+
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR",
+        Path("tests/fixtures") / "poetry_global_config_empty",
+    )
 
 
 def test_builder_find_excluded_files(mocker):

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -25,6 +25,16 @@ from poetry.utils.env import NullEnv
 fixtures_dir = Path(__file__).parent / "fixtures"
 
 
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR",
+        Path("tests/fixtures") / "poetry_global_config_empty",
+    )
+
+
 @pytest.fixture(autouse=True)
 def setup():
     clear_samples_dist()

--- a/tests/masonry/builders/test_editable.py
+++ b/tests/masonry/builders/test_editable.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import sys
 
+import pytest
+
 from clikit.io import NullIO
 
 from poetry.factory import Factory
@@ -12,6 +14,16 @@ from poetry.utils.env import MockEnv
 
 
 fixtures_dir = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR",
+        Path("tests/fixtures") / "poetry_global_config_empty",
+    )
 
 
 def test_build_should_delegate_to_pip_for_non_pure_python_packages(tmp_dir, mocker):

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -23,6 +23,16 @@ from tests.helpers import get_dependency
 fixtures_dir = Path(__file__).parent / "fixtures"
 
 
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR",
+        Path("tests/fixtures") / "poetry_global_config_empty",
+    )
+
+
 @pytest.fixture(autouse=True)
 def setup():
     clear_samples_dist()

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -16,6 +16,16 @@ from poetry.utils.env import NullEnv
 fixtures_dir = Path(__file__).parent / "fixtures"
 
 
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR",
+        Path("tests/fixtures") / "poetry_global_config_empty",
+    )
+
+
 @pytest.fixture(autouse=True)
 def setup():
     clear_samples_dist()

--- a/tests/masonry/publishing/test_uploader.py
+++ b/tests/masonry/publishing/test_uploader.py
@@ -7,7 +7,16 @@ from poetry.masonry.publishing.uploader import UploadError
 from poetry.utils._compat import Path
 
 
-fixtures_dir = Path(__file__).parent.parent.parent / "fixtures"
+fixtures_dir = Path("tests/fixtures")
+
+
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR", fixtures_dir / "poetry_global_config_empty"
+    )
 
 
 def project(name):

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -7,6 +7,8 @@ import zipfile
 
 from contextlib import contextmanager
 
+import pytest
+
 from poetry import __version__
 from poetry.masonry import api
 from poetry.utils._compat import Path
@@ -25,6 +27,16 @@ def cwd(directory):
 
 
 fixtures = os.path.join(os.path.dirname(__file__), "builders", "fixtures")
+
+
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR",
+        Path("tests/fixtures") / "poetry_global_config_empty",
+    )
 
 
 def test_get_requires_for_build_wheel():

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -18,9 +18,21 @@ from poetry.utils.env import MockEnv as BaseMockEnv
 from tests.helpers import get_dependency
 
 
+fixtures_dir = Path("tests/fixtures")
+
+
 class MockEnv(BaseMockEnv):
     def run(self, bin, *args):
         raise EnvCommandError(CalledProcessError(1, "python", output=""))
+
+
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR", fixtures_dir / "poetry_global_config_empty"
+    )
 
 
 @pytest.fixture
@@ -131,13 +143,7 @@ def test_search_for_vcs_read_setup_raises_error_if_no_version(provider, mocker):
 @pytest.mark.parametrize("directory", ["demo", "non-canonical-name"])
 def test_search_for_directory_setup_egg_info(provider, directory):
     dependency = DirectoryDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "git"
-        / "github.com"
-        / "demo"
-        / directory,
+        "demo", fixtures_dir / "git" / "github.com" / "demo" / directory
     )
 
     package = provider.search_for_directory(dependency)[0]
@@ -153,13 +159,7 @@ def test_search_for_directory_setup_egg_info(provider, directory):
 
 def test_search_for_directory_setup_egg_info_with_extras(provider):
     dependency = DirectoryDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "git"
-        / "github.com"
-        / "demo"
-        / "demo",
+        "demo", fixtures_dir / "git" / "github.com" / "demo" / "demo"
     )
     dependency.extras.append("foo")
 
@@ -222,13 +222,7 @@ def test_search_for_directory_setup_read_setup(provider, mocker):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = DirectoryDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "git"
-        / "github.com"
-        / "demo"
-        / "demo",
+        "demo", fixtures_dir / "git" / "github.com" / "demo" / "demo"
     )
 
     package = provider.search_for_directory(dependency)[0]
@@ -247,13 +241,7 @@ def test_search_for_directory_setup_read_setup_with_extras(provider, mocker):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = DirectoryDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "git"
-        / "github.com"
-        / "demo"
-        / "demo",
+        "demo", fixtures_dir / "git" / "github.com" / "demo" / "demo"
     )
     dependency.extras.append("foo")
 
@@ -276,13 +264,7 @@ def test_search_for_directory_setup_read_setup_with_no_dependencies(provider, mo
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = DirectoryDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "git"
-        / "github.com"
-        / "demo"
-        / "no-dependencies",
+        "demo", fixtures_dir / "git" / "github.com" / "demo" / "no-dependencies"
     )
 
     package = provider.search_for_directory(dependency)[0]
@@ -295,8 +277,7 @@ def test_search_for_directory_setup_read_setup_with_no_dependencies(provider, mo
 
 def test_search_for_directory_poetry(provider):
     dependency = DirectoryDependency(
-        "project-with-extras",
-        Path(__file__).parent.parent / "fixtures" / "project_with_extras",
+        "project-with-extras", fixtures_dir / "project_with_extras"
     )
 
     package = provider.search_for_directory(dependency)[0]
@@ -312,8 +293,7 @@ def test_search_for_directory_poetry(provider):
 
 def test_search_for_directory_poetry_with_extras(provider):
     dependency = DirectoryDependency(
-        "project-with-extras",
-        Path(__file__).parent.parent / "fixtures" / "project_with_extras",
+        "project-with-extras", fixtures_dir / "project_with_extras"
     )
     dependency.extras.append("extras_a")
 
@@ -330,11 +310,7 @@ def test_search_for_directory_poetry_with_extras(provider):
 
 def test_search_for_file_sdist(provider):
     dependency = FileDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "distributions"
-        / "demo-0.1.0.tar.gz",
+        "demo", fixtures_dir / "distributions" / "demo-0.1.0.tar.gz"
     )
 
     package = provider.search_for_file(dependency)[0]
@@ -350,11 +326,7 @@ def test_search_for_file_sdist(provider):
 
 def test_search_for_file_sdist_with_extras(provider):
     dependency = FileDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "distributions"
-        / "demo-0.1.0.tar.gz",
+        "demo", fixtures_dir / "distributions" / "demo-0.1.0.tar.gz"
     )
     dependency.extras.append("foo")
 
@@ -374,11 +346,7 @@ def test_search_for_file_sdist_with_extras(provider):
 
 def test_search_for_file_wheel(provider):
     dependency = FileDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "distributions"
-        / "demo-0.1.0-py2.py3-none-any.whl",
+        "demo", fixtures_dir / "distributions" / "demo-0.1.0-py2.py3-none-any.whl"
     )
 
     package = provider.search_for_file(dependency)[0]
@@ -394,11 +362,7 @@ def test_search_for_file_wheel(provider):
 
 def test_search_for_file_wheel_with_extras(provider):
     dependency = FileDependency(
-        "demo",
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "distributions"
-        / "demo-0.1.0-py2.py3-none-any.whl",
+        "demo", fixtures_dir / "distributions" / "demo-0.1.0-py2.py3-none-any.whl"
     )
     dependency.extras.append("foo")
 

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -33,6 +33,16 @@ class Locker(BaseLocker):
         return "123456789"
 
 
+@pytest.fixture(
+    autouse=True
+)  # pytest will auto-run this fixture for every test in this module
+def mock_config_dir(mocker):
+    mocker.patch(
+        "poetry.factory.CONFIG_DIR",
+        Path("tests/fixtures") / "poetry_global_config_empty",
+    )
+
+
 @pytest.fixture()
 def locker():
     return Locker()


### PR DESCRIPTION
This PR adds two features:
1. Support for defining repositories in global config which can be used by search, init and add commands. It also fixes repository order for all commands (which should fix #1677)

2. Possibility to set a repository from global config as a default, making poetry to ignore all other repositories (behaviour similar to index-url from pip - explained in great details in #1632). In short - this feature is required in many enterprise environments where all packages should be fetched from private PyPI repo which hosts company's own packages and acts as a caching proxy/mirror to official PyPI repositories. In some companies does security scans, license checks, etc. and forbids some public packages form being installed. This feature was actually the main motivation for this PR but without proper support for repositories in global config it would look very hacky.

# Pull Request Check List
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.