### PR TITLE
Fix compatibility check for lock files

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -234,8 +234,10 @@ class Locker(object):
 
         lock_version = Version.parse(lock_data["metadata"].get("lock-version", "1.0"))
         current_version = Version.parse(self._VERSION)
+        # We expect the locker to be able to read lock files
+        # from the same semantic versioning range
         accepted_versions = parse_constraint(
-            "^{}".format(Version(current_version.major, current_version.minor))
+            "^{}".format(Version(current_version.major, 0))
         )
         lock_version_allowed = accepted_versions.allows(lock_version)
         if lock_version_allowed and current_version < lock_version:

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -340,3 +340,29 @@ A = []
         content = f.read()
 
     assert expected == content
+
+
+def test_locker_should_neither_emit_warnings_nor_raise_error_for_lower_compatible_versions(
+    locker, caplog
+):
+    current_version = Version.parse(Locker._VERSION)
+    older_version = ".".join(
+        [str(current_version.major), str(current_version.minor - 1)]
+    )
+    content = """\
+[metadata]
+content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77"
+lock-version = "{version}"
+python-versions = "~2.7 || ^3.4"
+
+[metadata.files]
+""".format(
+        version=older_version
+    )
+    caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
+
+    locker.lock.write(tomlkit.parse(content))
+
+    _ = locker.lock_data
+
+    assert 0 == len(caplog.records)


### PR DESCRIPTION
#2695 causes issues when reading older lock files due to a wrong check in the `Locker` class. This PR fixes it.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
