### PR TITLE
EditableBuilder: use pip with `--no-deps`

### DIFF
--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -31,14 +31,14 @@ class EditableBuilder(Builder):
 
         try:
             if self._env.pip_version < Version(19, 0):
-                self._env.run_pip("install", "-e", str(self._path))
+                self._env.run_pip("install", "-e", str(self._path), "--no-deps")
             else:
                 # Temporarily rename pyproject.toml
                 shutil.move(
                     str(self._poetry.file), str(self._poetry.file.with_suffix(".tmp"))
                 )
                 try:
-                    self._env.run_pip("install", "-e", str(self._path))
+                    self._env.run_pip("install", "-e", str(self._path), "--no-deps")
                 finally:
                     shutil.move(
                         str(self._poetry.file.with_suffix(".tmp")),

--- a/tests/masonry/builders/test_editable.py
+++ b/tests/masonry/builders/test_editable.py
@@ -23,7 +23,9 @@ def test_build_should_delegate_to_pip_for_non_pure_python_packages(tmp_dir, mock
     builder = EditableBuilder(Factory().create_poetry(module_path), env, NullIO())
     builder.build()
 
-    expected = [[sys.executable, "-m", "pip", "install", "-e", str(module_path)]]
+    expected = [
+        [sys.executable, "-m", "pip", "install", "-e", str(module_path), "--no-deps"]
+    ]
     assert expected == env.executed
 
     assert 0 == move.call_count
@@ -38,7 +40,9 @@ def test_build_should_temporarily_remove_the_pyproject_file(tmp_dir, mocker):
     builder = EditableBuilder(Factory().create_poetry(module_path), env, NullIO())
     builder.build()
 
-    expected = [[sys.executable, "-m", "pip", "install", "-e", str(module_path)]]
+    expected = [
+        [sys.executable, "-m", "pip", "install", "-e", str(module_path), "--no-deps"]
+    ]
     assert expected == env.executed
 
     assert 2 == move.call_count


### PR DESCRIPTION
Notes:

Fix #2126 

* Technically this is a change in behavior, albeit a subtle one, but I think we should update the Change Log anyway
* This fixes the issue I talked about in #2126 - go there to learn about the gory details

