### PR TITLE
Change usage example for poetry export

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -453,7 +453,7 @@ The table below illustrates the effect of these rules with concrete examples.
 This command exports the lock file to other formats.
 
 ```bash
-poetry export -f requirements.txt > requirements.txt
+poetry export -f requirements.txt --output requirements.txt
 ```
 
 !!!note


### PR DESCRIPTION
This is a one-line PR _only_ affecting the docs.

The existing example for exporting requirements is like this:
```
poetry export -f requirements.txt > requirements.txt
```
The problem with this is that any additional output from poetry will also end up in the requirements file. For instance, if the `poetry.lock` file is not present, poetry will output to stdout some extra text telling you about this. This breaks the requirements file. (I was burned by this problem, hence this PR)

Seeing as there is already a documented option to specify the filename directly, which resolves this issue, updating the docs like this seems reasonable.

New suggested example:
```
poetry export -f requirements.txt --output requirements.txt
```

I suppose an argument can be made around whether or not to use `-o` or `--output`.