### PR TITLE
`choco install poetry` on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ poetry self update 1.0.0
 
     If you are still on poetry version < 1.0 use `poetry self:update` instead.
 
+### Installing on Windows
+
+Windows users who have the [Chocolatey package manager](https://www.chocolatey.org) can use the following to install the latest stable version:
+
+```cmd
+choco install poetry
+```
 
 ## Enable tab completion for Bash, Fish, or Zsh
 


### PR DESCRIPTION
Docs for Windows package manager (choco install poetry)

# Pull Request Check List

Resolves: #2314 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Submitting this in parallel with the work in progress on the `choco-python-poetry` repo: https://github.com/aaronsteers/choco-python-poetry

This new chocolatey package enables the below to "just work" on Windows:

```cmd
choco install poetry
choco uninstall poetry
```

As mentioned in #2314, I would like to use Poetry more broadly for my projects, and to include Poetry in some trainings which I lead. The slightly cumbersome install steps have been a blocker for me to suggest onboarding students, and my hope is that this significantly reduces the friction for new installations.

Would love to have a discussion about the long-term plans for this, but in the short-run at least, I'm happy to manage that Chocolatey package. Essentially it is a pure and simple wrapper for `get-poetry.py`. The package also ensures the command will run elevated and it supports `choco uninstall poetry` in the same way as suggested, which is to pass `--uninstall` to `get-poetry.py`.
