### PR TITLE
Fix handling of markers in old lock files

### DIFF
--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -446,6 +446,10 @@ class Installer:
             if op.job_type == "uninstall":
                 continue
 
+            if not self._env.is_valid_for_marker(package.marker):
+                op.skip("Not needed for the current environment")
+                continue
+
             if self._update:
                 extras = {}
                 for extra, deps in self._package.extras.items():

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1627,7 +1627,8 @@ def test_installer_can_handle_old_lock_files(
 
     package.add_dependency("pytest", "^3.5", category="dev")
 
-    locker.mock_lock_data(fixture("with-pypi-repository"))
+    locker.locked()
+    locker.mock_lock_data(fixture("old-lock"))
 
     installer = Installer(
         NullIO(), MockEnv(), package, locker, pool, installed=installed


### PR DESCRIPTION
# Pull Request Check List

This PR fixes an issue with #2361.

Basically, we were no longer checking the validity of the markers for the current environment, leading to packages being installed when not necessary.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
