### PR TITLE
Fixtures test add

### DIFF
--- a/tests/console/commands/debug/test_resolve.py
+++ b/tests/console/commands/debug/test_resolve.py
@@ -9,7 +9,8 @@ def tester(command_tester_factory):
     return command_tester_factory("debug resolve")
 
 
-def test_debug_resolve_gives_resolution_results(tester, repo):
+@pytest.fixture()
+def cachy_repo(repo):
     cachy2 = get_package("cachy", "0.2.0")
     cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
 
@@ -17,6 +18,8 @@ def test_debug_resolve_gives_resolution_results(tester, repo):
     repo.add_package(cachy2)
     repo.add_package(get_package("msgpack-python", "0.5.3"))
 
+
+def test_debug_resolve_gives_resolution_results(tester, cachy_repo):
     tester.execute("cachy")
 
     expected = """\
@@ -31,14 +34,7 @@ cachy          0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_debug_resolve_tree_option_gives_the_dependency_tree(tester, repo):
-    cachy2 = get_package("cachy", "0.2.0")
-    cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
-
-    repo.add_package(get_package("cachy", "0.1.0"))
-    repo.add_package(cachy2)
-    repo.add_package(get_package("msgpack-python", "0.5.3"))
-
+def test_debug_resolve_tree_option_gives_the_dependency_tree(tester, cachy_repo):
     tester.execute("cachy --tree")
 
     expected = """\

--- a/tests/console/commands/debug/test_resolve.py
+++ b/tests/console/commands/debug/test_resolve.py
@@ -11,11 +11,11 @@ def tester(command_tester_factory):
 
 @pytest.fixture(autouse=True)
 def __add_packages(repo):
-    cachy2 = get_package("cachy", "0.2.0")
-    cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
+    cachy020 = get_package("cachy", "0.2.0")
+    cachy020.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
 
     repo.add_package(get_package("cachy", "0.1.0"))
-    repo.add_package(cachy2)
+    repo.add_package(cachy020)
     repo.add_package(get_package("msgpack-python", "0.5.3"))
 
     repo.add_package(get_package("pendulum", "2.0.3"))

--- a/tests/console/commands/debug/test_resolve.py
+++ b/tests/console/commands/debug/test_resolve.py
@@ -9,8 +9,8 @@ def tester(command_tester_factory):
     return command_tester_factory("debug resolve")
 
 
-@pytest.fixture()
-def cachy_repo(repo):
+@pytest.fixture(autouse=True)
+def __add_packages(repo):
     cachy2 = get_package("cachy", "0.2.0")
     cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
 
@@ -18,8 +18,11 @@ def cachy_repo(repo):
     repo.add_package(cachy2)
     repo.add_package(get_package("msgpack-python", "0.5.3"))
 
+    repo.add_package(get_package("pendulum", "2.0.3"))
+    repo.add_package(get_package("cleo", "0.6.5"))
 
-def test_debug_resolve_gives_resolution_results(tester, cachy_repo):
+
+def test_debug_resolve_gives_resolution_results(tester):
     tester.execute("cachy")
 
     expected = """\
@@ -34,7 +37,7 @@ cachy          0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_debug_resolve_tree_option_gives_the_dependency_tree(tester, cachy_repo):
+def test_debug_resolve_tree_option_gives_the_dependency_tree(tester):
     tester.execute("cachy --tree")
 
     expected = """\
@@ -49,10 +52,7 @@ cachy 0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_debug_resolve_git_dependency(tester, repo):
-    repo.add_package(get_package("pendulum", "2.0.3"))
-    repo.add_package(get_package("cleo", "0.6.5"))
-
+def test_debug_resolve_git_dependency(tester):
     tester.execute("git+https://github.com/demo/demo.git")
 
     expected = """\


### PR DESCRIPTION
Relates-to: #3155

Adding a fixture for packages in the repo to test add tests. Some tests require different extras which caused the tests to fail when autouse was used on the fixture so instead it was only added where it would not cause tests to fail.

Also removed some parameters that weren't being used on certain tests.
