### PR TITLE
normalize path if it is a case insensitive file system

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -711,7 +711,8 @@ class EnvManager(object):
     def generate_env_name(cls, name, cwd):  # type: (str, str) -> str
         name = name.lower()
         sanitized_name = re.sub(r'[ $`!*@"\\\r\n\t]', "_", name)[:42]
-        h = hashlib.sha256(encode(cwd)).digest()
+        normalized_cwd = os.path.normcase(cwd)
+        h = hashlib.sha256(encode(normalized_cwd)).digest()
         h = base64.urlsafe_b64encode(h).decode()[:8]
 
         return "{}-{}".format(sanitized_name, h)

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import sys
+import tempfile
 
 import pytest
 import tomlkit
@@ -831,3 +832,23 @@ def test_env_site_packages_should_raise_an_error_if_no_site_packages(tmp_dir):
 
     with pytest.raises(RuntimeError):
         env.site_packages
+
+
+def test_case_should_be_ignored_if_fs_is_case_sensitive(tmp_dir):
+    with tempfile.NamedTemporaryFile(prefix="TmP") as tmp_file:
+        if not os.path.exists(tmp_file.name.lower()):
+            path_with_lowercase = Path(tmp_dir) / "lowerpath"
+            path_with_uppercase = Path(tmp_dir) / "UPPERPATH"
+            path_with_bothcase = Path(tmp_dir) / "BoThCaSe"
+
+            venv_with_lowercase = EnvManager.generate_env_name(
+                "simple-project", str(path_with_lowercase)
+            )
+            venv_with_uppercase = EnvManager.generate_env_name(
+                "simple-project", str(path_with_uppercase)
+            )
+            venv_with_bothcase = EnvManager.generate_env_name(
+                "simple-project", str(path_with_bothcase)
+            )
+
+            assert venv_with_lowercase != venv_with_uppercase != venv_with_bothcase


### PR DESCRIPTION
closes #2419(Virtualenv not always found in case insensitive filesystem)
the util func for checking whether it is a case sentive
or not is from [Steve Cohen](https://stackoverflow.com/a/36580834/7899226)

# Pull Request Check List
Resolves: #2419
- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

I have no idea where to edit for documentation that I made the default behavior of `EnvManager.generate_env_name` normalize case of cwd. If needed, please let me know where to edit thank you.