### PR TITLE
Fix editable installations for Poetry packages

### DIFF
--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -16,7 +16,7 @@ from poetry.utils._compat import decode
 
 SCRIPT_TEMPLATE = """\
 #!{python}
-from {module} import {callable_}
+from {module} import {callable_holder}
 
 if __name__ == '__main__':
     {callable_}()
@@ -105,6 +105,8 @@ class EditableBuilder(Builder):
         for script in scripts:
             name, script = script.split(" = ")
             module, callable_ = script.split(":")
+            callable_holder = callable_.rsplit(".", 1)[0]
+
             script_file = scripts_path.joinpath(name)
             self._debug(
                 "  - Adding the <c2>{}</c2> script to <b>{}</b>".format(
@@ -117,6 +119,7 @@ class EditableBuilder(Builder):
                         SCRIPT_TEMPLATE.format(
                             python=self._env._bin("python"),
                             module=module,
+                            callable_holder=callable_holder,
                             callable_=callable_,
                         )
                     )

--- a/poetry/repositories/installed_repository.py
+++ b/poetry/repositories/installed_repository.py
@@ -49,6 +49,19 @@ class InstalledRepository(Repository):
                     is_standard_package = False
 
                 if is_standard_package:
+                    if (
+                        path.name.endswith(".dist-info")
+                        and env.site_packages.joinpath(
+                            "{}.pth".format(package.pretty_name)
+                        ).exists()
+                    ):
+                        with env.site_packages.joinpath(
+                            "{}.pth".format(package.pretty_name)
+                        ).open() as f:
+                            directory = Path(f.readline().strip())
+                            package.source_type = "directory"
+                            package.source_url = directory.as_posix()
+
                     continue
 
                 src_path = env.path / "src"

--- a/tests/fixtures/simple_project/pyproject.toml
+++ b/tests/fixtures/simple_project/pyproject.toml
@@ -26,3 +26,4 @@ python = "~2.7 || ^3.4"
 
 [tool.poetry.scripts]
 foo = "foo:bar"
+baz = "bar:baz.boom.bim"

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -70,7 +70,7 @@ def test_builder_installs_proper_files_for_standard_packages(simple_poetry, tmp_
 
     assert "poetry" == dist_info.joinpath("INSTALLER").read_text()
     assert (
-        "[console_scripts]\nfoo=foo:bar\n\n"
+        "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\n\n"
         == dist_info.joinpath("entry_points.txt").read_text()
     )
 
@@ -109,10 +109,35 @@ My Package
     records = dist_info.joinpath("RECORD").read_text()
     assert str(tmp_venv.site_packages.joinpath("simple_project.pth")) in records
     assert str(tmp_venv._bin_dir.joinpath("foo")) in records
+    assert str(tmp_venv._bin_dir.joinpath("baz")) in records
     assert str(dist_info.joinpath("METADATA")) in records
     assert str(dist_info.joinpath("INSTALLER")) in records
     assert str(dist_info.joinpath("entry_points.txt")) in records
     assert str(dist_info.joinpath("RECORD")) in records
+
+    baz_script = """\
+#!{python}
+from bar import baz.boom
+
+if __name__ == '__main__':
+    baz.boom.bim()
+""".format(
+        python=tmp_venv._bin("python")
+    )
+
+    assert baz_script == tmp_venv._bin_dir.joinpath("baz").read_text()
+
+    foo_script = """\
+#!{python}
+from foo import bar
+
+if __name__ == '__main__':
+    bar()
+""".format(
+        python=tmp_venv._bin("python")
+    )
+
+    assert foo_script == tmp_venv._bin_dir.joinpath("foo").read_text()
 
 
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/editable-2.3.4.dist-info/METADATA
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/editable-2.3.4.dist-info/METADATA
@@ -1,0 +1,22 @@
+Metadata-Version: 2.1
+Name: editable
+Version: 2.3.4
+Summary: Editable description.
+License: MIT
+Keywords: cli,commands
+Author: Foo Bar
+Author-email: foo@bar.com
+Requires-Python: >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+Classifier: License :: OSI Approved :: MIT License
+Classifier: Programming Language :: Python :: 2
+Classifier: Programming Language :: Python :: 2.7
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.4
+Classifier: Programming Language :: Python :: 3.5
+Classifier: Programming Language :: Python :: 3.6
+Classifier: Programming Language :: Python :: 3.7
+Classifier: Programming Language :: Python :: 3.8
+Description-Content-Type: text/x-rst
+
+Editable
+####

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/editable.pth
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/editable.pth
@@ -1,0 +1,1 @@
+/path/to/editable

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -17,6 +17,7 @@ INSTALLED_RESULTS = [
         zipp.Path(str(SITE_PACKAGES / "foo-0.1.0-py3.8.egg"), "EGG-INFO")
     ),
     metadata.PathDistribution(VENDOR_DIR / "attrs-19.3.0.dist-info"),
+    metadata.PathDistribution(SITE_PACKAGES / "editable-2.3.4.dist-info"),
 ]
 
 
@@ -45,7 +46,7 @@ def test_load(mocker):
     mocker.patch("poetry.repositories.installed_repository._VENDORS", str(VENDOR_DIR))
     repository = InstalledRepository.load(MockEnv(path=ENV_DIR))
 
-    assert len(repository.packages) == 3
+    assert len(repository.packages) == 4
 
     cleo = repository.packages[0]
     assert cleo.name == "cleo"
@@ -55,11 +56,11 @@ def test_load(mocker):
         == "Cleo allows you to create beautiful and testable command-line interfaces."
     )
 
-    foo = repository.packages[1]
+    foo = repository.packages[2]
     assert foo.name == "foo"
     assert foo.version.text == "0.1.0"
 
-    pendulum = repository.packages[2]
+    pendulum = repository.packages[3]
     assert pendulum.name == "pendulum"
     assert pendulum.version.text == "2.0.5"
     assert pendulum.description == "Python datetimes made easy"
@@ -69,3 +70,9 @@ def test_load(mocker):
 
     for pkg in repository.packages:
         assert pkg.name != "attrs"
+
+    editable = repository.packages[1]
+    assert "editable" == editable.name
+    assert "2.3.4" == editable.version.text
+    assert "directory" == editable.source_type
+    assert "/path/to/editable" == editable.source_url


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Followup to #2360 

Basically, editable installs for transitive packages failed due to the `build_script` attribute not being available on standard `Package` objects.

Also, the generated scripts weren't correct if the callable was a module attribute.

Finally, the loading of editable installed packages was not correct and they weren't marked as being directory dependencies which would lead to them being always updated when installing.

Note that we will rely on [PEP 610](https://www.python.org/dev/peps/pep-0610/) in the future for detection of such packages.
