### PR TITLE
Add missing quote to dependency-specification.md

### DIFF
--- a/docs/docs/dependency-specification.md
+++ b/docs/docs/dependency-specification.md
@@ -189,7 +189,7 @@ An example where this might be useful is the following:
 
 ```toml
 [tool.poetry.dev-dependencies]
-black = {version = "19.10b0", allow-prereleases = true, python = "^3.6", markers = "platform_python_implementation == 'CPython'}
+black = {version = "19.10b0", allow-prereleases = true, python = "^3.6", markers = "platform_python_implementation == 'CPython'"}
 ```
 
 As a single line, this is a lot to digest. To make this a little bit easier to


### PR DESCRIPTION
Pure documentation typo fix — no code changes.

I think this should also fix the confusing syntax highlighting at https://python-poetry.org/docs/dependency-specification/#expanded-dependency-specification-syntax where the `platform_python_implementation == 'CPython'` string literal edited here is not currently highlighted as a literal string value.