### PR TITLE
Show only existing profiles when installing Poetry

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -727,9 +727,6 @@ class Installer:
 
         profiles = self.get_unix_profiles()
         for profile in profiles:
-            if not os.path.exists(profile):
-                continue
-
             with open(profile, "r") as f:
                 content = f.read()
 
@@ -870,9 +867,6 @@ class Installer:
 
         profiles = self.get_unix_profiles()
         for profile in profiles:
-            if not os.path.exists(profile):
-                continue
-
             with open(profile, "r") as f:
                 content = f.readlines()
 
@@ -909,7 +903,8 @@ class Installer:
         if os.path.exists(bash_profile):
             profiles.append(bash_profile)
 
-        return profiles
+        existing = [p for p in profiles if os.path.exists(p)]
+        return existing
 
     def display_pre_message(self):
         if WINDOWS:


### PR DESCRIPTION
Resolves: #1429

- [x] Added **tests** for changed code (I found no existing tests or coverage stats for `get-poetry.py`)
- [x] Updated **documentation** for changed code (no documentation changes required)

Poetry says it will modify the following files.

![image](https://user-images.githubusercontent.com/8781107/95653378-0152ab80-0b01-11eb-97f5-a56981280b9a.png)

If there are not `.profile` or `.zprofile`, `get-poetry.py` will not create them (https://github.com/python-poetry/poetry/pull/2077#pullrequestreview-387693175) and will not modify them. This PR limits the list of displayed profiles to existing files that will be modified.

![image](https://user-images.githubusercontent.com/8781107/95653449-8b027900-0b01-11eb-8e85-ec1a22ef6ea0.png)
