### PR TITLE
Use `requirements.txt` as default export format

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -441,8 +441,8 @@ poetry export -f requirements.txt > requirements.txt
 
 ### Options
 
-* `--format (-f)`: The format to export to.  Currently, only
-  `requirements.txt` is supported.
+* `--format (-f)`: The format to export to (default: `requirements.txt`).
+  Currently, only `requirements.txt` is supported.
 * `--output (-o)`: The name of the output file.  If omitted, print to standard
   output.
 * `--dev`: Include development dependencies.

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -11,7 +11,13 @@ class ExportCommand(Command):
     description = "Exports the lock file to alternative formats."
 
     options = [
-        option("format", "f", "Format to export to.", flag=False),
+        option(
+            "format",
+            "f",
+            "Format to export to.",
+            flag=False,
+            default=Exporter.ACCEPTED_FORMATS[0],
+        ),
         option("output", "o", "The name of the output file.", flag=False),
         option("without-hashes", None, "Exclude hashes from the exported file."),
         option("dev", None, "Include development dependencies."),

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -16,7 +16,7 @@ class ExportCommand(Command):
             "f",
             "Format to export to.",
             flag=False,
-            default=Exporter.ACCEPTED_FORMATS[0],
+            default=Exporter.FORMAT_REQUIREMENTS_TXT,
         ),
         option("output", "o", "The name of the output file.", flag=False),
         option("without-hashes", None, "Exclude hashes from the exported file."),

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -17,6 +17,10 @@ class Exporter(object):
     Exporter class to export a lock file to alternative formats.
     """
 
+    #: The names of the supported export formats.  The first one will be
+    #: used as the default for the ``export`` CLI command.
+    #:
+    #: .. seealso:: :class:`poetry.console.commands.export.ExportCommand`
     ACCEPTED_FORMATS = ("requirements.txt",)
     ALLOWED_HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
 

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -17,11 +17,9 @@ class Exporter(object):
     Exporter class to export a lock file to alternative formats.
     """
 
-    #: The names of the supported export formats.  The first one will be
-    #: used as the default for the ``export`` CLI command.
-    #:
-    #: .. seealso:: :class:`poetry.console.commands.export.ExportCommand`
-    ACCEPTED_FORMATS = ("requirements.txt",)
+    FORMAT_REQUIREMENTS_TXT = "requirements.txt"
+    #: The names of the supported export formats.
+    ACCEPTED_FORMATS = (FORMAT_REQUIREMENTS_TXT,)
     ALLOWED_HASH_ALGORITHMS = ("sha256", "sha384", "sha512")
 
     def __init__(self, poetry):  # type: (Poetry) -> None

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -168,6 +168,28 @@ foo==1.0.0
     assert expected == tester.io.fetch_output()
 
 
+def test_export_uses_requirements_txt_format_by_default(app, repo):
+    repo.add_package(get_package("foo", "1.0.0"))
+    repo.add_package(get_package("bar", "1.1.0"))
+
+    command = app.find("lock")
+    tester = CommandTester(command)
+    tester.execute()
+
+    assert app.poetry.locker.lock.exists()
+
+    command = app.find("export")
+    tester = CommandTester(command)
+
+    tester.execute()
+
+    expected = """\
+foo==1.0.0
+"""
+
+    assert expected == tester.io.fetch_output()
+
+
 def test_export_includes_extras_by_flag(app, repo):
     repo.add_package(get_package("foo", "1.0.0"))
     repo.add_package(get_package("bar", "1.1.0"))


### PR DESCRIPTION
Prior to this change, users were always forced to specify the `--format`
option when invoking `poetry export`, although `requirements.txt` is
currently the only accepted value.

This patch modifies `poetry export` to make the `--format` option
nonobligatory.  If omitted, `requirements.txt` will be assumed as the
default value.

*(This is a follow-up to [my comment for PR #1035](https://github.com/python-poetry/poetry/pull/1035#issuecomment-483346513).)*


# Pull Request Check List

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.