### PR TITLE
Use dark_gray color for resolving dependencies msg instead of black+bold

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -807,7 +807,7 @@ class Provider:
             yield
         else:
             indicator = Indicator(
-                self._io, "{message} <fg=black;options=bold>({elapsed:2s})</>"
+                self._io, "{message} <fg=dark_gray;options=bold>({elapsed:2s})</>"
             )
 
             with indicator.auto(


### PR DESCRIPTION
In terminals where black+bold != gray the elapsed time is shown in black
and hence it's invisible to the user.

Details: https://github.com/hishamhm/htop/issues/35#issuecomment-266465736