### PR TITLE
Handle non-editable packages with pth files

### DIFF
--- a/poetry/repositories/installed_repository.py
+++ b/poetry/repositories/installed_repository.py
@@ -138,14 +138,22 @@ class InstalledRepository(Repository):
                     if path.name.endswith(".dist-info"):
                         paths = cls.get_package_paths(env=env, name=package.pretty_name)
                         if paths:
+                            is_editable_package = False
                             for src in paths:
                                 if cls.is_vcs_package(src, env):
                                     cls.set_package_vcs_properties(package, env)
                                     break
+
+                                if not (
+                                    is_editable_package
+                                    or env.is_path_relative_to_lib(src)
+                                ):
+                                    is_editable_package = True
                             else:
                                 # TODO: handle multiple source directories?
-                                package._source_type = "directory"
-                                package._source_url = paths.pop().as_posix()
+                                if is_editable_package:
+                                    package._source_type = "directory"
+                                    package._source_url = paths.pop().as_posix()
                     continue
 
                 if cls.is_vcs_package(path, env):

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/standard-1.2.3.dist-info/METADATA
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/standard-1.2.3.dist-info/METADATA
@@ -1,0 +1,22 @@
+Metadata-Version: 2.1
+Name: standard
+Version: 1.2.3
+Summary: Standard description.
+License: MIT
+Keywords: cli,commands
+Author: Foo Bar
+Author-email: foo@bar.com
+Requires-Python: >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+Classifier: License :: OSI Approved :: MIT License
+Classifier: Programming Language :: Python :: 2
+Classifier: Programming Language :: Python :: 2.7
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.4
+Classifier: Programming Language :: Python :: 3.5
+Classifier: Programming Language :: Python :: 3.6
+Classifier: Programming Language :: Python :: 3.7
+Classifier: Programming Language :: Python :: 3.8
+Description-Content-Type: text/x-rst
+
+Editable
+####

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/standard.pth
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/standard.pth
@@ -1,0 +1,1 @@
+standard

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -26,6 +26,7 @@ INSTALLED_RESULTS = [
         zipp.Path(str(SITE_PURELIB / "foo-0.1.0-py3.8.egg"), "EGG-INFO")
     ),
     metadata.PathDistribution(VENDOR_DIR / "attrs-19.3.0.dist-info"),
+    metadata.PathDistribution(SITE_PURELIB / "standard-1.2.3.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "editable-2.3.4.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "editable-with-import-2.3.4.dist-info"),
     metadata.PathDistribution(SITE_PLATLIB / "lib64-2.3.4.dist-info"),
@@ -158,3 +159,13 @@ def test_load_editable_with_import_package(repository):
     assert editable.version.text == "2.3.4"
     assert editable.source_type is None
     assert editable.source_url is None
+
+
+def test_load_standard_package_with_pth_file(repository):
+    # test standard packages with .pth file is not treated as editable
+    standard = get_package_from_repository("standard", repository)
+    assert standard is not None
+    assert standard.name == "standard"
+    assert standard.version.text == "1.2.3"
+    assert standard.source_type is None
+    assert standard.source_url is None


### PR DESCRIPTION
When detecting installed packages, this change ensures that packages
with .pth files are not incorrectly marked as editable. A package is
considered editable only if at least one of the paths detected is
not in the environment site.

Resolves: #3077
