### PR TITLE
Fix #2089: Make Python implementation type as part of the venv name.

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -200,21 +200,9 @@ class EnvManager(object):
             pass
 
         try:
-            python_version = decode(
-                subprocess.check_output(
-                    list_to_shell_command(
-                        [
-                            python,
-                            "-c",
-                            "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
-                        ]
-                    ),
-                    shell=True,
-                )
-            )
+            python_version, python_implementation = self.get_python_information(python)
         except CalledProcessError as e:
             raise EnvCommandError(e)
-
         python_version = Version.parse(python_version.strip())
         minor = "{}.{}".format(python_version.major, python_version.minor)
         patch = python_version.text
@@ -251,7 +239,7 @@ class EnvManager(object):
                     # We need to recreate
                     create = True
 
-        name = "{}-py{}".format(base_env_name, minor)
+        name = "{}-{}{}".format(base_env_name, python_implementation, minor)
         venv = venv_path / name
 
         # Create if needed
@@ -381,7 +369,7 @@ class EnvManager(object):
 
         env_list = [
             VirtualEnv(Path(p))
-            for p in sorted(venv_path.glob("{}-py*".format(venv_name)))
+            for p in sorted(venv_path.glob("{}-*".format(venv_name)))
         ]
 
         venv = self._poetry.file.parent / ".venv"
@@ -446,25 +434,13 @@ class EnvManager(object):
             pass
 
         try:
-            python_version = decode(
-                subprocess.check_output(
-                    list_to_shell_command(
-                        [
-                            python,
-                            "-c",
-                            "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
-                        ]
-                    ),
-                    shell=True,
-                )
-            )
+            python_version, python_implementation = self.get_python_information(python)
         except CalledProcessError as e:
             raise EnvCommandError(e)
-
         python_version = Version.parse(python_version.strip())
         minor = "{}.{}".format(python_version.major, python_version.minor)
 
-        name = "{}-py{}".format(base_env_name, minor)
+        name = "{}-{}{}".format(base_env_name, python_implementation, minor)
         venv = venv_path / name
 
         if not venv.exists():
@@ -518,18 +494,12 @@ class EnvManager(object):
 
         python_patch = ".".join([str(v) for v in sys.version_info[:3]])
         python_minor = ".".join([str(v) for v in sys.version_info[:2]])
+        python_implementation = self.normalize_python_implementation(
+            platform.python_implementation()
+        )
         if executable:
-            python_patch = decode(
-                subprocess.check_output(
-                    list_to_shell_command(
-                        [
-                            executable,
-                            "-c",
-                            "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
-                        ]
-                    ),
-                    shell=True,
-                ).strip()
+            python_patch, python_implementation = self.get_python_information(
+                executable
             )
             python_minor = ".".join(python_patch.split(".")[:2])
 
@@ -576,18 +546,8 @@ class EnvManager(object):
                     io.write_line("<debug>Trying {}</debug>".format(python))
 
                 try:
-                    python_patch = decode(
-                        subprocess.check_output(
-                            list_to_shell_command(
-                                [
-                                    python,
-                                    "-c",
-                                    "\"import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))\"",
-                                ]
-                            ),
-                            stderr=subprocess.STDOUT,
-                            shell=True,
-                        ).strip()
+                    python_patch, python_implementation = self.get_python_information(
+                        python
                     )
                 except CalledProcessError:
                     continue
@@ -610,7 +570,7 @@ class EnvManager(object):
             venv = venv_path
         else:
             name = self.generate_env_name(name, str(cwd))
-            name = "{}-py{}".format(name, python_minor.strip())
+            name = "{}-{}{}".format(name, python_implementation, python_minor.strip())
             venv = venv_path / name
 
         if not venv.exists():
@@ -722,6 +682,38 @@ class EnvManager(object):
         h = base64.urlsafe_b64encode(h).decode()[:8]
 
         return "{}-{}".format(sanitized_name, h)
+
+    @classmethod
+    def get_python_information(cls, executable):
+        command_output = decode(
+            subprocess.check_output(
+                list_to_shell_command(
+                    [
+                        executable,
+                        "-c",
+                        '"'
+                        "import sys;"
+                        "import platform;"
+                        "print('.'.join([str(s) for s in sys.version_info[:3]]));"
+                        "print(platform.python_implementation());"
+                        '"',
+                    ]
+                ),
+                shell=True,
+            ).strip()
+        )
+        python_patch, python_implementation = command_output.split("\n")
+        python_implementation = cls.normalize_python_implementation(
+            python_implementation
+        )
+        return python_patch, python_implementation
+
+    @classmethod
+    def normalize_python_implementation(cls, python_implementation):
+        python_implementation = python_implementation.lower()
+        if python_implementation == "cpython":
+            python_implementation = "py"
+        return python_implementation
 
 
 class Env(object):

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -26,8 +26,8 @@ def remove_venv(path):
 
 def check_output_wrapper(version=Version.parse("3.7.1")):
     def check_output(cmd, *args, **kwargs):
-        if "sys.version_info[:3]" in cmd:
-            return version.text
+        if "sys.version_info[:3]" in cmd and "platform.python_implementation" in cmd:
+            return "{}\n{}".format(version.text, "CPython")
         elif "sys.version_info[:2]" in cmd:
             return "{}.{}".format(version.major, version.minor)
         else:

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -105,8 +105,8 @@ def remove_venv(path):
 
 def check_output_wrapper(version=Version.parse("3.7.1")):
     def check_output(cmd, *args, **kwargs):
-        if "sys.version_info[:3]" in cmd:
-            return version.text
+        if "sys.version_info[:3]" in cmd and "platform.python_implementation" in cmd:
+            return "{}\n{}".format(version.text, "CPython")
         elif "sys.version_info[:2]" in cmd:
             return "{}.{}".format(version.major, version.minor)
         else:
@@ -611,7 +611,8 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
 
     mocker.patch("sys.version_info", (2, 7, 16))
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output", side_effect=["3.5.3", "3.8.0"]
+        "poetry.utils._compat.subprocess.check_output",
+        side_effect=["3.5.3\nCPython", "3.8.0\nCPython"],
     )
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
@@ -660,7 +661,9 @@ def test_create_venv_does_not_try_to_find_compatible_versions_with_executable(
 
     poetry.package.python_versions = "^4.8"
 
-    mocker.patch("poetry.utils._compat.subprocess.check_output", side_effect=["3.8.0"])
+    mocker.patch(
+        "poetry.utils._compat.subprocess.check_output", side_effect=["3.8.0\nCPython"]
+    )
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
     )


### PR DESCRIPTION
Resolves: #2089. Now "pypy" is part of the venv name so that it can be used together with poetry. Virtualenvs using Cpython will not change names to ensure backwards compatibility.

- [x] Added **tests** for changed code.