### PR TITLE
Add --lock option to the `add` command

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -245,6 +245,7 @@ poetry add "git+https://github.com/pallets/flask.git@1.1.1[dotenv,dev]"
 * `--path`: The path to a dependency.
 * `--optional` : Add as an optional dependency.
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
+* `--lock` : Do not perform install (only update the lockfile).
 
 
 ## remove

--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -45,6 +45,7 @@ class AddCommand(EnvCommand, InitCommand):
             None,
             "Output the operations but do not execute anything (implicitly enables --verbose).",
         ),
+        option("lock", None, "Do not perform operations (only update the lockfile)."),
     ]
 
     help = """The add command adds required packages to your <comment>pyproject.toml</> and installs them.
@@ -154,6 +155,8 @@ If you do not specify a version constraint, poetry will choose a suitable one ba
 
         installer.dry_run(self.option("dry-run"))
         installer.update(True)
+        if self.option("lock"):
+            installer.lock()
         installer.whitelist([r["name"] for r in requirements])
 
         try:

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -870,3 +870,23 @@ Package operations: 1 install, 0 updates, 0 removals
 """
 
     assert expected in tester.io.fetch_output()
+
+
+def test_add_with_lock(app, repo, installer):
+    command = app.find("add")
+    tester = CommandTester(command)
+
+    repo.add_package(get_package("cachy", "0.2.0"))
+
+    tester.execute("cachy --lock")
+
+    expected = """\
+Using version ^0.2.0 for cachy
+
+Updating dependencies
+Resolving dependencies...
+
+Writing lock file
+"""
+
+    assert expected == tester.io.fetch_output()


### PR DESCRIPTION
The option is similar to the --lock option in the `update` command, and is useful for cases when the subsequent installation of the packages is not needed.

# Pull Request Check List

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.


