### PR TITLE
Propagate package inspection logs

### DIFF
--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -60,7 +60,7 @@ class AddCommand(InstallerCommand, InitCommand):
         "  - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)\n"
     )
 
-    loggers = ["poetry.repositories.pypi_repository"]
+    loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]
 
     def handle(self):
         from poetry.core.semver import parse_constraint

--- a/poetry/console/commands/debug/resolve.py
+++ b/poetry/console/commands/debug/resolve.py
@@ -25,7 +25,7 @@ class DebugResolveCommand(InitCommand):
         option("install", None, "Show what would be installed for the current system."),
     ]
 
-    loggers = ["poetry.repositories.pypi_repository"]
+    loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]
 
     def handle(self):
         from poetry.core.packages.project_package import ProjectPackage

--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -45,7 +45,7 @@ dependencies and not including the current project, run the command with the
 <info> poetry install --no-root</info>
 """
 
-    _loggers = ["poetry.repositories.pypi_repository"]
+    _loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]
 
     def handle(self):
         from poetry.masonry.builders import EditableBuilder

--- a/poetry/console/commands/remove.py
+++ b/poetry/console/commands/remove.py
@@ -25,7 +25,7 @@ list of installed packages
 
 <info>poetry remove</info>"""
 
-    loggers = ["poetry.repositories.pypi_repository"]
+    loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]
 
     def handle(self):
         packages = self.argument("packages")

--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -155,7 +155,7 @@ class PackageInfo:
                 self._log(
                     "Invalid constraint ({}) found in {}-{} dependencies, "
                     "skipping".format(req, package.name, package.version),
-                    level="debug",
+                    level="warning",
                 )
                 continue
 


### PR DESCRIPTION
When transitioning to the new inspection logic, the new logger was not added at the appropriate places leading to log messages not being displayed.

## Pull Request Check List

Resolves: #2738 

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
