### PR TITLE
editable builder: handle package includes correctly

### DIFF
--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -8,6 +8,7 @@ from base64 import urlsafe_b64encode
 
 from poetry.core.masonry.builders.builder import Builder
 from poetry.core.masonry.builders.sdist import SdistBuilder
+from poetry.core.masonry.utils.package_include import PackageInclude
 from poetry.core.semver.version import Version
 from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import Path
@@ -91,8 +92,17 @@ class EditableBuilder(Builder):
                 pth.name, self._env.site_packages, self._poetry.file.parent
             )
         )
+
+        paths = set()
+        for include in self._module.includes:
+            if isinstance(include, PackageInclude) and (
+                include.is_module() or include.is_package()
+            ):
+                paths.add(include.base.resolve().as_posix())
+
         with pth.open("w", encoding="utf-8") as f:
-            f.write(decode(str(self._poetry.file.parent.resolve())))
+            for path in paths:
+                f.write(decode(path + os.linesep))
 
         return [pth]
 


### PR DESCRIPTION
Previously, the editable builder contained a regression that only
included poetry root when generating .pth files. This change ensure
that all package or module sources are included as per configuration.

Resolves: #2657

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.