### PR TITLE
Warning about deprecated python version should go to stderr

### DIFF
--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -56,7 +56,7 @@ class Application(BaseApplication):
                 "See <fg=blue>https://python-poetry.org/docs/managing-environments/</> "
                 "for more information."
             ).format(python_version, poetry_feature_release, python_version)
-            self._preliminary_io.write_line("<fg=yellow>{}</>\n".format(message))
+            self._preliminary_io.error_line("<fg=yellow>{}</>\n".format(message))
 
     @property
     def poetry(self):


### PR DESCRIPTION
At the moment the warning about the deprecated python version goes to stdout. This makes it impossible to pipe the output of poetry commands like `poetry env info --path` to somewhere else. This PR fixes it, by printing the message to stderr.

Resolves: #2754