### PR TITLE
remove outdated `--only-name` search option from docs

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -413,10 +413,6 @@ This command searches for packages on a remote index.
 poetry search requests pendulum
 ```
 
-### Options
-
-* `--only-name (-N)`: Search only in name.
-
 ## lock
 
 This command locks (without installing) the dependencies specified in `pyproject.toml`.


### PR DESCRIPTION
This PR removes outdated `--only-name` search option from docs.

# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/2803

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** <strike>for changed code.</strike>

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
