### PR TITLE
Remove py34 environment from tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27, py34, py35, py36, py37, py38
+envlist = py27, py35, py36, py37, py38
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
Since poetry-core does not support python 3.4, local tests
fail when run with tox.

# Pull Request Check List
- ~~Added **tests** for changed code.~~
- ~~Updated **documentation** for changed code.~~