### PR TITLE
[WIP] Add test for pip installing pendulum failing

### DIFF
--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -9,7 +9,9 @@ from poetry.packages.package import Package
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool
 from poetry.utils._compat import Path
-from poetry.utils.env import EnvManager, NullEnv, VirtualEnv
+from poetry.utils.env import EnvManager
+from poetry.utils.env import NullEnv
+from poetry.utils.env import VirtualEnv
 
 
 @pytest.fixture

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -1,7 +1,6 @@
 import shutil
 
 import pytest
-
 from poetry.factory import Factory
 from poetry.installation.pip_installer import PipInstaller
 from poetry.io.null_io import NullIO

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -1,12 +1,15 @@
+import shutil
+
 import pytest
 
+from poetry.factory import Factory
 from poetry.installation.pip_installer import PipInstaller
 from poetry.io.null_io import NullIO
 from poetry.packages.package import Package
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool
 from poetry.utils._compat import Path
-from poetry.utils.env import NullEnv, VirtualEnv
+from poetry.utils.env import EnvManager, NullEnv, VirtualEnv
 
 
 @pytest.fixture
@@ -60,11 +63,6 @@ def test_requirement_source_type_url():
     expected = "{}#egg={}".format(foo.source_url, foo.name)
 
     assert expected == result
-
-
-from poetry.factory import Factory
-from poetry.utils.env import EnvManager
-import shutil
 
 
 @pytest.fixture()

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -1,6 +1,7 @@
 import shutil
 
 import pytest
+
 from poetry.factory import Factory
 from poetry.installation.pip_installer import PipInstaller
 from poetry.io.null_io import NullIO

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -95,7 +95,7 @@ def tmp_venv(tmp_dir, manager):
 def test_can_install_pendulum_sdist(tmp_venv):
     installer = PipInstaller(tmp_venv, NullIO(), Pool())
 
-    installer.run('install', '--no-binary', ':all:', 'pendulum')
+    installer.run("install", "--no-binary", ":all:", "pendulum")
 
 
 def test_requirement_git_develop_false(installer, package_git):


### PR DESCRIPTION
sdispater/pendulum#458

This PR is most likely going to be deleted but I wanted to provide a reproducible scenario for ... well, the `--no-binary` part is what I did in #458 but the error is what is reported in #454.

I will explicitly point out that this would \_not\_ use the `master` source of poetry but rather whatever pendulum claims to depend on.  Again, this is a publicly running demonstration, not a proposed test or solution.  My guess at the solution is to add `setuptools` as a poetry installation dependency so it will have setuptools when 517 results in poetry installation.  Or maybe the `build-system` `requires` for pendulum should just get a setuptools.  I dunno...