### PR TITLE
Ensure retry logic does not fail on empty io

### DIFF
--- a/poetry/installation/authenticator.py
+++ b/poetry/installation/authenticator.py
@@ -40,7 +40,7 @@ class Authenticator(object):
         self, method, url, **kwargs
     ):  # type: (str, str, Any) -> requests.Response
         request = requests.Request(method, url)
-        io = kwargs.get("io", self._io)
+        io = kwargs.get("io") or self._io
 
         username, password = self._get_credentials_for_url(url)
 
@@ -83,9 +83,12 @@ class Authenticator(object):
             if not is_last_attempt:
                 attempt += 1
                 delay = 0.5 * attempt
-                io.write_line(
-                    "<debug>Retrying HTTP request in {} seconds.</debug>".format(delay)
-                )
+                if io is not None:
+                    io.write_line(
+                        "<debug>Retrying HTTP request in {} seconds.</debug>".format(
+                            delay
+                        )
+                    )
                 time.sleep(delay)
                 continue
 


### PR DESCRIPTION
Apparrently #2548 identified an issue with the retry logic. Sometimes the `io` seems to be `None`. Adding some defensive handling of this scenario so as to note fail on a non-functional issue.

```console
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 251, in _do_execute_operation
    result = getattr(self, '_execute_{}'.format(method))(operation)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 386, in _execute_install
    return self._install(operation)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 412, in _install
    archive = self._download(operation)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 564, in _download
    link = self._chooser.choose_for(operation.package)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/chooser.py", line 60, in choose_for
    for link in self._get_links(package):
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/chooser.py", line 94, in _get_links
    links = repository.find_links_for_package(package)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/repositories/pypi_repository.py", line 249, in find_links_for_package
    json_data = self._get('pypi/{}/{}/json'.format(package.name, package.version))
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/repositories/pypi_repository.py", line 323, in _get
    json_response = self.session.get(self._base_url + endpoint)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/requests/sessions.py", line 543, in get
    return self.request('GET', url, **kwargs)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/requests/sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/requests/sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/cachecontrol/adapter.py", line 53, in send
    resp = super(CacheControlAdapter, self).send(request, **kw)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/requests/adapters.py", line 498, in send
    raise ConnectionError(err, request=request)



AttributeError

'NoneType' object has no attribute 'write_line'

Traceback (most recent call last):
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 177, in _execute_operation
    result = self._do_execute_operation(operation)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 251, in _do_execute_operation
    result = getattr(self, '_execute_{}'.format(method))(operation)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 386, in _execute_install
    return self._install(operation)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 412, in _install
    archive = self._download(operation)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 566, in _download
    return self._download_link(operation, link)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 575, in _download_link
    archive = self._download_archive(operation, link)
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/executor.py", line 602, in _download_archive
    "get", link.url, stream=True, io=self._sections.get(id(operation))
  File "/tmp/cirrus-ci-build/.tox/py/lib/python2.7/site-packages/poetry/installation/authenticator.py", line 86, in request
    io.write_line(
```