### PR TITLE
Add publish-default package setting that overrides the default behavior of publish.

### DIFF
--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -293,3 +293,7 @@ build-backend = "poetry.core.masonry.api"
 
     If your `pyproject.toml` file still references `poetry` directly as a build backend,
     you should update it to reference `poetry_core` instead.
+
+## publish-default
+
+Name of the repository that will be used as a default when running `poetry publish`. If not provided the [PyPI](https://pypi.org) will be used.

--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -3,7 +3,8 @@
 ## Using the PyPI repository
 
 By default, Poetry is configured to use the [PyPI](https://pypi.org) repository,
-for package installation and publishing.
+for package installation and publishing. User can override this behavior by setting
+`publish-default` in the `[tool.poetry]` section.
 
 So, when you add dependencies to your project, Poetry will assume they are available
 on PyPI.

--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -173,6 +173,10 @@
                     "description": "The full url of the custom url."
                 }
             }
+        },
+        "publish-default": {
+            "type": "string",
+            "description": "Name of the default publish repository."
         }
     },
     "definitions": {

--- a/poetry/publishing/publisher.py
+++ b/poetry/publishing/publisher.py
@@ -38,6 +38,9 @@ class Publisher:
         client_cert=None,
         dry_run=False,
     ):  # type: (Optional[str], Optional[str], Optional[str], Optional[Path], Optional[Path], Optional[bool]) -> None
+        # Set repository name to publish-default. It will be None if not set
+        repository_name = repository_name or self._package.publish_default
+
         if not repository_name:
             url = "https://upload.pypi.org/legacy/"
             repository_name = "pypi"

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -107,3 +107,17 @@ def test_publish_dry_run(app_tester, http):
     assert "Publishing simple-project (1.2.3) to PyPI" in output
     assert "- Uploading simple-project-1.2.3.tar.gz" in error
     assert "- Uploading simple_project-1.2.3-py2.py3-none-any.whl" in error
+
+
+def test_publish_with_publish_default_set(app, app_tester, http):
+    app.poetry.package.publish_default = "private_pypi"
+    app_tester.execute("publish")
+
+    expected = """
+Publishing simple-project (1.2.3) to private_pypi
+
+[RuntimeError]
+Repository private_pypi is not defined
+"""
+
+    assert app_tester.io.fetch_output() == expected


### PR DESCRIPTION
This PR add possibility to override default behavior of `poetry publish` and to define new default publish repository per project.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Requires: https://github.com/python-poetry/core/pull/19

I don't know how to make it use the `core` version from above PR. If somebody could point me to a documentation it would be great. 