### PR TITLE
fix METADATA generation for url dependencies with extras

### DIFF
--- a/poetry/packages/dependency.py
+++ b/poetry/packages/dependency.py
@@ -228,7 +228,7 @@ class Dependency(object):
             )
 
         if markers:
-            if self.is_vcs():
+            if self.is_vcs() or self.is_url():
                 requirement += " "
 
             if len(markers) > 1:

--- a/tests/packages/test_url_dependency.py
+++ b/tests/packages/test_url_dependency.py
@@ -1,5 +1,3 @@
-import pytest
-
 from poetry.packages.url_dependency import URLDependency
 
 

--- a/tests/packages/test_url_dependency.py
+++ b/tests/packages/test_url_dependency.py
@@ -10,7 +10,7 @@ EXAMPLE_URL = (
 def test_to_pep_508():
     dependency = URLDependency("poetry", EXAMPLE_URL,)
 
-    expected = f"poetry @ {EXAMPLE_URL}"
+    expected = "poetry @ {}".format(EXAMPLE_URL)
 
     assert expected == dependency.to_pep_508()
 
@@ -19,5 +19,5 @@ def test_to_pep_508_in_extras():
     dependency = URLDependency("poetry", EXAMPLE_URL,)
     dependency.in_extras.append("foo")
 
-    expected = f'poetry @ {EXAMPLE_URL} ; extra == "foo"'
+    expected = 'poetry @ {} ; extra == "foo"'.format(EXAMPLE_URL)
     assert expected == dependency.to_pep_508()

--- a/tests/packages/test_url_dependency.py
+++ b/tests/packages/test_url_dependency.py
@@ -1,0 +1,25 @@
+import pytest
+
+from poetry.packages.url_dependency import URLDependency
+
+
+EXAMPLE_URL = (
+    "https://github.com/python-poetry/poetry/releases/"
+    "download/1.0.9/poetry-1.0.9-linux.tar.gz"
+)
+
+
+def test_to_pep_508():
+    dependency = URLDependency("poetry", EXAMPLE_URL,)
+
+    expected = f"poetry @ {EXAMPLE_URL}"
+
+    assert expected == dependency.to_pep_508()
+
+
+def test_to_pep_508_in_extras():
+    dependency = URLDependency("poetry", EXAMPLE_URL,)
+    dependency.in_extras.append("foo")
+
+    expected = f'poetry @ {EXAMPLE_URL} ; extra == "foo"'
+    assert expected == dependency.to_pep_508()


### PR DESCRIPTION
# Pull Request Check List

Resolves: same error as #1129

Insert trailing space at the end of the URL before the semicolon when extra field id specified.
same as #1129 for URL.
Tested with poetry 1.0.9 and pip 20.1.1.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
