### PR TITLE
Add package licenses to poetry.lock

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -277,6 +277,10 @@ class Locker(object):
             "python-versions": package.python_versions,
             "files": sorted(package.files, key=lambda x: x["file"]),
         }
+
+        if package.license:
+            data["license"] = package.license.id or package.license.name
+
         if not package.marker.is_any():
             data["marker"] = str(package.marker)
 

--- a/poetry/packages/package.py
+++ b/poetry/packages/package.py
@@ -204,12 +204,15 @@ class Package(object):
 
     @license.setter
     def license(self, value):
-        if value is None:
-            self._license = value
+        if not value:
+            self._license = None
         elif isinstance(value, License):
             self._license = value
         else:
-            self._license = license_by_id(value)
+            try:
+                self._license = license_by_id(value)
+            except ValueError:
+                self._license = License("", value, False, False)
 
     @property
     def all_classifiers(self):

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -209,6 +209,8 @@ class PyPiRepository(Repository):
         # Adding hashes information
         package.files = release_info["files"]
 
+        package.license = release_info["license"]
+
         # Activate extra dependencies
         for extra in extras:
             if extra in package.extras:
@@ -316,6 +318,7 @@ class PyPiRepository(Repository):
             "requires_python": info["requires_python"],
             "files": [],
             "_cache_version": str(self.CACHE_VERSION),
+            "license": info["license"],
         }
 
         try:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,10 @@
 import os
 import shutil
 
+from functools import wraps
+
+import tomlkit
+
 from poetry.packages import Dependency
 from poetry.packages import Package
 from poetry.utils._compat import PY2
@@ -88,3 +92,63 @@ def mock_download(self, url, dest):
     fixture = fixtures / parts.path.lstrip("/")
 
     copy_or_symlink(fixture, dest)
+
+
+def assert_deepequals(a, b, ignore_paths=None, _path=None):
+    """Compare objects a and b keeping track of object path for error reporting.
+
+    Keyword arguments:
+    a -- Object a
+    b -- Object b
+    ignore_paths -- List of object paths (delimited by .)
+
+    Example:
+    assert_deepequals({
+        "poetry-version": "1.0.0a3",
+        "content-hash": "example",
+    }, {
+      "metadata": {
+        "poetry-version": "1.0.0a4",
+        "content-hash": "example",
+      }
+    }, ignore_paths=set(["metadata.poetry-version"]))
+    """
+
+    _path = _path if _path else tuple()
+    ignore_paths = ignore_paths if ignore_paths else set()
+    path = ".".join(_path)
+    err = ValueError("{}: {} != {}".format(path, a, b))
+
+    def make_path(entry):
+        return _path + (str(entry),)
+
+    if isinstance(a, list):
+        if not isinstance(b, list) or len(a) != len(b):
+            raise err
+
+        for vals in zip(a, b):
+            p = make_path("[]")
+            if ".".join(p) not in ignore_paths:
+                assert_deepequals(*vals, _path=p, ignore_paths=ignore_paths)
+
+    elif isinstance(a, dict):
+        if not isinstance(b, dict):
+            raise err
+
+        for key in set(a.keys()) | set(b.keys()):
+            p = make_path(key)
+            if ".".join(p) not in ignore_paths:
+                assert_deepequals(a[key], b[key], _path=p, ignore_paths=ignore_paths)
+
+    elif a == b:
+        return
+
+    else:
+        raise err
+
+
+@wraps(assert_deepequals)
+def assert_deepequals_toml(a, b, **kwargs):
+    a = dict(tomlkit.parse(a))
+    b = dict(tomlkit.parse(b))
+    return assert_deepequals(a, b, **kwargs)

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -17,6 +17,7 @@ from poetry.utils._compat import PY2
 from poetry.utils._compat import Path
 from poetry.utils.env import NullEnv
 from poetry.utils.toml_file import TomlFile
+from tests.helpers import assert_deepequals
 from tests.helpers import get_dependency
 from tests.helpers import get_package
 from tests.repositories.test_legacy_repository import (
@@ -128,14 +129,14 @@ def installer(package, pool, locker, env, installed):
 def fixture(name):
     file = TomlFile(Path(__file__).parent / "fixtures" / "{}.test".format(name))
 
-    return file.read()
+    return dict(file.read())
 
 
 def test_run_no_dependencies(installer, locker):
     installer.run()
     expected = fixture("no-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_with_dependencies(installer, locker, repo, package):
@@ -150,7 +151,7 @@ def test_run_with_dependencies(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_update_after_removing_dependencies(
@@ -214,7 +215,7 @@ def test_run_update_after_removing_dependencies(
     installer.run()
     expected = fixture("with-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
     assert len(installs) == 0
@@ -334,7 +335,7 @@ def test_run_whitelist_add(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_whitelist_remove(installer, locker, repo, package, installed):
@@ -383,7 +384,7 @@ def test_run_whitelist_remove(installer, locker, repo, package, installed):
     installer.run()
     expected = fixture("remove")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
     assert len(installer.installer.installs) == 1
     assert len(installer.installer.updates) == 0
     assert len(installer.installer.removals) == 1
@@ -408,7 +409,7 @@ def test_add_with_sub_dependencies(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-sub-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_with_python_versions(installer, locker, repo, package):
@@ -433,7 +434,7 @@ def test_run_with_python_versions(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-python-versions")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_with_optional_and_python_restricted_dependencies(
@@ -462,7 +463,7 @@ def test_run_with_optional_and_python_restricted_dependencies(
     installer.run()
     expected = fixture("with-optional-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installer = installer.installer
     # We should only have 2 installs:
@@ -499,7 +500,7 @@ def test_run_with_optional_and_platform_restricted_dependencies(
     installer.run()
     expected = fixture("with-platform-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installer = installer.installer
     # We should only have 2 installs:
@@ -528,7 +529,7 @@ def test_run_with_dependencies_extras(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-dependencies-extras")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_does_not_install_extras_if_not_requested(installer, locker, repo, package):
@@ -552,7 +553,7 @@ def test_run_does_not_install_extras_if_not_requested(installer, locker, repo, p
     expected = fixture("extras")
 
     # Extras are pinned in lock
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     # But should not be installed
     installer = installer.installer
@@ -581,7 +582,7 @@ def test_run_installs_extras_if_requested(installer, locker, repo, package):
     expected = fixture("extras")
 
     # Extras are pinned in lock
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     # But should not be installed
     installer = installer.installer
@@ -611,7 +612,7 @@ def test_run_installs_extras_with_deps_if_requested(installer, locker, repo, pac
     expected = fixture("extras-with-dependencies")
 
     # Extras are pinned in lock
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     # But should not be installed
     installer = installer.installer
@@ -661,7 +662,9 @@ def test_installer_with_pypi_repository(package, locker, installed):
 
     expected = fixture("with-pypi-repository")
 
-    assert locker.written_data == expected
+    assert_deepequals(
+        dict(locker.written_data), expected, ignore_paths=set(["package.[].license"])
+    )
 
 
 def test_run_installs_with_local_file(installer, locker, repo, package):
@@ -674,7 +677,7 @@ def test_run_installs_with_local_file(installer, locker, repo, package):
 
     expected = fixture("with-file-dependency")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 2
 
@@ -689,7 +692,7 @@ def test_run_installs_wheel_with_no_requires_dist(installer, locker, repo, packa
 
     expected = fixture("with-wheel-dependency-no-requires-dist")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 1
 
@@ -708,7 +711,7 @@ def test_run_installs_with_local_poetry_directory_and_extras(
 
     expected = fixture("with-directory-dependency-poetry")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 2
 
@@ -730,7 +733,7 @@ def test_run_installs_with_local_poetry_directory_transitive(
 
     expected = fixture("with-directory-dependency-poetry-transitive")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 2
 
@@ -750,7 +753,7 @@ def test_run_installs_with_local_poetry_file_transitive(
 
     expected = fixture("with-file-dependency-transitive")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 3
 
@@ -768,7 +771,7 @@ def test_run_installs_with_local_setuptools_directory(
 
     expected = fixture("with-directory-dependency-setuptools")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 3
 
@@ -810,7 +813,7 @@ def test_run_with_prereleases(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-prereleases")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_changes_category_if_needed(installer, locker, repo, package):
@@ -851,7 +854,7 @@ def test_run_changes_category_if_needed(installer, locker, repo, package):
     installer.run()
     expected = fixture("with-category-change")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_update_all_with_lock(installer, locker, repo, package):
@@ -888,7 +891,7 @@ def test_run_update_all_with_lock(installer, locker, repo, package):
     installer.run()
     expected = fixture("update-with-lock")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_update_with_locked_extras(installer, locker, repo, package):
@@ -957,7 +960,7 @@ def test_run_update_with_locked_extras(installer, locker, repo, package):
     installer.run()
     expected = fixture("update-with-locked-extras")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
 
 def test_run_install_duplicate_dependencies_different_constraints(
@@ -987,7 +990,7 @@ def test_run_install_duplicate_dependencies_different_constraints(
 
     expected = fixture("with-duplicate-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
     assert len(installs) == 3
@@ -1097,7 +1100,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock(
 
     expected = fixture("with-duplicate-dependencies")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
     assert len(installs) == 3
@@ -1264,7 +1267,7 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
 
     expected = fixture("with-duplicate-dependencies-update")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
     assert len(installs) == 2
@@ -1295,7 +1298,7 @@ def test_installer_test_solver_finds_compatible_package_for_dependency_python_no
     installer.run()
 
     expected = fixture("with-conditional-dependency")
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     installs = installer.installer.installs
 
@@ -1526,7 +1529,7 @@ def test_run_installs_with_url_file(installer, locker, repo, package):
 
     expected = fixture("with-url-dependency")
 
-    assert locker.written_data == expected
+    assert_deepequals(dict(locker.written_data), expected)
 
     assert len(installer.installer.installs) == 2
 

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -6,6 +6,7 @@ import tomlkit
 from poetry.packages.locker import Locker
 from poetry.packages.project_package import ProjectPackage
 
+from ..helpers import assert_deepequals_toml
 from ..helpers import get_dependency
 from ..helpers import get_package
 
@@ -66,7 +67,7 @@ A = [
 B = []
 """
 
-    assert expected == content
+    assert_deepequals_toml(expected, content)
 
 
 def test_locker_properly_loads_extras(locker):
@@ -138,7 +139,7 @@ python-versions = "*"
 A = []
 """
 
-    assert expected == content
+    assert_deepequals_toml(expected, content)
 
 
 def test_lock_file_should_not_have_mixed_types(locker, root):
@@ -180,7 +181,7 @@ A = []
     with locker.lock.open(encoding="utf-8") as f:
         content = f.read()
 
-    assert expected == content
+    assert_deepequals_toml(expected, content)
 
 
 def test_reading_lock_file_should_raise_an_error_on_invalid_data(locker):
@@ -245,4 +246,4 @@ python-versions = "*"
 A = []
 """
 
-    assert expected == content
+    assert_deepequals_toml(expected, content)

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -85,6 +85,8 @@ def test_package():
     assert len(package.extras["security"]) == 3
     assert len(package.extras["socks"]) == 2
 
+    assert package.license.name == "Apache 2.0"
+
     win_inet = package.extras["socks"][0]
     assert win_inet.name == "win-inet-pton"
     assert win_inet.python_versions == "~2.7 || ~2.6"


### PR DESCRIPTION
I want to be able to gather licenses from my requirements.

This introduces a slight change in how non-spdx licenses are handled in `package.py`.
We first _try_ to look up the license as if it was an SPDX identifier but if that fails we create a `License` instance with the verbatim license from PyPi metadata and an empty identifier.

Also dusted off a commit from https://github.com/python-poetry/poetry/pull/1185 that makes tests assert the data structure instead of strings.
This makes it easier to introduce format changes with much better error reporting from tests as you'll now get the _path_ to the offending key, not just an error message stating that one really huge multiline string is not the same as another multiline string.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
