### PR TITLE
When Building Wheels, Resolve Relative Path Dependencies Correctly

### DIFF
--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -30,7 +30,7 @@ class Factory:
     """
 
     def create_poetry(
-        self, cwd=None, io=None
+        self, cwd=None, io=None, original_root=None,
     ):  # type: (Optional[Path], Optional[IO]) -> Poetry
         if io is None:
             io = NullIO()
@@ -57,7 +57,7 @@ class Factory:
         name = local_config["name"]
         version = local_config["version"]
         package = ProjectPackage(name, version, version)
-        package.root_dir = poetry_file.parent
+        package.root_dir = original_root or poetry_file.parent
 
         for author in local_config["authors"]:
             package.authors.append(author)

--- a/poetry/masonry/builders/complete.py
+++ b/poetry/masonry/builders/complete.py
@@ -43,7 +43,9 @@ class CompleteBuilder(Builder):
 
                 with self.unpacked_tarball(sdist_file) as tmpdir:
                     WheelBuilder.make_in(
-                        Factory().create_poetry(tmpdir),
+                        Factory().create_poetry(
+                            tmpdir, original_root=self._poetry.file.path.parent
+                        ),
                         self._env,
                         self._io,
                         dist_dir,
@@ -52,7 +54,9 @@ class CompleteBuilder(Builder):
         else:
             with self.unpacked_tarball(sdist_file) as tmpdir:
                 WheelBuilder.make_in(
-                    Factory().create_poetry(tmpdir),
+                    Factory().create_poetry(
+                        tmpdir, original_root=self._poetry.file.path.parent
+                    ),
                     self._env,
                     self._io,
                     dist_dir,


### PR DESCRIPTION
Building wheels unpacks the sdist which includes a copy of the
`pyproject.toml`.  If dependencies are declared using relative paths
(such as `mymodule = { path = '../mymodule' }`), these relative paths
are not available from the temporary directory created to unpack and
build the wheel.  This fix retains the original path to the project for
those relative dependencies.

Fixes #266.
Fixes #2046

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
