### PR TITLE
add config option to force `--always-copy` parameter for virtualenv

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -34,6 +34,7 @@ which will give you something similar to this:
 cache-dir = "/path/to/cache/directory"
 virtualenvs.create = true
 virtualenvs.in-project = null
+virtualenvs.options.always-copy = true
 virtualenvs.path = "{cache-dir}/virtualenvs"  # /path/to/cache/directory/virtualenvs
 ```
 
@@ -127,6 +128,12 @@ If not set explicitly (default), `poetry` will use the virtualenv from the `.ven
 
 Directory where virtual environments will be created.
 Defaults to `{cache-dir}/virtualenvs` (`{cache-dir}\virtualenvs` on Windows).
+
+### `virtualenvs.options.always-copy`: boolean
+
+If set to `true` the `--always-copy` parameter is passed to `virtualenv` on creation of the venv. Thus all needed files are copied into the venv instead of symlinked.
+Defaults to `false`.
+
 
 ### `repositories.<name>`: string
 

--- a/poetry/config/config.py
+++ b/poetry/config/config.py
@@ -36,6 +36,7 @@ class Config(object):
             "create": True,
             "in-project": None,
             "path": os.path.join("{cache-dir}", "virtualenvs"),
+            "options": {"always-copy": False},
         },
         "experimental": {"new-installer": True},
     }
@@ -87,7 +88,11 @@ class Config(object):
             for key in config:
                 value = self.get(parent_key + key)
                 if isinstance(value, dict):
-                    all_[key] = _all(config[key], parent_key=key + ".")
+                    if parent_key != "":
+                        current_parent = parent_key + key + "."
+                    else:
+                        current_parent = key + "."
+                    all_[key] = _all(config[key], parent_key=current_parent)
                     continue
 
                 all_[key] = value
@@ -131,14 +136,22 @@ class Config(object):
         return re.sub(r"{(.+?)}", lambda m: self.get(m.group(1)), value)
 
     def _get_validator(self, name):  # type: (str) -> Callable
-        if name in {"virtualenvs.create", "virtualenvs.in-project"}:
+        if name in {
+            "virtualenvs.create",
+            "virtualenvs.in-project",
+            "virtualenvs.options.always-copy",
+        }:
             return boolean_validator
 
         if name == "virtualenvs.path":
             return str
 
     def _get_normalizer(self, name):  # type: (str) -> Callable
-        if name in {"virtualenvs.create", "virtualenvs.in-project"}:
+        if name in {
+            "virtualenvs.create",
+            "virtualenvs.in-project",
+            "virtualenvs.options.always-copy",
+        }:
             return boolean_normalizer
 
         if name == "virtualenvs.path":

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -63,6 +63,11 @@ To remove a repository (repo is a short alias for repositories):
                 boolean_normalizer,
                 True,
             ),
+            "virtualenvs.options.always-copy": (
+                boolean_validator,
+                boolean_normalizer,
+                False,
+            ),
         }
 
         return unique_config_values

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -5,7 +5,9 @@ from poetry.core.semver import Version
 from poetry.utils._compat import Path
 
 
-def build_venv(path, executable=None):  # type: (Union[Path,str], Optional[str]) -> ()
+def build_venv(
+    path, executable=None, flags=None
+):  # type: (Union[Path,str], Optional[str], bool) -> ()
     Path(path).mkdir(parents=True, exist_ok=True)
 
 

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -50,7 +50,9 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     tester.execute("3.7")
 
     venv_py37 = venv_cache / "{}-py3.7".format(venv_name)
-    mock_build_env.assert_called_with(venv_py37, executable="python3.7")
+    mock_build_env.assert_called_with(
+        venv_py37, executable="python3.7", flags={"always-copy": False}
+    )
 
     envs_file = TOMLFile(venv_cache / "envs.toml")
     assert envs_file.exists()

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -19,6 +19,7 @@ def test_list_displays_default_value_if_not_set(tester, config):
 experimental.new-installer = true
 virtualenvs.create = true
 virtualenvs.in-project = null
+virtualenvs.options.always-copy = false
 virtualenvs.path = {path}  # /foo{sep}virtualenvs
 """.format(
         path=json.dumps(os.path.join("{cache-dir}", "virtualenvs")), sep=os.path.sep
@@ -36,6 +37,7 @@ def test_list_displays_set_get_setting(tester, config):
 experimental.new-installer = true
 virtualenvs.create = false
 virtualenvs.in-project = null
+virtualenvs.options.always-copy = false
 virtualenvs.path = {path}  # /foo{sep}virtualenvs
 """.format(
         path=json.dumps(os.path.join("{cache-dir}", "virtualenvs")), sep=os.path.sep
@@ -75,6 +77,7 @@ def test_list_displays_set_get_local_setting(tester, config):
 experimental.new-installer = true
 virtualenvs.create = false
 virtualenvs.in-project = null
+virtualenvs.options.always-copy = false
 virtualenvs.path = {path}  # /foo{sep}virtualenvs
 """.format(
         path=json.dumps(os.path.join("{cache-dir}", "virtualenvs")), sep=os.path.sep

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -118,7 +118,9 @@ def test_env_get_venv_with_venv_folder_present(
         assert venv.path == in_project_venv_dir
 
 
-def build_venv(path, executable=None):  # type: (Union[Path,str], Optional[str]) -> ()
+def build_venv(
+    path, executable=None, flags=None
+):  # type: (Union[Path,str], Optional[str], bool) -> ()
     os.mkdir(str(path))
 
 
@@ -156,7 +158,9 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     venv_name = EnvManager.generate_env_name("simple-project", str(poetry.file.parent))
 
     m.assert_called_with(
-        Path(tmp_dir) / "{}-py3.7".format(venv_name), executable="python3.7"
+        Path(tmp_dir) / "{}-py3.7".format(venv_name),
+        executable="python3.7",
+        flags={"always-copy": False},
     )
 
     envs_file = TOMLFile(Path(tmp_dir) / "envs.toml")
@@ -274,7 +278,9 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     env = manager.activate("python3.6", NullIO())
 
     m.assert_called_with(
-        Path(tmp_dir) / "{}-py3.6".format(venv_name), executable="python3.6"
+        Path(tmp_dir) / "{}-py3.6".format(venv_name),
+        executable="python3.6",
+        flags={"always-copy": False},
     )
 
     assert envs_file.exists()
@@ -326,7 +332,9 @@ def test_activate_activates_recreates_for_different_patch(
     env = manager.activate("python3.7", NullIO())
 
     build_venv_m.assert_called_with(
-        Path(tmp_dir) / "{}-py3.7".format(venv_name), executable="python3.7"
+        Path(tmp_dir) / "{}-py3.7".format(venv_name),
+        executable="python3.7",
+        flags={"always-copy": False},
     )
     remove_venv_m.assert_called_with(Path(tmp_dir) / "{}-py3.7".format(venv_name))
 
@@ -654,7 +662,9 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
     manager.create_venv(NullIO())
 
     m.assert_called_with(
-        Path("/foo/virtualenvs/{}-py3.7".format(venv_name)), executable="python3"
+        Path("/foo/virtualenvs/{}-py3.7".format(venv_name)),
+        executable="python3",
+        flags={"always-copy": False},
     )
 
 
@@ -678,7 +688,9 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     manager.create_venv(NullIO())
 
     m.assert_called_with(
-        Path("/foo/virtualenvs/{}-py3.9".format(venv_name)), executable="python3.9"
+        Path("/foo/virtualenvs/{}-py3.9".format(venv_name)),
+        executable="python3.9",
+        flags={"always-copy": False},
     )
 
 
@@ -767,6 +779,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
             )
         ),
         executable=None,
+        flags={"always-copy": False},
     )
 
 
@@ -804,6 +817,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility_with_executable(
             )
         ),
         executable="python{}.{}".format(version.major, version.minor - 1),
+        flags={"always-copy": False},
     )
 
 
@@ -834,7 +848,11 @@ def test_activate_with_in_project_setting_does_not_fail_if_no_venvs_dir(
 
     manager.activate("python3.7", NullIO())
 
-    m.assert_called_with(poetry.file.parent / ".venv", executable="python3.7")
+    m.assert_called_with(
+        poetry.file.parent / ".venv",
+        executable="python3.7",
+        flags={"always-copy": False},
+    )
 
     envs_file = TOMLFile(Path(tmp_dir) / "virtualenvs" / "envs.toml")
     assert not envs_file.exists()


### PR DESCRIPTION
`virtualenv` uses symlink to the interpreter when creating a venv. While this reduces space and runtime this might lead to unexpected results, when the interpreter to which the symlink points get upgraded.

This PR introduce a config option `virtualenvs.options.always-copy`. If setting to `true` the `--always-copy` parameter is added to virtualenv command on creating the venv.

To keep the current behavior as default, this option is set to `false` by default.

# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/3134

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
