### PR TITLE
Fix release workflow and scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,11 @@ jobs:
     - name: Preparing Python executables
       run: |
         curl -L https://github.com/sdispater/python-binaries/releases/download/2.7.17/python-2.7.17.macos.tar.xz -o python-2.7.17.tar.xz
-        curl -L https://github.com/sdispater/python-binaries/releases/download/3.4.10/python-3.4.10.macos.tar.xz -o python-3.4.10.tar.xz
         curl -L https://github.com/sdispater/python-binaries/releases/download/3.5.9/python-3.5.9.macos.tar.xz -o python-3.5.9.tar.xz
         curl -L https://github.com/sdispater/python-binaries/releases/download/3.6.8/python-3.6.8.macos.tar.xz -o python-3.6.8.tar.xz
         curl -L https://github.com/sdispater/python-binaries/releases/download/3.7.6/python-3.7.6.macos.tar.xz -o python-3.7.6.tar.xz
         curl -L https://github.com/sdispater/python-binaries/releases/download/3.8.2/python-3.8.2.macos.tar.xz -o python-3.8.2.tar.xz
         tar -zxf python-2.7.17.tar.xz
-        tar -zxf python-3.4.10.tar.xz
         tar -zxf python-3.5.9.tar.xz
         tar -zxf python-3.6.8.tar.xz
         tar -zxf python-3.7.6.tar.xz
@@ -68,7 +66,7 @@ jobs:
     - name: Build specific release
       run: |
         source $HOME/.poetry/env
-        poetry run python sonnet make release --ansi -P "2.7:python-2.7.17/bin/python" -P "3.4:python-3.4.10/bin/python" -P "3.5:python-3.5.9/bin/python" -P "3.6:python-3.6.8/bin/python" -P "3.7:python-3.7.6/bin/python" -P "3.8:python-3.8.2/bin/python"
+        poetry run python sonnet make release --ansi -P "2.7:python-2.7.17/bin/python" -P "3.5:python-3.5.9/bin/python" -P "3.6:python-3.6.8/bin/python" -P "3.7:python-3.7.6/bin/python" -P "3.8:python-3.8.2/bin/python"
     - name: Upload release file
       uses: actions/upload-artifact@v1
       with:
@@ -105,13 +103,11 @@ jobs:
     - name: Preparing Python executables
       run: |
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/2.7.17/python-2.7.17.windows.tar.xz -O python-2.7.17.tar.xz
-        Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.4.4/python-3.4.4.windows.tar.xz -O python-3.4.4.tar.xz
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.5.4/python-3.5.4.windows.tar.xz -O python-3.5.4.tar.xz
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.6.8/python-3.6.8.windows.tar.xz -O python-3.6.8.tar.xz
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.7.6/python-3.7.6.windows.tar.xz -O python-3.7.6.tar.xz
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.8.2/python-3.8.2.windows.tar.xz -O python-3.8.2.tar.xz
         7z x python-2.7.17.tar.xz
-        7z x python-3.4.4.tar.xz
         7z x python-3.5.4.tar.xz
         7z x python-3.6.8.tar.xz
         7z x python-3.7.6.tar.xz
@@ -125,7 +121,7 @@ jobs:
     - name: Build specific release
       run: |
         $env:Path += ";$env:Userprofile\.poetry\bin"
-        poetry run python sonnet make release --ansi -P "2.7:python-2.7.17\python.exe" -P "3.4:python-3.4.4\python.exe" -P "3.5:python-3.5.4\python.exe" -P "3.6:python-3.6.8\python.exe" -P "3.7:python-3.7.6\python.exe" -P "3.8:python-3.8.2\python.exe"
+        poetry run python sonnet make release --ansi -P "2.7:python-2.7.17\python.exe" -P "3.5:python-3.5.4\python.exe" -P "3.6:python-3.6.8\python.exe" -P "3.7:python-3.7.6\python.exe" -P "3.8:python-3.8.2\python.exe"
     - name: Upload release file
       uses: actions/upload-artifact@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This release **must** be downloaded via the `get-poetry.py` script and not via the `self update` command.
 
+### Added
+
+- Added a new `--dry-run` option to the `publish` command ([#2199](https://github.com/python-poetry/poetry/pull/2199)).
+
 ### Changed
 
 - The core features of Poetry have been extracted in to a separate library: `poetry-core` ([#2212](https://github.com/python-poetry/poetry/pull/2212)).

--- a/sonnet
+++ b/sonnet
@@ -10,6 +10,7 @@ from gzip import GzipFile
 
 from cleo import Application
 from cleo import Command
+from clikit.api.formatter import Style
 
 
 WINDOWS = sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt")
@@ -272,6 +273,7 @@ class MakeCommand(Command):
 
 
 app = Application("sonnet")
+app.config.add_style(Style("debug").fg("default").dark())
 
 app.add(MakeCommand())
 


### PR DESCRIPTION
Since we will no longer support Python 3.4 in the 1.1.0 release we need to remove it from the release workflow.

I also needed to update the change log since due to a mistake on my part the #2199 PR will make it to the 1.1.0a1 release.
