### PR TITLE
Fix legacy repositories information not being set on packages

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -269,6 +269,8 @@ class LegacyRepository(PyPiRepository):
 
         for version in versions:
             package = Package(name, version)
+            package.source_type = "legacy"
+            package.source_reference = self.name
             package.source_url = self._url
 
             if extras is not None:
@@ -313,6 +315,7 @@ class LegacyRepository(PyPiRepository):
             if release_info["requires_python"]:
                 package.python_versions = release_info["requires_python"]
 
+            package.source_type = "legacy"
             package.source_url = self._url
             package.source_reference = self.name
 

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -84,6 +84,9 @@ def test_get_package_information_fallback_read_setup():
 
     package = repo.package("jupyter", "1.0.0")
 
+    assert package.source_type == "legacy"
+    assert package.source_reference == repo.name
+    assert package.source_url == repo.url
     assert package.name == "jupyter"
     assert package.version.text == "1.0.0"
     assert (
@@ -141,6 +144,10 @@ def test_find_packages_no_prereleases():
     packages = repo.find_packages("pyyaml")
 
     assert len(packages) == 1
+
+    assert packages[0].source_type == "legacy"
+    assert packages[0].source_reference == repo.name
+    assert packages[0].source_url == repo.url
 
 
 def test_get_package_information_chooses_correct_distribution():


### PR DESCRIPTION
Up until now, the source type and sometimes the reference were not set on packages coming from "legacy" repository which can cause issues in the way we want to detect the source of a package.

This PR fixes it.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
