### PR TITLE
Feature/new author option

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -65,6 +65,12 @@ my-package
     └── test_my_package.py
 ```
 
+### Options
+
+* `--name`: Set the resulting package name.
+* `--author`: Author name of the package.
+* `--src`: Use the src layout for the project.
+
 ## init
 
 This command will help you create a `pyproject.toml` file interactively

--- a/poetry/console/commands/new.py
+++ b/poetry/console/commands/new.py
@@ -16,6 +16,7 @@ class NewCommand(Command):
     arguments = [argument("path", "The path to create the project at.")]
     options = [
         option("name", None, "Set the resulting package name.", flag=False),
+        option("author", None, "Author name of the package.", flag=False),
         option("src", None, "Use the src layout for the project."),
     ]
 
@@ -47,8 +48,8 @@ class NewCommand(Command):
         readme_format = "rst"
 
         config = GitConfig()
-        author = None
-        if config.get("user.name"):
+        author = self.option("author")
+        if (not author) and config.get("user.name"):
             author = config["user.name"]
             author_email = config.get("user.email")
             if author_email:

--- a/poetry/console/commands/new.py
+++ b/poetry/console/commands/new.py
@@ -49,7 +49,15 @@ class NewCommand(Command):
 
         config = GitConfig()
         author = self.option("author")
-        if (not author) and config.get("user.name"):
+        if author:
+            from poetry.packages.package import AUTHOR_REGEX
+
+            if not AUTHOR_REGEX.match(author):
+                raise ValueError(
+                    "Invalid author string. Must be in the format: "
+                    "John Smith <john@example.com>"
+                )
+        elif config.get("user.name"):
             author = config["user.name"]
             author_email = config.get("user.email")
             if author_email:


### PR DESCRIPTION
Resolves: #2697 

Adds an `--author` option to the `new` command. This PR basically just ports the `--author` option from `init` to `new`.

- [ ] Added **tests** for changed code.
  - I didn't see any tests for the `new` command, so I didn't add any
- [x] Updated **documentation** for changed code.
  - Added **Options** header under the ***new*** header
