### PR TITLE
Sort extras constraints of dependencies in lockfile

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -247,7 +247,7 @@ class Locker(object):
             constraint = {"version": str(dependency.pretty_constraint)}
 
             if dependency.extras:
-                constraint["extras"] = dependency.extras
+                constraint["extras"] = sorted(dependency.extras)
 
             if dependency.is_optional():
                 constraint["optional"] = True

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -246,3 +246,40 @@ A = []
 """
 
     assert expected == content
+
+
+def test_extras_dependencies_are_ordered(locker, root):
+    package_a = get_package("A", "1.0.0")
+    package_a.add_dependency(
+        "B", {"version": "^1.0.0", "optional": True, "extras": ["c", "a", "b"]}
+    )
+    package_a.requires[-1].activate()
+
+    locker.set_lock_data(root, [package_a])
+
+    expected = """[[package]]
+category = "main"
+description = ""
+name = "A"
+optional = false
+python-versions = "*"
+version = "1.0.0"
+
+[package.dependencies]
+[package.dependencies.B]
+extras = ["a", "b", "c"]
+optional = true
+version = "^1.0.0"
+
+[metadata]
+content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
+python-versions = "*"
+
+[metadata.files]
+A = []
+"""
+
+    with locker.lock.open(encoding="utf-8") as f:
+        content = f.read()
+
+    assert expected == content


### PR DESCRIPTION
The extras constraints ordering is not guaranteed on metadata and it causes changes in poetry.lock file during the update process even when the dependency did not change.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.