### PR TITLE
pre-commit: replace isort mirror with isort upstream

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
     hooks:
       - id: flake8
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
     hooks:
       - id: isort
         additional_dependencies: [toml]


### PR DESCRIPTION
The isort pre-commit mirror has been deprecated. This change updates
configuration to use the upstream package repository instead of the
mirror.

Refer: https://github.com/pre-commit/mirrors-isort

# Pull Request Check List

- [N/A] Added **tests** for changed code.
- [N/A] Updated **documentation** for changed code.
