### PR TITLE
Relax licence restrictions to support custom licences

### DIFF
--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -40,6 +40,10 @@ The recommended notation for the most common licenses is (alphabetical):
 Optional, but it is highly recommended to supply this.
 More identifiers are listed at the [SPDX Open Source License Registry](https://www.spdx.org/licenses/).
 
+!!!note
+
+    If your project is proprietary and does not use a specific licence, you can set this value as `Proprietary`.
+
 ## authors
 
 The authors of the package. **Required**

--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -44,6 +44,8 @@ More identifiers are listed at the [SPDX Open Source License Registry](https://w
 
     If your project is proprietary and does not use a specific licence, you can set this value as `Proprietary`.
 
+    A custom licence name may also be used here. If used, it will appear as is in your project metadata.
+
 ## authors
 
 The authors of the package. **Required**

--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -275,15 +275,6 @@ class Factory:
 
         if strict:
             # If strict, check the file more thoroughly
-
-            # Checking license
-            license = config.get("license")
-            if license:
-                try:
-                    license_by_id(license)
-                except ValueError:
-                    result["errors"].append("{} is not a valid license".format(license))
-
             if "dependencies" in config:
                 python_versions = config["dependencies"]["python"]
                 if python_versions == "*":

--- a/poetry/spdx/__init__.py
+++ b/poetry/spdx/__init__.py
@@ -17,7 +17,9 @@ def license_by_id(identifier):
     id = identifier.lower()
 
     if id not in _licenses:
-        raise ValueError("Invalid license id: {}".format(identifier))
+        if not identifier:
+            raise ValueError("A license identifier is required")
+        return License(identifier, identifier, False, False)
 
     return _licenses[id]
 

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -34,14 +34,12 @@ def test_check_invalid(app, mocker):
     if PY2:
         expected = """\
 Error: u'description' is a required property
-Error: INVALID is not a valid license
 Warning: A wildcard Python dependency is ambiguous. Consider specifying a more explicit one.
 Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.
 """
     else:
         expected = """\
 Error: 'description' is a required property
-Error: INVALID is not a valid license
 Warning: A wildcard Python dependency is ambiguous. Consider specifying a more explicit one.
 Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.
 """

--- a/tests/spdx/test_license.py
+++ b/tests/spdx/test_license.py
@@ -48,3 +48,9 @@ def test_proprietary_license():
     license = license_by_id("Proprietary")
 
     assert "License :: Other/Proprietary License" == license.classifier
+
+
+def test_custom_license():
+    license = license_by_id("Amazon Software License")
+
+    assert "License :: Other/Proprietary License" == license.classifier

--- a/tests/spdx/test_main.py
+++ b/tests/spdx/test_main.py
@@ -40,4 +40,13 @@ def test_license_by_id_with_full_name():
 
 def test_license_by_id_invalid():
     with pytest.raises(ValueError):
-        license_by_id("invalid")
+        license_by_id("")
+
+
+def test_license_by_id_custom():
+    license = license_by_id("Custom")
+
+    assert license.id == "Custom"
+    assert license.name == "Custom"
+    assert not license.is_osi_approved
+    assert not license.is_deprecated


### PR DESCRIPTION
This change adds support of use of custom licenses for projects. If the
value specified for `licence` is not in the SPDX License List or 
"Proprietary", we treat it as a custom licence withe value (as is) as 
the name.

As a side-effect, the validation of licence is no longer performed when
executing `poetry check`.

Resolves: #2020 #2198

# Pull Request Check List
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
