### PR TITLE
fix: fix handling of packages referenced by the multiple 'extra'

### DIFF
--- a/poetry/version/markers.py
+++ b/poetry/version/markers.py
@@ -658,7 +658,10 @@ class MarkerUnion(BaseMarker):
         return False
 
     def without_extras(self):
-        return self.exclude("extra")
+        marker = self.exclude("extra")
+        if marker.is_empty():
+            return AnyMarker()
+        return marker
 
     def exclude(self, marker_name):  # type: (str) -> BaseMarker
         new_markers = []

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -431,6 +431,30 @@ def test_solver_returns_extras_if_requested(solver, repo, package):
     assert ops[0].package.marker.is_any()
 
 
+def test_solver_returns_extras_multi_markers(solver, repo, package):
+    package.add_dependency("A", {"version": "*", "extras": ["foo"]})
+
+    package_a = get_package("A", "1.0")
+    package_b = get_package("B", "1.0")
+
+    package_a.add_dependency(
+        "B", {"version": "^1.0", "markers": "extra == 'foo' or extra == 'bar'"}
+    )
+
+    repo.add_package(package_a)
+    repo.add_package(package_b)
+
+    ops = solver.solve()
+
+    check_solver_result(
+        ops,
+        [
+            {"job": "install", "package": package_b},
+            {"job": "install", "package": package_a},
+        ],
+    )
+
+
 def test_solver_returns_prereleases_if_requested(solver, repo, package):
     package.add_dependency("A")
     package.add_dependency("B")


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2676 

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

For a package referenced by a single extra, a SingleMarker is used, where the result of without_extra is AnyMarker.
In the case of a package referenced by a multiple extra, a MarkerUnion is used, where the result of without_extra is an empty MarkerUnion.
There was a problem because the package was not installed if the package's Marker was an empty MarkerUnion.
