### PR TITLE
Inform user about option to skip changing PATH

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -23,11 +23,11 @@ recommended way of installing `poetry`.
 
 ### osx / linux / bashonwindows install instructions
 ```bash
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 ```
 ### windows powershell install instructions
 ```powershell
-(Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python
+(Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python -
 ```
 
 !!! note
@@ -38,9 +38,12 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poet
 The installer installs the `poetry` tool to Poetry's `bin` directory.
 On Unix it is located at `$HOME/.poetry/bin` and on Windows at `%USERPROFILE%\.poetry\bin`.
 
-This directory will be in your `$PATH` environment variable,
-which means you can run them from the shell without further configuration.
-Open a new shell and type the following:
+This directory will be automatically added to your `$PATH` environment variable,
+by appending a statement to your `$HOME/.profile` configuration (or equivalent files).
+If you do not feel comfortable with this, please pass the `--no-modify-path` flag to
+the installer and manually add the Poetry's `bin` directory to your path.
+
+Finally, open a new shell and type the following:
 
 ```bash
 poetry --version


### PR DESCRIPTION
I also added the `-` argument to `python`, because without it you cannot simply append flags for the script.
Hope this is just the same for powershell, as for bash.

Cf. #898

This is only a documentation change.

Btw. your contributing guidelines should say which branch to work from (I assume it’s master) and maybe use less bold highlight to increase readability.