### PR TITLE
Improve dependency resolution and markers handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Run pytest
         shell: bash
-        run: poetry run pytest -q tests
+        run: poetry run pytest -v tests

--- a/poetry/console/commands/debug/resolve.py
+++ b/poetry/console/commands/debug/resolve.py
@@ -28,9 +28,8 @@ class DebugResolveCommand(InitCommand):
     loggers = ["poetry.repositories.pypi_repository"]
 
     def handle(self):
+        from poetry.core.packages.project_package import ProjectPackage
         from poetry.io.null_io import NullIO
-        from poetry.core.packages import ProjectPackage
-        from poetry.installation.installer import Installer
         from poetry.puzzle import Solver
         from poetry.repositories.pool import Pool
         from poetry.repositories.repository import Repository
@@ -106,7 +105,6 @@ class DebugResolveCommand(InitCommand):
 
         if self.option("install"):
             env = EnvManager(self.poetry).get()
-            current_python_version = ".".join(str(v) for v in env.version_info)
             pool = Pool()
             locked_repository = Repository()
             for op in ops:
@@ -114,11 +112,9 @@ class DebugResolveCommand(InitCommand):
 
             pool.add_repository(locked_repository)
 
-            with package.with_python_versions(current_python_version):
-                installer = Installer(NullIO(), env, package, self.poetry.locker, pool)
-                solver = Solver(package, pool, Repository(), Repository(), NullIO())
+            solver = Solver(package, pool, Repository(), Repository(), NullIO())
+            with solver.use_environment(env):
                 ops = solver.solve()
-                installer._filter_operations(ops, Repository())
 
         for op in ops:
             if self.option("install") and op.skipped:

--- a/poetry/mixology/version_solver.py
+++ b/poetry/mixology/version_solver.py
@@ -440,6 +440,13 @@ class VersionSolver:
         if dependency.extras:
             locked.requires_extras = dependency.extras
 
+        if not dependency.transitive_marker.without_extras().is_any():
+            marker_intersection = dependency.transitive_marker.without_extras().intersect(
+                locked.dependency.marker.without_extras()
+            )
+            if not marker_intersection.is_empty():
+                locked.dependency.transitive_marker = marker_intersection
+
         return locked
 
     def _log(self, text):

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -244,7 +244,8 @@ class Locker(object):
             if dependency.pretty_name not in dependencies:
                 dependencies[dependency.pretty_name] = []
 
-            constraint = {"version": str(dependency.pretty_constraint)}
+            constraint = inline_table()
+            constraint["version"] = str(dependency.pretty_constraint)
 
             if dependency.extras:
                 constraint["extras"] = sorted(dependency.extras)
@@ -252,8 +253,8 @@ class Locker(object):
             if dependency.is_optional():
                 constraint["optional"] = True
 
-            if not dependency.python_constraint.is_any():
-                constraint["python"] = str(dependency.python_constraint)
+            if not dependency.marker.is_any():
+                constraint["markers"] = str(dependency.marker)
 
             dependencies[dependency.pretty_name].append(constraint)
 
@@ -274,8 +275,6 @@ class Locker(object):
             "python-versions": package.python_versions,
             "files": sorted(package.files, key=lambda x: x["file"]),
         }
-        if not package.marker.is_any():
-            data["marker"] = str(package.marker)
 
         if package.extras:
             extras = {}

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -984,7 +984,9 @@ class SystemEnv(Env):
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": ".".join(
+                v for v in platform.python_version().split(".")[:2]
+            ),
             "sys_platform": sys.platform,
             "version_info": sys.version_info,
         }
@@ -1151,6 +1153,7 @@ class MockEnv(NullEnv):
         is_venv=False,
         pip_version="19.1",
         sys_path=None,
+        marker_env=None,
         **kwargs
     ):
         super(MockEnv, self).__init__(**kwargs)
@@ -1162,14 +1165,7 @@ class MockEnv(NullEnv):
         self._is_venv = is_venv
         self._pip_version = Version.parse(pip_version)
         self._sys_path = sys_path
-
-    @property
-    def version_info(self):  # type: () -> Tuple[int]
-        return self._version_info
-
-    @property
-    def python_implementation(self):  # type: () -> str
-        return self._python_implementation
+        self._mock_marker_env = marker_env
 
     @property
     def platform(self):  # type: () -> str
@@ -1189,6 +1185,18 @@ class MockEnv(NullEnv):
             return super(MockEnv, self).sys_path
 
         return self._sys_path
+
+    def get_marker_env(self):  # type: () -> Dict[str, Any]
+        if self._mock_marker_env is not None:
+            return self._mock_marker_env
+
+        marker_env = super(MockEnv, self).get_marker_env()
+        marker_env["python_implementation"] = self._python_implementation
+        marker_env["version_info"] = self._version_info
+        marker_env["python_version"] = ".".join(str(v) for v in self._version_info[:2])
+        marker_env["sys_platform"] = self._platform
+
+        return marker_env
 
     def is_venv(self):  # type: () -> bool
         return self._is_venv

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -598,8 +598,9 @@ Package operations: 1 install, 0 updates, 0 removals
     assert content["dependencies"]["cachy"] == {"version": "0.2.0", "python": ">=2.7"}
 
 
-def test_add_constraint_with_platform(app, repo, installer):
+def test_add_constraint_with_platform(app, repo, installer, env):
     platform = sys.platform
+    env._platform = platform
     command = app.find("add")
     tester = CommandTester(command)
 
@@ -608,7 +609,7 @@ def test_add_constraint_with_platform(app, repo, installer):
     repo.add_package(get_package("cachy", "0.1.0"))
     repo.add_package(cachy2)
 
-    tester.execute("cachy=0.2.0 --platform {}".format(platform))
+    tester.execute("cachy=0.2.0 --platform {} -vvv".format(platform))
 
     expected = """\
 

--- a/tests/installation/fixtures/old-lock.test
+++ b/tests/installation/fixtures/old-lock.test
@@ -16,6 +16,7 @@ name = "colorama"
 version = "0.3.9"
 description = "Cross-platform colored terminal text."
 category = "dev"
+marker = "sys_platform == \"win32\""
 optional = false
 python-versions = "*"
 
@@ -24,6 +25,7 @@ name = "funcsigs"
 version = "1.0.2"
 description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
 category = "dev"
+marker = "python_version < \"3.0\""
 optional = false
 python-versions = "*"
 
@@ -68,8 +70,8 @@ six = ">=1.10.0"
 attrs = ">=17.4.0"
 more-itertools = ">=4.0.0"
 pluggy = ">=0.5,<0.7"
-funcsigs = {"version" = "*", "markers" = "python_version < \"3.0\""}
-colorama = {"version" = "*", "markers" = "sys_platform == \"win32\""}
+funcsigs = {"version" = "*", "python" = "<3.0"}
+colorama = "*"
 
 [[package]]
 name = "six"

--- a/tests/installation/fixtures/update-with-locked-extras.test
+++ b/tests/installation/fixtures/update-with-locked-extras.test
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [package.dependencies]
 "B" = {version = "^1.0", optional = true}
-"C" = {"version" = "^1.0", "python" = ">=2.7,<2.8"}
+"C" = {version = "^1.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
 
 [package.extras]
 foo = ["b"]
@@ -26,7 +26,6 @@ name = "C"
 version = "1.1"
 description = ""
 category = "main"
-marker = "python_version >= \"2.7\" and python_version < \"2.8\""
 optional = false
 python-versions = "*"
 

--- a/tests/installation/fixtures/with-directory-dependency-poetry.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry.test
@@ -16,7 +16,7 @@ python-versions = "*"
 version = "1.2.3"
 
 [package.dependencies]
-pendulum = {version = ">=1.4.4", optional = true}
+pendulum = {version = ">=1.4.4", optional = true, markers = "extra == \"extras_a\""}
 
 [package.extras]
 extras_a = ["pendulum (>=1.4.4)"]

--- a/tests/installation/fixtures/with-duplicate-dependencies-update.test
+++ b/tests/installation/fixtures/with-duplicate-dependencies-update.test
@@ -23,7 +23,6 @@ C = "1.5"
 [[package]]
 name = "C"
 version = "1.5"
-marker = "python_version >= \"2.7\""
 description = ""
 category = "main"
 optional = false

--- a/tests/installation/fixtures/with-duplicate-dependencies.test
+++ b/tests/installation/fixtures/with-duplicate-dependencies.test
@@ -8,8 +8,8 @@ python-versions = "*"
 
 [package.dependencies]
 B = [
-    {"version" = "^1.0", "python" = "<4.0"},
-    {"version" = "^2.0", "python" = ">=4.0"},
+    {version = "^1.0", markers = "python_version < \"4.0\""},
+    {version = "^2.0", markers = "python_version >= \"4.0\""},
 ]
 
 [[package]]
@@ -17,7 +17,6 @@ name = "B"
 version = "1.0"
 description = ""
 category = "main"
-marker = "python_version < \"4.0\""
 optional = false
 python-versions = "*"
 
@@ -29,7 +28,6 @@ name = "B"
 version = "2.0"
 description = ""
 category = "main"
-marker = "python_version >= \"4.0\""
 optional = false
 python-versions = "*"
 
@@ -41,7 +39,6 @@ name = "C"
 version = "1.2"
 description = ""
 category = "main"
-marker = "python_version < \"4.0\""
 optional = false
 python-versions = "*"
 
@@ -50,7 +47,6 @@ name = "C"
 version = "1.5"
 description = ""
 category = "main"
-marker = "python_version >= \"4.0\""
 optional = false
 python-versions = "*"
 

--- a/tests/installation/fixtures/with-multiple-updates.test
+++ b/tests/installation/fixtures/with-multiple-updates.test
@@ -1,6 +1,6 @@
 [[package]]
 name = "A"
-version = "1.0"
+version = "1.1"
 description = ""
 category = "main"
 optional = false
@@ -9,17 +9,17 @@ python-versions = "*"
 [package.dependencies]
 B = ">=1.0.1"
 C = [
-    {version = "^1.0", python = ">=2.7,<2.8"},
-    {version = "^2.0", python = ">=3.4,<4.0"},
+    {version = "^1.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""},
+    {version = "^2.0", markers = "python_version >= \"3.4\" and python_version < \"4.0\""},
 ]
 
 [[package]]
 name = "B"
-version = "1.0.1"
+version = "1.1.0"
 description = ""
 category = "main"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+python-versions = "*"
 
 [[package]]
 name = "C"
@@ -27,7 +27,6 @@ version = "1.0"
 description = ""
 category = "main"
 optional = false
-marker = "python_version >= \"2.7\" and python_version < \"2.8\""
 python-versions = "*"
 
 [[package]]
@@ -36,7 +35,6 @@ version = "2.0"
 description = ""
 category = "main"
 optional = false
-marker = "python_version >= \"3.4\" and python_version < \"4.0\""
 python-versions = "*"
 
 [metadata]

--- a/tests/installation/fixtures/with-optional-dependencies.test
+++ b/tests/installation/fixtures/with-optional-dependencies.test
@@ -11,7 +11,6 @@ name = "C"
 version = "1.3"
 description = ""
 category = "main"
-marker = "python_version >= \"2.7\" and python_version < \"2.8\" or python_version >= \"3.4\" and python_version < \"4.0\""
 optional = false
 python-versions = "*"
 
@@ -23,7 +22,6 @@ name = "D"
 version = "1.4"
 description = ""
 category = "main"
-marker = "python_version >= \"2.7\" and python_version < \"2.8\" or python_version >= \"3.4\" and python_version < \"4.0\""
 optional = false
 python-versions = "*"
 

--- a/tests/installation/fixtures/with-platform-dependencies.test
+++ b/tests/installation/fixtures/with-platform-dependencies.test
@@ -11,7 +11,6 @@ name = "B"
 version = "1.1"
 description = ""
 category = "main"
-marker = "sys_platform == \"custom\""
 optional = false
 python-versions = "*"
 
@@ -20,7 +19,6 @@ name = "C"
 version = "1.3"
 description = ""
 category = "main"
-marker = "sys_platform == \"darwin\""
 optional = false
 python-versions = "*"
 
@@ -32,7 +30,6 @@ name = "D"
 version = "1.4"
 description = ""
 category = "main"
-marker = "sys_platform == \"darwin\""
 optional = false
 python-versions = "*"
 

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -266,10 +266,7 @@ python-versions = "*"
 version = "1.0.0"
 
 [package.dependencies]
-[package.dependencies.B]
-extras = ["a", "b", "c"]
-optional = true
-version = "^1.0.0"
+B = {version = "^1.0.0", extras = ["a", "b", "c"], optional = true}
 
 [metadata]
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -559,21 +559,6 @@ def test_solver_sub_dependencies_with_requirements_complex(solver, repo, package
         ],
     )
 
-    op = ops[3]  # d
-    assert str(op.package.marker) == 'python_version < "4.0"'
-
-    op = ops[0]  # e
-    assert str(op.package.marker) == (
-        'python_version < "4.0" and sys_platform == "win32" '
-        'or python_version < "5.0" and sys_platform == "win32"'
-    )
-
-    op = ops[1]  # f
-    assert str(op.package.marker) == 'python_version < "5.0"'
-
-    op = ops[4]  # a
-    assert str(op.package.marker) == 'python_version < "5.0"'
-
 
 def test_solver_sub_dependencies_with_not_supported_python_version(
     solver, repo, package
@@ -773,11 +758,6 @@ def test_solver_duplicate_dependencies_same_constraint(solver, repo, package):
         ],
     )
 
-    op = ops[0]
-    assert (
-        str(op.package.marker) == 'python_version == "2.7" or python_version >= "3.4"'
-    )
-
 
 def test_solver_duplicate_dependencies_different_constraints(solver, repo, package):
     package.add_dependency("A")
@@ -803,12 +783,6 @@ def test_solver_duplicate_dependencies_different_constraints(solver, repo, packa
             {"job": "install", "package": package_a},
         ],
     )
-
-    op = ops[0]
-    assert str(op.package.marker) == 'python_version < "3.4"'
-
-    op = ops[1]
-    assert str(op.package.marker) == 'python_version >= "3.4"'
 
 
 def test_solver_duplicate_dependencies_different_constraints_same_requirements(
@@ -871,12 +845,6 @@ def test_solver_duplicate_dependencies_sub_dependencies(solver, repo, package):
             {"job": "install", "package": package_a},
         ],
     )
-
-    op = ops[2]
-    assert str(op.package.marker) == 'python_version < "3.4"'
-
-    op = ops[3]
-    assert str(op.package.marker) == 'python_version >= "3.4"'
 
 
 def test_solver_fails_if_dependency_name_does_not_match_package(solver, repo, package):
@@ -1006,11 +974,6 @@ def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requir
 
     check_solver_result(ops, [{"job": "install", "package": package_a}])
 
-    assert (
-        str(ops[0].package.marker)
-        == 'python_version >= "3.6" and python_version < "4.0"'
-    )
-
 
 def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requirement_is_compatible_multiple(
     solver, repo, package
@@ -1037,11 +1000,6 @@ def test_solver_does_not_trigger_conflict_for_python_constraint_if_python_requir
             {"job": "install", "package": package_b},
             {"job": "install", "package": package_a},
         ],
-    )
-
-    assert str(ops[0].package.marker) == (
-        'python_version >= "3.6" and python_version < "4.0" '
-        'or python_version >= "3.5.3" and python_version < "4.0.0"'
     )
 
 
@@ -1078,44 +1036,6 @@ def test_solver_finds_compatible_package_for_dependency_python_not_fully_compati
     ops = solver.solve()
 
     check_solver_result(ops, [{"job": "install", "package": package_a100}])
-
-    assert (
-        str(ops[0].package.marker)
-        == 'python_version >= "3.5" and python_version < "4.0"'
-    )
-
-
-def test_solver_sets_appropriate_markers_when_solving(solver, repo, package):
-    dep = dependency_from_pep_508(
-        'B (>=1.0); python_version >= "3.6" and sys_platform != "win32"'
-    )
-
-    package.add_dependency("A", "^1.0")
-
-    package_a = get_package("A", "1.0.0")
-    package_a.requires.append(dep)
-
-    package_b = get_package("B", "1.0.0")
-
-    repo.add_package(package_a)
-    repo.add_package(package_b)
-
-    ops = solver.solve()
-
-    check_solver_result(
-        ops,
-        [
-            {"job": "install", "package": package_b},
-            {"job": "install", "package": package_a},
-        ],
-    )
-
-    assert (
-        str(ops[0].package.marker)
-        == 'python_version >= "3.6" and sys_platform != "win32"'
-    )
-
-    assert str(ops[1].package.marker) == ""
 
 
 def test_solver_does_not_trigger_new_resolution_on_duplicate_dependencies_if_only_extras(
@@ -1902,31 +1822,6 @@ def test_ignore_python_constraint_no_overlap_dependencies(solver, repo, package)
     )
 
 
-def test_solver_properly_propagates_markers(solver, repo, package):
-    package.python_versions = "~2.7 || ^3.4"
-    package.add_dependency(
-        "A",
-        {
-            "version": "^1.0",
-            "markers": "python_version >= '3.6' and implementation_name != 'pypy'",
-        },
-    )
-
-    package_a = get_package("A", "1.0.0")
-    package_a.python_versions = ">=3.6"
-
-    repo.add_package(package_a)
-
-    ops = solver.solve()
-
-    check_solver_result(ops, [{"job": "install", "package": package_a}])
-
-    assert (
-        str(ops[0].package.marker)
-        == 'python_version >= "3.6" and implementation_name != "pypy"'
-    )
-
-
 def test_solver_should_not_go_into_an_infinite_loop_on_duplicate_dependencies(
     solver, repo, package
 ):
@@ -1956,6 +1851,3 @@ def test_solver_should_not_go_into_an_infinite_loop_on_duplicate_dependencies(
             {"job": "install", "package": package_a},
         ],
     )
-
-    assert 'implementation_name == "pypy"' == str(ops[0].package.marker)
-    assert 'implementation_name != "pypy"' == str(ops[1].package.marker)


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2187 
Resolves: #2138 
Resolves: #1728
Resolves: #1457
Resolves: #907
Resolves: #1772
And possibly more

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR improves the overall dependency resolution logic and the way we handle environment markers during resolution.

Since managing environment markers was proving to be a headache, the best course of action was to just no longer try to dump and reconcile them in the lock file at the package level.

The environment markers of each dependencies (and transitive dependencies) are now dumped in the lock file. That way we can do a full resolution using the lock file for the current environment before installing.

This was made possible by the previous work in #2342 

This introduces changes to the lock file which are backwards compatible (new versions of Poetry won't break with the older lock files) but not forward compatible (older versions of Poetry might break with this new lock file format).

Unfortunately, there is no way around it and this is the best way to fix a lot of issues with the dependency resolution aspect of Poetry.

Hopefully, the 1.1 release will be good enough for people not to want to downgrade to a previous version 😅 
