### PR TITLE
Fix executor deadlock when IO doesn't support non-ascii characters

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -134,32 +134,29 @@ class Executor(object):
             return
 
         if self._io.is_debug():
-            self._lock.acquire()
-            section = self._sections[id(operation)]
-            section.write_line(line)
-            self._lock.release()
+            with self._lock:
+                section = self._sections[id(operation)]
+                section.write_line(line)
 
             return
 
-        self._lock.acquire()
-        section = self._sections[id(operation)]
-        section.output.clear()
-        section.write(line)
-        self._lock.release()
+        with self._lock:
+            section = self._sections[id(operation)]
+            section.output.clear()
+            section.write(line)
 
     def _execute_operation(self, operation):
         try:
             if self.supports_fancy_output():
                 if id(operation) not in self._sections:
                     if self._should_write_operation(operation):
-                        self._lock.acquire()
-                        self._sections[id(operation)] = self._io.section()
-                        self._sections[id(operation)].write_line(
-                            "  <fg=blue;options=bold>•</> {message}: <fg=blue>Pending...</>".format(
-                                message=self.get_operation_message(operation),
-                            ),
-                        )
-                        self._lock.release()
+                        with self._lock:
+                            self._sections[id(operation)] = self._io.section()
+                            self._sections[id(operation)].write_line(
+                                "  <fg=blue;options=bold>•</> {message}: <fg=blue>Pending...</>".format(
+                                    message=self.get_operation_message(operation),
+                                ),
+                            )
             else:
                 if self._should_write_operation(operation):
                     if not operation.skipped:
@@ -204,14 +201,12 @@ class Executor(object):
                 self._write(operation, message)
                 io = self._sections.get(id(operation), self._io)
 
-            self._lock.acquire()
+            with self._lock:
+                trace = ExceptionTrace(e)
+                trace.render(io)
+                io.write_line("")
 
-            trace = ExceptionTrace(e)
-            trace.render(io)
-            io.write_line("")
-
-            self._shutdown = True
-            self._lock.release()
+                self._shutdown = True
         except KeyboardInterrupt:
             message = "  <warning>•</warning> {message}: <warning>Cancelled</warning>".format(
                 message=self.get_operation_message(operation, warning=True),
@@ -221,9 +216,8 @@ class Executor(object):
             else:
                 self._write(operation, message)
 
-            self._lock.acquire()
-            self._shutdown = True
-            self._lock.release()
+            with self._lock:
+                self._shutdown = True
 
     def _do_execute_operation(self, operation):
         method = operation.job_type
@@ -269,14 +263,12 @@ class Executor(object):
         return result
 
     def _increment_operations_count(self, operation, executed):
-        self._lock.acquire()
-        if executed:
-            self._executed_operations += 1
-            self._executed[operation.job_type] += 1
-        else:
-            self._skipped[operation.job_type] += 1
-
-        self._lock.release()
+        with self._lock:
+            if executed:
+                self._executed_operations += 1
+                self._executed[operation.job_type] += 1
+            else:
+                self._skipped[operation.job_type] += 1
 
     def run_pip(self, *args, **kwargs):  # type: (...) -> int
         try:
@@ -625,9 +617,8 @@ class Executor(object):
                 progress.set_format(message + " <b>%percent%%</b>")
 
         if progress:
-            self._lock.acquire()
-            progress.start()
-            self._lock.release()
+            with self._lock:
+                progress.start()
 
         done = 0
         archive = self._chef.get_cache_directory_for_link(link) / link.filename
@@ -640,16 +631,14 @@ class Executor(object):
                 done += len(chunk)
 
                 if progress:
-                    self._lock.acquire()
-                    progress.set_progress(done)
-                    self._lock.release()
+                    with self._lock:
+                        progress.set_progress(done)
 
                 f.write(chunk)
 
         if progress:
-            self._lock.acquire()
-            progress.finish()
-            self._lock.release()
+            with self._lock:
+                progress.finish()
 
         return archive
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -182,6 +182,36 @@ Package operations: 1 install, 0 updates, 0 removals
     assert expected == io.fetch_output()
 
 
+def test_execute_should_gracefully_handle_io_error(config, mocker, io):
+    env = MockEnv()
+    executor = Executor(env, pool, config, io)
+    executor.verbose()
+
+    original_write_line = executor._io.write_line
+
+    def write_line(string, flags=None):
+        # Simulate UnicodeEncodeError
+        string.encode("ascii")
+        original_write_line(string, flags)
+
+    mocker.patch.object(io, "write_line", side_effect=write_line)
+
+    assert 1 == executor.execute([Install(Package("clikit", "0.2.3"))])
+
+    expected = r"""
+Package operations: 1 install, 0 updates, 0 removals
+
+
+  UnicodeEncodeError
+
+  'ascii' codec can't encode character '\\u2022' in position \d+: ordinal not in range\(128\)
+
+  at tests/installation/test_executor\.py:\d+ in write_line
+"""
+
+    assert re.match(expected, io.fetch_output())
+
+
 def test_executor_should_delete_incomplete_downloads(
     config, io, tmp_dir, mocker, pool, mock_file_downloads
 ):

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -202,11 +202,7 @@ def test_execute_should_gracefully_handle_io_error(config, mocker, io):
 Package operations: 1 install, 0 updates, 0 removals
 
 
-  UnicodeEncodeError
-
-  'ascii' codec can't encode character '\\u2022' in position \d+: ordinal not in range\(128\)
-
-  at tests/installation/test_executor\.py:\d+ in write_line
+\s*Unicode\w+Error
 """
 
     assert re.match(expected, io.fetch_output())


### PR DESCRIPTION
My environment happened to have a faulty locale setup and running `poetry install` got stuck for no apparent reason. This PR makes it so that the command doesn't get stuck in similar situations.

How to repro against 1.1.0b2

```sh
# set up a new project
mkdir test && cd test
python3.8 -m venv env
. env/bin/activate
pip install -U pip
pip install https://github.com/python-poetry/poetry/archive/1.1.0b2.tar.gz
poetry init -n

# use a clean virtualenv
poetry env use python

# note: the filetype package is just an example
# it's the first package I found that doesn't have external dependencies
# (to keep dependency resolution quick)
PYTHONIOENCODING=ascii poetry add filetype
```

Expected: fails with a nice error

Actual: gets stuck waiting for a `threading.Lock` to become available.

```sh
Using version ^1.0.7 for filetype

Updating dependencies
Resolving dependencies... (0.1s)

Writing lock file

Package operations: 1 install, 0 updates, 0 removal
# no progress beyond this
```

strace:

```sh
sudo $(which strace) -p $(ps -C poetry -o pid=)
[..]
futex(0x1f53d50, FUTEX_WAIT_BITSET_PRIVATE|FUTEX_CLOCK_REALTIME, 0, NULL, FUTEX_BITSET_MATCH_ANY
```

Ctrl-C gets it unstuck, but the new package isn't installed (while it's added to pyproject.toml).

### With this fix

```sh
# clean up
$ poetry remove filetype

$ pip install path/to/poetry-checkout
$ PYTHONIOENCODING=ascii poetry add filetype                                                           
Using version ^1.0.7 for filetype                                                                      

Updating dependencies
Resolving dependencies... (0.1s)

Package operations: 1 install, 0 updates, 0 removals

Failed to add packages, reverting the pyproject.toml file to its original content.
```

Note: the expected output in the new test added by this PR includes information about the exception (the "Unicode\w+Error" part) because the `io` object used in tests _doesn't_ support ansi.

On the other hand, when the `io` object supports ansi and `PYTHONIOENCODING=ascii` is set like in the case above, the exception handling code tries to write a message that contains a unicode character that cannot be encoded with ascii (`•`), resulting in no information about the exception getting logged. `PYTHONIOENCODING=ascii poetry add filetype | tee /dev/null` is one way to see the exception.

A more thorough 'fix' for environments that don't support non-ascii characters might be to add a check for it somewhere earlier in the app, like [click does](https://github.com/pallets/click/blob/7.1.2/src/click/_unicodefun.py). I'm leaving such changes out of this PR to keep it focused on fixing the deadlock and also because I'm not sure what the desired behavior would be (the app could exit with an error message, or it could switch to a non-ascii output format).

# Pull Request Check List

Resolves: no corresponding issue

- [x] Added **tests** for changed code. (sorta; not all changes might not be covered by new and existing tests)
- [ ] Updated **documentation** for changed code.
