### PR TITLE
remove 'm' and 'd' ABI tags for Python 3.8 wheels

### DIFF
--- a/poetry/masonry/utils/tags.py
+++ b/poetry/masonry/utils/tags.py
@@ -75,11 +75,16 @@ def get_abi_tag(env):
         if get_flag(
             env,
             "Py_DEBUG",
-            lambda: hasattr(sys, "gettotalrefcount"),
-            warn=(impl == "cp"),
+            lambda: (hasattr(sys, "gettotalrefcount") and env.version_info < (3, 8)),
+            warn=(impl == "cp" and env.version_info < (3, 8)),
         ):
             d = "d"
-        if get_flag(env, "WITH_PYMALLOC", lambda: impl == "cp", warn=(impl == "cp")):
+        if get_flag(
+            env,
+            "WITH_PYMALLOC",
+            lambda: (impl == "cp" and env.version_info < (3, 8)),
+            warn=(impl == "cp" and env.version_info < (3, 8)),
+        ):
             m = "m"
         if get_flag(
             env,

--- a/poetry/masonry/utils/tags.py
+++ b/poetry/masonry/utils/tags.py
@@ -75,25 +75,23 @@ def get_abi_tag(env):
         if get_flag(
             env,
             "Py_DEBUG",
-            lambda: (hasattr(sys, "gettotalrefcount") and env.version_info < (3, 8)),
+            lambda: hasattr(sys, "gettotalrefcount"),
             warn=(impl == "cp" and env.version_info < (3, 8)),
         ):
             d = "d"
-        if get_flag(
-            env,
-            "WITH_PYMALLOC",
-            lambda: (impl == "cp" and env.version_info < (3, 8)),
-            warn=(impl == "cp" and env.version_info < (3, 8)),
-        ):
-            m = "m"
-        if get_flag(
-            env,
-            "Py_UNICODE_SIZE",
-            lambda: sys.maxunicode == 0x10FFFF,
-            expected=4,
-            warn=(impl == "cp" and env.version_info < (3, 3)),
-        ) and env.version_info < (3, 3):
-            u = "u"
+        if env.version_info < (3, 8):
+            if get_flag(
+                env, "WITH_PYMALLOC", lambda: impl == "cp", warn=(impl == "cp")
+            ):
+                m = "m"
+            if get_flag(
+                env,
+                "Py_UNICODE_SIZE",
+                lambda: sys.maxunicode == 0x10FFFF,
+                expected=4,
+                warn=(impl == "cp" and env.version_info < (3, 3)),
+            ) and env.version_info < (3, 3):
+                u = "u"
         abi = "%s%s%s%s%s" % (impl, get_impl_ver(env), d, m, u)
     elif soabi and soabi.startswith("cpython-"):
         abi = "cp" + soabi.split("-")[1]

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -881,7 +881,7 @@ class Env(object):
                     stderr=subprocess.STDOUT,
                     input=encode(input_),
                     check=True,
-                    **kwargs,
+                    **kwargs
                 ).stdout
             elif call:
                 return subprocess.call(cmd, stderr=subprocess.STDOUT, **kwargs)

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1152,7 +1152,7 @@ class MockEnv(NullEnv):
         pip_version="19.1",
         sys_path=None,
         config_vars=None,
-        **kwargs,
+        **kwargs
     ):
         super(MockEnv, self).__init__(**kwargs)
 

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -881,7 +881,7 @@ class Env(object):
                     stderr=subprocess.STDOUT,
                     input=encode(input_),
                     check=True,
-                    **kwargs
+                    **kwargs,
                 ).stdout
             elif call:
                 return subprocess.call(cmd, stderr=subprocess.STDOUT, **kwargs)
@@ -1151,7 +1151,8 @@ class MockEnv(NullEnv):
         is_venv=False,
         pip_version="19.1",
         sys_path=None,
-        **kwargs
+        config_vars=None,
+        **kwargs,
     ):
         super(MockEnv, self).__init__(**kwargs)
 
@@ -1162,6 +1163,7 @@ class MockEnv(NullEnv):
         self._is_venv = is_venv
         self._pip_version = Version.parse(pip_version)
         self._sys_path = sys_path
+        self._config_vars = config_vars
 
     @property
     def version_info(self):  # type: () -> Tuple[int]
@@ -1192,3 +1194,12 @@ class MockEnv(NullEnv):
 
     def is_venv(self):  # type: () -> bool
         return self._is_venv
+
+    def config_var(self, var):  # type: (str) -> Any
+        if self._config_vars is None:
+            return super().config_var(var)
+        else:
+            try:
+                return self._config_vars[var]
+            except KeyError:
+                return None

--- a/tests/masonry/utils/test_tags.py
+++ b/tests/masonry/utils/test_tags.py
@@ -1,5 +1,3 @@
-import pytest
-
 from poetry.masonry.utils.tags import get_abi_tag
 from poetry.utils.env import MockEnv
 

--- a/tests/masonry/utils/test_tags.py
+++ b/tests/masonry/utils/test_tags.py
@@ -1,0 +1,25 @@
+import pytest
+
+from poetry.masonry.utils.tags import get_abi_tag
+from poetry.utils.env import MockEnv
+
+
+def test_tags_cpython38():
+    assert (
+        get_abi_tag(
+            MockEnv(
+                version_info=(3, 8, 0),
+                python_implementation="CPython",
+                config_vars={"Py_DEBUG": True},
+            )
+        )
+        == "cp38d"
+    )
+    assert (
+        get_abi_tag(
+            MockEnv(
+                version_info=(3, 8, 0), python_implementation="CPython", config_vars={},
+            )
+        )
+        == "cp38"
+    )

--- a/tests/masonry/utils/test_tags.py
+++ b/tests/masonry/utils/test_tags.py
@@ -1,3 +1,5 @@
+import pytest
+
 from poetry.masonry.utils.tags import get_abi_tag
 from poetry.utils.env import MockEnv
 
@@ -21,3 +23,57 @@ def test_tags_cpython38():
         )
         == "cp38"
     )
+
+
+def test_tags_cpython37():
+    assert (
+        get_abi_tag(
+            MockEnv(
+                version_info=(3, 7, 3),
+                python_implementation="CPython",
+                config_vars={"Py_DEBUG": True, "WITH_PYMALLOC": True},
+            )
+        )
+        == "cp37dm"
+    )
+    assert (
+        get_abi_tag(
+            MockEnv(
+                version_info=(3, 7, 3),
+                python_implementation="CPython",
+                config_vars={"Py_DEBUG": True, "WITH_PYMALLOC": False},
+            )
+        )
+        == "cp37d"
+    )
+    assert (
+        get_abi_tag(
+            MockEnv(
+                version_info=(3, 7, 3),
+                python_implementation="CPython",
+                config_vars={"Py_DEBUG": False, "WITH_PYMALLOC": True},
+            )
+        )
+        == "cp37m"
+    )
+    assert (
+        get_abi_tag(
+            MockEnv(
+                version_info=(3, 7, 3),
+                python_implementation="CPython",
+                config_vars={"Py_DEBUG": False, "WITH_PYMALLOC": False},
+            )
+        )
+        == "cp37"
+    )
+    with pytest.warns(RuntimeWarning):
+        assert (
+            get_abi_tag(
+                MockEnv(
+                    version_info=(3, 7, 3),
+                    python_implementation="CPython",
+                    config_vars={"Py_DEBUG": False},
+                )
+            )
+            == "cp37m"
+        )


### PR DESCRIPTION
Hey everyone,

as of Python 3.8 the `m` and `d` ABI flags became obsolete (see [1] and [2]). In fact, if present, they do prevent the installation of wheels. However, poetry seems to add those flags anyway. As a result, I cannot install wheels build with `poetry build` on the same system they were built on.

This pull request fixes a `RuntimeWarning` if the flags are not present in the environment and prevents the flags from being added to the ABI tag if the Python version is `>= 3.8`.

Cheers,
Maximilian

[1]: https://docs.python.org/3/whatsnew/3.8.html#build-and-c-api-changes
[2]: https://docs.python.org/3/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build

Resolves: https://github.com/sdispater/pendulum/issues/456