### PR TITLE
Update release script to support freebsd builds

### DIFF
--- a/make-nix-release.sh
+++ b/make-nix-release.sh
@@ -1,15 +1,24 @@
 #!/bin/sh
 
-set -e
+set -ex
+
+RUNTIMES[0]="${PYTHON27:+-P "2.7:$PYTHON27"}"
+RUNTIMES[1]="${PYTHON35:+-P "3.5:$PYTHON35"}"
+RUNTIMES[2]="${PYTHON36:+-P "3.6:$PYTHON36"}"
+RUNTIMES[3]="${PYTHON37:+-P "3.7:$PYTHON37"}"
+RUNTIMES[4]="${PYTHON38:+-P "3.8:$PYTHON38"}"
 
 test -n "$PYTHON" || PYTHON="python3"
-$PYTHON get-poetry.py -y --preview
-$PYTHON $HOME/.poetry/bin/poetry config virtualenvs.create false
-$PYTHON $HOME/.poetry/bin/poetry install --no-dev
-$PYTHON $HOME/.poetry/bin/poetry run python sonnet make release \
-    ${PYTHON27:+-P "2.7:$PYTHON27"} \
-    ${PYTHON35:+-P "3.5:$PYTHON35"} \
-    ${PYTHON36:+-P "3.6:$PYTHON36"} \
-    ${PYTHON37:+-P "3.7:$PYTHON37"} \
-    ${PYTHON38:+-P "3.8:$PYTHON38"} \
-    ${PYTHON39:+-P "3.9:$PYTHON39"}
+
+if [ "$OSTYPE" == "linux-gnu" ]; then
+  $PYTHON get-poetry.py -y --preview
+  POETRY="$PYTHON $HOME/.poetry/bin/poetry"
+  RUNTIMES[5]="${PYTHON39:+-P "3.9:$PYTHON39"}"
+else
+  $PYTHON -m pip install poetry -U --pre
+  POETRY="$PYTHON -m poetry"
+fi
+
+$POETRY config virtualenvs.create false
+$POETRY install --no-dev
+$POETRY run python sonnet make release ${RUNTIMES[@]}


### PR DESCRIPTION
FreeBSD build environments cannot use `get-poetry.py` script as this
requires a release to be bootstrapped. These environments also do not
support Python 3.9 yet. This change ensures that non-linux
environments use `pip` to install poetry.

Resolves: #2815