### PR TITLE
docs: add mention of editable installation

### DIFF
--- a/docs/docs/dependency-specification.md
+++ b/docs/docs/dependency-specification.md
@@ -117,6 +117,12 @@ my-package = { path = "../my-package/" }
 my-package = { path = "../my-package/dist/my-package-0.1.0.tar.gz" }
 ```
 
+The package is installed as an "editable installation" by default. This can be specified more explicitly:
+
+```toml
+my-package = { path = "../my-package/", develop = true }
+```
+
 
 ## `url` dependencies
 


### PR DESCRIPTION
This adds a mention about editable installs for path installations, as discussed in https://github.com/python-poetry/poetry/issues/34