### PR TITLE
Ensure we have the latest pip version in CI before installing dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,10 @@ jobs:
         shell: bash
         run: poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
 
+      - name: Upgrade pip
+        shell: bash
+        run: poetry run python -m pip install pip -U
+
       - name: Install dependencies
         shell: bash
         run: poetry install


### PR DESCRIPTION
Following the changes made in #2595 the chosen wheels for installation can not be always be installed with old versions of pip if they are too specific or with recent tags.

This caused our CI to fail. This PR fixes it by ensuring we use the latest version of pip.

## Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
