### PR TITLE
Use `.zshrc` instead of `.zprofile`

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -903,7 +903,7 @@ class Installer:
 
         if "zsh" in SHELL:
             zdotdir = os.getenv("ZDOTDIR", HOME)
-            profiles.append(os.path.join(zdotdir, ".zprofile"))
+            profiles.append(os.path.join(zdotdir, ".zshrc"))
 
         bash_profile = os.path.join(HOME, ".bash_profile")
         if os.path.exists(bash_profile):


### PR DESCRIPTION
Because `.zprofile` is only run for login shells, it is not used
by graphical terminals. `.zprofile` is also not created by default.

Resolves: #2620

- [ ] Added **tests** for changed code.

  No tests for `get-poetry.py`

- [ ] Updated **documentation** for changed code.

  Not documented as far as I can see.
