### PR TITLE
Add support to use repository url when unspecified

### DIFF
--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -121,6 +121,11 @@ a custom certificate authority or client certificates, similarly refer to the ex
 looking for packages.
 
 
+If no url is specified for a repository in your `pyproject.toml`, poetry will fall
+back to the url configured for a corresponding repository.foo given a source with
+name = foo.
+
+
 ### Disabling the PyPI repository
 
 If you want your packages to be exclusively looked up from a private

--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -236,12 +236,18 @@ class Factory:
         from .utils.helpers import get_client_cert, get_cert
         from .utils.password_manager import PasswordManager
 
+        if "name" not in source:
+            raise RuntimeError("Missing [name] in source.")
+        name = source["name"]
+
+        url = None
         if "url" in source:
-            # PyPI-like repository
-            if "name" not in source:
-                raise RuntimeError("Missing [name] in source.")
+            url = source["url"]
         else:
-            raise RuntimeError("Unsupported source specified")
+            url = auth_config.get("repositories", {}).get(name, {}).get("url")
+
+        if url is None:
+            raise RuntimeError("Unsupported source specified: no url.")
 
         password_manager = PasswordManager(auth_config)
         name = source["name"]


### PR DESCRIPTION
Currently, even if a url is defined for a user level configured
repository we require it also be specified in the project's
pyproject.toml. With this change, if no url is specified in a
pyproject.toml a user level configured repository url is used as a
fallback. This also improves the error message when no URL is found for
a repository.

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.