### PR TITLE
Fix issue when PATH is missing in os.environ

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1212,7 +1212,7 @@ class VirtualEnv(Env):
             del os.environ[key]
 
     def _updated_path(self):
-        return os.pathsep.join([str(self._bin_dir), os.environ["PATH"]])
+        return os.pathsep.join([str(self._bin_dir), os.environ.get("PATH", "")])
 
 
 class NullEnv(SystemEnv):


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3144 

I'm not really sure any of the two check-boxes apply for this change. Is the effort of preparing `os.environ` for the unit-test really worth the effort? Considering that this might interfere with other tests, so it needs to be mocked or patched. I feel that all this effort for this small change is a bit over-the-top. The call itself (and thus a runtime syntax-error) is already covered by existing tests.

If you disagree, let me know and I will add the required test.

As for documentation, as this is an internal change not externally visible I don't think it warrants docs. Again, let me know if you disagree.

And finally, I decided to target `master` instead of `develop` for this PR because it is a bugfix on the current released version. But that's anyway something you can modify yourself 😉 

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.