### PR TITLE
locker: move export logic into locker for reuse

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -234,8 +234,15 @@ class Locker(object):
                     # project level dependencies take precedence
                     continue
 
-                # we make a copy to avoid any side-effects
-                requirement = deepcopy(requirement)
+                locked_package = __get_locked_package(requirement)
+                if locked_package:
+                    # create dependency from locked package to retain dependency metadata
+                    # if this is not done, we can end-up with incorrect nested dependencies
+                    requirement = locked_package.to_dependency()
+                else:
+                    # we make a copy to avoid any side-effects
+                    requirement = deepcopy(requirement)
+
                 requirement._category = pkg.category
 
                 if pinned_versions:

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -5,11 +5,14 @@ import re
 
 from copy import deepcopy
 from hashlib import sha256
+from typing import Dict
 from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import Set
+from typing import Tuple
 from typing import Union
 
 from tomlkit import array
@@ -185,36 +188,107 @@ class Locker(object):
 
         return packages
 
+    @staticmethod
+    def __get_locked_package(
+        _dependency, packages_by_name
+    ):  # type: (Dependency, Dict[str, List[Package]]) -> Optional[Package]
+        """
+        Internal helper to identify corresponding locked package using dependency
+        version constraints.
+        """
+        for _package in packages_by_name.get(_dependency.name, []):
+            if _dependency.constraint.allows(_package.version):
+                return _package
+        return None
+
+    @classmethod
+    def __walk_dependency_level(
+        cls,
+        dependencies,
+        level,
+        pinned_versions,
+        packages_by_name,
+        project_level_dependencies,
+        nested_dependencies,
+    ):  # type: (List[Dependency], int,  bool, Dict[str, List[Package]], Set[str], Dict[Tuple[str, str], Dependency]) -> Dict[Tuple[str, str], Dependency]
+        if not dependencies:
+            return nested_dependencies
+
+        next_level_dependencies = []
+
+        for requirement in dependencies:
+            locked_package = cls.__get_locked_package(requirement, packages_by_name)
+
+            if locked_package:
+                for require in locked_package.requires:
+                    if require.marker.is_empty():
+                        require.marker = requirement.marker
+                    else:
+                        require.marker = require.marker.intersect(requirement.marker)
+
+                    require.marker = require.marker.intersect(locked_package.marker)
+                    next_level_dependencies.append(require)
+
+            if requirement.name in project_level_dependencies and level == 0:
+                # project level dependencies take precedence
+                continue
+
+            if locked_package:
+                # create dependency from locked package to retain dependency metadata
+                # if this is not done, we can end-up with incorrect nested dependencies
+                marker = requirement.marker
+                requirement = locked_package.to_dependency()
+                requirement.marker = requirement.marker.intersect(marker)
+            else:
+                # we make a copy to avoid any side-effects
+                requirement = deepcopy(requirement)
+
+            if pinned_versions:
+                requirement.set_constraint(
+                    cls.__get_locked_package(requirement, packages_by_name)
+                    .to_dependency()
+                    .constraint
+                )
+
+            # dependencies use extra to indicate that it was activated via parent
+            # package's extras, this is not required for nested exports as we assume
+            # the resolver already selected this dependency
+            requirement.marker = requirement.marker.without_extras()
+
+            key = (requirement.name, requirement.pretty_constraint)
+            if key not in nested_dependencies:
+                nested_dependencies[key] = requirement
+            else:
+                nested_dependencies[key].marker = nested_dependencies[
+                    key
+                ].marker.intersect(requirement.marker)
+
+        return cls.__walk_dependency_level(
+            dependencies=next_level_dependencies,
+            level=level + 1,
+            pinned_versions=pinned_versions,
+            packages_by_name=packages_by_name,
+            project_level_dependencies=project_level_dependencies,
+            nested_dependencies=nested_dependencies,
+        )
+
     @classmethod
     def get_project_dependencies(
         cls, project_requires, locked_packages, pinned_versions=False, with_nested=False
     ):  # type: (List[Dependency], List[Package], bool, bool) -> Iterable[Dependency]
-        # group packages entries by name, this is required because requirement might use
-        # different constraints
+        # group packages entries by name, this is required because requirement might use different constraints
         packages_by_name = {}
         for pkg in locked_packages:
             if pkg.name not in packages_by_name:
                 packages_by_name[pkg.name] = []
             packages_by_name[pkg.name].append(pkg)
 
-        def __get_locked_package(
-            _dependency,
-        ):  # type: (Dependency) -> Optional[Package]
-            """
-            Internal helper to identify corresponding locked package using dependency
-            version constraints.
-            """
-            for _package in packages_by_name.get(_dependency.name, []):
-                if _dependency.constraint.allows(_package.version):
-                    return _package
-            return None
-
         project_level_dependencies = set()
         dependencies = []
 
         for dependency in project_requires:
             dependency = deepcopy(dependency)
-            locked_package = __get_locked_package(dependency)
+            locked_package = cls.__get_locked_package(dependency, packages_by_name)
             if locked_package:
                 locked_dependency = locked_package.to_dependency()
                 locked_dependency.marker = dependency.marker.intersect(
@@ -233,68 +307,14 @@ class Locker(object):
             # return only with project level dependencies
             return dependencies
 
-        nested_dependencies = dict()
-
-        def __walk_level(
-            __dependencies, __level
-        ):  # type: (List[Dependency], int) -> None
-            if not __dependencies:
-                return
-
-            __next_level = []
-
-            for requirement in __dependencies:
-                __locked_package = __get_locked_package(requirement)
-
-                if __locked_package:
-                    for require in __locked_package.requires:
-                        if require.marker.is_empty():
-                            require.marker = requirement.marker
-                        else:
-                            require.marker = require.marker.intersect(
-                                requirement.marker
-                            )
-
-                        require.marker = require.marker.intersect(
-                            __locked_package.marker
-                        )
-                        __next_level.append(require)
-
-                if requirement.name in project_level_dependencies and __level == 0:
-                    # project level dependencies take precedence
-                    continue
-
-                if __locked_package:
-                    # create dependency from locked package to retain dependency metadata
-                    # if this is not done, we can end-up with incorrect nested dependencies
-                    marker = requirement.marker
-                    requirement = __locked_package.to_dependency()
-                    requirement.marker = requirement.marker.intersect(marker)
-                else:
-                    # we make a copy to avoid any side-effects
-                    requirement = deepcopy(requirement)
-
-                if pinned_versions:
-                    requirement.set_constraint(
-                        __get_locked_package(requirement).to_dependency().constraint
-                    )
-
-                # dependencies use extra to indicate that it was activated via parent
-                # package's extras, this is not required for nested exports as we assume
-                # the resolver already selected this dependency
-                requirement.marker = requirement.marker.without_extras()
-
-                key = (requirement.name, requirement.pretty_constraint)
-                if key not in nested_dependencies:
-                    nested_dependencies[key] = requirement
-                else:
-                    nested_dependencies[key].marker = nested_dependencies[
-                        key
-                    ].marker.intersect(requirement.marker)
-
-            return __walk_level(__next_level, __level + 1)
-
-        __walk_level(dependencies, 0)
+        nested_dependencies = cls.__walk_dependency_level(
+            dependencies=dependencies,
+            level=0,
+            pinned_versions=pinned_versions,
+            packages_by_name=packages_by_name,
+            project_level_dependencies=project_level_dependencies,
+            nested_dependencies=dict(),
+        )
 
         # Merge same dependencies using marker union
         for requirement in dependencies:

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -318,20 +318,30 @@ class Locker(object):
                 )
             )
 
+        # If a package is optional and we haven't opted in to it, do not select
+        selected = []
+        for dependency in project_requires:
+            try:
+                package = repository.find_packages(dependency=dependency)[0]
+            except IndexError:
+                continue
+
+            if extra_package_names is not None and (
+                package.optional and package.name not in extra_package_names
+            ):
+                # a package is locked as optional, but is not activated via extras
+                continue
+
+            selected.append(dependency)
+
         for dependency in self.get_project_dependencies(
-            project_requires=project_requires,
+            project_requires=selected,
             locked_packages=repository.packages,
             with_nested=True,
         ):
             try:
                 package = repository.find_packages(dependency=dependency)[0]
             except IndexError:
-                continue
-
-            # If a package is optional and we haven't opted in to it, continue
-            if extra_package_names is not None and (
-                package.optional and package.name not in extra_package_names
-            ):
                 continue
 
             for extra in dependency.extras:

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -1,3 +1,5 @@
+from typing import Optional
+from typing import Sequence
 from typing import Union
 
 from clikit.api.io import IO
@@ -5,7 +7,6 @@ from clikit.api.io import IO
 from poetry.poetry import Poetry
 from poetry.utils._compat import Path
 from poetry.utils._compat import decode
-from poetry.utils.extras import get_extra_package_names
 
 
 class Exporter(object):
@@ -51,37 +52,18 @@ class Exporter(object):
         dev=False,
         extras=None,
         with_credentials=False,
-    ):  # type: (Path, Union[IO, str], bool, bool, bool) -> None
+    ):  # type: (Path, Union[IO, str], bool, bool, Optional[Union[bool, Sequence[str]]], bool) -> None
         indexes = set()
         content = ""
-        repository = self._poetry.locker.locked_repository(dev)
-
-        # Build a set of all packages required by our selected extras
-        extra_package_names = set(
-            get_extra_package_names(
-                repository.packages,
-                self._poetry.locker.lock_data.get("extras", {}),
-                extras or (),
-            )
-        )
-
         dependency_lines = set()
 
-        for dependency in self._poetry.locker.get_project_dependencies(
-            project_requires=self._poetry.package.all_requires,
-            with_nested=True,
-            with_dev=dev,
+        for dependency_package in self._poetry.locker.get_project_dependency_packages(
+            project_requires=self._poetry.package.all_requires, dev=dev, extras=extras
         ):
-            try:
-                package = repository.find_packages(dependency=dependency)[0]
-            except IndexError:
-                continue
-
-            # If a package is optional and we haven't opted in to it, continue
-            if package.optional and package.name not in extra_package_names:
-                continue
-
             line = ""
+
+            dependency = dependency_package.dependency
+            package = dependency_package.package
 
             if package.develop:
                 line += "-e "

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -31,7 +31,7 @@ class Exporter(object):
         dev=False,
         extras=None,
         with_credentials=False,
-    ):  # type: (str, Path, Union[IO, str], bool, bool, bool) -> None
+    ):  # type: (str, Path, Union[IO, str], bool, bool, Optional[Union[bool, Sequence[str]]], bool) -> None
         if fmt not in self.ACCEPTED_FORMATS:
             raise ValueError("Invalid export format: {}".format(fmt))
 

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -256,8 +256,12 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers(
     assert expected == {}
 
 
+@pytest.mark.parametrize(
+    "dev,lines",
+    [(False, ['a==1.2.3; python_version < "3.8"']), (True, ["a==1.2.3", "b==4.5.6"])],
+)
 def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers_any(
-    tmp_dir, poetry
+    tmp_dir, poetry, dev, lines
 ):
     poetry.locker.mock_lock_data(
         {
@@ -295,24 +299,16 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_markers_a
         Factory.create_dependency(
             name="b", constraint=dict(version="^4.5.6"), category="dev"
         ),
-        Factory.create_dependency(name="a", constraint=dict(version="^1.2.3")),
     ]
 
     exporter = Exporter(poetry)
 
-    exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt", dev=True)
+    exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt", dev=dev)
 
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
         content = f.read()
 
-    assert (
-        content
-        == """\
-a==1.2.3
-a==1.2.3; python_version < "3.8"
-b==4.5.6
-"""
-    )
+    assert content.strip() == "\n".join(lines)
 
 
 def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes(


### PR DESCRIPTION
This change, moves common functionality from exporter into the locker
to allow for sharing of logic that can generate `DependencyPackage`
instances given a a list of requirements using the lock data.

This change set also resolves #3115. 

Resolves: #3112
Resolves: #3115
Resolves: #3160 
Closes: #3125