### PR TITLE
Add 'rc' to VERSION_REGEX

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -317,7 +317,7 @@ class Installer:
         r"v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?"
         "("
         "[._-]?"
-        r"(?:(stable|beta|b|RC|alpha|a|patch|pl|p)((?:[.-]?\d+)*)?)?"
+        r"(?:(stable|beta|b|rc|RC|alpha|a|patch|pl|p)((?:[.-]?\d+)*)?)?"
         "([.-]?dev)?"
         ")?"
         r"(?:\+[^\s]+)?"


### PR DESCRIPTION
The previous VERSION_REGEX string only checks for 'RC', however, the
latest RC submitted to the poetry project is '1.1.0rc1' which fails the
regex test for allowing installation of PREVIEW releases.

fixes: https://github.com/python-poetry/poetry/issues/2977
