### PR TITLE
Python 2.7 and 3.5 deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ ensuring you have the right stack everywhere.
 
 ![Poetry Install](https://raw.githubusercontent.com/python-poetry/poetry/master/assets/install.gif)
 
-It supports Python 2.7 and 3.4+.
+It supports Python 2.7 and 3.5+.
+
+**Note**: Python 2.7 and 3.5 will no longer be supported in the next feature release (1.2).
+You should consider updating your Python version to a supported one.
 
 [![Tests Status](https://github.com/python-poetry/poetry/workflows/Tests/badge.svg?branch=master&event=push)](https://github.com/python-poetry/poetry/actions?query=workflow%3ATests+branch%3Amaster+event%3Apush)
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,8 +6,13 @@ It allows you to declare the libraries your project depends on and it will manag
 
 ## System requirements
 
-Poetry requires Python 2.7 or 3.4+. It is multi-platform and the goal is to make it work equally well
+Poetry requires Python 2.7 or 3.5+. It is multi-platform and the goal is to make it work equally well
 on Windows, Linux and OSX.
+
+!!! note
+
+    Python 2.7 and 3.5 will no longer be supported in the next feature release (1.2).
+    You should consider updating your Python version to a supported one.
 
 
 ## Installation

--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -1,3 +1,5 @@
+import sys
+
 from cleo import Application as BaseApplication
 
 from poetry.__version__ import __version__
@@ -37,6 +39,24 @@ class Application(BaseApplication):
 
         for command in self.get_default_commands():
             self.add(command)
+
+        if sys.version_info[:2] < (3, 6):
+            python_version = "<c1>{}</c1>".format(
+                ".".join(str(v) for v in sys.version_info[:2])
+            )
+            poetry_feature_release = "<c1>1.2</c1>"
+            message = (
+                "\n"
+                "Python {} will no longer be supported "
+                "in the next feature release of Poetry ({}).\n"
+                "You should consider updating your Python version to a supported one.\n\n"
+                ""
+                "Note that you will still be able to manage Python {} projects "
+                "by using the <c1>env</c1> command.\n"
+                "See <fg=blue>https://python-poetry.org/docs/managing-environments/</> "
+                "for more information."
+            ).format(python_version, poetry_feature_release, python_version)
+            self._preliminary_io.write_line("<fg=yellow>{}</>\n".format(message))
 
     @property
     def poetry(self):


### PR DESCRIPTION
This PR makes the necessary changes to notify users of the deprecation of Python 2.7 and 3.5 in Poetry:

- The documentation has been updated
- The CLI will now display a message when using Python 2.7 and 3.5.

<img width="613" alt="Screenshot 2020-07-17 at 16 44 09" src="https://user-images.githubusercontent.com/555648/87800249-72f6c280-c84e-11ea-8c4a-031e1367e473.png">

## Pull Request Check List

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
