### PR TITLE
Add lock versioning support

### DIFF
--- a/poetry/console/config/application_config.py
+++ b/poetry/console/config/application_config.py
@@ -54,7 +54,11 @@ class ApplicationConfig(BaseApplicationConfig):
 
         io = event.io
 
-        loggers = ["poetry.packages.package", "poetry.utils.password_manager"]
+        loggers = [
+            "poetry.packages.locker",
+            "poetry.packages.package",
+            "poetry.utils.password_manager",
+        ]
 
         loggers += command.loggers
 
@@ -65,7 +69,6 @@ class ApplicationConfig(BaseApplicationConfig):
             logger = logging.getLogger(logger)
 
             logger.handlers = [handler]
-            logger.propagate = False
 
             level = logging.WARNING
             if io.is_debug():

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 
 from hashlib import sha256
@@ -13,12 +14,19 @@ from tomlkit.exceptions import TOMLKitError
 import poetry.packages
 import poetry.repositories
 
+from poetry.semver import parse_constraint
+from poetry.semver.version import Version
 from poetry.utils._compat import Path
 from poetry.utils.toml_file import TomlFile
 from poetry.version.markers import parse_marker
 
 
+logger = logging.getLogger(__name__)
+
+
 class Locker(object):
+
+    _VERSION = "1.0"
 
     _relevant_keys = ["dependencies", "dev-dependencies", "source", "extras"]
 
@@ -180,6 +188,7 @@ class Locker(object):
             }
 
         lock["metadata"] = {
+            "lock-version": self._VERSION,
             "python-versions": root.python_versions,
             "content-hash": self._content_hash,
             "files": files,
@@ -222,9 +231,30 @@ class Locker(object):
             raise RuntimeError("No lockfile found. Unable to read locked packages")
 
         try:
-            return self._lock.read()
+            lock_data = self._lock.read()
         except TOMLKitError as e:
             raise RuntimeError("Unable to read the lock file ({}).".format(e))
+
+        lock_version = Version.parse(lock_data["metadata"].get("lock-version", "1.0"))
+        current_version = Version.parse(self._VERSION)
+        accepted_versions = parse_constraint(
+            "^{}".format(Version(current_version.major, current_version.minor))
+        )
+        lock_version_allowed = accepted_versions.allows(lock_version)
+        if lock_version_allowed and current_version < lock_version:
+            logger.warning(
+                "The lock file might not be compatible with the current version of Poetry.\n"
+                "Upgrade Poetry to ensure the lock file is read properly or, alternatively, "
+                "regenerate the lock file with the `poetry lock` command."
+            )
+        elif not lock_version_allowed:
+            raise RuntimeError(
+                "The lock file is not compatible with the current version of Poetry.\n"
+                "Upgrade Poetry to be able to read the lock file or, alternatively, "
+                "regenerate the lock file with the `poetry lock` command."
+            )
+
+        return lock_data
 
     def _lock_packages(
         self, packages

--- a/tests/installation/fixtures/extras-with-dependencies.test
+++ b/tests/installation/fixtures/extras-with-dependencies.test
@@ -38,6 +38,7 @@ foo = ["C"]
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/extras.test
+++ b/tests/installation/fixtures/extras.test
@@ -35,6 +35,7 @@ foo = ["D"]
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/install-no-dev.test
+++ b/tests/installation/fixtures/install-no-dev.test
@@ -24,6 +24,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/no-dependencies.test
+++ b/tests/installation/fixtures/no-dependencies.test
@@ -2,6 +2,7 @@ package = []
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/remove.test
+++ b/tests/installation/fixtures/remove.test
@@ -8,6 +8,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/update-with-lock.test
+++ b/tests/installation/fixtures/update-with-lock.test
@@ -8,6 +8,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/update-with-locked-extras.test
+++ b/tests/installation/fixtures/update-with-locked-extras.test
@@ -40,6 +40,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-category-change.test
+++ b/tests/installation/fixtures/with-category-change.test
@@ -19,6 +19,7 @@ A = "^1.0"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-conditional-dependency.test
+++ b/tests/installation/fixtures/with-conditional-dependency.test
@@ -22,6 +22,7 @@ python = ">=3.6,<4.0"
 
 [metadata]
 python-versions = "~2.7 || ^3.4"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-dependencies-extras.test
+++ b/tests/installation/fixtures/with-dependencies-extras.test
@@ -30,6 +30,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-dependencies.test
+++ b/tests/installation/fixtures/with-dependencies.test
@@ -16,6 +16,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
@@ -96,6 +96,7 @@ url = "project_with_transitive_file_dependencies"
 
 [metadata]
 content-hash = "123456789"
+lock-version = "1.0"
 python-versions = "*"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-directory-dependency-poetry.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry.test
@@ -29,6 +29,7 @@ url = "tests/fixtures/project_with_extras"
 
 [metadata]
 content-hash = "123456789"
+lock-version = "1.0"
 python-versions = "*"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-directory-dependency-setuptools.test
+++ b/tests/installation/fixtures/with-directory-dependency-setuptools.test
@@ -34,6 +34,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-duplicate-dependencies-update.test
+++ b/tests/installation/fixtures/with-duplicate-dependencies-update.test
@@ -31,6 +31,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-duplicate-dependencies.test
+++ b/tests/installation/fixtures/with-duplicate-dependencies.test
@@ -56,6 +56,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-file-dependency-transitive.test
+++ b/tests/installation/fixtures/with-file-dependency-transitive.test
@@ -60,6 +60,7 @@ url = "project_with_transitive_file_dependencies"
 
 [metadata]
 content-hash = "123456789"
+lock-version = "1.0"
 python-versions = "*"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-file-dependency.test
+++ b/tests/installation/fixtures/with-file-dependency.test
@@ -28,6 +28,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-multiple-updates.test
+++ b/tests/installation/fixtures/with-multiple-updates.test
@@ -49,6 +49,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "~2.7 || ^3.4"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-optional-dependencies.test
+++ b/tests/installation/fixtures/with-optional-dependencies.test
@@ -32,6 +32,7 @@ foo = ["A"]
 
 [metadata]
 python-versions = "~2.7 || ^3.4"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-platform-dependencies.test
+++ b/tests/installation/fixtures/with-platform-dependencies.test
@@ -41,6 +41,7 @@ foo = ["A"]
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-prereleases.test
+++ b/tests/installation/fixtures/with-prereleases.test
@@ -16,6 +16,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-pypi-repository.test
+++ b/tests/installation/fixtures/with-pypi-repository.test
@@ -84,6 +84,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-python-versions.test
+++ b/tests/installation/fixtures/with-python-versions.test
@@ -24,6 +24,7 @@ python-versions = "~2.7 || ^3.3"
 
 [metadata]
 python-versions = "~2.7 || ^3.4"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-sub-dependencies.test
+++ b/tests/installation/fixtures/with-sub-dependencies.test
@@ -38,6 +38,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-url-dependency.test
+++ b/tests/installation/fixtures/with-url-dependency.test
@@ -28,6 +28,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-wheel-dependency-no-requires-dist.test
+++ b/tests/installation/fixtures/with-wheel-dependency-no-requires-dist.test
@@ -13,6 +13,7 @@ url = "tests/fixtures/wheel_with_no_requires_dist/demo-0.1.0-py2.py3-none-any.wh
 
 [metadata]
 python-versions = "*"
+lock-version = "1.0"
 content-hash = "123456789"
 
 [metadata.files]


### PR DESCRIPTION
This PR adds lock file versioning support in order to ease lock file changes transitions, like the one we will have when upgrading from `1.0` to `1.1`.

The versioning will have a compatibility system, close to semver. Basically if the lock file is newer but compatible version-wise, then only a warning will be displayed, prompting the user to upgrade Poetry or to relock the dependencies. However, if the lock file is not compatible version-wise, an error will be raised.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
