### PR TITLE
Fix #1429: Create .profile or .zprofile if it doesn't exist

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -618,7 +618,7 @@ class Installer:
 
     def update_path(self):
         """
-        Tries to update the $PATH automatically.
+        Tries to update the $PATH automatically. Creates .profile and .zprofile if absent
         """
         if not self._modify_path:
             return
@@ -636,14 +636,17 @@ class Installer:
 
         profiles = self.get_unix_profiles()
         for profile in profiles:
+            update_path = False
             if not os.path.exists(profile):
-                continue
+                update_path = True
+            else:
+                with open(profile, "r") as f:
+                    content = f.read()
+                    if addition not in content:
+                        update_path = True
 
-            with open(profile, "r") as f:
-                content = f.read()
-
-            if addition not in content:
-                with open(profile, "a") as f:
+            if update_path:
+                with open(profile, "a+") as f:
                     f.write(u(addition))
 
     def add_to_fish_path(self):


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR fixes the issue where poetry isn't automatically added to the PATH if there are no .profile .zprofile files when executing the installation. 

What changed: if .profile and .zprofile files do not exist, they are created. Content added to the files is the same as when they already exist.

I didn't add any tests because I only changed the installation script, and I noticed there are no tests for this. I considered adding them, but then I wondered where to place them - it might look confusing in the current tests directory since its purpose is to test the core code. I can add the tests if necessary, and if anybody clarifies to me where to place them.

Fixes #1429 