### PR TITLE
Fix installer script and self update command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,7 @@ jobs:
       - name: Install poetry
         shell: bash
         run: |
-          curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
-          python get-poetry.py --preview -y
+          python get-poetry.py -y
           echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
 
       - name: Configure poetry

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -606,9 +606,9 @@ class Installer:
                 continue
 
             match = version_matcher.match(raw_version.strip())
-            if match and tuple(map(int, match.groups())) >= (3, 0):
-                # favor the first py3 executable we can find.
+            if match:
                 return executable
+
             if fallback is None:
                 # keep this one as the fallback; it was the first valid executable we found.
                 fallback = executable

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -630,6 +630,14 @@ class Installer:
 
         if WINDOWS:
             with open(os.path.join(POETRY_BIN, "poetry.bat"), "w") as f:
+                print(
+                    BAT.format(
+                        python_executable=python_executable,
+                        poetry_bin=os.path.join(POETRY_BIN, "poetry").replace(
+                            os.environ["USERPROFILE"], "%USERPROFILE%"
+                        ),
+                    )
+                )
                 f.write(
                     u(
                         BAT.format(

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -626,6 +626,7 @@ class Installer:
             os.mkdir(POETRY_BIN, 0o755)
 
         python_executable = self._which_python()
+        print('Using "{}" executable'.format(python_executable))
 
         if WINDOWS:
             with open(os.path.join(POETRY_BIN, "poetry.bat"), "w") as f:

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -216,7 +216,11 @@ if __name__ == "__main__":
     main()
 """
 
-BAT = u('@echo off\r\n{python_executable} "{poetry_bin}" %*\r\n')
+BAT = u(
+    """\
+@echo off\r\n{python_executable} "%~dp0\\{poetry_bin}" %*\r\n
+"""
+)
 
 
 PRE_MESSAGE = """# Welcome to {poetry}!
@@ -626,18 +630,9 @@ class Installer:
             os.mkdir(POETRY_BIN, 0o755)
 
         python_executable = self._which_python()
-        print('Using "{}" executable'.format(python_executable))
 
         if WINDOWS:
             with open(os.path.join(POETRY_BIN, "poetry.bat"), "w") as f:
-                print(
-                    BAT.format(
-                        python_executable=python_executable,
-                        poetry_bin=os.path.join(POETRY_BIN, "poetry").replace(
-                            os.environ["USERPROFILE"], "%USERPROFILE%"
-                        ),
-                    )
-                )
                 f.write(
                     u(
                         BAT.format(

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -320,8 +320,7 @@ class SelfUpdateCommand(Command):
                 continue
 
             match = version_matcher.match(raw_version.strip())
-            if match and tuple(map(int, match.groups())) >= (3, 0):
-                # favor the first py3 executable we can find.
+            if match:
                 return executable
 
             if fallback is None:


### PR DESCRIPTION
The changes made in #2426 (and #1878) can break systems that want to use Python 2 (via `python`) with a `python3` executable available. This is the setup we have in our own CI for Python 2.7.

This PR fixes this by selecting the first executable available. Note that it will still look for `python3` is `python` does not exist.

## Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
