### PR TITLE
feat: add --no-hash option to update, preventing metadata.content-hash

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -174,6 +174,7 @@ update the constraint, for example `^2.3`. You can do this using the `add` comma
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
 * `--no-dev` : Do not install dev dependencies.
 * `--lock` : Do not perform install (only update the lockfile).
+* `--no-hash` : Do not write a content-hash to the lockfile. Useful with merge conflics.
 
 ## add
 

--- a/poetry/console/commands/update.py
+++ b/poetry/console/commands/update.py
@@ -23,6 +23,7 @@ class UpdateCommand(InstallerCommand):
             "(implicitly enables --verbose).",
         ),
         option("lock", None, "Do not perform operations (only update the lockfile)."),
+        option("no-hash", None, "Do not write a content-hash to the lockfile."),
     ]
 
     loggers = ["poetry.repositories.pypi_repository"]
@@ -39,6 +40,7 @@ class UpdateCommand(InstallerCommand):
 
         self._installer.dev_mode(not self.option("no-dev"))
         self._installer.dry_run(self.option("dry-run"))
+        self.poetry.locker.set_write_hash(not self.option("no-hash"))
         self._installer.execute_operations(not self.option("lock"))
 
         # Force update

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -36,6 +36,7 @@ class Locker(object):
         self._local_config = local_config
         self._lock_data = None
         self._content_hash = self._get_content_hash()
+        self._write_hash = True
 
     @property
     def lock(self):  # type: () -> TomlFile
@@ -190,6 +191,8 @@ class Locker(object):
             "content-hash": self._content_hash,
             "files": files,
         }
+        if not self._write_hash:
+            del lock["metadata"]["content-hash"]
 
         if not self.is_locked() or lock != self.lock_data:
             self._write_lock_data(lock)
@@ -206,6 +209,9 @@ class Locker(object):
             raise RuntimeError("Inconsistent lock file data.")
 
         self._lock_data = None
+
+    def set_write_hash(self, write_hash=True):
+        self._write_hash = write_hash
 
     def _get_content_hash(self):  # type: () -> str
         """

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -139,6 +139,7 @@ class Locker(BaseLocker):
         self._locked = False
         self._lock_data = None
         self._write = False
+        self._write_hash = True
 
     def write(self, write=True):
         self._write = write

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -82,6 +82,7 @@ class Locker(BaseLocker):
         self._written_data = None
         self._locked = False
         self._content_hash = self._get_content_hash()
+        self._write_hash = True
 
     @property
     def written_data(self):

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -14,6 +14,7 @@ class Locker(BaseLocker):
     def __init__(self):
         self._locked = True
         self._content_hash = self._get_content_hash()
+        self._write_hash = True
 
     def locked(self, is_locked=True):
         self._locked = is_locked


### PR DESCRIPTION
Currently when creating a lockfile, a metadata.content-hash field is
generated, containing the hash of the sorted contents of pyproject.toml.

However (see #496) this causes merge conflicts, particularly
when using a tool such as dependabot that makes multiple parallel
branches with dependency changes.

Add a --no-hash option to poetry update. This causes metadata.content-hash
to be omitted. In turn poetry will later complain that the lock file
may not be fresh, (although it is correct), and the user can run poetry lock
to update it, after all the merges are complete.

dependabot currently runs `poetry update <DEPENDENCY> --lock`, I would
propose to incrporate this PR to poetry and then modify dependabot
to have teh --no-hash option.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
