### PR TITLE
actions: trigger only for pushes to master/develop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,13 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   Linting:


### PR DESCRIPTION
This changes the triggers to ensure that checks are tirggered only once when pull requests are created from upstream remote. Pushes to master/develop and all pull requests will still trigger checks. 