### PR TITLE
Show why package is required

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -299,6 +299,7 @@ dependencies:
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.
+* `--why`: Show why the package is required.
 
 
 ## build

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1183,6 +1183,8 @@ def test_show_why(app, poetry, installed):
     tester.execute("--tree --why msgpack-python")
 
     expected = """\
+Determining why msgpack-python is installed.
+
 msgpack-python 0.5.1 Msgpack
 cachy 0.2.0 Cachy
 `-- msgpack-python >=0.5 <0.6
@@ -1194,6 +1196,8 @@ cachy 0.2.0 Cachy
     tester.execute("--tree --why requests")
 
     expected = """\
+Determining why requests is installed.
+
 requests 2.23.0 Requests
 cachy 0.2.0 Cachy
 `-- requests >=2.20 <2.24
@@ -1205,8 +1209,9 @@ cachy 0.2.0 Cachy
     tester.execute("--why requests")
 
     expected = """\
-requests 2.23.0 Requests
-cachy    0.2.0  Cachy
+Determining why requests is installed.
+
+The package is required by cachy (0.2.0).
 """
 
     assert expected == tester.io.fetch_output()
@@ -1215,8 +1220,9 @@ cachy    0.2.0  Cachy
     tester.execute("--why msgpack-python")
 
     expected = """\
-msgpack-python (!) 0.5.1 Msgpack
-cachy              0.2.0 Cachy
+Determining why msgpack-python is installed.
+
+The package is required by cachy (0.2.0).
 """
 
     assert expected == tester.io.fetch_output()


### PR DESCRIPTION
# Pull Request Check List

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

Add a flag `--why` to `poetry show`. User should see a filtered output why the package is required.
Example (run on poetry repo):
```
$ poetry show --tree --why pluggy
pluggy 0.13.1 plugin and hook calling mechanisms for python
pytest 4.6.9 pytest: simple powerful testing with Python
└── pluggy >=0.12,<1.0
tox 3.12.1 tox is a generic virtualenv management and test command line tool
└── pluggy >=0.3.0,<1
tox 3.14.3 tox is a generic virtualenv management and test command line tool
└── pluggy >=0.12.0,<1
pytest-cov 2.8.1 Pytest plugin for measuring coverage.
└── pytest >=3.6
    └── pluggy >=0.12,<1.0 
pytest-mock 1.13.0 Thin-wrapper around the mock package for easier use with py.test
└── pytest >=2.7
    └── pluggy >=0.12,<1.0 
pytest-sugar 0.9.2 pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly).
└── pytest >=2.9
    └── pluggy >=0.12,<1.0 
```
or
```
$ poetry show --why pluggy
pluggy       0.13.1 plugin and hook calling mechanisms for python
pytest       4.6.9  pytest: simple powerful testing with Python
tox          3.12.1 tox is a generic virtualenv management and test command line tool
tox          3.14.3 tox is a generic virtualenv management and test command line tool
pytest-cov   2.8.1  Pytest plugin for measuring coverage.
pytest-mock  1.13.0 Thin-wrapper around the mock package for easier use with py.test
pytest-sugar 0.9.2  pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail ...
```

closes: #1906 