### PR TITLE
Add meaningful tests to new-layout

### DIFF
--- a/docs/docs/basic-usage.md
+++ b/docs/docs/basic-usage.md
@@ -39,6 +39,7 @@ python = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.4"
+toml = "^0.10.0"
 ```
 
 ### Specifying dependencies

--- a/poetry/console/commands/new.py
+++ b/poetry/console/commands/new.py
@@ -59,7 +59,9 @@ class NewCommand(Command):
             ".".join(str(v) for v in current_env.version_info[:2])
         )
 
-        dev_dependencies = {}
+        dev_dependencies = {
+            "toml": "^0.10.0",
+        }
         python_constraint = parse_constraint(default_python)
         if parse_constraint("<3.5").allows_any(python_constraint):
             dev_dependencies["pytest"] = "^4.6"

--- a/poetry/layouts/layout.py
+++ b/poetry/layouts/layout.py
@@ -5,11 +5,20 @@ from tomlkit import table
 from poetry.utils.helpers import module_name
 
 
-TESTS_DEFAULT = u"""from {package_name} import __version__
+TESTS_DEFAULT = u"""\
+from pathlib import Path
+
+import toml
+
+from {package_name} import __version__ as module_version
 
 
 def test_version():
-    assert __version__ == '{version}'
+    pyproject_file = Path(__file__).parents[1] / "pyproject.toml"
+    pyproject = toml.load(pyproject_file)
+    pyproject_version = pyproject["tool"]["poetry"]["version"]
+
+    assert module_version == pyproject_version
 """
 
 


### PR DESCRIPTION
This PR adds a more meaningful template-test to the `poetry new` standard layout. The new test checks whether the module-version and the `pyproject.toml`-version are equal.

# Pull Request Check List

Resolves: -

- [ ] Added **tests** for changed code.
  - I'm not sure how to test this change properly - suggestions are welcome.
- [X] Updated **documentation** for changed code.