### PR TITLE
Add Triage label to new issues and clean the PR template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41E Bug Report"
 about: Did you find a bug?
 title: ''
-labels: 'Bug'
+labels: Bug, Triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/---documentation.md
+++ b/.github/ISSUE_TEMPLATE/---documentation.md
@@ -2,7 +2,7 @@
 name: "\U0001F4DA Documentation"
 about: Did you find errors, problems, or anything unintelligible in the docs (https://python-poetry.org/docs)?
 title: ''
-labels: 'Documentation'
+labels: Documentation, Triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -2,7 +2,7 @@
 name: "\U0001F381 Feature Request"
 about: Do you have ideas for new features and improvements?
 title: ''
-labels: 'Feature'
+labels: Feature, Triage
 assignees: ''
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,13 @@
 # Pull Request Check List
 
-This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
+Resolves: #issue-number-here
+
+<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->
 
 - [ ] Added **tests** for changed code.
 - [ ] Updated **documentation** for changed code.
 
-**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
-on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.
+<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
+on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->
 
-If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
+<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


### PR DESCRIPTION
This pull request automatically adds to new issues that are either bugs, feature requests or documentation. The PR template is also cleaned up a bit to have information for the PR author only to be commented out.