### PR TITLE
[Repositories] consider "data-requires-python" anchor in the link when finding packages

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -389,6 +389,7 @@ class LegacyRepository(PyPiRepository):
                 )
             )
         urls = defaultdict(list)
+        url_requires_python_dict = {}
         files = []
         for link in links:
             if link.is_wheel:
@@ -398,6 +399,7 @@ class LegacyRepository(PyPiRepository):
             ):
                 urls["sdist"].append(link.url)
 
+            url_requires_python_dict[link.url] = link.requires_python
             h = link.hash
             if h:
                 h = link.hash_name + ":" + link.hash
@@ -405,7 +407,7 @@ class LegacyRepository(PyPiRepository):
 
         data["files"] = files
 
-        info = self._get_info_from_urls(urls)
+        info = self._get_info_from_urls(urls, url_requires_python_dict)
 
         data["summary"] = info["summary"]
         data["requires_dist"] = info["requires_dist"]

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -375,7 +375,7 @@ class PyPiRepository(RemoteRepository):
         # If requires_python exists in anchor of link, apply it to the release info (PEP503)
         def _get_info_with_url_requires_python(url, get_info_handler):
             info = get_info_handler(url)
-            if url_requires_python_dict[url]:
+            if url_requires_python_dict[url] and not info["requires_python"]:
                 info["requires_python"] = url_requires_python_dict[url]
             return info
 


### PR DESCRIPTION
## Pull Request Check List

Resolves: #2588

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

## Description
According to [PEP 503](https://www.python.org/dev/peps/pep-0503/), a repository MAY include a `data-requires-python` attribute on a file link. This exposes the `Requires-Python` metadata field, specified in `PEP 345`, for the corresponding release. Where this is present, installer tools SHOULD ignore the download when installing to a Python version that doesn't satisfy the requirement. 

However, in current logic `data-requires-python` in link is not considered in the `_get_release_info` method of `legacyRepository` class, which is the root cause of the #2588 .

This PR adds the checking of `data-requires-python` attribute. If it exists, we set `requires_python` in `release_info` as it says.
