### PR TITLE
Fix handling of dependency markers with python precision >= 3

### DIFF
--- a/poetry/packages/dependency.py
+++ b/poetry/packages/dependency.py
@@ -271,16 +271,30 @@ class Dependency(object):
 
             marker = glue.join(parts)
         elif isinstance(constraint, Version):
+            if constraint.precision >= 3 and name == "python_version":
+                name = "python_full_version"
+
             marker = '{} == "{}"'.format(name, constraint.text)
         else:
             if constraint.min is not None:
+                min_name = name
+                if constraint.min.precision >= 3 and name == "python_version":
+                    min_name = "python_full_version"
+
+                    if constraint.max is None:
+                        name = min_name
+
                 op = ">="
                 if not constraint.include_min:
                     op = ">"
 
                 version = constraint.min.text
                 if constraint.max is not None:
-                    text = '{} {} "{}"'.format(name, op, version)
+                    max_name = name
+                    if constraint.max.precision >= 3 and name == "python_version":
+                        max_name = "python_full_version"
+
+                    text = '{} {} "{}"'.format(min_name, op, version)
 
                     op = "<="
                     if not constraint.include_max:
@@ -288,10 +302,13 @@ class Dependency(object):
 
                     version = constraint.max
 
-                    text += ' and {} {} "{}"'.format(name, op, version)
+                    text += ' and {} {} "{}"'.format(max_name, op, version)
 
                     return text
             elif constraint.max is not None:
+                if constraint.max.precision >= 3 and name == "python_version":
+                    name = "python_full_version"
+
                 op = "<="
                 if not constraint.include_max:
                     op = "<"

--- a/poetry/version/markers.py
+++ b/poetry/version/markers.py
@@ -270,7 +270,11 @@ class EmptyMarker(BaseMarker):
 class SingleMarker(BaseMarker):
 
     _CONSTRAINT_RE = re.compile(r"(?i)^(~=|!=|>=?|<=?|==?|in|not in)?\s*(.+)$")
-    _VERSION_LIKE_MARKER_NAME = {"python_version", "platform_release"}
+    _VERSION_LIKE_MARKER_NAME = {
+        "python_version",
+        "python_full_version",
+        "platform_release",
+    }
 
     def __init__(self, name, constraint):
         from poetry.packages.constraints import (

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -1,3 +1,5 @@
+import pytest
+
 from poetry.packages import Dependency
 from poetry.packages import Package
 
@@ -108,3 +110,23 @@ def test_to_pep_508_with_single_version_excluded():
     dependency = Dependency("foo", "!=1.2.3")
 
     assert "foo (!=1.2.3)" == dependency.to_pep_508()
+
+
+@pytest.mark.parametrize(
+    "python_versions, marker",
+    [
+        (">=3.5,<3.5.4", 'python_version >= "3.5" and python_full_version < "3.5.4"'),
+        (">=3.5.4,<3.6", 'python_full_version >= "3.5.4" and python_version < "3.6"'),
+        ("<3.5.4", 'python_full_version < "3.5.4"'),
+        (">=3.5.4", 'python_full_version >= "3.5.4"'),
+        ("== 3.5.4", 'python_full_version == "3.5.4"'),
+    ],
+)
+def test_to_pep_508_with_patch_python_version(python_versions, marker):
+    dependency = Dependency("Django", "^1.23")
+    dependency.python_versions = python_versions
+
+    expected = "Django (>=1.23,<2.0); {}".format(marker)
+
+    assert expected == dependency.to_pep_508()
+    assert marker == str(dependency.marker)

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -218,3 +218,21 @@ def test_dependency_from_pep_508_with_wheel_url():
 
     assert "example-wheel" == dep.name
     assert str(dep.constraint) == "14.0.2"
+
+
+def test_dependency_from_pep_508_with_python_full_version():
+    name = (
+        "requests (==2.18.0); "
+        '(python_version >= "2.7" and python_version < "2.8") '
+        'or (python_full_version >= "3.4" and python_full_version < "3.5.4")'
+    )
+    dep = dependency_from_pep_508(name)
+
+    assert dep.name == "requests"
+    assert str(dep.constraint) == "2.18.0"
+    assert dep.extras == []
+    assert dep.python_versions == ">=2.7 <2.8 || >=3.4 <3.5.4"
+    assert str(dep.marker) == (
+        'python_version >= "2.7" and python_version < "2.8" '
+        'or python_full_version >= "3.4" and python_full_version < "3.5.4"'
+    )


### PR DESCRIPTION
If a dependency was specifying a `python` condition with a python version with a precision of 3 or more (for instance, `>=3.5,<3.5.4`), it would generate an incorrect marker leading to issues while evaluating the marker against the environment.

For instance, the `>=3.5,<3.5.4` condition would generate the following marker: `python_version >= "3.5" and python_version < "3.5.4"`. However, the correct marker is: `python_version >= "3.5" and python_full_version < "3.5.4"`.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
