### PR TITLE
Fix error in "poetry config" when Poetry is not configured in pyproject.toml (3084)

### DIFF
--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -4,6 +4,7 @@ import re
 from cleo import argument
 from cleo import option
 
+from poetry.core.pyproject import PyProjectException
 from poetry.core.toml.file import TOMLFile
 from poetry.factory import Factory
 
@@ -80,7 +81,7 @@ To remove a repository (repo is a short alias for repositories):
             local_config_file = TOMLFile(self.poetry.file.parent / "poetry.toml")
             if local_config_file.exists():
                 config.merge(local_config_file.read())
-        except RuntimeError:
+        except (RuntimeError, PyProjectException):
             local_config_file = TOMLFile(Path.cwd() / "poetry.toml")
 
         if self.option("local"):

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -4,12 +4,23 @@ import os
 import pytest
 
 from poetry.config.config_source import ConfigSource
+from poetry.core.pyproject import PyProjectException
 from poetry.factory import Factory
 
 
 @pytest.fixture()
 def tester(command_tester_factory):
     return command_tester_factory("config")
+
+
+def test_show_config_with_local_config_file_empty(tester, mocker):
+    mocker.patch(
+        "poetry.factory.Factory.create_poetry",
+        side_effect=PyProjectException("[tool.poetry] section not found"),
+    )
+    tester.execute()
+
+    assert "" == tester.io.fetch_output()
 
 
 def test_list_displays_default_value_if_not_set(tester, config):


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3084 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


Add catch for`PyProjectException` in `ConfigCommand`. I also add a test and patch the `poetry.factory.Factory.create_poetry` to raise the exception... 
I'm not sure is the best option as I can't figure out how to create an app/poetry object with empty configuration...

Fyi this PR is related to Hacktoberfest :) 
