### PR TITLE
Add log warning if auth fails when accessing repository

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -426,4 +426,8 @@ class LegacyRepository(PyPiRepository):
         if response.status_code == 404:
             return
 
+        if response.status_code == 403:
+            self._log("Authorization error accessing {url}".format(url=url), level="warn")
+            return
+
         return Page(url, response.content, response.headers)

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -427,7 +427,9 @@ class LegacyRepository(PyPiRepository):
             return
 
         if response.status_code == 403:
-            self._log("Authorization error accessing {url}".format(url=url), level="warn")
+            self._log(
+                "Authorization error accessing {url}".format(url=url), level="warn"
+            )
             return
 
         return Page(url, response.content, response.headers)

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -426,7 +426,7 @@ class LegacyRepository(PyPiRepository):
         if response.status_code == 404:
             return
 
-        if response.status_code == 403:
+        if response.status_code in (401, 403):
             self._log(
                 "Authorization error accessing {url}".format(url=url), level="warn"
             )


### PR DESCRIPTION
Resolves: #2576 

This just adds a more informative error message in the event that a repository fails due to an authorization error.  Right now, poetry fails silently on that case.

I tried to add tests here, but because this is part of the core `_get` method, I couldn't really do so using the existing mock.  I could perform mocking at the `requests` level, but wasn't sure if that was the usual way in the poetry project.  Let me know the best way to test this.

Thanks!
Tim