### PR TITLE
Fix locking for nested dependencies (fixes #3115)

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -231,7 +231,7 @@ class Locker(object):
                     continue
 
                 # we make a copy to avoid any side-effects
-                requirement = deepcopy(requirement)
+                requirement = deepcopy(packages_by_name[requirement.name].to_dependency())
                 requirement._category = pkg.category
 
                 if pinned_versions:

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -231,7 +231,9 @@ class Locker(object):
                     continue
 
                 # we make a copy to avoid any side-effects
-                requirement = deepcopy(packages_by_name[requirement.name].to_dependency())
+                requirement = deepcopy(
+                    packages_by_name[requirement.name].to_dependency()
+                )
                 requirement._category = pkg.category
 
                 if pinned_versions:


### PR DESCRIPTION
# Pull Request Check List

Resolves: moneymeets/python-poetry-buildpack#13, python-poetry/poetry#3115

Currently the type of nested dependencies is lost, because they come from `pkg.requires` as an abstract class, and therefore `requirements.txt` exporter wrongly writes version out instead of URL for nested git dependencies (see #3115). This is my attempt to fix it...