### PR TITLE
ci: skip builds for doc changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,14 @@ name: Tests
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - master
       - develop
   pull_request:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - '**'
 


### PR DESCRIPTION
This should skip running the main workflow for doc only changes. 