### PR TITLE
Fix regression where package.source_reference is unset

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -297,6 +297,7 @@ class LegacyRepository(PyPiRepository):
         except ValueError:
             package = super(LegacyRepository, self).package(name, version, extras)
             package.source_url = self._url
+            package.source_reference = self.name
             return package
 
     def _get_release_info(self, name, version):  # type: (str, str) -> dict

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -72,6 +72,15 @@ def test_sdist_format_support():
     assert bz2_links[0].filename == "poetry-0.1.1.tar.bz2"
 
 
+def test_get_package_sets_source_reference_and_url():
+    repo = MockRepository()
+
+    package = repo.package("jupyter", "1.0.0")
+
+    assert "legacy" == package.source_reference
+    assert "http://legacy.foo.bar" == package.source_url
+
+
 def test_missing_version():
     repo = MockRepository()
 


### PR DESCRIPTION
# Change

This fixes an issue that looks like it's a regression on the develop branch.

The problem occurs with packages from private repos:
```
# Assume private repo called pypi-local exists.
poetry add private-package
Creating virtualenv test1-b4L2acJf-py3.8 in /root/.cache/pypoetry/virtualenvs
Using version ^3.1.6 for private-package

Updating dependencies
Resolving dependencies... (11.5s)

Writing lock file


Package operations: 25 installs, 0 updates, 0 removals

  - Installing blahblah...
    [snip irrelevant text...]
  - Installing private-package (3.1.6)

  ValueError

  Repository "" does not exist.

  at /poetry/poetry/repositories/pool.py:40 in repository
       36|     def repository(self, name):  # type: (str) -> Repository
       37|         if name in self._lookup:
       38|             return self._repositories[self._lookup[name]]
       39|
    >  40|         raise ValueError('Repository "{}" does not exist.'.format(name))
       41|
       42|     def add_repository(
       43|         self, repository, default=False, secondary=False
       44|     ):  # type: (Repository, bool, bool) -> Pool
```

It's caused by `source_reference` not being set in the lock file.

In lockfile on master:
```
[package.source]
reference = "pypi-local"
url = "https://xyz.jfrog.io/xyz/api/pypi/pip/simple"
```
In lockfile on develop:
```
[package.source]
reference = ""
url = "https://xyz.jfrog.io/xyz/api/pypi/pip/simple"
```

It was removed in [this change](https://github.com/python-poetry/poetry/pull/2301/files#diff-82b23d5737d621bcdd9009dfa78a88f2L311). This PR just adds it back with a test.

# Pull Request Check List

Resolves: I didn't file an issue for this because it's only on the develop branch, not master.

- [x] Added **tests** for changed code.
- [ ] ~Updated **documentation** for changed code.~ (bug fix)
