### PR TITLE
Do not raise error if package is already in pyproject.toml on poetry add

### DIFF
--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from typing import Dict
 from typing import List
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -725,8 +725,12 @@ def test_add_should_skip_when_adding_existing_package_with_no_constraint(
     tester.execute("foo")
 
     expected = """\
-foo is already in pyproject.toml. Skipping.
-Nothing to add.
+The following packages are already present in the pyproject.toml and will be skipped:
+
+  • foo
+
+If you want to update it to the latest compatible version, you can use `poetry update package`.
+If you prefer to upgrade it to the latest available version, you can use `poetry add package@latest`.
 """
 
     assert expected in tester.io.fetch_output()
@@ -1542,8 +1546,12 @@ def test_add_should_skip_when_adding_existing_package_with_no_constraint_old_ins
     old_tester.execute("foo")
 
     expected = """\
-foo is already in pyproject.toml. Skipping.
-Nothing to add.
+The following packages are already present in the pyproject.toml and will be skipped:
+
+  • foo
+
+If you want to update it to the latest compatible version, you can use `poetry update package`.
+If you prefer to upgrade it to the latest available version, you can use `poetry add package@latest`.
 """
 
     assert expected in old_tester.io.fetch_output()

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -714,7 +714,7 @@ Package operations: 1 install, 0 updates, 0 removals
     assert content["dependencies"]["pyyaml"] == "^3.13"
 
 
-def test_add_should_display_an_error_when_adding_existing_package_with_no_constraint(
+def test_add_should_skip_when_adding_existing_package_with_no_constraint(
     app, repo, tester
 ):
     content = app.poetry.file.read()
@@ -722,11 +722,14 @@ def test_add_should_display_an_error_when_adding_existing_package_with_no_constr
     app.poetry.file.write(content)
 
     repo.add_package(get_package("foo", "1.1.2"))
+    tester.execute("foo")
 
-    with pytest.raises(ValueError) as e:
-        tester.execute("foo")
+    expected = """\
+foo is already in pyproject.toml. Skipping.
+Nothing to add.
+"""
 
-    assert "Package foo is already present" == str(e.value)
+    assert expected in tester.io.fetch_output()
 
 
 def test_add_should_work_when_adding_existing_package_with_latest_constraint(
@@ -1527,7 +1530,7 @@ Package operations: 1 install, 0 updates, 0 removals
     assert content["dependencies"]["pyyaml"] == "^3.13"
 
 
-def test_add_should_display_an_error_when_adding_existing_package_with_no_constraint_old_installer(
+def test_add_should_skip_when_adding_existing_package_with_no_constraint_old_installer(
     app, repo, installer, old_tester
 ):
     content = app.poetry.file.read()
@@ -1536,10 +1539,14 @@ def test_add_should_display_an_error_when_adding_existing_package_with_no_constr
 
     repo.add_package(get_package("foo", "1.1.2"))
 
-    with pytest.raises(ValueError) as e:
-        old_tester.execute("foo")
+    old_tester.execute("foo")
 
-    assert "Package foo is already present" == str(e.value)
+    expected = """\
+foo is already in pyproject.toml. Skipping.
+Nothing to add.
+"""
+
+    assert expected in old_tester.io.fetch_output()
 
 
 def test_add_should_work_when_adding_existing_package_with_latest_constraint_old_installer(


### PR DESCRIPTION
At the moment `poetry` raises a `ValueError` when trying to add a package that is already in the `pyproject.toml`. This PR change the behaviour as follows:

* Do not raise ValueError if a dependency is added via `poetry add` and this dependency is already in `pyproject.toml`.
* Instead just print a warning and skip this package

# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/98

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
