### PR TITLE
Fix errors on Python 2.7 when a file could not be downloaded

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -583,7 +583,11 @@ class Executor(object):
                 archive = self._download_archive(operation, link)
             except BaseException:
                 cache_directory = self._chef.get_cache_directory_for_link(link)
-                cache_directory.joinpath(link.filename).unlink(missing_ok=True)
+                cached_file = cache_directory.joinpath(link.filename)
+                # We can't use unlink(missing_ok=True) because it's not available
+                # in pathlib2 for Python 2.7
+                if cached_file.exists():
+                    cached_file.unlink()
 
                 raise
 


### PR DESCRIPTION
This PR fixes on issue on Python 2.7 where partially downloaded files would not be deleted due to the fact that `pathlib2` does not provide the `missing_ok` keyword argument for `unlink`.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
