### PR TITLE
try to find shell via os.environ if detect_shell fail (#2115)

### DIFF
--- a/poetry/utils/shell.py
+++ b/poetry/utils/shell.py
@@ -42,17 +42,18 @@ class Shell:
 
         try:
             name, path = detect_shell(os.getpid())
-        except ShellDetectionFailure:
+        except (RuntimeError, ShellDetectionFailure):
+            shell = None
+
             if os.name == "posix":
-                shell = os.environ["SHELL"]
+                shell = os.environ.get("SHELL")
             elif os.name == "nt":
-                shell = os.environ["COMSPEC"]
-            else:
+                shell = os.environ.get("COMSPEC")
+
+            if not shell:
                 raise RuntimeError("Unable to detect the current shell.")
 
             name, path = Path(shell).stem, shell
-        except RuntimeError:
-            raise RuntimeError("Unable to detect the current shell.")
 
         cls._shell = cls(name, path)
 

--- a/poetry/utils/shell.py
+++ b/poetry/utils/shell.py
@@ -9,6 +9,7 @@ from shellingham import ShellDetectionFailure
 from shellingham import detect_shell
 
 from ._compat import WINDOWS
+from ._compat import Path
 from .env import VirtualEnv
 
 
@@ -41,7 +42,16 @@ class Shell:
 
         try:
             name, path = detect_shell(os.getpid())
-        except (RuntimeError, ShellDetectionFailure):
+        except ShellDetectionFailure:
+            if os.name == "posix":
+                shell = os.environ["SHELL"]
+            elif os.name == "nt":
+                shell = os.environ["COMSPEC"]
+            else:
+                raise RuntimeError
+
+            name, path = Path(shell).stem, shell
+        except RuntimeError:
             raise RuntimeError("Unable to detect the current shell.")
 
         cls._shell = cls(name, path)

--- a/poetry/utils/shell.py
+++ b/poetry/utils/shell.py
@@ -48,7 +48,7 @@ class Shell:
             elif os.name == "nt":
                 shell = os.environ["COMSPEC"]
             else:
-                raise RuntimeError
+                raise RuntimeError("Unable to detect the current shell.")
 
             name, path = Path(shell).stem, shell
         except RuntimeError:


### PR DESCRIPTION
If poetry is not run within a shell, like explained in #2115, shell detection fails.

[shellingham](https://github.com/sarugaku/shellingham#notes-for-application-developers) itself explain how one can try to detect a default shell via environment variables. This PR implements the suggestion.

Fixes: #2115 
