### PR TITLE
doc: explain why `update` sometimes causes a no-op

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -165,6 +165,11 @@ If you just want to update a few packages and not all, you can list them as such
 poetry update requests toml
 ```
 
+Note that this will not update versions for dependencies outside their version constraints specified
+in the `pyproject.toml` file. In other terms, `poetry update foo` will be a no-op if the version constraint
+specified for `foo` is `~2.3` or `2.3` and `2.4` is available. In order for `foo` to be updated, you must
+update the constraint, for example `^2.3`. You can do this using the `add` command.
+
 ### Options
 
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).


### PR DESCRIPTION
Just something my co-workers struggled with - without having authored `pyproject.toml` themselves, they went straight to the `cli.md` page - so I thought I'd duplicate a bit of information from the `basic-usage.md` there.

Maybe there's a better way to fix this, though, like explaining why `update` did not update anything or something like that.

Or maybe it should go in the FAQ.

Tell me what you think!