### PR TITLE
Updated 'create virtualenvs' link in index.md to match changes made in d24dab0.

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -456,4 +456,4 @@ poetry export -f requirements.txt > requirements.txt
 The `env` command regroups sub commands to interact with the virtualenvs
 associated with a specific project.
 
-See [Managing environments](./managing-environments.md) for more information about these commands.
+See [Managing environments](/docs/managing-environments.md) for more information about these commands.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -28,7 +28,7 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poet
 !!! note
 
     You only need to install Poetry once. It will automatically pick up the current
-    Python version and use it to [create virtualenvs](/docs/basic-usage/#poetry-and-virtualenvs) accordingly.
+    Python version and use it to [create virtualenvs](/docs/managing-environments.md) accordingly.
 
 The installer installs the `poetry` tool to Poetry's `bin` directory.
 On Unix it is located at `$HOME/.poetry/bin` and on Windows at `%USERPROFILE%\.poetry\bin`.


### PR DESCRIPTION
This tiny PR fixes a broken link in the documentation. Unfortunately, it was the first link I clicked when going through the Poetry documentation. The breakage seems to have been introduced in d24dab0.