### PR TITLE
add support for `poetry env remove` when `virtualenvs.in-project = true`

### DIFF
--- a/docs/docs/managing-environments.md
+++ b/docs/docs/managing-environments.md
@@ -116,7 +116,10 @@ poetry env remove /full/path/to/python
 poetry env remove python3.7
 poetry env remove 3.7
 poetry env remove test-O3eWbxRl-py3.7
-poetry env remove .venv
+poetry env remove
 ```
+
+If an argument for the python virtual environment to remove is not passed to the command, the currently activated virtual environment will be removed.
+This includes any virtual environment created in-project.
 
 If you remove the currently activated virtual environment, it will be automatically deactivated.

--- a/docs/docs/managing-environments.md
+++ b/docs/docs/managing-environments.md
@@ -116,6 +116,7 @@ poetry env remove /full/path/to/python
 poetry env remove python3.7
 poetry env remove 3.7
 poetry env remove test-O3eWbxRl-py3.7
+poetry env remove .venv
 ```
 
 If you remove the currently activated virtual environment, it will be automatically deactivated.

--- a/poetry/console/commands/env/remove.py
+++ b/poetry/console/commands/env/remove.py
@@ -11,7 +11,10 @@ class EnvRemoveCommand(Command):
     arguments = [
         argument(
             "python",
-            "The python executable to remove the virtualenv for.",
+            "The python executable to remove the virtualenv for."
+            "If not provided, defaults to removing the virtualenv that is currently active. "
+            'If "virtualenvs.in-project = True", defaults to removing ".venv/" in the '
+            "current working directory if it exists.",
             optional=True,
         )
     ]

--- a/poetry/console/commands/env/remove.py
+++ b/poetry/console/commands/env/remove.py
@@ -9,7 +9,12 @@ class EnvRemoveCommand(Command):
     description = "Removes a specific virtualenv associated with the project."
 
     arguments = [
-        argument("python", "The python executable to remove the virtualenv for.")
+        argument(
+            "python",
+            "The python executable to remove the virtualenv for.",
+            default=".venv",
+            optional=True,
+        )
     ]
 
     def handle(self):

--- a/poetry/console/commands/env/remove.py
+++ b/poetry/console/commands/env/remove.py
@@ -12,7 +12,6 @@ class EnvRemoveCommand(Command):
         argument(
             "python",
             "The python executable to remove the virtualenv for.",
-            default=".venv",
             optional=True,
         )
     ]
@@ -22,5 +21,4 @@ class EnvRemoveCommand(Command):
 
         manager = EnvManager(self.poetry)
         venv = manager.remove(self.argument("python"))
-
         self.line("Deleted virtualenv: <comment>{}</comment>".format(venv.path))

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -524,6 +524,22 @@ class EnvManager(object):
         return env_list
 
     def remove(self, python):  # type: (str) -> Env
+        cwd = self._poetry.file.parent
+
+        # check python value to allow for removal of other environments even
+        # though virtualenvs.in-project is used
+        if self._poetry.config.get("virtualenvs.in-project") and python == ".venv":
+            env = cwd / ".venv"
+            if not env.exists():
+                raise ValueError(
+                    '<warning>Environment "{}" does not exist.</warning>'.format(
+                        env.name
+                    )
+                )
+            self.remove_venv(env)
+
+            return VirtualEnv(env)
+
         venv_path = self._poetry.config.get("virtualenvs.path")
         if venv_path is None:
             venv_path = Path(CACHE_DIR) / "virtualenvs"

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -533,7 +533,7 @@ class EnvManager(object):
         base_env_name = self.generate_env_name(self._poetry.package.name, str(cwd))
 
         if python.startswith(base_env_name):
-            venv = self._find_with_base_name(python)
+            venv = self._find_by_exact_name(python)
             if venv:
                 return venv
 
@@ -550,7 +550,7 @@ class EnvManager(object):
 
         return VirtualEnv(venv)
 
-    def _find_with_base_name(self, python):  # type: (str) -> Env
+    def _find_by_exact_name(self, python):  # type: (str) -> Env
         for venv in self.list():
             if venv.path.name == python:
                 return venv

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -585,7 +585,9 @@ class EnvManager(object):
 
     def remove(self, python):  # type: (Optional[str]) -> Env
         venv = self.get() if not python else self.find(python)
-        self._remove_from_venv_file(python, venv)
+        if venv.path.name != ".venv":
+            # skip removing from venv file when it in the project
+            self._remove_from_venv_file(python, venv)
         self.remove_venv(venv.path)
         return venv
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,10 @@ def tmp_venv(tmp_dir):
     venv = VirtualEnv(venv_path)
     yield venv
 
-    shutil.rmtree(str(venv.path))
+    try:
+        shutil.rmtree(str(venv.path))
+    except FileNotFoundError:
+        pass  # was deleted during a test
 
 
 @pytest.fixture

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -41,19 +41,10 @@ def test_remove_by_name(tester, venvs_in_cache_dirs, venv_name, venv_cache):
     assert expected == tester.io.fetch_output()
 
 
-# TODO rewrite after implementing
-# @pytest.mark.parametrize("python_arg", ["", ".venv"])
-# def test_remove_in_project(python_arg, app, tmp_path, monkeypatch):
-#     app.poetry.config.merge({"virtualenvs": {"in-project": True}})
-#     monkeypatch.setattr(app.poetry.file, "_path_", tmp_path / "pyproject.toml")
-
-#     venv_path = tmp_path / ".venv"
-#     venv_path.mkdir()
-#     command = app.find("env remove")
-#     tester = CommandTester(command)
-#     tester.execute(python_arg)
-
-#     expected = "Deleted virtualenv: {}\n".format(venv_path)
-
-#     assert not venv_path.exists()
-#     assert expected == tester.io.fetch_output()
+def test_remove_in_project(app, mocker, tester, tmp_venv):
+    app.poetry.config.merge({"virtualenvs": {"in-project": True}})
+    mock_manager = mocker.patch("poetry.utils.env.EnvManager")
+    mock_manager.return_value = mock_manager
+    mock_manager.remove.return_value = tmp_venv
+    tester.execute()
+    assert tester.io.fetch_output() == "Deleted virtualenv: {}\n".format(tmp_venv.path)

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -1,7 +1,5 @@
 import pytest
 
-from cleo.testers import CommandTester
-
 from poetry.core.semver.version import Version
 from tests.console.commands.env.helpers import check_output_wrapper
 
@@ -43,18 +41,19 @@ def test_remove_by_name(tester, venvs_in_cache_dirs, venv_name, venv_cache):
     assert expected == tester.io.fetch_output()
 
 
-@pytest.mark.parametrize("python_arg", ["", ".venv"])
-def test_remove_in_project(python_arg, app, tmp_path, monkeypatch):
-    app.poetry.config.merge({"virtualenvs": {"in-project": True}})
-    monkeypatch.setattr(app.poetry.file, "_path_", tmp_path / "pyproject.toml")
+# TODO rewrite after implementing
+# @pytest.mark.parametrize("python_arg", ["", ".venv"])
+# def test_remove_in_project(python_arg, app, tmp_path, monkeypatch):
+#     app.poetry.config.merge({"virtualenvs": {"in-project": True}})
+#     monkeypatch.setattr(app.poetry.file, "_path_", tmp_path / "pyproject.toml")
 
-    venv_path = tmp_path / ".venv"
-    venv_path.mkdir()
-    command = app.find("env remove")
-    tester = CommandTester(command)
-    tester.execute(python_arg)
+#     venv_path = tmp_path / ".venv"
+#     venv_path.mkdir()
+#     command = app.find("env remove")
+#     tester = CommandTester(command)
+#     tester.execute(python_arg)
 
-    expected = "Deleted virtualenv: {}\n".format(venv_path)
+#     expected = "Deleted virtualenv: {}\n".format(venv_path)
 
-    assert not venv_path.exists()
-    assert expected == tester.io.fetch_output()
+#     assert not venv_path.exists()
+#     assert expected == tester.io.fetch_output()

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -43,7 +43,6 @@ def test_remove_by_name(tester, venvs_in_cache_dirs, venv_name, venv_cache):
     assert expected == tester.io.fetch_output()
 
 
-@pytest.mark.wip
 @pytest.mark.parametrize("python_arg", ["", ".venv"])
 def test_remove_in_project(python_arg, app, tmp_path, monkeypatch):
     app.poetry.config.merge({"virtualenvs": {"in-project": True}})

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -572,20 +572,11 @@ def test_remove_also_deactivates(tmp_dir, manager, poetry, config, mocker):
     assert venv_name not in envs
 
 
-# TODO rewrite after implementing
-# def test_remove_in_project(config, manager, monkeypatch, tmp_path):
-#     config.merge({"virtualenvs": {"in-project": True}})
-#     monkeypatch.setattr(manager._poetry.file, "parent", tmp_path)
-
-#     venv_path = tmp_path / ".venv"
-#     venv_path.mkdir()
-
-#     manager.remove(".venv")
-#     assert not venv_path.exists()
-
-#     with pytest.raises(ValueError) as excinfo:
-#         manager.remove(".venv")
-#     assert venv_path.name in str(excinfo.value)
+def test_remove_in_project(tmp_venv, config, manager, monkeypatch):
+    config.merge({"virtualenvs": {"in-project": True}})
+    monkeypatch.setattr(manager, "get", lambda: tmp_venv)
+    manager.remove(None)
+    assert not tmp_venv.path.exists()
 
 
 def test_remove_in_project_external(

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -572,19 +572,20 @@ def test_remove_also_deactivates(tmp_dir, manager, poetry, config, mocker):
     assert venv_name not in envs
 
 
-def test_remove_in_project(config, manager, monkeypatch, tmp_path):
-    config.merge({"virtualenvs": {"in-project": True}})
-    monkeypatch.setattr(manager._poetry.file, "parent", tmp_path)
+# TODO rewrite after implementing
+# def test_remove_in_project(config, manager, monkeypatch, tmp_path):
+#     config.merge({"virtualenvs": {"in-project": True}})
+#     monkeypatch.setattr(manager._poetry.file, "parent", tmp_path)
 
-    venv_path = tmp_path / ".venv"
-    venv_path.mkdir()
+#     venv_path = tmp_path / ".venv"
+#     venv_path.mkdir()
 
-    manager.remove(".venv")
-    assert not venv_path.exists()
+#     manager.remove(".venv")
+#     assert not venv_path.exists()
 
-    with pytest.raises(ValueError) as excinfo:
-        manager.remove(".venv")
-    assert venv_path.name in str(excinfo.value)
+#     with pytest.raises(ValueError) as excinfo:
+#         manager.remove(".venv")
+#     assert venv_path.name in str(excinfo.value)
 
 
 def test_remove_in_project_external(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2124

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

## What Changed

- `poetry env remove` argument now defaults to `.venv` for ease of use with the static value
- when `.venv` is passed as the `<python>` argument and `virtualenvs.in-project=true`, it will remove the `.env` directory in the root of the project