### PR TITLE
exporter: prepend file for local dependencies

### DIFF
--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -87,15 +87,15 @@ class Exporter(object):
                 line += "-e "
 
             requirement = dependency.to_pep_508(with_extras=False)
-            is_direct_reference = (
-                dependency.is_vcs()
-                or dependency.is_url()
-                or dependency.is_file()
-                or dependency.is_directory()
+            is_direct_local_reference = (
+                dependency.is_file() or dependency.is_directory()
             )
+            is_direct_remote_reference = dependency.is_vcs() or dependency.is_url()
 
-            if is_direct_reference:
+            if is_direct_remote_reference:
                 line = requirement
+            elif is_direct_local_reference:
+                line = requirement.replace("@ ", "@ file://")
             else:
                 line = "{}=={}".format(package.name, package.version)
                 if ";" in requirement:
@@ -103,7 +103,11 @@ class Exporter(object):
                     if markers:
                         line += "; {}".format(markers)
 
-            if not is_direct_reference and package.source_url:
+            if (
+                not is_direct_remote_reference
+                and not is_direct_local_reference
+                and package.source_url
+            ):
                 indexes.add(package.source_url)
 
             if package.files and with_hashes:

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -95,9 +95,12 @@ class Exporter(object):
             if is_direct_remote_reference:
                 line = requirement
             elif is_direct_local_reference:
-                line = requirement.replace("@ ", "@ file://")
+                dependency_uri = Path(dependency.source_url).resolve().as_uri()
+                line = "{} @ {}".format(dependency.name, dependency_uri)
             else:
                 line = "{}=={}".format(package.name, package.version)
+
+            if not is_direct_remote_reference:
                 if ";" in requirement:
                     markers = requirement.split(";", 1)[1].strip()
                     if markers:

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -2,6 +2,7 @@ from typing import Union
 
 from clikit.api.io import IO
 
+from poetry.core.packages.utils.utils import path_to_url
 from poetry.poetry import Poetry
 from poetry.utils._compat import Path
 from poetry.utils._compat import decode
@@ -95,7 +96,7 @@ class Exporter(object):
             if is_direct_remote_reference:
                 line = requirement
             elif is_direct_local_reference:
-                dependency_uri = Path(dependency.source_url).resolve().as_uri()
+                dependency_uri = path_to_url(dependency.source_url)
                 line = "{} @ {}".format(dependency.name, dependency_uri)
             else:
                 line = "{}=={}".format(package.name, package.version)

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -582,7 +582,7 @@ def test_exporter_can_export_requirements_txt_with_directory_packages(
         content = f.read()
 
     expected = """\
-foo @ {}/tests/fixtures/sample_project
+foo @ file://{}/tests/fixtures/sample_project
 """.format(
         working_directory.as_posix()
     )
@@ -627,7 +627,7 @@ def test_exporter_can_export_requirements_txt_with_directory_packages_and_marker
         content = f.read()
 
     expected = """\
-foo @ {}/tests/fixtures/sample_project; python_version < "3.7"
+foo @ file://{}/tests/fixtures/sample_project; python_version < "3.7"
 """.format(
         working_directory.as_posix()
     )
@@ -671,7 +671,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages(
         content = f.read()
 
     expected = """\
-foo @ {}/tests/fixtures/distributions/demo-0.1.0.tar.gz
+foo @ file://{}/tests/fixtures/distributions/demo-0.1.0.tar.gz
 """.format(
         working_directory.as_uri()
     )
@@ -716,7 +716,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
         content = f.read()
 
     expected = """\
-foo @ {}/tests/fixtures/distributions/demo-0.1.0.tar.gz; python_version < "3.7"
+foo @ file://{}/tests/fixtures/distributions/demo-0.1.0.tar.gz; python_version < "3.7"
 """.format(
         working_directory.as_uri()
     )

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -582,9 +582,9 @@ def test_exporter_can_export_requirements_txt_with_directory_packages(
         content = f.read()
 
     expected = """\
-foo @ file://{}/tests/fixtures/sample_project
+foo @ {}/tests/fixtures/sample_project
 """.format(
-        working_directory.as_posix()
+        working_directory.as_uri()
     )
 
     assert expected == content
@@ -627,9 +627,9 @@ def test_exporter_can_export_requirements_txt_with_directory_packages_and_marker
         content = f.read()
 
     expected = """\
-foo @ file://{}/tests/fixtures/sample_project; python_version < "3.7"
+foo @ {}/tests/fixtures/sample_project; python_version < "3.7"
 """.format(
-        working_directory.as_posix()
+        working_directory.as_uri()
     )
 
     assert expected == content
@@ -671,7 +671,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages(
         content = f.read()
 
     expected = """\
-foo @ file://{}/tests/fixtures/distributions/demo-0.1.0.tar.gz
+foo @ {}/tests/fixtures/distributions/demo-0.1.0.tar.gz
 """.format(
         working_directory.as_uri()
     )
@@ -716,7 +716,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
         content = f.read()
 
     expected = """\
-foo @ file://{}/tests/fixtures/distributions/demo-0.1.0.tar.gz; python_version < "3.7"
+foo @ {}/tests/fixtures/distributions/demo-0.1.0.tar.gz; python_version < "3.7"
 """.format(
         working_directory.as_uri()
     )

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -590,6 +590,78 @@ foo @ {}/tests/fixtures/sample_project
     assert expected == content
 
 
+def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
+    tmp_dir, poetry, working_directory
+):
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "directory",
+                        "url": "tests/fixtures/sample_project",
+                        "reference": "",
+                    },
+                },
+                {
+                    "name": "bar",
+                    "version": "4.5.6",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "directory",
+                        "url": "tests/fixtures/sample_project/../project_with_nested_local/bar",
+                        "reference": "",
+                    },
+                },
+                {
+                    "name": "baz",
+                    "version": "7.8.9",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "directory",
+                        "url": "tests/fixtures/sample_project/../project_with_nested_local/bar/..",
+                        "reference": "",
+                    },
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo": [], "bar": [], "baz": []},
+            },
+        }
+    )
+    set_package_requires(poetry)
+
+    exporter = Exporter(poetry)
+
+    exporter.export("requirements.txt", Path(tmp_dir), "requirements.txt")
+
+    with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """\
+bar @ {}/tests/fixtures/project_with_nested_local/bar
+baz @ {}/tests/fixtures/project_with_nested_local
+foo @ {}/tests/fixtures/sample_project
+""".format(
+        working_directory.as_uri(),
+        working_directory.as_uri(),
+        working_directory.as_uri(),
+    )
+
+    assert expected == content
+
+
 def test_exporter_can_export_requirements_txt_with_directory_packages_and_markers(
     tmp_dir, poetry, working_directory
 ):


### PR DESCRIPTION
# Pull Request Check List

When exporting to `requirements.txt` poetry uses the PEP-508 standard. However pip install supports [direct references](https://www.python.org/dev/peps/pep-0440/#direct-references) which need a prependend `file://` information for local dependencies. This PR includes this `file://` annotation for file and directory depencies.
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Resolves: #3189