### PR TITLE
Increment lock file version to 1.1

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class Locker(object):
 
-    _VERSION = "1.0"
+    _VERSION = "1.1"
 
     _relevant_keys = ["dependencies", "dev-dependencies", "source", "extras"]
 

--- a/tests/installation/fixtures/extras-with-dependencies.test
+++ b/tests/installation/fixtures/extras-with-dependencies.test
@@ -38,7 +38,7 @@ foo = ["C"]
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/extras.test
+++ b/tests/installation/fixtures/extras.test
@@ -35,7 +35,7 @@ foo = ["D"]
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/install-no-dev.test
+++ b/tests/installation/fixtures/install-no-dev.test
@@ -24,7 +24,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/no-dependencies.test
+++ b/tests/installation/fixtures/no-dependencies.test
@@ -2,7 +2,7 @@ package = []
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/remove.test
+++ b/tests/installation/fixtures/remove.test
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/update-with-lock.test
+++ b/tests/installation/fixtures/update-with-lock.test
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/update-with-locked-extras.test
+++ b/tests/installation/fixtures/update-with-locked-extras.test
@@ -39,7 +39,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-category-change.test
+++ b/tests/installation/fixtures/with-category-change.test
@@ -19,7 +19,7 @@ A = "^1.0"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-conditional-dependency.test
+++ b/tests/installation/fixtures/with-conditional-dependency.test
@@ -22,7 +22,7 @@ python = ">=3.6,<4.0"
 
 [metadata]
 python-versions = "~2.7 || ^3.4"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-dependencies-extras.test
+++ b/tests/installation/fixtures/with-dependencies-extras.test
@@ -30,7 +30,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-dependencies.test
+++ b/tests/installation/fixtures/with-dependencies.test
@@ -16,7 +16,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
@@ -96,7 +96,7 @@ url = "project_with_transitive_file_dependencies"
 
 [metadata]
 content-hash = "123456789"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-directory-dependency-poetry.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry.test
@@ -29,7 +29,7 @@ url = "tests/fixtures/project_with_extras"
 
 [metadata]
 content-hash = "123456789"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-directory-dependency-setuptools.test
+++ b/tests/installation/fixtures/with-directory-dependency-setuptools.test
@@ -34,7 +34,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-duplicate-dependencies-update.test
+++ b/tests/installation/fixtures/with-duplicate-dependencies-update.test
@@ -30,7 +30,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-duplicate-dependencies.test
+++ b/tests/installation/fixtures/with-duplicate-dependencies.test
@@ -52,7 +52,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-file-dependency-transitive.test
+++ b/tests/installation/fixtures/with-file-dependency-transitive.test
@@ -60,7 +60,7 @@ url = "project_with_transitive_file_dependencies"
 
 [metadata]
 content-hash = "123456789"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-file-dependency.test
+++ b/tests/installation/fixtures/with-file-dependency.test
@@ -28,7 +28,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-multiple-updates.test
+++ b/tests/installation/fixtures/with-multiple-updates.test
@@ -39,7 +39,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "~2.7 || ^3.4"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-optional-dependencies.test
+++ b/tests/installation/fixtures/with-optional-dependencies.test
@@ -30,7 +30,7 @@ foo = ["A"]
 
 [metadata]
 python-versions = "~2.7 || ^3.4"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-platform-dependencies.test
+++ b/tests/installation/fixtures/with-platform-dependencies.test
@@ -38,7 +38,7 @@ foo = ["A"]
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-prereleases.test
+++ b/tests/installation/fixtures/with-prereleases.test
@@ -16,7 +16,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-pypi-repository.test
+++ b/tests/installation/fixtures/with-pypi-repository.test
@@ -81,7 +81,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-python-versions.test
+++ b/tests/installation/fixtures/with-python-versions.test
@@ -24,7 +24,7 @@ python-versions = "~2.7 || ^3.3"
 
 [metadata]
 python-versions = "~2.7 || ^3.4"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-sub-dependencies.test
+++ b/tests/installation/fixtures/with-sub-dependencies.test
@@ -38,7 +38,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-url-dependency.test
+++ b/tests/installation/fixtures/with-url-dependency.test
@@ -28,7 +28,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/installation/fixtures/with-wheel-dependency-no-requires-dist.test
+++ b/tests/installation/fixtures/with-wheel-dependency-no-requires-dist.test
@@ -13,7 +13,7 @@ url = "tests/fixtures/wheel_with_no_requires_dist/demo-0.1.0-py2.py3-none-any.wh
 
 [metadata]
 python-versions = "*"
-lock-version = "1.0"
+lock-version = "1.1"
 content-hash = "123456789"
 
 [metadata.files]

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -5,6 +5,7 @@ import pytest
 import tomlkit
 
 from poetry.core.packages.project_package import ProjectPackage
+from poetry.core.semver.version import Version
 from poetry.packages.locker import Locker
 
 from ..helpers import get_dependency
@@ -57,7 +58,7 @@ version = "1.2"
 
 [metadata]
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]
@@ -95,7 +96,7 @@ redis = ["redis (>=2.10.5)"]
 
 [metadata]
 content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "~2.7 || ^3.4"
 
 [metadata.files]
@@ -135,7 +136,7 @@ version = "1.0.0"
 
 [metadata]
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]
@@ -175,7 +176,7 @@ foo = ["B (>=1.0.0)"]
 
 [metadata]
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]
@@ -205,7 +206,7 @@ foo = ["bar"]
 
 [metadata]
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]
@@ -245,7 +246,7 @@ url = "https://foo.bar"
 
 [metadata]
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]
@@ -261,11 +262,13 @@ def test_locker_should_emit_warnings_if_lock_version_is_newer_but_allowed(
     content = """\
 [metadata]
 content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77"
-lock-version = "1.1"
+lock-version = "{version}"
 python-versions = "~2.7 || ^3.4"
 
 [metadata.files]
-"""
+""".format(
+        version=".".join(Version.parse(Locker._VERSION).next_minor.text.split(".")[:2])
+    )
     caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
 
     locker.lock.write(tomlkit.parse(content))
@@ -326,7 +329,7 @@ B = {version = "^1.0.0", extras = ["a", "b", "c"], optional = true}
 
 [metadata]
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "*"
 
 [metadata.files]


### PR DESCRIPTION
Since the lock file format in the `1.1` release will change slightly we need to bump the lock file version. This is not a completely breaking change so just bumping the minor version is enough.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
