### PR TITLE
publish: ensure config url is preferred

### DIFF
--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -51,11 +51,13 @@ class Factory(BaseFactory):
 
         # Load local sources
         repositories = {}
+        existing_repositories = config.get("repositories", {})
         for source in base_poetry.pyproject.poetry_config.get("source", []):
             name = source.get("name")
             url = source.get("url")
             if name and url:
-                repositories[name] = {"url": url}
+                if name not in existing_repositories:
+                    repositories[name] = {"url": url}
 
         config.merge({"repositories": repositories})
 


### PR DESCRIPTION
Seems that the url configured for publishing and source tends to be different at the moment. This ensures that we do not use the source url for publishing, since repo urls are only used for netloc identification when searching for auth, this should be safe.

Resolves: #3052 #3053 