### PR TITLE
Fix legacy repositories packages being continuously updated

### DIFF
--- a/poetry/puzzle/solver.py
+++ b/poetry/puzzle/solver.py
@@ -92,7 +92,7 @@ class Solver:
                     elif package.version != pkg.version:
                         # Checking version
                         operations.append(Update(pkg, package))
-                    elif package.source_type != pkg.source_type:
+                    elif pkg.source_type and package.source_type != pkg.source_type:
                         operations.append(Update(pkg, package))
                     else:
                         operations.append(Install(package).skip("Already installed"))

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -2039,3 +2039,22 @@ def test_solver_cannot_choose_another_version_for_url_dependencies(
     # via the git dependency
     with pytest.raises(SolverProblemError):
         solver.solve()
+
+
+def test_solver_should_not_update_same_version_packages_if_installed_has_no_source_type(
+    solver, repo, package, installed
+):
+    package.add_dependency("foo", "1.0.0")
+
+    foo = get_package("foo", "1.0.0")
+    foo.source_type = "legacy"
+    foo.source_reference = "custom"
+    foo.source_url = "https://foo.bar"
+    repo.add_package(foo)
+    installed.add_package(get_package("foo", "1.0.0"))
+
+    ops = solver.solve()
+
+    check_solver_result(
+        ops, [{"job": "install", "package": foo, "skipped": True}],
+    )


### PR DESCRIPTION
Following the fix in #2484, installed packages with the same version were continuously updated. This was caused by a check in the `Solver` class that compared the source types of both packages and if they were different it would trigger an update.

This is fixed by ensuring we do this check only if the installed packages already has a source type.

## Pull Request Check List

Resolves: #2502 

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.