### PR TITLE
Enable parallelization in CI

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -29,7 +29,7 @@ from .operations.update import Update
 
 
 class Executor(object):
-    def __init__(self, env, pool, config, io, parallel=None):
+    def __init__(self, env, pool, config, io, parallel=True):
         self._env = env
         self._io = io
         self._dry_run = False
@@ -38,9 +38,6 @@ class Executor(object):
         self._authenticator = Authenticator(config, self._io)
         self._chef = Chef(config, self._env)
         self._chooser = Chooser(pool, self._env)
-
-        if parallel is None:
-            parallel = self.supports_fancy_output()
 
         if parallel:
             # This should be directly handled by ThreadPoolExecutor

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -513,8 +513,8 @@ Package operations: 4 installs, 0 updates, 0 removals
   • Installing demo (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
     # Order might be different, split into lines and compare the overall output.
-    expected = set(expected.splitlines)
-    output = set(tester.io.fetch_output())
+    expected = set(expected.splitlines())
+    output = set(tester.io.fetch_output().splitlines())
     assert expected == output
     assert 4 == tester._command.installer.executor.installations_count
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -512,8 +512,10 @@ Package operations: 4 installs, 0 updates, 0 removals
   • Installing tomlkit (0.5.5)
   • Installing demo (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
-
-    assert expected == tester.io.fetch_output()
+    # Order might be different, split into lines and compare the overall output.
+    expected = set(expected.splitlines)
+    output = set(tester.io.fetch_output())
+    assert expected == output
     assert 4 == tester._command.installer.executor.installations_count
 
     content = app.poetry.file.read()["tool"]["poetry"]

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -253,7 +253,7 @@ Package operations: 4 installs, 0 updates, 0 removals
   • Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert expected.strip() == tester.io.fetch_output().strip()
     assert 4 == tester._command.installer.executor.installations_count
 
     content = app.poetry.file.read()["tool"]["poetry"]

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -109,7 +109,10 @@ Package operations: 4 installs, 1 update, 1 removal
 """.format(
         file_package.source_url, directory_package.source_url
     )
-    assert expected == io.fetch_output()
+
+    expected = set(expected.splitlines())
+    output = set(io.fetch_output().splitlines())
+    assert expected == output
     assert 5 == len(env.executed)
 
 


### PR DESCRIPTION
As discussed in https://github.com/python-poetry/poetry/pull/2648 this check is probably no longer needed.