### PR TITLE
Fix the lock content hash not being updated with the add/remove commands

### DIFF
--- a/poetry/console/commands/installer_command.py
+++ b/poetry/console/commands/installer_command.py
@@ -5,13 +5,20 @@ from .env_command import EnvCommand
 
 if TYPE_CHECKING:
     from poetry.installation.installer import Installer
+    from poetry.installation.installer import Optional
 
 
 class InstallerCommand(EnvCommand):
     def __init__(self):
-        self._installer = None
+        self._installer = None  # type: Optional[Installer]
 
         super(InstallerCommand, self).__init__()
+
+    def reset_poetry(self):
+        super(InstallerCommand, self).reset_poetry()
+
+        self._installer.set_package(self.poetry.package)
+        self._installer.set_locker(self.poetry.locker)
 
     @property
     def installer(self):  # type: () -> Installer

--- a/poetry/console/commands/remove.py
+++ b/poetry/console/commands/remove.py
@@ -60,7 +60,6 @@ list of installed packages
         # Update packages
         self.reset_poetry()
 
-        self._installer.set_package(self.poetry.package)
         self._installer.use_executor(
             self.poetry.config.get("experimental.new-installer", False)
         )

--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -79,6 +79,11 @@ class Installer:
 
         return self
 
+    def set_locker(self, locker):  # type: (Locker) -> Installer
+        self._locker = locker
+
+        return self
+
     def run(self):
         # Force update if there is no lock file present
         if not self._update and not self._locker.is_locked():

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -792,6 +792,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
 
 def test_add_with_lock(app, repo, tester):
+    content_hash = app.poetry.locker._get_content_hash()
     repo.add_package(get_package("cachy", "0.2.0"))
 
     tester.execute("cachy --lock")
@@ -806,6 +807,7 @@ Writing lock file
 """
 
     assert expected == tester.io.fetch_output()
+    assert content_hash != app.poetry.locker.lock_data["metadata"]["content-hash"]
 
 
 def test_add_no_constraint_old_installer(app, repo, installer, old_tester):

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -125,7 +125,9 @@ class Application(BaseApplication):
         self._poetry = Factory().create_poetry(self._poetry.file.path.parent)
         self._poetry.set_pool(poetry.pool)
         self._poetry.set_config(poetry.config)
-        self._poetry.set_locker(poetry.locker)
+        self._poetry.set_locker(
+            Locker(poetry.locker.lock.path, self._poetry.local_config)
+        )
 
 
 class Locker(BaseLocker):
@@ -163,7 +165,7 @@ class Locker(BaseLocker):
             self._locked = True
             return
 
-        self._lock_data = None
+        self._lock_data = data
 
 
 class Poetry(BasePoetry):


### PR DESCRIPTION
This one was caused by the changes done for the new installer.

Basically, when the `Poetry` object was reset to take the packages changes into account, the locker was not refreshed leading to an outdated hash.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
