### PR TITLE
poetry init uses existing pyproject.toml if possible

### DIFF
--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -23,9 +23,6 @@ from .command import Command
 from .env_command import EnvCommand
 
 
-# import tomlkit
-
-
 class InitCommand(Command):
     name = "init"
     description = (

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -74,14 +74,11 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             with (Path.cwd() / "pyproject.toml").open() as toml_file:
                 original_toml = tomlkit.loads(toml_file.read())
 
-                try:
-                    if original_toml["tool"]["poetry"]:
-                        self.line(
-                            "<error>A pyproject.toml file with a poetry section already exists.</error>"
-                        )
-                        return 1
-                except KeyError:
-                    pass
+                if original_toml.get("tool", {}).get("poetry"):
+                    self.line(
+                        "<error>A pyproject.toml file with a poetry section already exists.</error>"
+                    )
+                    return 1
 
                 if original_toml.get("build-system"):
                     self.line(
@@ -216,7 +213,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             dev_dependencies=dev_requirements,
         )
 
-        content = layout_.generate_poetry_content()
+        content = layout_.generate_poetry_content(original_toml)
         if self.io.is_interactive():
             self.line("<info>Generated file</info>")
             self.line("")
@@ -230,10 +227,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         with (Path.cwd() / "pyproject.toml").open("w", encoding="utf-8") as f:
             f.write(content)
-
-            if original_toml:
-                f.write("\n")
-                f.write(tomlkit.dumps(original_toml))
 
     def _determine_requirements(
         self, requires, allow_prereleases=False, source=None

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -67,16 +67,16 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         from poetry.utils._compat import Path
         from poetry.utils.env import SystemEnv
 
-        original_toml = PyProjectTOML(Path.cwd() / "pyproject.toml")
+        pyproject = PyProjectTOML(Path.cwd() / "pyproject.toml")
 
-        if original_toml.file.exists():
-            if original_toml.is_poetry_project():
+        if pyproject.file.exists():
+            if pyproject.is_poetry_project():
                 self.line(
                     "<error>A pyproject.toml file with a poetry section already exists.</error>"
                 )
                 return 1
 
-            if original_toml.data.get("build-system"):
+            if pyproject.data.get("build-system"):
                 self.line(
                     "<error>A pyproject.toml file with a defined build-system already exists.</error>"
                 )
@@ -209,7 +209,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             dev_dependencies=dev_requirements,
         )
 
-        content = layout_.generate_poetry_content(original_toml)
+        content = layout_.generate_poetry_content(pyproject)
         if self.io.is_interactive():
             self.line("<info>Generated file</info>")
             self.line("")

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -14,7 +14,6 @@ from cleo import option
 from tomlkit import inline_table
 
 from poetry.core.pyproject.toml import PyProjectTOML
-from poetry.core.toml.file import TOMLFile
 from poetry.utils._compat import OrderedDict
 from poetry.utils._compat import Path
 from poetry.utils._compat import urlparse
@@ -68,16 +67,16 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         from poetry.utils._compat import Path
         from poetry.utils.env import SystemEnv
 
-        original_toml = TOMLFile(Path.cwd() / "pyproject.toml")
+        original_toml = PyProjectTOML(Path.cwd() / "pyproject.toml")
 
-        if original_toml.exists():
-            if PyProjectTOML(original_toml.path).is_poetry_project():
+        if original_toml.file.exists():
+            if original_toml.is_poetry_project():
                 self.line(
                     "<error>A pyproject.toml file with a poetry section already exists.</error>"
                 )
                 return 1
 
-            if original_toml.read().get("build-system"):
+            if original_toml.data.get("build-system"):
                 self.line(
                     "<error>A pyproject.toml file with a defined build-system already exists.</error>"
                 )

--- a/poetry/layouts/layout.py
+++ b/poetry/layouts/layout.py
@@ -81,7 +81,7 @@ class Layout(object):
 
         self._write_poetry(path)
 
-    def generate_poetry_content(self):
+    def generate_poetry_content(self, original_toml):
         template = POETRY_DEFAULT
         if self._license:
             template = POETRY_WITH_LICENSE
@@ -114,7 +114,12 @@ class Layout(object):
 
         content.add("build-system", build_system)
 
-        return dumps(content)
+        content = dumps(content)
+
+        if original_toml:
+            content += "\n" + dumps(original_toml)
+
+        return content
 
     def _create_default(self, path, src=True):
         raise NotImplementedError()

--- a/poetry/layouts/layout.py
+++ b/poetry/layouts/layout.py
@@ -1,9 +1,14 @@
+from typing import TYPE_CHECKING
+
 from tomlkit import dumps
 from tomlkit import loads
 from tomlkit import table
 
 from poetry.utils.helpers import module_name
 
+
+if TYPE_CHECKING:
+    from poetry.core.toml.file import TOMLFile
 
 TESTS_DEFAULT = u"""from {package_name} import __version__
 
@@ -81,7 +86,7 @@ class Layout(object):
 
         self._write_poetry(path)
 
-    def generate_poetry_content(self, original_toml):
+    def generate_poetry_content(self, original_toml):  # type: ("TOMLFile") -> str
         template = POETRY_DEFAULT
         if self._license:
             template = POETRY_WITH_LICENSE
@@ -116,8 +121,8 @@ class Layout(object):
 
         content = dumps(content)
 
-        if original_toml:
-            content = dumps(original_toml) + "\n" + content
+        if original_toml.exists():
+            content = dumps(original_toml.read()) + "\n" + content
 
         return content
 

--- a/poetry/layouts/layout.py
+++ b/poetry/layouts/layout.py
@@ -117,7 +117,7 @@ class Layout(object):
         content = dumps(content)
 
         if original_toml:
-            content += "\n" + dumps(original_toml)
+            content = dumps(original_toml) + "\n" + content
 
         return content
 

--- a/poetry/layouts/layout.py
+++ b/poetry/layouts/layout.py
@@ -8,7 +8,7 @@ from poetry.utils.helpers import module_name
 
 
 if TYPE_CHECKING:
-    from poetry.core.toml.file import TOMLFile
+    from poetry.core.pyproject.toml import PyProjectTOML
 
 TESTS_DEFAULT = u"""from {package_name} import __version__
 
@@ -86,7 +86,7 @@ class Layout(object):
 
         self._write_poetry(path)
 
-    def generate_poetry_content(self, original_toml):  # type: ("TOMLFile") -> str
+    def generate_poetry_content(self, original_toml):  # type: ("PyProjectTOML") -> str
         template = POETRY_DEFAULT
         if self._license:
             template = POETRY_WITH_LICENSE
@@ -121,8 +121,8 @@ class Layout(object):
 
         content = dumps(content)
 
-        if original_toml.exists():
-            content = dumps(original_toml.read()) + "\n" + content
+        if original_toml.file.exists():
+            content = dumps(original_toml.data) + "\n" + content
 
         return content
 


### PR DESCRIPTION
At the moment a `poetry init` will fail, if a `pyproject.toml` already exists.

As this file is becoming more and more widely used to store configuration for other tools like `black` and `isort`, this PR changes the behavior to only skip creating the content for `pyproject.toml` if the file already contains a `tool.poetry` section or a `build-system` section.

closes: #1639 