### PR TITLE
Change documentation of path dependency

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -230,15 +230,17 @@ poetry add ../my-package/dist/my-package-0.1.0.tar.gz
 poetry add ../my-package/dist/my_package-0.1.0.whl
 ```
 
-Path dependencies pointing to a local directory will be installed in editable mode (i.e. setuptools "develop mode").
-It means that changes in the local directory will be reflected directly in environment.
-
-If you don't want the dependency to be installed in editable mode you can specify it in the `pyproject.toml` file:
+If you want the dependency to be installed in editable mode you can specify it in the `pyproject.toml` file. It means that changes in the local directory will be reflected directly in environment.
 
 ```toml
 [tool.poetry.dependencies]
-my-package = {path = "../my/path", develop = false}
+my-package = {path = "../my/path", develop = true}
 ```
+
+!!!note
+
+    Before poetry 1.1 path dependencies were installed in editable mode by default. You should always set the `develop` attribute explicit,
+    to make sure the behavior is the same for all poetry versions.
 
 If the package(s) you want to install provide extras, you can specify them
 when adding the package:


### PR DESCRIPTION
From poetry 1.1 on path dependencies are no longer installed in editable mode by default. This PR fixes the documentation for it.

# Pull Request Check List

Replaces: https://github.com/python-poetry/poetry/pull/2780

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** <strike>for changed code.</strike>

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
