### PR TITLE
Add documentation on inline tables in include. Resolves: Core #8.

### DIFF
--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -173,14 +173,14 @@ If a VCS is being used for a package, the exclude field will be seeded with the 
 include = ["CHANGELOG.md"]
 ```
 
-You can also use inline tables for `include`:
+You can also specify the formats for which these patterns have to be included, as shown here:
 
 ```toml
 [tool.poetry]
 # ...
 include = [
     { path = "tests", format = "sdist" },
-    { path = "for_wheel.txt", format = "wheel" }
+    { path = "for_wheel.txt", format = ["sdist", "wheel"] }
 ]
 ```
 

--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -184,6 +184,8 @@ include = [
 ]
 ```
 
+If no format is specified, it will default to include to a `wheel` only.
+
 ```toml
 exclude = ["my_package/excluded.py"]
 ```

--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -184,7 +184,7 @@ include = [
 ]
 ```
 
-If no format is specified, it will default to include to a `wheel` only.
+If no format is specified, it will default to include both `sdist` and `wheel`.
 
 ```toml
 exclude = ["my_package/excluded.py"]

--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -173,6 +173,17 @@ If a VCS is being used for a package, the exclude field will be seeded with the 
 include = ["CHANGELOG.md"]
 ```
 
+You can also use inline tables for `include`:
+
+```toml
+[tool.poetry]
+# ...
+include = [
+    { path = "tests", format = "sdist" },
+    { path = "for_wheel.txt", format = "wheel" }
+]
+```
+
 ```toml
 exclude = ["my_package/excluded.py"]
 ```


### PR DESCRIPTION
Resolves: #2353
Relates to: python-poetry/poetry-core#6
Resolves: #3823

- [x] Added **tests** for changed code. (see https://github.com/python-poetry/core/pull/6)
- [x] Updated **documentation** for changed code.

This PR is an accompaniment to the pull request on core which add inline tables to `include` in pyproject.toml.