### PR TITLE
Fix credentials set via environment variables

### DIFF
--- a/poetry/installation/authenticator.py
+++ b/poetry/installation/authenticator.py
@@ -134,21 +134,15 @@ class Authenticator(object):
     def _get_credentials_for_netloc_from_config(
         self, netloc
     ):  # type: (str) -> Tuple[Optional[str], Optional[str]]
-        for repository_name in self._config.get("repositories", {}):
-            repository_config = self._config.get(
-                "repositories.{}".format(repository_name)
-            )
-            if not repository_config:
-                continue
-
-            url = repository_config.get("url")
+        for repo_name, repo_config in self._config.get("repositories", {}).items():
+            url = repo_config.get("url")
             if not url:
                 continue
 
             parsed_url = urlparse.urlsplit(url)
 
             if netloc == parsed_url.netloc:
-                auth = self._password_manager.get_http_auth(repository_name)
+                auth = self._password_manager.get_http_auth(repo_name)
 
                 if auth is None:
                     continue

--- a/poetry/installation/authenticator.py
+++ b/poetry/installation/authenticator.py
@@ -134,7 +134,6 @@ class Authenticator(object):
     def _get_credentials_for_netloc_from_config(
         self, netloc
     ):  # type: (str) -> Tuple[Optional[str], Optional[str]]
-        credentials = (None, None)
         for repository_name in self._config.get("repositories", {}):
             repository_config = self._config.get(
                 "repositories.{}".format(repository_name)
@@ -156,4 +155,4 @@ class Authenticator(object):
 
                 return auth["username"], auth["password"]
 
-        return credentials
+        return (None, None)

--- a/poetry/installation/authenticator.py
+++ b/poetry/installation/authenticator.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 from typing import TYPE_CHECKING
@@ -134,8 +135,14 @@ class Authenticator(object):
     def _get_credentials_for_netloc_from_config(
         self, netloc
     ):  # type: (str) -> Tuple[Optional[str], Optional[str]]
-        for repo_name, repo_config in self._config.get("repositories", {}).items():
-            url = repo_config.get("url")
+        environ_repo_names = [
+            v.split("_")[2].lower()
+            for v in os.environ
+            if v.startswith("POETRY_REPOSITORIES_")
+        ]
+        config_repo_names = list(self._config.get("repositories", {}))
+        for repo_name in config_repo_names + environ_repo_names:
+            url = self._config.get("repositories.{}.url".format(repo_name))
             if not url:
                 continue
 

--- a/poetry/installation/authenticator.py
+++ b/poetry/installation/authenticator.py
@@ -135,7 +135,7 @@ class Authenticator(object):
         self, netloc
     ):  # type: (str) -> Tuple[Optional[str], Optional[str]]
         credentials = (None, None)
-        for repository_name in self._config.get("http-basic", {}):
+        for repository_name in self._config.get("repositories", {}):
             repository_config = self._config.get(
                 "repositories.{}".format(repository_name)
             )

--- a/tests/installation/test_authenticator.py
+++ b/tests/installation/test_authenticator.py
@@ -48,6 +48,21 @@ def test_authenticator_uses_env_provided_credentials(
     assert "Basic YmFyOmJheg==" == request.headers["Authorization"]
 
 
+def test_authenticator_uses_env_provided_credentials_and_repo(
+    config, environ, mock_remote, http
+):
+    os.environ["POETRY_REPOSITORIES_FOO_URL"] = "https://foo.bar/simple/"
+    os.environ["POETRY_HTTP_BASIC_FOO_USERNAME"] = "bar"
+    os.environ["POETRY_HTTP_BASIC_FOO_PASSWORD"] = "baz"
+
+    authenticator = Authenticator(config, NullIO())
+    authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
+
+    request = http.last_request()
+
+    assert "Basic YmFyOmJheg==" == request.headers["Authorization"]
+
+
 def test_authenticator_uses_credentials_from_config_if_not_provided(
     config, mock_remote, http
 ):

--- a/tests/installation/test_authenticator.py
+++ b/tests/installation/test_authenticator.py
@@ -1,3 +1,4 @@
+import os
 import re
 import uuid
 
@@ -30,6 +31,21 @@ def test_authenticator_uses_url_provided_credentials(config, mock_remote, http):
     request = http.last_request()
 
     assert "Basic Zm9vMDAxOmJhcjAwMg==" == request.headers["Authorization"]
+
+
+def test_authenticator_uses_env_provided_credentials(
+    config, environ, mock_remote, http
+):
+    os.environ["POETRY_HTTP_BASIC_FOO_USERNAME"] = "bar"
+    os.environ["POETRY_HTTP_BASIC_FOO_PASSWORD"] = "baz"
+    config.merge({"repositories": {"foo": {"url": "https://foo.bar/simple/"}}})
+
+    authenticator = Authenticator(config, NullIO())
+    authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
+
+    request = http.last_request()
+
+    assert "Basic YmFyOmJheg==" == request.headers["Authorization"]
 
 
 def test_authenticator_uses_credentials_from_config_if_not_provided(


### PR DESCRIPTION
`config.get('http-basic')` may not list repositories if credentials are set via environment variables. This fixes that by listing repositories from `config.get('repositories')`.

However, the user still need to configure the repo url like `poetry config repositories.foo ...`. It doesn't work by simply setting the environment variable `POETRY_REPOSITORIES_FOO_URL`, as there is currently no way to iterate over the repository names set via environment variables.

I added a commit 1733ed9 to show a potential solution to this, but it might need to be reworked a bit. I can split it out in a separate PR if needed. 

# Pull Request Check List

Resolves: #2799

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->