### PR TITLE
Fix issue when PATH is missing in os.environ

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1212,7 +1212,7 @@ class VirtualEnv(Env):
             del os.environ[key]
 
     def _updated_path(self):
-        return os.pathsep.join([str(self._bin_dir), os.environ["PATH"]])
+        return os.pathsep.join([str(self._bin_dir), os.environ.get("PATH", "")])
 
 
 class NullEnv(SystemEnv):


### PR DESCRIPTION
As mentioned in PR #3146 by @abn, this is a PR to get the fix into a bugfix release.