### PR TITLE
🎉 Drop Python 2.7/3.5 support validation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,8 @@ test_task:
   skip: "!changesInclude('.cirrus.yml', 'poetry.lock', 'pyproject.toml', '**.json','**.py')"
   env:
     matrix:
-      - PYTHON: python2.7
-      - PYTHON: python3.7
+      - PYTHON: python3.6
+      - PYTHON: python3.8
   python_script:
     - PYPACKAGE=$(printf '%s' $PYTHON | tr -d '.')
     - SQLPACKAGE=$(printf '%s-sqlite3' $PYPACKAGE | sed 's/thon//')
@@ -31,7 +31,6 @@ release_task:
   env:
     GITHUB_TOKEN: ENCRYPTED[2b573a2d28a03523ac6fb5b3c2f513a41c0a98db81e40e50e1d103b171f85c57e58ae38d957499dbf7fd7635cfcfd7be]
     PYTHON: python3.8
-    PYTHON27: python2.7
     PYTHON36: python3.6
     PYTHON37: python3.7
     PYTHON38: python3.8
@@ -40,9 +39,8 @@ release_task:
       - image_family: freebsd-12-1-snap
       - image_family: freebsd-13-0-snap
       - image_family: freebsd-11-4-snap
-  python_script: pkg install -y curl bash jq python3 python27 python36 python37 python38
+  python_script: pkg install -y curl bash jq python3 python36 python37 python38
   pip_script:
-    - python2.7 -m ensurepip
     - python3.6 -m ensurepip
     - python3.7 -m ensurepip
     - python3.8 -m ensurepip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,10 @@ jobs:
         poetry install --no-dev
     - name: Preparing Python executables
       run: |
-        curl -L https://github.com/sdispater/python-binaries/releases/download/2.7.17/python-2.7.17.macos.tar.xz -o python-2.7.17.tar.xz
-        curl -L https://github.com/sdispater/python-binaries/releases/download/3.5.9/python-3.5.9.macos.tar.xz -o python-3.5.9.tar.xz
         curl -L https://github.com/sdispater/python-binaries/releases/download/3.6.8/python-3.6.8.macos.tar.xz -o python-3.6.8.tar.xz
         curl -L https://github.com/sdispater/python-binaries/releases/download/3.7.6/python-3.7.6.macos.tar.xz -o python-3.7.6.tar.xz
         curl -L https://github.com/sdispater/python-binaries/releases/download/3.8.3/python-3.8.3.macos.tar.xz -o python-3.8.3.tar.xz
         curl -L https://github.com/sdispater/python-binaries/releases/download/3.9.0b4/python-3.9.0b4.macos.tar.xz -o python-3.9.0b4.tar.xz
-        tar -zxf python-2.7.17.tar.xz
-        tar -zxf python-3.5.9.tar.xz
         tar -zxf python-3.6.8.tar.xz
         tar -zxf python-3.7.6.tar.xz
         tar -zxf python-3.8.3.tar.xz
@@ -68,7 +64,7 @@ jobs:
     - name: Build specific release
       run: |
         source $HOME/.poetry/env
-        poetry run python sonnet make release --ansi -P "2.7:python-2.7.17/bin/python" -P "3.5:python-3.5.9/bin/python" -P "3.6:python-3.6.8/bin/python" -P "3.7:python-3.7.6/bin/python" -P "3.8:python-3.8.3/bin/python" -P "3.9:python-3.9.0b4/bin/python"
+        poetry run python sonnet make release --ansi -P "3.6:python-3.6.8/bin/python" -P "3.7:python-3.7.6/bin/python" -P "3.8:python-3.8.3/bin/python" -P "3.9:python-3.9.0b4/bin/python"
     - name: Upload release file
       uses: actions/upload-artifact@v1
       with:
@@ -104,21 +100,14 @@ jobs:
         poetry install --no-dev
     - name: Preparing Python executables
       run: |
-        Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/2.7.17/python-2.7.17.windows.tar.xz -O python-2.7.17.tar.xz
-        Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.5.4/python-3.5.4.windows.tar.xz -O python-3.5.4.tar.xz
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.6.8/python-3.6.8.windows.tar.xz -O python-3.6.8.tar.xz
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.7.6/python-3.7.6.windows.tar.xz -O python-3.7.6.tar.xz
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.8.3/python-3.8.3.windows.tar.xz -O python-3.8.3.tar.xz
         Invoke-WebRequest https://github.com/sdispater/python-binaries/releases/download/3.9.0b4/python-3.9.0b4.windows.tar.xz -O python-3.9.0b4.tar.xz
-        7z x python-2.7.17.tar.xz
-        7z x python-3.5.4.tar.xz
         7z x python-3.6.8.tar.xz
         7z x python-3.7.6.tar.xz
         7z x python-3.8.3.tar.xz
         7z x python-3.9.0b4.tar.xz
-        7z x python-2.7.17.tar
-        7z x python-3.4.4.tar
-        7z x python-3.5.4.tar
         7z x python-3.6.8.tar
         7z x python-3.7.6.tar
         7z x python-3.8.3.tar
@@ -126,7 +115,7 @@ jobs:
     - name: Build specific release
       run: |
         $env:Path += ";$env:Userprofile\.poetry\bin"
-        poetry run python sonnet make release --ansi -P "2.7:python-2.7.17\python.exe" -P "3.5:python-3.5.4\python.exe" -P "3.6:python-3.6.8\python.exe" -P "3.7:python-3.7.6\python.exe" -P "3.8:python-3.8.3\python.exe" -P "3.9:python-3.9.0b4\python.exe"
+        poetry run python sonnet make release --ansi -P "3.6:python-3.6.8\python.exe" -P "3.7:python-3.7.6\python.exe" -P "3.8:python-3.8.3\python.exe" -P "3.9:python-3.9.0b4\python.exe"
     - name: Upload release file
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/skip.yml
+++ b/.github/workflows/skip.yml
@@ -32,6 +32,6 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - run: exit 0

--- a/sonnet
+++ b/sonnet
@@ -25,8 +25,6 @@ class MakeReleaseCommand(Command):
     """
 
     PYTHON = {
-        "2.7": "python2.7",
-        "3.5": "python3.5",
         "3.6": "python3.6",
         "3.7": "python3.7",
         "3.8": "python3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.3.0
 isolated_build = True
-envlist = py27, py35, py36, py37, py38, py39, doc
+envlist = py36, py37, py38, py39, doc
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
This change drops support for Python 2.7 and 3.5 in tox, ci and release
workflows in preparation for dropping support for these versions in
Poetry 1.2.0.