### PR TITLE
Support retries when checking associated release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,12 +50,19 @@ release_task:
   upload_script: |
     #!/usr/bin/env bash
 
-    if [[ "$CIRRUS_RELEASE" == "" ]]; then
+    NUM_TRIES=0
+    until [ $NUM_TRIES -eq 5 ]
+    do
+      echo "Retrying to find a release associated with this tag"
       CIRRUS_RELEASE=$(curl -sL https://api.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/tags/$CIRRUS_TAG | jq -r '.id')
-      if [[ "$CIRRUS_RELEASE" == "null" ]]; then
+      [[ "$CIRRUS_RELEASE" != "null" ]] && break
+      NUM_TRIES=$((NUM_TRIES+1)) 
+      sleep 3
+    done
+
+    if [[ "$CIRRUS_RELEASE" == "null" ]]; then
         echo "Failed to find a release associated with this tag!"
         exit 0
-      fi
     fi
 
     if [[ "$GITHUB_TOKEN" == "" ]]; then

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,7 @@ release_task:
       echo "Retrying to find a release associated with this tag"
       CIRRUS_RELEASE=$(curl -sL https://api.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/tags/$CIRRUS_TAG | jq -r '.id')
       [[ "$CIRRUS_RELEASE" != "null" ]] && break
-      NUM_TRIES=$((NUM_TRIES+1)) 
+      NUM_TRIES=$((NUM_TRIES+1))
       sleep 3
     done
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,13 +51,13 @@ release_task:
     #!/usr/bin/env bash
 
     NUM_TRIES=0
-    until [ $NUM_TRIES -eq 5 ]
+    until [ $NUM_TRIES -eq 20 ]
     do
       echo "Retrying to find a release associated with this tag"
       CIRRUS_RELEASE=$(curl -sL https://api.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/tags/$CIRRUS_TAG | jq -r '.id')
       [[ "$CIRRUS_RELEASE" != "null" ]] && break
       NUM_TRIES=$((NUM_TRIES+1))
-      sleep 3
+      sleep 30
     done
 
     if [[ "$CIRRUS_RELEASE" == "null" ]]; then


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/3154

Currently, the cirrus ci release logic checks if release is ready, if not it simply skips the upload.
This PR will try to check if release is ready for at most 20 times, and `sleep 30` seconds within those intervals

Risks: maybe it's an overkill solution? 😅 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

[ ] Added **tests** for changed code.
[ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
