### PR TITLE
Whitelisting externals for an isolated tox build hardly makes any sense. 

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -54,10 +54,9 @@ isolated_build = true
 envlist = py27, py36
 
 [testenv]
-whitelist_externals = poetry
 commands =
-    poetry install -v
-    poetry run pytest tests/
+    {toxworkdir}/.package/bin/poetry install -v
+    {toxworkdir}/.package/bin/poetry run pytest tests/
 ```
 
 ## I don't want Poetry to manage my virtual environments. Can I disable it?


### PR DESCRIPTION
# Pull Request Check List

Resolves: #918

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Minor update

Problem: 
- While running tox in azure-pipelines I bumped into this Invocation error.

Solution:
- Specifying the absolute isolated poetry path in the `build-system` tox environment namely ".package".
- Refer: [Default isolated build env dir @ tox](https://tox.readthedocs.io/en/latest/config.html#conf-isolated_build_env)

