### PR TITLE
poetry show <package> now also shows which packages depend on it

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -407,10 +407,13 @@ name        : pendulum
 version     : 1.4.2
 description : Python datetimes made easy
 
-dependencies:
+dependencies
  - python-dateutil >=2.6.1
  - tzlocal >=1.4
  - pytzdata >=2017.2.2
+
+required by
+ - calendar >=1.4.0
 ```
 
 ### Options

--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -180,6 +180,13 @@ lists all packages available."""
 
                 return 0
 
+            required_by = {}
+            for parent in locked_packages:
+                children = {d.pretty_name: d.pretty_constraint for d in parent.requires}
+
+                if pkg.pretty_name in children:
+                    required_by[parent.pretty_name] = children[pkg.pretty_name]
+
             rows = [
                 ["<info>name</>", " : <c1>{}</>".format(pkg.pretty_name)],
                 ["<info>version</>", " : <b>{}</b>".format(pkg.pretty_version)],
@@ -197,6 +204,14 @@ lists all packages available."""
                         " - <c1>{}</c1> <b>{}</b>".format(
                             dependency.pretty_name, dependency.pretty_constraint
                         )
+                    )
+
+            if required_by:
+                self.line("")
+                self.line("<info>required by</info>")
+                for parent, requires_version in required_by.items():
+                    self.line(
+                        " - <c1>{}</c1> <b>{}</b>".format(parent, requires_version)
                     )
 
             return 0

--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -180,12 +180,12 @@ lists all packages available."""
 
                 return 0
 
-            required_by = {}
-            for parent in locked_packages:
-                children = {d.pretty_name: d.pretty_constraint for d in parent.requires}
+            required_by = {}  # type: Dict[str, str]
+            for locked in locked_packages:
+                dependencies = {d.name: d.pretty_constraint for d in locked.requires}
 
-                if pkg.pretty_name in children:
-                    required_by[parent.pretty_name] = children[pkg.pretty_name]
+                if pkg.name in dependencies:
+                    required_by[locked.pretty_name] = dependencies[pkg.name]
 
             rows = [
                 ["<info>name</>", " : <c1>{}</>".format(pkg.pretty_name)],

--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -180,7 +180,7 @@ lists all packages available."""
 
                 return 0
 
-            required_by = {}  # type: Dict[str, str]
+            required_by = {}
             for locked in locked_packages:
                 dependencies = {d.name: d.pretty_constraint for d in locked.requires}
 

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1419,3 +1419,78 @@ cachy 0.2.0
 """
 
     assert expected == tester.io.fetch_output()
+
+
+def test_show_required_by_deps(tester, poetry, installed):
+    poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.2.0"))
+    poetry.package.add_dependency(Factory.create_dependency("pendulum", "2.0.0"))
+
+    cachy2 = get_package("cachy", "0.2.0")
+    cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
+
+    pendulum = get_package("pendulum", "2.0.0")
+    pendulum.add_dependency(Factory.create_dependency("CachY", "^0.2.0"))
+
+    installed.add_package(cachy2)
+    installed.add_package(pendulum)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.2.0",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"msgpack-python": ">=0.5 <0.6"},
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "description": "Pendulum package",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"cachy": ">=0.2.0 <0.3.0"},
+                },
+                {
+                    "name": "msgpack-python",
+                    "version": "0.5.1",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"cachy": [], "pendulum": [], "msgpack-python": []},
+            },
+        }
+    )
+
+    tester.execute("cachy")
+
+    expected = """\
+name         : cachy
+version      : 0.2.0
+description  :
+
+dependencies
+ - msgpack-python >=0.5 <0.6
+
+required by
+ - pendulum >=0.2.0 <0.3.0
+"""
+
+    assert expected == tester.io.fetch_output()

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1482,15 +1482,15 @@ def test_show_required_by_deps(tester, poetry, installed):
     tester.execute("cachy")
 
     expected = """\
-name         : cachy
-version      : 0.2.0
-description  :
+ name         : cachy
+ version      : 0.2.0
+ description  :
 
 dependencies
  - msgpack-python >=0.5 <0.6
 
 required by
  - pendulum >=0.2.0 <0.3.0
-"""
-
-    assert expected == tester.io.fetch_output()
+""".splitlines()
+    actual = [line.rstrip() for line in tester.io.fetch_output().splitlines()]
+    assert actual == expected


### PR DESCRIPTION
# Pull Request Check List

Partly resolves: #1906 


- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

#1906 Requested an ability to know **why** packages are required. Even though the suggestion outlined a reverse-tree based approach, I believe that this can also be solved using a more simple approach: by providing the `required by` information in the `poetry show <package>` output - done with just 15 lines of code. 

I had this patch applied locally since a couple of weeks ago and I found it extremely useful - there's no need to do `poetry show --tree | ag <package> -C 20` anymore just to find out where some 3rd party dependencies come from.

Summary of what's been done:
* 15 lines of business logic in `commands/show.py`
* A test for `poetry show <package>` command - realised a test for this command didn't exist, so it tests both the default output and my changes
* Documentation update and a little typo fix, where `dependencies` isn't supposed to have a colon at the end. 

Please see the screenshot below for a little teaser:
![image](https://user-images.githubusercontent.com/16212750/80312332-9d4f5b80-87dc-11ea-8580-245cfb90048a.png)

