### PR TITLE
Fix Timer appears dark on dark terminal 

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -803,7 +803,7 @@ class Provider:
             self._io.write_line("Resolving dependencies...")
             yield
         else:
-            indicator = Indicator(self._io, "{message} ({elapsed:2s})</>")
+            indicator = Indicator(self._io, "{message} ({elapsed:2s})")
 
             with indicator.auto(
                 "<info>Resolving dependencies...</info>",

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -804,7 +804,7 @@ class Provider:
             yield
         else:
             indicator = Indicator(
-                self._io, "{message} <fg=black;options=bold>({elapsed:2s})</>"
+                self._io, "{message} ({elapsed:2s})</>"
             )
 
             with indicator.auto(

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -803,9 +803,7 @@ class Provider:
             self._io.write_line("Resolving dependencies...")
             yield
         else:
-            indicator = Indicator(
-                self._io, "{message} ({elapsed:2s})</>"
-            )
+            indicator = Indicator(self._io, "{message} ({elapsed:2s})</>")
 
             with indicator.auto(
                 "<info>Resolving dependencies...</info>",


### PR DESCRIPTION
Resolves: #2228

Original Issue: https://github.com/python-poetry/poetry/issues/2228

This removes the hard-coded black color. 

**Before**
<img width="387" alt="image" src="https://user-images.githubusercontent.com/24614127/80308661-d643fc00-87ed-11ea-8c56-3824e1130951.png">

**After** 
<img width="518" alt="image" src="https://user-images.githubusercontent.com/24614127/80308674-dfcd6400-87ed-11ea-9b6b-d8239d3b6746.png">

Since the hardcoded color is removed the timer just takes the color depending on the terminal theme. 
