### PR TITLE
[WIP] fix poetry env remove does not work with in-project = true

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -417,7 +417,7 @@ class EnvManager(object):
         envs_file = TomlFile(venv_path / self.ENVS_FILE)
         base_env_name = self.generate_env_name(self._poetry.package.name, str(cwd))
 
-        if python.startswith(base_env_name):
+        if python.startswith(base_env_name) or python == ".venv":
             venvs = self.list()
             for venv in venvs:
                 if venv.path.name == python:


### PR DESCRIPTION
#2908 

Fixing issue where a `poetry env remove .venv` fails in a project with `virtualenvs.in-project = true` in `poetry.toml` (so the virtualenv is stored in `.venv`).

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
