### PR TITLE
Suppress click stacktrace in case of invalid cli option (#2854)

### DIFF
--- a/poetry/console/config/application_config.py
+++ b/poetry/console/config/application_config.py
@@ -223,7 +223,15 @@ class ApplicationConfig(BaseApplicationConfig):
         try:
             resolved_command = application.resolve_command(args)
         except NoSuchOptionException as ex:
-            raise PoetryException(str(ex)) from None
+            # according to https://www.python.org/dev/peps/pep-0415/
+            # raise ... from ... overrides __cause__, so do it manually
+            # it should be replaced by raise PoetryException(str(ex)) from None
+            # as soon as python2.7 has been dropped
+
+            new_ex = PoetryException(str(ex))
+            new_ex.__cause__ = None
+            new_ex.__suppress_context__ = True
+            raise new_ex
 
         # If the current command is the run one, skip option
         # check and interpret them as part of the executed command

--- a/poetry/console/config/application_config.py
+++ b/poetry/console/config/application_config.py
@@ -223,15 +223,7 @@ class ApplicationConfig(BaseApplicationConfig):
         try:
             resolved_command = application.resolve_command(args)
         except NoSuchOptionException as ex:
-            # according to https://www.python.org/dev/peps/pep-0415/
-            # raise ... from ... overrides __cause__, so do it manually
-            # it should be replaced by raise PoetryException(str(ex)) from None
-            # as soon as python2.7 has been dropped
-
-            new_ex = PoetryException(str(ex))
-            new_ex.__cause__ = None
-            new_ex.__suppress_context__ = True
-            raise new_ex
+            raise PoetryException(str(ex)) from None
 
         # If the current command is the run one, skip option
         # check and interpret them as part of the executed command

--- a/poetry/console/config/application_config.py
+++ b/poetry/console/config/application_config.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from cleo.config import ApplicationConfig as BaseApplicationConfig
 from clikit.api.application.application import Application
+from clikit.api.args.exceptions import NoSuchOptionException
 from clikit.api.args.raw_args import RawArgs
 from clikit.api.event import PRE_HANDLE
 from clikit.api.event import PreHandleEvent
@@ -30,6 +31,7 @@ from poetry.console.commands.env_command import EnvCommand
 from poetry.console.commands.installer_command import InstallerCommand
 from poetry.console.logging.io_formatter import IOFormatter
 from poetry.console.logging.io_handler import IOHandler
+from poetry.exceptions import PoetryException
 from poetry.utils._compat import PY36
 
 
@@ -218,7 +220,11 @@ class ApplicationConfig(BaseApplicationConfig):
             Output(error_stream, error_formatter),
         )
 
-        resolved_command = application.resolve_command(args)
+        try:
+            resolved_command = application.resolve_command(args)
+        except NoSuchOptionException as ex:
+            raise PoetryException(str(ex)) from None
+
         # If the current command is the run one, skip option
         # check and interpret them as part of the executed command
         if resolved_command.command.name == "run":

--- a/poetry/console/config/application_config.py
+++ b/poetry/console/config/application_config.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from cleo.config import ApplicationConfig as BaseApplicationConfig
 from clikit.api.application.application import Application
-from clikit.api.args.exceptions import NoSuchOptionException
 from clikit.api.args.raw_args import RawArgs
 from clikit.api.event import PRE_HANDLE
 from clikit.api.event import PreHandleEvent
@@ -222,7 +221,7 @@ class ApplicationConfig(BaseApplicationConfig):
 
         try:
             resolved_command = application.resolve_command(args)
-        except NoSuchOptionException as ex:
+        except RuntimeError as ex:
             raise PoetryException(str(ex)) from None
 
         # If the current command is the run one, skip option

--- a/tests/console/commands/test_invalid_command.py
+++ b/tests/console/commands/test_invalid_command.py
@@ -10,5 +10,8 @@ def test_overwrite_exception_in_case_of_invalid_command(app):
     conf = ApplicationConfig()
     args = ArgvArgs(["poetry", "--vers"])
 
-    with pytest.raises(PoetryException):
+    with pytest.raises(PoetryException) as cm:
         conf.create_io(app, args)
+
+    stacktrace_files = [str(stack_frame.path) for stack_frame in cm.traceback]
+    assert all(("poetry" in path for path in stacktrace_files))

--- a/tests/console/commands/test_invalid_command.py
+++ b/tests/console/commands/test_invalid_command.py
@@ -1,0 +1,14 @@
+import pytest
+
+from clikit.args import ArgvArgs
+
+from poetry.console.config import ApplicationConfig
+from poetry.exceptions import PoetryException
+
+
+def test_overwrite_exception_in_case_of_invalid_command(app):
+    conf = ApplicationConfig()
+    args = ArgvArgs(["poetry", "--vers"])
+
+    with pytest.raises(PoetryException):
+        conf.create_io(app, args)

--- a/tests/console/commands/test_invalid_command.py
+++ b/tests/console/commands/test_invalid_command.py
@@ -14,4 +14,5 @@ def test_overwrite_exception_in_case_of_invalid_command(app):
         conf.create_io(app, args)
 
     stacktrace_files = [str(stack_frame.path) for stack_frame in cm.traceback]
-    assert all(("poetry" in path for path in stacktrace_files))
+    stacktrace_files_without_the_test_file = stacktrace_files[1:]
+    assert all(("poetry" in path for path in stacktrace_files_without_the_test_file))


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2854

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code (I didn't find any cli-parsing tests in CI)
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

After the fix, the stacktrace looks the different:
```
(poetry) sergei.krotov ~/workspace/skv/poetry % poetry run poetry --vers

  Stack trace:

  1  ~/.pyenv/versions/3.8.5/envs/poetry/lib/python3.8/site-packages/clikit/console_application.py:123 in run
     io = io_factory(

  PoetryException

  The "--vers" option does not exist.

  at poetry/console/config/application_config.py:234 in create_io
      230│
      231│             new_ex = PoetryException(str(ex))
      232│             new_ex.__cause__ = None
      233│             new_ex.__suppress_context__ = True
    → 234│             raise new_ex
      235│
      236│         # If the current command is the run one, skip option
      237│         # check and interpret them as part of the executed command
      238│         if resolved_command.command.name == "run":
```
