### PR TITLE
install: skip unsupported binary distributions

### DIFF
--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -63,7 +63,7 @@ class Chooser:
             ):
                 continue
 
-            if link.ext == ".egg":
+            if link.ext in {".egg", ".exe", ".msi", ".rpm", ".srpm"}:
                 continue
 
             links.append(link)


### PR DESCRIPTION
Seems we were selecting exe files in some cases.

Resolves: #3045