### PR TITLE
Update the installer script to handle future releases

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -204,8 +204,12 @@ import sys
 import os
 
 lib = os.path.normpath(os.path.join(os.path.realpath(__file__), "../..", "lib"))
-
+vendors = os.path.join(lib, "poetry", "_vendor")
+current_vendors = os.path.join(
+    vendors, "py{}".format(".".join(str(v) for v in sys.version_info[:2]))
+)
 sys.path.insert(0, lib)
+sys.path.insert(0, current_vendors)
 
 if __name__ == "__main__":
     from poetry.console import main


### PR DESCRIPTION
## Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

The future releases will no longer inject the vendors directory into the path in the `__init__.py` script (see #2212).

This PR adds the injection logic into the the `poetry` script installed by the official installer.
