### PR TITLE
Handle inspection for package without dependencies and no setup.py files

### DIFF
--- a/tests/fixtures/inspection/demo/pyproject.toml
+++ b/tests/fixtures/inspection/demo/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "demo"
+version = "0.1.0"
+description = ""
+authors = ["Sébastien Eustace <sebastien@eustace.io>"]
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.4"
+pendulum = ">=1.4.4"
+cleo = {version = "*", optional = true}
+tomlkit = {version = "*", optional = true}
+
+[tool.poetry.extras]
+foo = ["cleo"]
+bar = ["tomlkit"]
+
+[tool.poetry.dev-dependencies]
+pytest = "^3.0"

--- a/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps/PKG-INFO
+++ b/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps/PKG-INFO
@@ -1,0 +1,10 @@
+Metadata-Version: 1.0
+Name: demo
+Version: 0.1.0
+Summary: Demo project.
+Home-page: https://github.com/demo/demo
+Author: Sébastien Eustace
+Author-email: sebastien@eustace.io
+License: MIT
+Description: UNKNOWN
+Platform: UNKNOWN

--- a/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps/pyproject.toml
+++ b/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps/pyproject.toml
@@ -1,0 +1,19 @@
+# this was copied over and modified from orjson project's pyproject.toml
+# https://github.com/ijl/orjson/blob/master/pyproject.toml
+[project]
+name = "demo"
+repository = "https://github.com/demo/demo"
+
+[build-system]
+build-backend = "maturin"
+requires = ["maturin>=0.8.1,<0.9"]
+
+[tool.maturin]
+manylinux = "off"
+sdist-include = ["Cargo.lock", "json/**/*"]
+strip = "on"
+
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'

--- a/tests/fixtures/inspection/demo_only_requires_txt.egg-info/PKG-INFO
+++ b/tests/fixtures/inspection/demo_only_requires_txt.egg-info/PKG-INFO
@@ -1,0 +1,10 @@
+Metadata-Version: 1.0
+Name: demo
+Version: 0.1.0
+Summary: Demo project.
+Home-page: https://github.com/demo/demo
+Author: Sébastien Eustace
+Author-email: sebastien@eustace.io
+License: MIT
+Description: UNKNOWN
+Platform: UNKNOWN

--- a/tests/fixtures/inspection/demo_only_requires_txt.egg-info/requires.txt
+++ b/tests/fixtures/inspection/demo_only_requires_txt.egg-info/requires.txt
@@ -1,0 +1,3 @@
+cleo; extra == "foo"
+pendulum (>=1.4.4)
+tomlkit; extra == "bar"

--- a/tests/fixtures/inspection/demo_only_setup/setup.py
+++ b/tests/fixtures/inspection/demo_only_setup/setup.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from setuptools import setup
+
+
+kwargs = dict(
+    name="demo",
+    license="MIT",
+    version="0.1.0",
+    description="Demo project.",
+    author="Sébastien Eustace",
+    author_email="sebastien@eustace.io",
+    url="https://github.com/demo/demo",
+    packages=["my_package"],
+    install_requires=[
+        'cleo; extra == "foo"',
+        "pendulum (>=1.4.4)",
+        'tomlkit; extra == "bar"',
+    ],
+)
+
+
+setup(**kwargs)

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -1,0 +1,71 @@
+import pytest
+
+from poetry.inspection.info import PackageInfo
+from poetry.utils._compat import PY35
+from poetry.utils._compat import Path
+
+
+FIXTURE_DIR_BASE = Path(__file__).parent.parent / "fixtures"
+FIXTURE_DIR_INSPECTIONS = FIXTURE_DIR_BASE / "inspection"
+
+
+@pytest.fixture
+def demo_sdist():  # type: () -> Path
+    return FIXTURE_DIR_BASE / "distributions" / "demo-0.1.0.tar.gz"
+
+
+@pytest.fixture
+def demo_wheel():  # type: () -> Path
+    return FIXTURE_DIR_BASE / "distributions" / "demo-0.1.0-py2.py3-none-any.whl"
+
+
+def demo_check_info(info):  # type: (PackageInfo) -> None
+    assert info.name == "demo"
+    assert info.version == "0.1.0"
+    assert set(info.requires_dist) == {
+        'cleo; extra == "foo"',
+        "pendulum (>=1.4.4)",
+        'tomlkit; extra == "bar"',
+    }
+
+
+def test_info_from_sdist(demo_sdist):
+    info = PackageInfo.from_sdist(demo_sdist)
+    demo_check_info(info)
+
+
+def test_info_from_wheel(demo_wheel):
+    info = PackageInfo.from_wheel(demo_wheel)
+    demo_check_info(info)
+
+
+def test_info_from_bdist(demo_wheel):
+    info = PackageInfo.from_bdist(demo_wheel)
+    demo_check_info(info)
+
+
+def test_info_from_poetry_directory():
+    info = PackageInfo.from_directory(FIXTURE_DIR_INSPECTIONS / "demo")
+    demo_check_info(info)
+
+
+def test_info_from_requires_txt():
+    info = PackageInfo.from_metadata(
+        FIXTURE_DIR_INSPECTIONS / "demo_only_requires_txt.egg-info"
+    )
+    demo_check_info(info)
+
+
+@pytest.mark.skipif(not PY35, reason="Parsing of setup.py is skipped for Python < 3.5")
+def test_info_from_setup_py():
+    info = PackageInfo.from_setup_py(FIXTURE_DIR_INSPECTIONS / "demo_only_setup")
+    demo_check_info(info)
+
+
+def test_info_no_setup_pkg_info_no_deps():
+    info = PackageInfo.from_directory(
+        FIXTURE_DIR_INSPECTIONS / "demo_no_setup_pkg_info_no_deps"
+    )
+    assert info.name == "demo"
+    assert info.version == "0.1.0"
+    assert info.requires_dist is None


### PR DESCRIPTION
This change improves handling for packages without setup.py files nor any additional dependencies. In addition, inspection test cases have also been added.

Resolves: #2603

- [x] Added **tests** for changed code.