### PR TITLE
Don't swallow ImportError in temporary_directory()

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -159,15 +159,15 @@ def colorize(style, text):
 def temporary_directory(*args, **kwargs):
     try:
         from tempfile import TemporaryDirectory
-
-        with TemporaryDirectory(*args, **kwargs) as name:
-            yield name
     except ImportError:
         name = tempfile.mkdtemp(*args, **kwargs)
 
         yield name
 
         shutil.rmtree(name)
+    else:
+        with TemporaryDirectory(*args, **kwargs) as name:
+            yield name
 
 
 def string_to_bool(value):


### PR DESCRIPTION
This is a backport of #3031 for `1.1`

Fixes #3026

If the context wrapped by the temporary_directory() context manager
raised ImportError (for example because distutils.util cannot be
imported, #721 #1837), it would previously keep going, causing a
RuntimeError from contextlib:

    RuntimeError: generator didn't stop after throw()