### PR TITLE
Add --dry-run option for publish command

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -325,6 +325,7 @@ It can also build the package if you pass it the `--build` option.
 Should match a repository name set by the [`config`](#config) command.
 * `--username (-u)`: The username to access the repository.
 * `--password (-p)`: The password to access the repository.
+* `--dry-run`: Perform all actions except upload the package.
 
 ## config
 

--- a/poetry/console/commands/publish.py
+++ b/poetry/console/commands/publish.py
@@ -26,6 +26,7 @@ class PublishCommand(Command):
             flag=False,
         ),
         option("build", None, "Build the package before publishing."),
+        option("dry-run", None, "Perform all actions except upload the package."),
     ]
 
     help = """The publish command builds and uploads the package to a remote repository.
@@ -79,4 +80,5 @@ the config command.
             self.option("password"),
             cert,
             client_cert,
+            self.option("dry-run"),
         )

--- a/poetry/publishing/publisher.py
+++ b/poetry/publishing/publisher.py
@@ -26,7 +26,15 @@ class Publisher:
     def files(self):
         return self._uploader.files
 
-    def publish(self, repository_name, username, password, cert=None, client_cert=None):
+    def publish(
+        self,
+        repository_name,
+        username,
+        password,
+        cert=None,
+        client_cert=None,
+        dry_run=False,
+    ):
         if repository_name:
             self._io.write_line(
                 "Publishing <c1>{}</c1> (<b>{}</b>) "
@@ -90,4 +98,5 @@ class Publisher:
             url,
             cert=cert or get_cert(self._poetry.config, repository_name),
             client_cert=resolved_client_cert,
+            dry_run=dry_run,
         )

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -27,7 +27,7 @@ def test_publish_with_cert(app_tester, mocker):
     app_tester.execute("publish --cert path/to/ca.pem")
 
     assert [
-        (None, None, None, Path("path/to/ca.pem"), None)
+        (None, None, None, Path("path/to/ca.pem"), None, False)
     ] == publisher_publish.call_args
 
 
@@ -36,5 +36,22 @@ def test_publish_with_client_cert(app_tester, mocker):
 
     app_tester.execute("publish --client-cert path/to/client.pem")
     assert [
-        (None, None, None, None, Path("path/to/client.pem"))
+        (None, None, None, None, Path("path/to/client.pem"), False)
     ] == publisher_publish.call_args
+
+
+def test_publish_dry_run(app_tester, http):
+    http.register_uri(
+        http.POST, "https://upload.pypi.org/legacy/", status=403, body="Forbidden"
+    )
+
+    exit_code = app_tester.execute("publish --dry-run --username foo --password bar")
+
+    assert 0 == exit_code
+
+    output = app_tester.io.fetch_output()
+    error = app_tester.io.fetch_error()
+
+    assert "Publishing simple-project (1.2.3) to PyPI" in output
+    assert "- Uploading simple-project-1.2.3.tar.gz" in error
+    assert "- Uploading simple_project-1.2.3-py2.py3-none-any.whl" in error

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -23,7 +23,7 @@ def test_publish_publishes_to_pypi_by_default(fixture_dir, mocker, config):
     assert [("foo", "bar")] == uploader_auth.call_args
     assert [
         ("https://upload.pypi.org/legacy/",),
-        {"cert": None, "client_cert": None},
+        {"cert": None, "client_cert": None, "dry_run": False},
     ] == uploader_upload.call_args
 
 
@@ -45,7 +45,7 @@ def test_publish_can_publish_to_given_repository(fixture_dir, mocker, config):
     assert [("foo", "bar")] == uploader_auth.call_args
     assert [
         ("http://foo.bar",),
-        {"cert": None, "client_cert": None},
+        {"cert": None, "client_cert": None, "dry_run": False},
     ] == uploader_upload.call_args
 
 
@@ -74,7 +74,7 @@ def test_publish_uses_token_if_it_exists(fixture_dir, mocker, config):
     assert [("__token__", "my-token")] == uploader_auth.call_args
     assert [
         ("https://upload.pypi.org/legacy/",),
-        {"cert": None, "client_cert": None},
+        {"cert": None, "client_cert": None, "dry_run": False},
     ] == uploader_upload.call_args
 
 
@@ -98,7 +98,7 @@ def test_publish_uses_cert(fixture_dir, mocker, config):
     assert [("foo", "bar")] == uploader_auth.call_args
     assert [
         ("https://foo.bar",),
-        {"cert": Path(cert), "client_cert": None},
+        {"cert": Path(cert), "client_cert": None, "dry_run": False},
     ] == uploader_upload.call_args
 
 
@@ -119,7 +119,7 @@ def test_publish_uses_client_cert(fixture_dir, mocker, config):
 
     assert [
         ("https://foo.bar",),
-        {"cert": None, "client_cert": Path(client_cert)},
+        {"cert": None, "client_cert": Path(client_cert), "dry_run": False},
     ] == uploader_upload.call_args
 
 
@@ -137,5 +137,5 @@ def test_publish_read_from_environment_variable(fixture_dir, environ, mocker, co
     assert [("bar", "baz")] == uploader_auth.call_args
     assert [
         ("https://foo.bar",),
-        {"cert": None, "client_cert": None},
+        {"cert": None, "client_cert": None, "dry_run": False},
     ] == uploader_upload.call_args


### PR DESCRIPTION
This change introduces `--dry-run` option for the publish
command. When used, will perform all actions required for
publishing except for uploading build artifacts.

Resolves: #2181

# Pull Request Check List
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
