### PR TITLE
Use URL from response to support redirects

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -391,7 +391,8 @@ class LegacyRepository(PyPiRepository):
 
         if response.status_code in (401, 403):
             self._log(
-                "Authorization error accessing {url}".format(url=response.url), level="warn"
+                "Authorization error accessing {url}".format(url=response.url),
+                level="warn"
             )
             return
 

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -400,7 +400,8 @@ class LegacyRepository(PyPiRepository):
             self._log(
                 "Response URL {response_url} differs from request URL {url}".format(
                     response_url=response.url, url=url
-                )
+                ),
+                level="debug",
             )
 
         return Page(response.url, response.content, response.headers)

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -396,4 +396,11 @@ class LegacyRepository(PyPiRepository):
             )
             return
 
+        if response.url != url:
+            self._log(
+                "Response URL {response_url} differs from request URL {url}".format(
+                    response_url=response.url, url=url
+                )
+            )
+
         return Page(response.url, response.content, response.headers)

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -395,4 +395,4 @@ class LegacyRepository(PyPiRepository):
             )
             return
 
-        return Page(url, response.content, response.headers)
+        return Page(response.url, response.content, response.headers)

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -392,7 +392,7 @@ class LegacyRepository(PyPiRepository):
         if response.status_code in (401, 403):
             self._log(
                 "Authorization error accessing {url}".format(url=response.url),
-                level="warn"
+                level="warn",
             )
             return
 

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -391,7 +391,7 @@ class LegacyRepository(PyPiRepository):
 
         if response.status_code in (401, 403):
             self._log(
-                "Authorization error accessing {url}".format(url=url), level="warn"
+                "Authorization error accessing {url}".format(url=response.url), level="warn"
             )
             return
 

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -345,5 +345,6 @@ def test_get_redirect_has_redirect(http, monkeypatch):
         response.status_code = 200
         response.url = redirect_url + "/foo"
         return response
-    monkeypatch.setattr(repo.session, 'get', get_mock)
+
+    monkeypatch.setattr(repo.session, "get", get_mock)
     assert repo._get("/foo")._url == "http://legacy.redirect.bar/foo/"

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -1,6 +1,5 @@
 import shutil
 
-import httpretty
 import pytest
 import requests
 

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -335,7 +335,7 @@ def test_get_4xx_and_5xx_raises(http):
             repo._get(endpoint)
 
 
-def test_get_redirect_has_redirect(http, monkeypatch):
+def test_get_redirected_response_url(http, monkeypatch):
     repo = MockHttpRepository({"/foo": 200}, http)
     redirect_url = "http://legacy.redirect.bar"
 


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.

I don't know if this change needs additional tests or documentation, since it is a small bugfix from an issue I've encountered.  Also don't know if I should have created an issue first to report the bug.  Any guidance here is appreciated.

On my team, we host our custom packages on a pypiserver that redirects to an Artifactory PyPI mirror if the package isn't a custom one.  So we add a source section to our pyproject.toml.

```toml
[[tool.poetry.source]]
name = "ourserver"
url = "https://ourserver.example.com/pypiserver"
default = true
```

However, when we have `default=True`, the installation fails.

```
$> ~/.local/bin/poetry install -vvv
Creating virtualenv tool-G6amg8OA-py3.8 in /home/jyamauchi/.cache/pypoetry/virtualenvs
Using virtualenv: /home/jyamauchi/.cache/pypoetry/virtualenvs/tool-G6amg8OA-py3.8
Updating dependencies
Resolving dependencies...
   1: fact: tool is 0.7.4
   1: derived: tool
   1: fact: tool depends on click (^7.1.1)
   1: fact: tool depends on openpyxl (^3.0.3)
   1: fact: tool depends on pytest (^5.2)
   1: fact: tool depends on pytest (^5.2)
   1: selecting tool (0.7.4)
   1: derived: pytest (^5.2)
   1: derived: openpyxl (^3.0.3)
   1: derived: click (^7.1.1)
   1: selecting click (7.1.2)
   1: fact: openpyxl (3.0.5) depends on jdcal (*)
   1: fact: openpyxl (3.0.5) depends on et-xmlfile (*)
   1: selecting openpyxl (3.0.5)
   1: derived: et-xmlfile (*)
   1: derived: jdcal (*)
   1: selecting et-xmlfile (1.0.1)
   1: selecting jdcal (1.4.1)
   1: fact: pytest (5.4.3) depends on py (>=1.5.0)
   1: fact: pytest (5.4.3) depends on packaging (*)
   1: fact: pytest (5.4.3) depends on attrs (>=17.4.0)
   1: fact: pytest (5.4.3) depends on more-itertools (>=4.0.0)
   1: fact: pytest (5.4.3) depends on pluggy (>=0.12,<1.0)
   1: fact: pytest (5.4.3) depends on wcwidth (*)
   1: fact: pytest (5.4.3) depends on importlib-metadata (>=0.12)
   1: fact: pytest (5.4.3) depends on atomicwrites (>=1.0)
   1: fact: pytest (5.4.3) depends on colorama (*)
   1: selecting pytest (5.4.3)
   1: derived: colorama (*)
   1: derived: atomicwrites (>=1.0)
   1: derived: importlib-metadata (>=0.12)
   1: derived: wcwidth (*)
   1: derived: pluggy (>=0.12,<1.0)
   1: derived: more-itertools (>=4.0.0)
   1: derived: attrs (>=17.4.0)
   1: derived: packaging (*)
   1: derived: py (>=1.5.0)
   1: fact: pluggy (0.13.1) depends on importlib-metadata (>=0.12)
   1: selecting pluggy (0.13.1)
   1: selecting atomicwrites (1.4.0)
   1: selecting attrs (20.2.0)
   1: selecting py (1.9.0)
   1: selecting wcwidth (0.2.5)
   1: selecting more-itertools (8.5.0)
   1: fact: importlib-metadata (2.0.0) depends on zipp (>=0.5)
   1: selecting importlib-metadata (2.0.0)
   1: derived: zipp (>=0.5)
   1: selecting zipp (3.3.0)
   1: fact: packaging (20.4) depends on pyparsing (>=2.0.2)
   1: fact: packaging (20.4) depends on six (*)
   1: selecting packaging (20.4)
   1: derived: six (*)
   1: derived: pyparsing (>=2.0.2)
   1: selecting six (1.15.0)
   1: selecting pyparsing (2.4.7)
   1: selecting colorama (0.4.4)
   1: Version solving took 4.621 seconds.
   1: Tried 1 solutions.

Writing lock file

Finding the necessary packages for the current system

Package operations: 13 installs, 0 updates, 0 removals

  • Installing pyparsing (2.4.7): Pending...
  • Installing pyparsing (2.4.7): Failed

  HTTPError

  404 Client Error: Not Found for url: https://mtecsvr4.micron.com/packages/packages/8a/bb/488841f56197b13700afd5658fc279a2025a39e22449b7cf29864669b15d/pyparsing-2.4.7-py2.py3-none-any.whl#sha256=ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b

  at ~/.local/pipx/venvs/poetry/lib/python3.8/site-packages/requests/models.py:941 in raise_for_status
      937│         elif 500 <= self.status_code < 600:
      938│             http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
      939│ 
      940│         if http_error_msg:
    → 941│             raise HTTPError(http_error_msg, response=self)
      942│ 
      943│     def close(self):
      944│         
      945│         called the underlying ``raw`` object must not be accessed again.

  • Installing six (1.15.0): Pending...
  • Installing six (1.15.0): Failed

  HTTPError

  404 Client Error: Not Found for url: https://ourserver.example.com/packages/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl#sha256=8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced

  at ~/.local/pipx/venvs/poetry/lib/python3.8/site-packages/requests/models.py:941 in raise_for_status
      937│         elif 500 <= self.status_code < 600:
      938│             http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
      939│ 
      940│         if http_error_msg:
    → 941│             raise HTTPError(http_error_msg, response=self)
      942│ 
      943│     def close(self):
      944│         
      945│         called the underlying ``raw`` object must not be accessed again.
```

Tracking through the code, it appears the code uses the initially requested URL, but doesn't realize the request was redirected.  So when requesting click, for example, it requests the URL `https://ourserver.example.com/pypiserver/click`, but that got redirected to `https://artifactory.example.com/long/url/thing`.  Further down the line, poetry tries to grab the resource using a relative URL and combining it with the first URL, when in fact it should be combining it with the second URL.
