### PR TITLE
Removes unnecessary paths nesting in release workflow file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,32 +152,32 @@ jobs:
         uses: actions/download-artifact@master
         with:
           name: poetry-${{ steps.tag.outputs.tag }}-linux.tar.gz
-          path: releases/poetry-${{ steps.tag.outputs.tag }}-linux.tar.gz
+          path: releases/
       - name: Download Linux checksum file
         uses: actions/download-artifact@master
         with:
           name: poetry-${{ steps.tag.outputs.tag }}-linux.sha256sum
-          path: releases/poetry-${{ steps.tag.outputs.tag }}-linux.sha256sum
+          path: releases/
       - name: Download MacOS release file
         uses: actions/download-artifact@master
         with:
           name: poetry-${{ steps.tag.outputs.tag }}-darwin.tar.gz
-          path: releases/poetry-${{ steps.tag.outputs.tag }}-darwin.tar.gz
+          path: releases/
       - name: Download MacOS checksum file
         uses: actions/download-artifact@master
         with:
           name: poetry-${{ steps.tag.outputs.tag }}-darwin.sha256sum
-          path: releases/poetry-${{ steps.tag.outputs.tag }}-darwin.sha256sum
+          path: releases/
       - name: Download Windows release file
         uses: actions/download-artifact@master
         with:
           name: poetry-${{ steps.tag.outputs.tag }}-win32.tar.gz
-          path: releases/poetry-${{ steps.tag.outputs.tag }}-win32.tar.gz
+          path: releases/
       - name: Download Windows checksum file
         uses: actions/download-artifact@master
         with:
           name: poetry-${{ steps.tag.outputs.tag }}-win32.sha256sum
-          path: releases/poetry-${{ steps.tag.outputs.tag }}-win32.sha256sum
+          path: releases/
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -194,7 +194,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-linux.tar.gz/poetry-${{ steps.tag.outputs.tag }}-linux.tar.gz
+          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-linux.tar.gz
           asset_name: poetry-${{ steps.tag.outputs.tag }}-linux.tar.gz
           asset_content_type: application/gzip
       - name: Upload Linux checksum file asset
@@ -203,7 +203,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-linux.sha256sum/poetry-${{ steps.tag.outputs.tag }}-linux.sha256sum
+          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-linux.sha256sum
           asset_name: poetry-${{ steps.tag.outputs.tag }}-linux.sha256sum
           asset_content_type: text/pain
       - name: Upload MacOS release file asset
@@ -212,7 +212,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-darwin.tar.gz/poetry-${{ steps.tag.outputs.tag }}-darwin.tar.gz
+          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-darwin.tar.gz
           asset_name: poetry-${{ steps.tag.outputs.tag }}-darwin.tar.gz
           asset_content_type: application/gzip
       - name: Upload MacOS checksum file asset
@@ -221,7 +221,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-darwin.sha256sum/poetry-${{ steps.tag.outputs.tag }}-darwin.sha256sum
+          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-darwin.sha256sum
           asset_name: poetry-${{ steps.tag.outputs.tag }}-darwin.sha256sum
           asset_content_type: text/pain
       - name: Upload Windows release file asset
@@ -230,7 +230,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-win32.tar.gz/poetry-${{ steps.tag.outputs.tag }}-win32.tar.gz
+          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-win32.tar.gz
           asset_name: poetry-${{ steps.tag.outputs.tag }}-win32.tar.gz
           asset_content_type: application/gzip
       - name: Upload Windows checksum file asset
@@ -239,7 +239,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-win32.sha256sum/poetry-${{ steps.tag.outputs.tag }}-win32.sha256sum
+          asset_path: releases/poetry-${{ steps.tag.outputs.tag }}-win32.sha256sum
           asset_name: poetry-${{ steps.tag.outputs.tag }}-win32.sha256sum
           asset_content_type: text/pain
       - name: Install Poetry


### PR DESCRIPTION
# Pull Request Check List
<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->
- [ ] Added **tests** for changed code.
Not relevant
- [ ] Updated **documentation** for changed code.
Not relevant

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

While using the plugin download-artifacts it is not necessary to mention filename in path
```
- uses: actions/download-artifact@v1
  with:
    name: my-artifact.ext
    path: path/to/artifact
# This will resolve to: 'path/to/artifact/my-artifact.ext'
```
But the current release.yml has something like
```
- uses: actions/download-artifact@v1
  with:
    name: my-artifact.ext
    path: path/to/artifact/my-artifact.ext
# This will resolve to: 'path/to/artifact/my-artifact.ext/my-artifact.ext'
```
which i think is unnecessary and removing  it will save long lines of duplications.
I have tested the release workflow in my forked repo

https://github.com/hemanta212/poetry/actions/runs/49999321