### PR TITLE
allow appending deployment key to username (#2062)

### DIFF
--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -9,7 +9,7 @@ from poetry.utils._compat import decode
 
 pattern_formats = {
     "protocol": r"\w+",
-    "user": r"[a-zA-Z0-9_.\+-]+(:[\w\d]+)?",
+    "user": r"[a-zA-Z0-9_.\+-]+(:[\w\d-]+)?",
     "resource": r"[a-zA-Z0-9_.-]+",
     "port": r"\d+",
     "path": r"[\w~.\-/\\]+",

--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -9,7 +9,7 @@ from poetry.utils._compat import decode
 
 pattern_formats = {
     "protocol": r"\w+",
-    "user": r"[a-zA-Z0-9_.-]+",
+    "user": r"[a-zA-Z0-9_.\+-]+(:[\w\d]+)?",
     "resource": r"[a-zA-Z0-9_.-]+",
     "port": r"\d+",
     "path": r"[\w~.\-/\\]+",

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -75,6 +75,13 @@ from poetry.vcs.git import ParsedUrl
             "git+ssh://git@git.example.com:sdispater/project/my_repo.git",
             GitUrl("git@git.example.com:sdispater/project/my_repo.git", None),
         ),
+        (
+            "git+https://user:fafb334cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
+            GitUrl(
+                "https://user:fafb334cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
+                None,
+            ),
+        ),
     ],
 )
 def test_normalize_url(url, normalized):
@@ -237,6 +244,18 @@ def test_normalize_url(url, normalized):
                 "git",
                 None,
                 "my_repo",
+                None,
+            ),
+        ),
+        (
+            "git+https://user:fafb334cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
+            ParsedUrl(
+                "https",
+                "hostname",
+                "/project/blah.git",
+                "user:fafb334cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a",
+                None,
+                "blah",
                 None,
             ),
         ),

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -76,9 +76,9 @@ from poetry.vcs.git import ParsedUrl
             GitUrl("git@git.example.com:sdispater/project/my_repo.git", None),
         ),
         (
-            "git+https://user:fafb334cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
+            "git+https://user:fafb334-cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
             GitUrl(
-                "https://user:fafb334cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
+                "https://user:fafb334-cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
                 None,
             ),
         ),
@@ -248,12 +248,12 @@ def test_normalize_url(url, normalized):
             ),
         ),
         (
-            "git+https://user:fafb334cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
+            "git+https://user:fafb334-cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a@hostname/project/blah.git",
             ParsedUrl(
                 "https",
                 "hostname",
                 "/project/blah.git",
-                "user:fafb334cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a",
+                "user:fafb334-cb038533f851c23d0b63254223Abf72ce4f02987e7064b0c95566699a",
                 None,
                 "blah",
                 None,


### PR DESCRIPTION
This PR allows appending deployment keys to usernames as used by gitlab. According to [gitlab's docs](https://docs.gitlab.com/ee/user/project/deploy_tokens/) a `+` is allowed in usernames. This is fixed as well.

Fixes: #2062 

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
