### PR TITLE
Fix requirement string parsing for URLs

### DIFF
--- a/poetry/version/requirements.py
+++ b/poetry/version/requirements.py
@@ -161,7 +161,7 @@ IDENTIFIER = Combine(ALPHANUM + ZeroOrMore(IDENTIFIER_END))
 NAME = IDENTIFIER("name")
 EXTRA = IDENTIFIER
 
-URI = Regex(r"[^ ]+")("url")
+URI = Regex(r"[^ ;]+")("url")
 URL = AT + URI
 
 EXTRAS_LIST = EXTRA + ZeroOrMore(COMMA + EXTRA)


### PR DESCRIPTION
Resolves: #2326

If we want support url containing the `;` character, we can use the following regex instead:

`((?!; )(?!;^)(?! ).)+`