### PR TITLE
Fix requirements.txt export for git dependencies

### DIFF
--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -134,11 +134,14 @@ class Exporter(object):
             # If we have extra indexes, we add them to the beginning of the output
             indexes_header = ""
             for index in sorted(indexes):
-                repository = [
+                repositories = [
                     r
                     for r in self._poetry.pool.repositories
                     if r.url == index.rstrip("/")
-                ][0]
+                ]
+                if not repositories:
+                    continue
+                repository = repositories[0]
                 if (
                     self._poetry.pool.has_default()
                     and repository is self._poetry.pool.repositories[0]


### PR DESCRIPTION
After python-poetry/poetry#2662 was merged, exporting requirements with git dependencies triggers an exception due to accessing the first element of an empty list:

```toml
[tool.poetry.dependencies]
foo = { git = "ssh://git@github.com/foo/bar.git", rev = "301c6cb9f06ab071da7cb942060c64bdf59cd40a" }
```

This commit adds an empty check to avoid the exception.

# Pull Request Check List

Resolves: moneymeets/python-poetry-buildpack#13