### PR TITLE
Fix dependency overrides for packages with multiple duplicate dependencies

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -646,7 +646,7 @@ class Provider:
             overrides = []
             for _dep in _deps:
                 current_overrides = self._overrides.copy()
-                package_overrides = current_overrides.get(package, {})
+                package_overrides = current_overrides.get(package, {}).copy()
                 package_overrides.update({_dep.name: _dep})
                 current_overrides.update({package: package_overrides})
                 overrides.append(current_overrides)


### PR DESCRIPTION
Whenever a package had multiple duplicate dependencies the overrides system was buggy and only retained one overridden version leading to resolution errors at installation times.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] ~Updated **documentation** for changed code.~
