### PR TITLE
Update pyproject.md

### DIFF
--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -216,6 +216,8 @@ poetry = 'poetry.console:run'
 
 Here, we will have the `poetry` script installed which will execute `console.run` in the `poetry` package.
 
+When developing, run `poetry install` after editing the `scripts` section, to install the scripts in the virtualenv.
+
 ## `extras`
 
 Poetry supports extras to allow expression of:

--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -216,7 +216,9 @@ poetry = 'poetry.console:run'
 
 Here, we will have the `poetry` script installed which will execute `console.run` in the `poetry` package.
 
-When developing, run `poetry install` after editing the `scripts` section, to install the scripts in the virtualenv.
+!!!note
+
+    When a script is added or updated, run `poetry install` to make them available in the project's virtualenv.
 
 ## `extras`
 


### PR DESCRIPTION
Explain that `poetry install` installs the scripts in the virtualenv. See #2179 for the use case.

Having a script inside the virtualenv allows it to be run from a different working directory. Both @bphunter1972 and I didn't think about running `poetry install` in order to create the script. So I think that saying this explicitly may help others as well.