### PR TITLE
Update flake8. Dont override flake8 defaults

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,8 @@
 [flake8]
 max-line-length = 88
-ignore = E501, E203, W503
+extend-ignore = E501, E203
 per-file-ignores = __init__.py:F401
-exclude =
-    .git
-    __pycache__
+extend-exclude =
     setup.py
     build
     dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
       - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.8
+    rev: 3.8.3
     hooks:
       - id: flake8
 
@@ -17,7 +17,7 @@ repos:
         exclude: ^.*/?setup\.py$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.1.0
     hooks:
       - id: trailing-whitespace
         exclude: ^tests/.*/fixtures/.*

--- a/poetry/masonry/builders/builder.py
+++ b/poetry/masonry/builders/builder.py
@@ -5,6 +5,7 @@ import tempfile
 
 from collections import defaultdict
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 from typing import Set
 from typing import Union
 
@@ -19,6 +20,12 @@ from poetry.vcs import get_vcs
 from ..metadata import Metadata
 from ..utils.module import Module
 from ..utils.package_include import PackageInclude
+
+
+if TYPE_CHECKING:
+    from clikit.api.io import IO
+    from poetry.poetry import Poetry
+    from poetry.utils.env import Env
 
 
 AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()]+) <(?P<email>.+?)>$")
@@ -38,7 +45,7 @@ class Builder(object):
 
     def __init__(
         self, poetry, env, io, ignore_packages_formats=False
-    ):  # type: ("Poetry", "Env", "IO", bool) -> None
+    ):  # type: (Poetry, Env, IO, bool) -> None
         self._poetry = poetry
         self._env = env
         self._io = io

--- a/poetry/repositories/pool.py
+++ b/poetry/repositories/pool.py
@@ -99,7 +99,7 @@ class Pool(BaseRepository):
 
     def package(
         self, name, version, extras=None, repository=None
-    ):  # type: (str, str, List[str], str) -> "Package"
+    ):  # type: (str, str, List[str], str) -> Package
         if (
             repository is not None
             and repository not in self._lookup

--- a/poetry/repositories/pool.py
+++ b/poetry/repositories/pool.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -5,6 +6,10 @@ from typing import Optional
 from .base_repository import BaseRepository
 from .exceptions import PackageNotFound
 from .repository import Repository
+
+
+if TYPE_CHECKING:
+    from poetry.packages import Package
 
 
 class Pool(BaseRepository):

--- a/poetry/semver/version_constraint.py
+++ b/poetry/semver/version_constraint.py
@@ -1,3 +1,10 @@
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from .version import Version
+
+
 class VersionConstraint:
     def is_empty(self):  # type: () -> bool
         raise NotImplementedError()
@@ -5,7 +12,7 @@ class VersionConstraint:
     def is_any(self):  # type: () -> bool
         raise NotImplementedError()
 
-    def allows(self, version):  # type: ("Version") -> bool
+    def allows(self, version):  # type: (Version) -> bool
         raise NotImplementedError()
 
     def allows_all(self, other):  # type: (VersionConstraint) -> bool

--- a/poetry/semver/version_range.py
+++ b/poetry/semver/version_range.py
@@ -65,7 +65,7 @@ class VersionRange(VersionConstraint):
     def is_any(self):
         return self._min is None and self._max is None
 
-    def allows(self, other):  # type: ("Version") -> bool
+    def allows(self, other):  # type: (Version) -> bool
         if self._min is not None:
             if other < self._min:
                 return False

--- a/poetry/semver/version_range.py
+++ b/poetry/semver/version_range.py
@@ -1,8 +1,13 @@
+from typing import TYPE_CHECKING
 from typing import List
 
 from .empty_constraint import EmptyConstraint
 from .version_constraint import VersionConstraint
 from .version_union import VersionUnion
+
+
+if TYPE_CHECKING:
+    from .version import Version
 
 
 class VersionRange(VersionConstraint):

--- a/poetry/semver/version_union.py
+++ b/poetry/semver/version_union.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
 from typing import List
 
 from .empty_constraint import EmptyConstraint
 from .version_constraint import VersionConstraint
+
+
+if TYPE_CHECKING:
+    from .version import Version
 
 
 class VersionUnion(VersionConstraint):
@@ -74,7 +79,7 @@ class VersionUnion(VersionConstraint):
     def is_any(self):
         return False
 
-    def allows(self, version):  # type: ("Version") -> bool
+    def allows(self, version):  # type: (Version) -> bool
         return any([constraint.allows(version) for constraint in self._ranges])
 
     def allows_all(self, other):  # type: (VersionConstraint) -> bool

--- a/poetry/vcs/git.py
+++ b/poetry/vcs/git.py
@@ -128,7 +128,7 @@ class ParsedUrl:
         )
 
     def format(self):
-        return "{}".format(self.url, "#{}".format(self.rev) if self.rev else "",)
+        return "{}".format(self.url)
 
     def __str__(self):  # type: () -> str
         return self.format()

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -714,7 +714,7 @@ cachy      0.1.0                       0.2.0
 my-package 0.1.1 ../project_with_setup 0.1.2 ../project_with_setup
 """
     assert expected.rstrip() == "\n".join(
-        l.rstrip() for l in tester.io.fetch_output().splitlines()
+        line.rstrip() for line in tester.io.fetch_output().splitlines()
     )
 
 


### PR DESCRIPTION
- Run `pre-commit autoupdate` to get flake8 v3.8.*
- Fix errors when running up-to-date flake8
- Use `extend-ignore` and `extend-exclude` in `.flake8` conf file to not override flake8 ignore and exclude defaults