### PR TITLE
feat(installer): add only dev mode option

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -116,6 +116,13 @@ the `--no-dev` option.
 poetry install --no-dev
 ```
 
+In contrast, if you only need the dev dependencies to e.g. run linters, you can use the
+`only-dev` option.
+
+```bash
+poetry install --only-dev
+```
+
 You can also specify the extras you want installed
 by passing the `--E|--extras` option (See [Extras](#extras) for more info)
 

--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -10,6 +10,7 @@ class InstallCommand(EnvCommand):
 
     options = [
         option("no-dev", None, "Do not install the development dependencies."),
+        option("only-dev", None, "Only install the development dependencies."),
         option(
             "no-root", None, "Do not install the root package (the current project)."
         ),
@@ -56,6 +57,7 @@ exist it will look for <comment>pyproject.toml</> and do the same.
                 extras.append(extra)
 
         installer.extras(extras)
+        installer.only_dev_mode(self.option("only-dev"))
         installer.dev_mode(not self.option("no-dev"))
         installer.dry_run(self.option("dry-run"))
         installer.verbose(self.option("verbose"))

--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -43,6 +43,7 @@ class Installer:
         self._verbose = False
         self._write_lock = True
         self._dev_mode = True
+        self._only_dev = False
         self._execute_operations = True
         self._lock = False
 
@@ -95,6 +96,14 @@ class Installer:
         self._dev_mode = dev_mode
 
         return self
+
+    def only_dev_mode(self, only_dev=False):  # type: (bool) -> Installer
+        self._only_dev = only_dev
+
+        return self
+
+    def is_only_dev(self):  # type: () -> Installer
+        return self._only_dev
 
     def is_dev_mode(self):  # type: () -> bool
         return self._dev_mode
@@ -462,6 +471,9 @@ class Installer:
             if package.optional:
                 if package.name not in extra_packages:
                     op.skip("Not required")
+
+            if package.category == "main" and self.is_only_dev():
+                op.skip("Main dependencies not requested")
 
             # If the package is a dev package and dev packages
             # are not requested, we skip it

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -295,6 +295,71 @@ def test_run_install_no_dev(installer, locker, repo, package, installed):
     assert len(removals) == 1
 
 
+def test_run_install_only_dev(installer, locker, repo, package, installed):
+    locker.locked(True)
+    locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "A",
+                    "version": "1.0",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "B",
+                    "version": "1.1",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "C",
+                    "version": "1.2",
+                    "category": "dev",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"A": [], "B": [], "C": []},
+            },
+        }
+    )
+    package_a = get_package("A", "1.0")
+    package_b = get_package("B", "1.1")
+    package_c = get_package("C", "1.2")
+    repo.add_package(package_a)
+    repo.add_package(package_b)
+    repo.add_package(package_c)
+
+    package.add_dependency("A", "~1.0")
+    package.add_dependency("B", "~1.1")
+    package.add_dependency("C", "~1.2", category="dev")
+
+    installer.only_dev_mode(True)
+    installer.run()
+
+    installs = installer.installer.installs
+    assert len(installs) == 1
+
+    updates = installer.installer.updates
+    assert len(updates) == 0
+
+    removals = installer.installer.removals
+    assert len(removals) == 0
+
+
 def test_run_whitelist_add(installer, locker, repo, package):
     locker.locked(True)
     locker.mock_lock_data(


### PR DESCRIPTION
This is a draft PR. I'm very much open to changes and suggestions!
I'm not sure, if I maybe should name it `only-main` instead and if `no-root` should automatically apply or not.

This commandline parameter adds the ability to install only dev
packages. That is often needed, when poetry is run in a CI/CD system
like GitLab CI or GitHub actions, where often not the whole test
suite for every PR is used, but only linters or static
type checkers are required. These often reside in dev dependencies.

I think this option is needed to avoid having to use another tool like `tox` or having to export files like `requirements-black.txt` to manage things like
linting before a PR.

Example use-case:
* Pull Request only pipeline, which only executes `black`, `flake8`, `pylint`, `mypy` and other linters or static type checkers. To execute this on a branch, no main dependencies are needed.