### PR TITLE
Feature/export all optionals

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -468,6 +468,7 @@ poetry export -f requirements.txt --output requirements.txt
   output.
 * `--dev`: Include development dependencies.
 * `--extras (-E)`: Extra sets of dependencies to include.
+* `--all-optional`: Include all optional dependencies.
 * `--without-hashes`: Exclude hashes from the exported file.
 * `--with-credentials`: Include credentials for extra indices.
 

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -29,6 +29,11 @@ class ExportCommand(Command):
             multiple=True,
         ),
         option("with-credentials", None, "Include credentials for extra indices."),
+        option(
+            "all-optional",
+            None,
+            "Include all optional dependencies.",
+        ),
     ]
 
     def handle(self):
@@ -71,4 +76,5 @@ class ExportCommand(Command):
             dev=self.option("dev"),
             extras=self.option("extras"),
             with_credentials=self.option("with-credentials"),
+            all_optional=self.option("all-optional"),
         )

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -29,11 +29,7 @@ class ExportCommand(Command):
             multiple=True,
         ),
         option("with-credentials", None, "Include credentials for extra indices."),
-        option(
-            "all-optional",
-            None,
-            "Include all optional dependencies.",
-        ),
+        option("all-optional", None, "Include all optional dependencies."),
     ]
 
     def handle(self):

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -34,7 +34,8 @@ class Exporter(object):
         dev=False,
         extras=None,
         with_credentials=False,
-    ):  # type: (str, Path, Union[IO, str], bool, bool, bool) -> None
+        all_optional=False,
+    ):  # type: (str, Path, Union[IO, str], bool, bool, bool, bool, bool) -> None
         if fmt not in self.ACCEPTED_FORMATS:
             raise ValueError("Invalid export format: {}".format(fmt))
 
@@ -45,6 +46,7 @@ class Exporter(object):
             dev=dev,
             extras=extras,
             with_credentials=with_credentials,
+            all_optional=all_optional,
         )
 
     def _export_requirements_txt(
@@ -55,7 +57,8 @@ class Exporter(object):
         dev=False,
         extras=None,
         with_credentials=False,
-    ):  # type: (Path, Union[IO, str], bool, bool, bool) -> None
+        all_optional=False,
+    ):  # type: (Path, Union[IO, str], bool, bool, bool, bool, bool) -> None
         indexes = set()
         content = ""
         packages = self._poetry.locker.locked_repository(dev).packages
@@ -69,7 +72,7 @@ class Exporter(object):
 
         for package in sorted(packages, key=lambda p: p.name):
             # If a package is optional and we haven't opted in to it, continue
-            if package.optional and package.name not in extra_package_names:
+            if not all_optional and package.optional and package.name not in extra_package_names:
                 continue
 
             if package.source_type == "git":

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -72,7 +72,11 @@ class Exporter(object):
 
         for package in sorted(packages, key=lambda p: p.name):
             # If a package is optional and we haven't opted in to it, continue
-            if not all_optional and package.optional and package.name not in extra_package_names:
+            if (
+                not all_optional
+                and package.optional
+                and package.name not in extra_package_names
+            ):
                 continue
 
             if package.source_type == "git":

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -211,3 +211,26 @@ foo==1.0.0
 """
 
     assert expected == tester.io.fetch_output()
+
+
+def test_export_include_all_extras(app, repo):
+    repo.add_package(get_package("foo", "1.0.0"))
+    repo.add_package(get_package("bar", "1.1.0"))
+
+    command = app.find("lock")
+    tester = CommandTester(command)
+    tester.execute()
+
+    assert app.poetry.locker.lock.exists()
+
+    command = app.find("export")
+    tester = CommandTester(command)
+
+    tester.execute("--format requirements.txt --all-optional")
+
+    expected = """\
+bar==1.1.0
+foo==1.0.0
+"""
+
+    assert expected == tester.io.fetch_output()


### PR DESCRIPTION
# Pull Request Check List

Resolves: None

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Situation

I use [safety](https://github.com/pyupio/safety) to check my dependencies. I also want to run this check in CI via [tox](https://github.com/tox-dev/tox) and I want to check **all** my dependencies, not only the install requirements.

## Problem

Safety can get the data (in requirements.txt format) by locking at the current active venv or via piping (`--stdin`) or file (`-r`). Piping in tox is not supported so this option is out. To look at the venv all dependencies must be installed. This costs time and for this all extras need to be specified by the `install` command. So not fire and forget solution possible. The last option is the file. `poetry export` has the same shortcoming in that you need to specify all extras. `poetry show` outputs all but the format is wrong.

`pip freeze` needs an install and cannot print to a file without piping. 

## Workaround

As a workaround I came up with this script:

```python
import subprocess
import re
with open("PATH/requirements.txt","w") as f:
    cmd = subprocess.run(["poetry", "show"], capture_output=True)
    cmd.check_returncode()
    f.write(re.sub(r"([\w-]+)[ (!)]+([\d.a-z-]+).*", r"\1==\2", cmd.stdout.decode()))
```

Which takes `poetry show`'s output and reformat it into requirements.txt format via regex. This script is needed by the tox env to run so I must include it somehow and came up with this:
```ini
[testenv:safety]
description = check all dependencies for known vulnerabilities
skip_install = true
deps =
    poetry>=0.12
    safety
commands =
    python -c \
       'f=open(r"{envtmpdir}/safety.py","w"); \
        f.write("""import subprocess\n"""); \
        f.write("""import re\n"""); \
        f.write("""with open("{envtmpdir}/requirements.txt","w") as f:\n"""); \
        f.write("""    cmd = subprocess.run(["poetry", "show"], capture_output=True)\n"""); \
        f.write("""    cmd.check_returncode()\n"""); \
        f.write("""    f.write(re.sub(r\"([\\w-]+)[ (!)]+([\\d.a-z-]+).*\", r\"\\1==\\2\", cmd.stdout.decode()))\n"""); \
        f.close()'
    python {envtmpdir}/safety.py
    safety check -r {envtmpdir}/requirements.txt --full-report
```

## Solution

While it runs I do not like this approach and would like to have a simpler solution. Preferably with poetry as dependency manager.

I came up with two Ideas:
1. Include my regex approach in the `show` command by giving a format argument  like the `export` command.
2. Include a switch to include all extras/optionals in the output of `export`.

I like the second solution more because the export command already has all the necessities and its easy to implement. Also the `export` command  is more suited for the job in regards to its purpose I think.

## Changes

So I added a simple `--all-optional` switch to the `export` command to not filter the extras out which are not named.
I also added a test case and updated the docs.

EDIT: Fixed typo and format