### PR TITLE
Make non-interactive get-poetry.py PATH optional / update with $POETRY_HOME

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -333,13 +333,14 @@ class Installer:
         version=None,
         preview=False,
         force=False,
+        modify_path=True,
         accept_all=False,
         base_url=BASE_URL,
     ):
         self._version = version
         self._preview = preview
         self._force = force
-        self._modify_path = True
+        self._modify_path = modify_path
         self._accept_all = accept_all
         self._base_url = base_url
 
@@ -926,6 +927,13 @@ def main():
         "-f", "--force", dest="force", action="store_true", default=False
     )
     parser.add_argument(
+        "-P",
+        "--no-modify-path",
+        dest="no_modify_path",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "-y", "--yes", dest="accept_all", action="store_true", default=False
     )
     parser.add_argument(
@@ -947,6 +955,7 @@ def main():
         version=args.version or os.getenv("POETRY_VERSION"),
         preview=args.preview or string_to_bool(os.getenv("POETRY_PREVIEW", "0")),
         force=args.force,
+        modify_path=not args.no_modify_path,
         accept_all=args.accept_all
         or string_to_bool(os.getenv("POETRY_ACCEPT", "0"))
         or not is_interactive(),

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -920,24 +920,43 @@ def main():
         description="Installs the latest (or given) version of poetry"
     )
     parser.add_argument(
-        "-p", "--preview", dest="preview", action="store_true", default=False
+        "-p",
+        "--preview",
+        help="install preview version",
+        dest="preview",
+        action="store_true",
+        default=False,
     )
-    parser.add_argument("--version", dest="version")
+    parser.add_argument("--version", help="install named version", dest="version")
     parser.add_argument(
-        "-f", "--force", dest="force", action="store_true", default=False
+        "-f",
+        "--force",
+        help="install on top of existing version",
+        dest="force",
+        action="store_true",
+        default=False,
     )
     parser.add_argument(
-        "-P",
         "--no-modify-path",
+        help="do not modify $PATH",
         dest="no_modify_path",
         action="store_true",
         default=False,
     )
     parser.add_argument(
-        "-y", "--yes", dest="accept_all", action="store_true", default=False
+        "-y",
+        "--yes",
+        help="accept all prompts",
+        dest="accept_all",
+        action="store_true",
+        default=False,
     )
     parser.add_argument(
-        "--uninstall", dest="uninstall", action="store_true", default=False
+        "--uninstall",
+        help="uninstall poetry",
+        dest="uninstall",
+        action="store_true",
+        default=False,
     )
 
     args = parser.parse_args()

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -39,9 +39,7 @@ class SelfUpdateCommand(Command):
         from poetry.utils._compat import Path
         from poetry.utils.appdirs import expanduser
 
-        home = Path(expanduser("~"))
-
-        return home / ".poetry"
+        return Path(os.environ.get("POETRY_HOME", expanduser("~/.poetry")))
 
     @property
     def lib(self):

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -37,9 +37,8 @@ class SelfUpdateCommand(Command):
     @property
     def home(self):
         from poetry.utils._compat import Path
-        from poetry.utils.appdirs import expanduser
 
-        return Path(os.environ.get("POETRY_HOME", expanduser("~/.poetry")))
+        return Path(os.environ.get("POETRY_HOME", "~/.poetry")).expanduser()
 
     @property
     def lib(self):


### PR DESCRIPTION
Update `get-poetry.py` to take a flag that allows not setting the path when run non-interactively.

Additionally, make `self update` respect `$POETRY_HOME`.