### PR TITLE
Support legacy repository fall back redirects

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -391,8 +391,9 @@ class LegacyRepository(PyPiRepository):
 
         if response.status_code in (401, 403):
             self._log(
-                "Authorization error accessing {url}".format(url=url), level="warn"
+                "Authorization error accessing {url}".format(url=response.url),
+                level="warn",
             )
             return
 
-        return Page(url, response.content, response.headers)
+        return Page(response.url, response.content, response.headers)


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Legacy repositories may specify a fallback url if a package is contained in an upstream repository.  To support this redirection we should use the `url` contained in the response when creating a `Page` object to ensure relative links are properly calculated.
