### PR TITLE
Include --extra-index-url

### DIFF
--- a/poetry/repositories/pool.py
+++ b/poetry/repositories/pool.py
@@ -87,6 +87,9 @@ class Pool(BaseRepository):
         if idx is not None:
             del self._repositories[idx]
 
+        if idx == 0 and self.has_default():
+            self._default = False
+
         return self
 
     def has_package(self, package):

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -135,7 +135,8 @@ class Exporter(object):
 
         if indexes:
             # If we have extra indexes, we add them to the beginning of the output
-            indexes_header = ""
+            default_index_header = ""
+            extra_indexes_header = ""
             for index in sorted(indexes):
                 repository = [
                     r
@@ -151,15 +152,15 @@ class Exporter(object):
                         if with_credentials
                         else repository.url
                     )
-                    indexes_header = "--index-url {}\n".format(url)
+                    default_index_header = "--index-url {}\n".format(url)
                     continue
 
                 url = (
                     repository.authenticated_url if with_credentials else repository.url
                 )
-                indexes_header += "--extra-index-url {}\n".format(url)
+                extra_indexes_header += "--extra-index-url {}\n".format(url)
 
-            content = indexes_header + "\n" + content
+            content = default_index_header + extra_indexes_header + "\n" + content
 
         self._output(content, cwd, output)
 

--- a/tests/repositories/test_pool.py
+++ b/tests/repositories/test_pool.py
@@ -69,3 +69,28 @@ def test_repository_with_normal_default_and_secondary_repositories():
     assert pool.repository("foo") is repo1
     assert pool.repository("bar") is repo2
     assert pool.has_default()
+
+
+def test_remove_default_repository():
+    pool = Pool()
+
+    repo = LegacyRepository("foo", "https://foo.bar")
+    pool.add_repository(repo, default=True)
+    assert pool.has_default()
+
+    pool.remove_repository("foo")
+    assert not pool.has_default()
+
+
+def test_remove_non_default_repository():
+    pool = Pool()
+
+    repo1 = LegacyRepository("foo", "https://foo.bar")
+    repo2 = LegacyRepository("bar", "https://bar.baz")
+
+    pool.add_repository(repo1, default=True)
+    pool.add_repository(repo2, default=False)
+    assert pool.has_default()
+
+    pool.remove_repository("bar")
+    assert pool.has_default()

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -898,8 +898,7 @@ def test_exporter_exports_requirements_txt_with_index_url_and_extra_index_url(
     poetry.pool.remove_repository("PyPI")
 
     poetry.pool.add_repository(
-        LegacyRepository("default", "https://example.com/default/simple"),
-        default=True,
+        LegacyRepository("default", "https://example.com/default/simple"), default=True,
     )
     # This non-default repository is prior to the defualt repository because
     # they are sorted by their URL. (.../custom/... < .../default/...)
@@ -945,10 +944,7 @@ def test_exporter_exports_requirements_txt_with_index_url_and_extra_index_url(
     exporter = Exporter(poetry)
 
     exporter.export(
-        "requirements.txt",
-        Path(tmp_dir),
-        "requirements.txt",
-        with_hashes=False,
+        "requirements.txt", Path(tmp_dir), "requirements.txt", with_hashes=False,
     )
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2617

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

---

# Bug

In some cases, an exported `requirements.txt` does not include `--extra-index-url` even it is required. The reason is that `--index-url` line may overwrite the buffered `--extra-index-url` lines. This bug depends on how the URLs are sorted.

# Fix

To fix this bug, I made `--index-url` line do not overwrite the buffered `--extra-index-url` lines. Also, to test the fix, I had to change `Pool.remove_repository()` on a default repository to reset `Pool.has_default()`.