### PR TITLE
Revert "get-poetry.py fallback to standard executables (#1878) (#2426)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,7 @@ jobs:
       - name: Install poetry
         shell: bash
         run: |
-          curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
-          python get-poetry.py --preview -y
+          python get-poetry.py -y
           echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
 
       - name: Configure poetry

--- a/README.md
+++ b/README.md
@@ -23,13 +23,6 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poet
 
 Alternatively, you can download the `get-poetry.py` file and execute it separately.
 
-The setup script must be able to find one of following executables in your shell's path environment:
-
-- `python` (which can be a py3 or py2 interpreter)
-- `python3`
-- `py.exe -3` (Windows)
-- `py.exe -2` (Windows)
-
 If you want to install prerelease versions, you can do so by passing `--preview` to `get-poetry.py`:
 
 ```bash


### PR DESCRIPTION
This reverts commit f81282213f88df2fdbc4d1c2eadbada47e0b4322.

The recent changes to the `get-poetry.py` script to select the appropriate Python executable seems to have broken the CI.

I tried to fix it but for some reason the CI on Windows broke for other reasons.

So, I prefer to revert this changes to ensure the CI works again.

I also changed the tests workflow to use the current branch/PR `get-poetry.py` script rather than the one on master to ensure that any change to it is tested.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
