### PR TITLE
Add note on editable installation

### DIFF
--- a/docs/docs/dependency-specification.md
+++ b/docs/docs/dependency-specification.md
@@ -117,7 +117,10 @@ my-package = { path = "../my-package/", develop = false }
 my-package = { path = "../my-package/dist/my-package-0.1.0.tar.gz" }
 ```
 
-For directories, set `develop = true` for editable installation.
+!!!note
+
+    Before poetry 1.1 directory path dependencies were installed in editable mode by default. You should set the `develop` attribute explicitly,
+    to make sure the behavior is the same for all poetry versions.
 
 ## `url` dependencies
 

--- a/docs/docs/dependency-specification.md
+++ b/docs/docs/dependency-specification.md
@@ -111,12 +111,13 @@ you can use the `path` property:
 ```toml
 [tool.poetry.dependencies]
 # directory
-my-package = { path = "../my-package/" }
+my-package = { path = "../my-package/", develop = false }
 
 # file
 my-package = { path = "../my-package/dist/my-package-0.1.0.tar.gz" }
 ```
 
+For directories, set `develop = true` for editable installation.
 
 ## `url` dependencies
 


### PR DESCRIPTION
This adds a note in the docs about editable installation, following the change in #2887, as part of release https://github.com/python-poetry/poetry/releases/tag/1.1.0b3