### PR TITLE
Fix: allow whitespace in list of extras for a package

### DIFF
--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -373,7 +373,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         for requirement in requirements:
             requirement = requirement.strip()
             extras = []
-            extras_m = re.search(r"\[([\w\d,-_]+)\]$", requirement)
+            extras_m = re.search(r"\[([\w\d,-_ ]+)\]$", requirement)
             if extras_m:
                 extras = [e.strip() for e in extras_m.group(1).split(",")]
                 requirement, _ = requirement.split("[")

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -558,8 +558,9 @@ python = "~2.7 || ^3.6"
     assert 'pytest = "^3.6.0"' in output
 
 
-def test_add_package_with_extras_and_whitespace(init_command):
-    result = init_command._parse_requirements(["databases[postgresql, sqlite]"])
+def test_add_package_with_extras_and_whitespace(app):
+    command = app.find("init")
+    result = command._parse_requirements(["databases[postgresql, sqlite]"])
 
     assert result[0]["name"] == "databases"
     assert len(result[0]["extras"]) == 2

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -558,9 +558,8 @@ python = "~2.7 || ^3.6"
     assert 'pytest = "^3.6.0"' in output
 
 
-def test_add_package_with_extras_and_whitespace(app):
-    command = app.find("init")
-    result = command._parse_requirements(["databases[postgresql, sqlite]"])
+def test_add_package_with_extras_and_whitespace(tester):
+    result = tester._command._parse_requirements(["databases[postgresql, sqlite]"])
 
     assert result[0]["name"] == "databases"
     assert len(result[0]["extras"]) == 2

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -556,3 +556,12 @@ python = "~2.7 || ^3.6"
     assert expected in output
     assert 'pytest-requests = "^0.2.0"' in output
     assert 'pytest = "^3.6.0"' in output
+
+
+def test_add_package_with_extras_and_whitespace(init_command):
+    result = init_command._parse_requirements(["databases[postgresql, sqlite]"])
+
+    assert result[0]["name"] == "databases"
+    assert len(result[0]["extras"]) == 2
+    assert "postgresql" in result[0]["extras"]
+    assert "sqlite" in result[0]["extras"]

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from cleo import ApplicationTester
 
+from poetry.console.commands import InitCommand
 from poetry.factory import Factory
 from poetry.installation.noop_installer import NoopInstaller
 from poetry.io.null_io import NullIO
@@ -113,3 +114,10 @@ def new_installer_disabled(config):
 @pytest.fixture()
 def executor(poetry, config, env):
     return TestExecutor(env, poetry.pool, config, NullIO())
+
+
+@pytest.fixture()
+def init_command(app):
+    command = InitCommand()
+    command._application = app
+    return command

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -4,7 +4,6 @@ import pytest
 
 from cleo import ApplicationTester
 
-from poetry.console.commands import InitCommand
 from poetry.factory import Factory
 from poetry.installation.noop_installer import NoopInstaller
 from poetry.io.null_io import NullIO
@@ -114,10 +113,3 @@ def new_installer_disabled(config):
 @pytest.fixture()
 def executor(poetry, config, env):
     return TestExecutor(env, poetry.pool, config, NullIO())
-
-
-@pytest.fixture()
-def init_command(app):
-    command = InitCommand()
-    command._application = app
-    return command


### PR DESCRIPTION
This fix allows having whitespaces in the list of extras during `poetry add`, e.g. `poetry add databases[postgresql, sqlite]`.

# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/2980

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
