### PR TITLE
Reuse locked package info for vcs/file/url deps

### DIFF
--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -178,7 +178,7 @@ class Installer:
 
         locked_repository = Repository()
         if self._update:
-            if self._locker.is_locked() and not self._lock:
+            if self._locker.is_locked():
                 locked_repository = self._locker.locked_repository(True)
 
                 # If no packages have been whitelisted (The ones we want to update),

--- a/poetry/puzzle/solver.py
+++ b/poetry/puzzle/solver.py
@@ -44,7 +44,9 @@ class Solver:
         self._io = io
 
         if provider is None:
-            provider = Provider(self._package, self._pool, self._io)
+            provider = Provider(
+                self._package, self._pool, self._io, locked=self._locked
+            )
 
         self._provider = provider
         self._overrides = []

--- a/tests/installation/fixtures/with-reusable-package-info-file.test
+++ b/tests/installation/fixtures/with-reusable-package-info-file.test
@@ -1,0 +1,21 @@
+[[package]]
+name = "demo"
+version = "0.1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.source]
+type = "file"
+reference = ""
+url = "tests/fixtures/distributions/demo-0.1.0-py2.py3-none-any.whl"
+
+[package.dependencies]
+
+[package.extras]
+
+[metadata.files]
+demo = [
+    {file = "demo-0.1.0-py2.py3-none-any.whl", hash = "sha256:70e704135718fffbcbf61ed1fc45933cfd86951a744b681000eaaa75da31f17a"},
+]

--- a/tests/installation/fixtures/with-reusable-package-info-git.test
+++ b/tests/installation/fixtures/with-reusable-package-info-git.test
@@ -1,0 +1,23 @@
+[[package]]
+name = "demo"
+version = "0.1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.source]
+type = "git"
+reference = "f64843797eb954d530b6bfd229bfd6a55d13fe68"
+url = "https://github.com/demo/demo.git"
+
+[package.dependencies]
+
+[package.extras]
+
+[metadata.files]
+demo = []
+
+type = "url"
+reference = ""
+url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"

--- a/tests/installation/fixtures/with-reusable-package-info-url.test
+++ b/tests/installation/fixtures/with-reusable-package-info-url.test
@@ -1,0 +1,19 @@
+[[package]]
+name = "demo"
+version = "0.1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.source]
+type = "url"
+reference = ""
+url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+
+[package.dependencies]
+
+[package.extras]
+
+[metadata.files]
+demo = []


### PR DESCRIPTION
Prior to this change, when add/remove/lock commands were executed,
poetry would re-inspect all locked vcs/file/url dependencies. This is
sub-optimal and not required. This change enables reuse of locked
package info. 

Might Resolves: #1614
Closes: #2327 #2325

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
