### PR TITLE
Fix incorrect resolution errors for dependencies with looser python constraints

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -392,6 +392,10 @@ class Provider:
                     transitive_python_constraint
                 )
                 difference = transitive_python_constraint.difference(intersection)
+
+                # The difference is only relevant if it intersects
+                # the root package python constraint
+                difference = difference.intersect(self._python_constraint)
                 if (
                     transitive_python_constraint.is_any()
                     or self._python_constraint.intersect(

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -2073,3 +2073,19 @@ def test_solver_should_resolve_all_versions_for_multiple_duplicate_dependencies(
             {"job": "install", "package": package_b40},
         ],
     )
+
+
+def test_solver_should_not_raise_errors_for_irrelevant_python_constraints(
+    solver, repo, package
+):
+    package.python_versions = "^3.6"
+    solver.provider.set_package_python_versions("^3.6")
+    package.add_dependency("dataclasses", {"version": "^0.7", "python": "<3.7"})
+
+    dataclasses = get_package("dataclasses", "0.7")
+    dataclasses.python_versions = ">=3.6, <3.7"
+
+    repo.add_package(dataclasses)
+    ops = solver.solve()
+
+    check_solver_result(ops, [{"job": "install", "package": dataclasses}])


### PR DESCRIPTION
This fixes issues in the dependency resolution process whenever a package has a specific python requirement and the corresponding dependency has a python restriction looser than the root package Python requirements.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
