### PR TITLE
Display better messages on legacy repo HTTP errors

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -27,6 +27,7 @@ from poetry.utils.patterns import wheel_file_re
 from ..inspection.info import PackageInfo
 from .auth import Auth
 from .exceptions import PackageNotFound
+from .exceptions import RepositoryError
 from .pypi_repository import PyPiRepository
 
 
@@ -349,8 +350,12 @@ class LegacyRepository(PyPiRepository):
 
     def _get(self, endpoint):  # type: (str) -> Union[Page, None]
         url = self._url + endpoint
-        response = self.session.get(url)
-        if response.status_code == 404:
-            return
+        try:
+            response = self.session.get(url)
+            if response.status_code == 404:
+                return
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            raise RepositoryError(e)
 
         return Page(url, response.content, response.headers)

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -5,6 +5,7 @@ import pytest
 from poetry.core.packages import Dependency
 from poetry.repositories.auth import Auth
 from poetry.repositories.exceptions import PackageNotFound
+from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.legacy_repository import Page
 from poetry.utils._compat import PY35
@@ -271,3 +272,36 @@ def test_username_password_special_chars():
     repo = MockRepository(auth=auth)
 
     assert "http://user%3A:%2F%252Fp%40ssword@legacy.foo.bar" == repo.authenticated_url
+
+
+class MockHttpRepository(LegacyRepository):
+    def __init__(self, endpoint_responses, http):
+        base_url = "http://legacy.foo.bar"
+        super(MockHttpRepository, self).__init__(
+            "legacy", url=base_url, auth=None, disable_cache=True
+        )
+
+        for endpoint, response in endpoint_responses.items():
+            url = base_url + endpoint
+            http.register_uri(http.GET, url, status=response)
+
+
+def test_get_200_returns_page(http):
+    repo = MockHttpRepository({"/foo": 200}, http)
+
+    assert repo._get("/foo")
+
+
+def test_get_404_returns_none(http):
+    repo = MockHttpRepository({"/foo": 404}, http)
+
+    assert repo._get("/foo") is None
+
+
+def test_get_4xx_and_5xx_raises(http):
+    endpoints = {"/{}".format(code): code for code in {401, 403, 500}}
+    repo = MockHttpRepository(endpoints, http)
+
+    for endpoint in endpoints:
+        with pytest.raises(RepositoryError):
+            repo._get(endpoint)


### PR DESCRIPTION
# Changes

This change gives a clear message to users when there's an error connecting to a private repo.

Current message:
```
$ export POETRY_HTTP_BASIC_PYPI_LOCAL_PASSWORD="incorrect-password"
$ poetry add private-package

[ValueError]
Could not find a matching version of package private-package
```
New message
```
  RepositoryError

  401 Client Error: Unauthorized for url: https://xyz.jfrog.io/xyz/api/pypi/pip/simple/private-package/
```

Notes:
* This PR will supersede: https://github.com/python-poetry/poetry/pull/1072. This PR is similar but doesn't introduce a new dependency.
* This will cause poetry to error out if it can't connect to a private repo, whereas currently it will ignore it. This seems better. However, there may be people who have an unused private repo configured, to which poetry can't connect. They'll start getting an error message. It should be an easy fix for them though.
* There might also possibly be some private repos that return (non-404) errors for certain endpoints, and it's conceivable that some user actually depends on this. E.g., maybe their repo returns 400 for /pytest, and they depend on that so poetry continues on to try PyPI. This seems like it would be an issue with the repo, but I'm just thinking through all the possible cases.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] ~Updated **documentation** for changed code.~ (seems unnecessary)

