### PR TITLE
Fix cases where poetry should fall back to pep517 metadata parsing

### DIFF
--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -326,7 +326,7 @@ class PackageInfo:
             requires_python=python_requires,
         )
 
-        if not info.name or not info.version:
+        if not (info.name and info.version) and not info.requires_dist:
             # there is nothing useful here
             raise PackageInfoError(path)
 
@@ -436,7 +436,7 @@ class PackageInfo:
         info = None
         try:
             info = cls.from_setup_files(path)
-            if info.requires_dist is not None:
+            if all([info.version, info.name, info.requires_dist]):
                 return info
         except PackageInfoError:
             pass

--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -326,7 +326,7 @@ class PackageInfo:
             requires_python=python_requires,
         )
 
-        if not (info.name and info.version) and not info.requires_dist:
+        if not info.name or not info.version:
             # there is nothing useful here
             raise PackageInfoError(path)
 

--- a/poetry/utils/setup_reader.py
+++ b/poetry/utils/setup_reader.py
@@ -8,6 +8,8 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from poetry.core.semver import Version
+
 from ._compat import PY35
 from ._compat import Path
 from ._compat import basestring
@@ -109,7 +111,7 @@ class SetupReader(object):
             name = parser.get("metadata", "name")
 
         if parser.has_option("metadata", "version"):
-            version = parser.get("metadata", "version")
+            version = Version.parse(parser.get("metadata", "version")).text
 
         install_requires = []
         extras_require = {}

--- a/tests/utils/fixtures/setups/with-setup-cfg-attr/setup.cfg
+++ b/tests/utils/fixtures/setups/with-setup-cfg-attr/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = with-setup-cfg-attr
+version = attr: with_setup_cfg_attr.__version__
+
+[options]
+zip_safe = true
+python_requires = >=2.6,!=3.0,!=3.1,!=3.2,!=3.3
+setup_requires = setuptools>=36.2.2
+install_requires =
+    six
+    tomlkit
+
+[options.extras_require]
+validation =
+    cerberus
+tests =
+    pytest
+    pytest-xdist
+    pytest-cov

--- a/tests/utils/fixtures/setups/with-setup-cfg-attr/setup.py
+++ b/tests/utils/fixtures/setups/with-setup-cfg-attr/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from poetry.core.semver.exceptions import ParseVersionError
 from poetry.utils._compat import PY35
 from poetry.utils.setup_reader import SetupReader
 
@@ -115,6 +116,11 @@ def test_setup_reader_read_setup_cfg(setup):
     assert expected_install_requires == result["install_requires"]
     assert expected_extras_require == result["extras_require"]
     assert expected_python_requires == result["python_requires"]
+
+
+def test_setup_reader_read_setup_cfg_with_attr(setup):
+    with pytest.raises(ParseVersionError):
+        SetupReader.read_from_directory(setup("with-setup-cfg-attr"))
 
 
 @pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")


### PR DESCRIPTION
https://github.com/python-poetry/poetry/issues/2761 discovered cases where `poetry` should fall back to pep517 to read metadata.

According to the [docs of setup.cfg](https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html#specifying-values) the version can be specified by linking to an attribute in a module by using `attr: somemodule:__version__`. At the moment `poetry` will extract this literally and will try to parse it later, when it cannot fall back to pep517. This PR changes it, by trying to parse the version at the moment of extracting from the `setup.cfg`. If it failes a `ParseVersionError` is thrown and poetry will fallback to pep517 parsing.

The second case appears if requirements and name or version (but not both) can be extracted from either `setup.py` or `setup.cfg`. name and version are mandatory information. If poetry cannot find any requirements, it cannot differ whether there are no or it was unable to parse it. So poetry should fall back to pep517 whenever any of these values are missing.


# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/2761

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
