### PR TITLE
Add missing as_posix() calls

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -143,7 +143,7 @@ class PipInstaller(BaseInstaller):
 
         if package.source_type in ["file", "directory"]:
             if package.root_dir:
-                req = os.path.join(package.root_dir.as_posix(), package.source_url)
+                req = (package.root_dir / package.source_url).as_posix()
             else:
                 req = os.path.realpath(package.source_url)
 
@@ -184,7 +184,7 @@ class PipInstaller(BaseInstaller):
         from poetry.utils.toml_file import TomlFile
 
         if package.root_dir:
-            req = os.path.join(package.root_dir.as_posix(), package.source_url)
+            req = (package.root_dir / package.source_url).as_posix()
         else:
             req = os.path.realpath(package.source_url)
 

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -143,7 +143,7 @@ class PipInstaller(BaseInstaller):
 
         if package.source_type in ["file", "directory"]:
             if package.root_dir:
-                req = os.path.join(package.root_dir, package.source_url)
+                req = os.path.join(package.root_dir.as_posix(), package.source_url)
             else:
                 req = os.path.realpath(package.source_url)
 
@@ -184,7 +184,7 @@ class PipInstaller(BaseInstaller):
         from poetry.utils.toml_file import TomlFile
 
         if package.root_dir:
-            req = os.path.join(package.root_dir, package.source_url)
+            req = os.path.join(package.root_dir.as_posix(), package.source_url)
         else:
             req = os.path.realpath(package.source_url)
 


### PR DESCRIPTION
As PR #2398 [changed package.root_dir from str to Path](https://github.com/python-poetry/poetry/pull/2398/files#diff-d1ad1ffd5c14b8d5a698ea2f12b5c0e7L281) , we need to call `as_posix()` to convert it to `str` before passing to `os.path.join`. Otherwise, it raises `'PosixPath' object has no attribute 'endswith'` error on Python <3.6.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
