### PR TITLE
Fix handling dependencies parameter during interactive init (#711)

### DIFF
--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -144,6 +144,10 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         self.line("")
 
         requirements = {}
+        if self.option("dependency"):
+            requirements = self._format_requirements(
+                self._determine_requirements(self.option("dependency"))
+            )
 
         question = "Would you like to define your main dependencies interactively?"
         help_message = (
@@ -160,12 +164,16 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if self.confirm(question, True):
             self.line(help_message)
             help_displayed = True
-            requirements = self._format_requirements(
-                self._determine_requirements(self.option("dependency"))
+            requirements.update(
+                self._format_requirements(self._determine_requirements([]))
             )
             self.line("")
 
         dev_requirements = {}
+        if self.option("dev-dependency"):
+            dev_requirements = self._format_requirements(
+                self._determine_requirements(self.option("dev-dependency"))
+            )
 
         question = (
             "Would you like to define your development dependencies interactively?"
@@ -174,8 +182,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             if not help_displayed:
                 self.line(help_message)
 
-            dev_requirements = self._format_requirements(
-                self._determine_requirements(self.option("dev-dependency"))
+            dev_requirements.update(
+                self._format_requirements(self._determine_requirements([]))
             )
             self.line("")
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -484,3 +484,195 @@ python = "~2.7 || ^3.6"
 """
 
     assert expected in tester.io.fetch_output()
+
+
+def test_predefined_dependency(app, repo, mocker, poetry):
+    repo.add_package(get_package("pendulum", "2.0.0"))
+
+    command = app.find("init")
+    command._pool = poetry.pool
+
+    mocker.patch("poetry.utils._compat.Path.open")
+    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p.return_value = Path(__file__)
+
+    tester = CommandTester(command)
+    tester.set_inputs(
+        [
+            "my-package",  # Package name
+            "1.2.3",  # Version
+            "This is a description",  # Description
+            "n",  # Author
+            "MIT",  # License
+            "~2.7 || ^3.6",  # Python
+            "n",  # Interactive packages
+            "n",  # Interactive dev packages
+            "\n",  # Generate
+        ]
+    )
+    tester.execute([("command", command.name), ("--dependency", ["pendulum"])])
+
+    output = tester.get_display(True)
+    expected = """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+pendulum = "^2.0"
+
+[tool.poetry.dev-dependencies]
+"""
+
+    assert expected in output
+
+
+def test_predefined_and_interactive_dependencies(app, repo, mocker, poetry):
+    repo.add_package(get_package("pendulum", "2.0.0"))
+    repo.add_package(get_package("pyramid", "1.10"))
+
+    command = app.find("init")
+    command._pool = poetry.pool
+
+    mocker.patch("poetry.utils._compat.Path.open")
+    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p.return_value = Path(__file__)
+
+    tester = CommandTester(command)
+    tester.set_inputs(
+        [
+            "my-package",  # Package name
+            "1.2.3",  # Version
+            "This is a description",  # Description
+            "n",  # Author
+            "MIT",  # License
+            "~2.7 || ^3.6",  # Python
+            "",  # Interactive packages
+            "pyramid",  # Search for package
+            "0",  # First option
+            "",  # Do not set constraint
+            "",  # Stop searching for packages
+            "n",  # Interactive dev packages
+            "\n",  # Generate
+        ]
+    )
+    tester.execute([("command", command.name), ("--dependency", ["pendulum"])])
+
+    output = tester.get_display(True)
+    expected = """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+pendulum = "^2.0"
+pyramid = "^1.10"
+
+[tool.poetry.dev-dependencies]
+"""
+
+    assert expected in output
+
+
+def test_predefined_dev_dependency(app, repo, mocker, poetry):
+    repo.add_package(get_package("pytest", "3.6.0"))
+
+    command = app.find("init")
+    command._pool = poetry.pool
+
+    mocker.patch("poetry.utils._compat.Path.open")
+    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p.return_value = Path(__file__)
+
+    tester = CommandTester(command)
+    tester.set_inputs(
+        [
+            "my-package",  # Package name
+            "1.2.3",  # Version
+            "This is a description",  # Description
+            "n",  # Author
+            "MIT",  # License
+            "~2.7 || ^3.6",  # Python
+            "n",  # Interactive packages
+            "n",  # Interactive dev packages
+            "\n",  # Generate
+        ]
+    )
+    tester.execute([("command", command.name), ("--dev-dependency", ["pytest"])])
+
+    output = tester.get_display(True)
+    expected = """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+
+[tool.poetry.dev-dependencies]
+pytest = "^3.6"
+"""
+
+    assert expected in output
+
+
+def test_predefined_and_interactive_dev_dependencies(app, repo, mocker, poetry):
+    repo.add_package(get_package("pytest", "3.6.0"))
+    repo.add_package(get_package("pytest-requests", "0.2.0"))
+
+    command = app.find("init")
+    command._pool = poetry.pool
+
+    mocker.patch("poetry.utils._compat.Path.open")
+    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p.return_value = Path(__file__)
+
+    tester = CommandTester(command)
+    tester.set_inputs(
+        [
+            "my-package",  # Package name
+            "1.2.3",  # Version
+            "This is a description",  # Description
+            "n",  # Author
+            "MIT",  # License
+            "~2.7 || ^3.6",  # Python
+            "n",  # Interactive packages
+            "",  # Interactive dev packages
+            "pytest-requests",  # Search for package
+            "0",  # Select first option
+            "",  # Do not set constraint
+            "",  # Stop searching for dev packages
+            "\n",  # Generate
+        ]
+    )
+    tester.execute([("command", command.name), ("--dev-dependency", ["pytest"])])
+
+    output = tester.get_display(True)
+    expected = """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+
+[tool.poetry.dev-dependencies]
+pytest = "^3.6"
+pytest-requests = "^0.2.0"
+"""
+
+    assert expected in output

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -497,22 +497,19 @@ def test_predefined_dependency(app, repo, mocker, poetry):
     p.return_value = Path(__file__)
 
     tester = CommandTester(command)
-    tester.set_inputs(
-        [
-            "my-package",  # Package name
-            "1.2.3",  # Version
-            "This is a description",  # Description
-            "n",  # Author
-            "MIT",  # License
-            "~2.7 || ^3.6",  # Python
-            "n",  # Interactive packages
-            "n",  # Interactive dev packages
-            "\n",  # Generate
-        ]
-    )
-    tester.execute([("command", command.name), ("--dependency", ["pendulum"])])
+    inputs = [
+        "my-package",  # Package name
+        "1.2.3",  # Version
+        "This is a description",  # Description
+        "n",  # Author
+        "MIT",  # License
+        "~2.7 || ^3.6",  # Python
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+    tester.execute("--dependency pendulum", inputs="\n".join(inputs))
 
-    output = tester.get_display(True)
     expected = """\
 [tool.poetry]
 name = "my-package"
@@ -523,12 +520,12 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
-pendulum = "^2.0"
+pendulum = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 """
 
-    assert expected in output
+    assert expected in tester.io.fetch_output()
 
 
 def test_predefined_and_interactive_dependencies(app, repo, mocker, poetry):
@@ -543,26 +540,24 @@ def test_predefined_and_interactive_dependencies(app, repo, mocker, poetry):
     p.return_value = Path(__file__)
 
     tester = CommandTester(command)
-    tester.set_inputs(
-        [
-            "my-package",  # Package name
-            "1.2.3",  # Version
-            "This is a description",  # Description
-            "n",  # Author
-            "MIT",  # License
-            "~2.7 || ^3.6",  # Python
-            "",  # Interactive packages
-            "pyramid",  # Search for package
-            "0",  # First option
-            "",  # Do not set constraint
-            "",  # Stop searching for packages
-            "n",  # Interactive dev packages
-            "\n",  # Generate
-        ]
-    )
-    tester.execute([("command", command.name), ("--dependency", ["pendulum"])])
+    inputs = [
+        "my-package",  # Package name
+        "1.2.3",  # Version
+        "This is a description",  # Description
+        "n",  # Author
+        "MIT",  # License
+        "~2.7 || ^3.6",  # Python
+        "",  # Interactive packages
+        "pyramid",  # Search for package
+        "0",  # First option
+        "",  # Do not set constraint
+        "",  # Stop searching for packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
 
-    output = tester.get_display(True)
+    tester.execute("--dependency pendulum", inputs="\n".join(inputs))
+
     expected = """\
 [tool.poetry]
 name = "my-package"
@@ -574,9 +569,9 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
 """
-
+    output = tester.io.fetch_output()
     assert expected in output
-    assert 'pendulum = "^2.0"' in output
+    assert 'pendulum = "^2.0.0"' in output
     assert 'pyramid = "^1.10"' in output
 
 
@@ -591,22 +586,20 @@ def test_predefined_dev_dependency(app, repo, mocker, poetry):
     p.return_value = Path(__file__)
 
     tester = CommandTester(command)
-    tester.set_inputs(
-        [
-            "my-package",  # Package name
-            "1.2.3",  # Version
-            "This is a description",  # Description
-            "n",  # Author
-            "MIT",  # License
-            "~2.7 || ^3.6",  # Python
-            "n",  # Interactive packages
-            "n",  # Interactive dev packages
-            "\n",  # Generate
-        ]
-    )
-    tester.execute([("command", command.name), ("--dev-dependency", ["pytest"])])
+    inputs = [
+        "my-package",  # Package name
+        "1.2.3",  # Version
+        "This is a description",  # Description
+        "n",  # Author
+        "MIT",  # License
+        "~2.7 || ^3.6",  # Python
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
 
-    output = tester.get_display(True)
+    tester.execute("--dev-dependency pytest", inputs="\n".join(inputs))
+
     expected = """\
 [tool.poetry]
 name = "my-package"
@@ -619,10 +612,10 @@ license = "MIT"
 python = "~2.7 || ^3.6"
 
 [tool.poetry.dev-dependencies]
-pytest = "^3.6"
+pytest = "^3.6.0"
 """
 
-    assert expected in output
+    assert expected in tester.io.fetch_output()
 
 
 def test_predefined_and_interactive_dev_dependencies(app, repo, mocker, poetry):
@@ -637,26 +630,24 @@ def test_predefined_and_interactive_dev_dependencies(app, repo, mocker, poetry):
     p.return_value = Path(__file__)
 
     tester = CommandTester(command)
-    tester.set_inputs(
-        [
-            "my-package",  # Package name
-            "1.2.3",  # Version
-            "This is a description",  # Description
-            "n",  # Author
-            "MIT",  # License
-            "~2.7 || ^3.6",  # Python
-            "n",  # Interactive packages
-            "",  # Interactive dev packages
-            "pytest-requests",  # Search for package
-            "0",  # Select first option
-            "",  # Do not set constraint
-            "",  # Stop searching for dev packages
-            "\n",  # Generate
-        ]
-    )
-    tester.execute([("command", command.name), ("--dev-dependency", ["pytest"])])
+    inputs = [
+        "my-package",  # Package name
+        "1.2.3",  # Version
+        "This is a description",  # Description
+        "n",  # Author
+        "MIT",  # License
+        "~2.7 || ^3.6",  # Python
+        "n",  # Interactive packages
+        "",  # Interactive dev packages
+        "pytest-requests",  # Search for package
+        "0",  # Select first option
+        "",  # Do not set constraint
+        "",  # Stop searching for dev packages
+        "\n",  # Generate
+    ]
 
-    output = tester.get_display(True)
+    tester.execute("--dev-dependency pytest", inputs="\n".join(inputs))
+
     expected = """\
 [tool.poetry]
 name = "my-package"
@@ -671,6 +662,7 @@ python = "~2.7 || ^3.6"
 [tool.poetry.dev-dependencies]
 """
 
+    output = tester.io.fetch_output()
     assert expected in output
     assert 'pytest-requests = "^0.2.0"' in output
-    assert 'pytest = "^3.6"' in output
+    assert 'pytest = "^3.6.0"' in output

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -573,13 +573,11 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
-pendulum = "^2.0"
-pyramid = "^1.10"
-
-[tool.poetry.dev-dependencies]
 """
 
     assert expected in output
+    assert 'pendulum = "^2.0"' in output
+    assert 'pyramid = "^1.10"' in output
 
 
 def test_predefined_dev_dependency(app, repo, mocker, poetry):
@@ -671,8 +669,8 @@ license = "MIT"
 python = "~2.7 || ^3.6"
 
 [tool.poetry.dev-dependencies]
-pytest = "^3.6"
-pytest-requests = "^0.2.0"
 """
 
     assert expected in output
+    assert 'pytest-requests = "^0.2.0"' in output
+    assert 'pytest = "^3.6"' in output


### PR DESCRIPTION
This PR is a fork of https://github.com/python-poetry/poetry/pull/786, because there was no answer by @silenc3r for a long time.

This PR makes the `--dependency` parameter available for the interactive  version of `poetry init`.

Fixes: #711
# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.