### PR TITLE
[bug] script entry point import path

### DIFF
--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -139,7 +139,7 @@ class EditableBuilder(Builder):
         for script in scripts:
             name, script = script.split(" = ")
             module, callable_ = script.split(":")
-            callable_holder = callable_.rsplit(".", 1)[0]
+            callable_holder = callable_.split(".", 1)[0]
 
             script_file = scripts_path.joinpath(name)
             self._debug(

--- a/tests/fixtures/simple_project/pyproject.toml
+++ b/tests/fixtures/simple_project/pyproject.toml
@@ -27,3 +27,4 @@ python = "~2.7 || ^3.4"
 [tool.poetry.scripts]
 foo = "foo:bar"
 baz = "bar:baz.boom.bim"
+fox = "fuz.foo:bar.baz"

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -92,7 +92,7 @@ def test_builder_installs_proper_files_for_standard_packages(simple_poetry, tmp_
 
     assert "poetry" == dist_info.joinpath("INSTALLER").read_text()
     assert (
-        "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\n\n"
+        "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\nfox=fuz.foo:bar.baz\n\n"
         == dist_info.joinpath("entry_points.txt").read_text()
     )
 
@@ -140,7 +140,7 @@ My Package
 
     baz_script = """\
 #!{python}
-from bar import baz.boom
+from bar import baz
 
 if __name__ == '__main__':
     baz.boom.bim()
@@ -161,6 +161,18 @@ if __name__ == '__main__':
     )
 
     assert foo_script == tmp_venv._bin_dir.joinpath("foo").read_text()
+
+    fox_script = """\
+#!{python}
+from fuz.foo import bar
+
+if __name__ == '__main__':
+    bar.baz()
+""".format(
+        python=tmp_venv._bin("python")
+    )
+
+    assert fox_script == tmp_venv._bin_dir.joinpath("fox").read_text()
 
 
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(


### PR DESCRIPTION
```toml
[tool.poetry.scripts]
baz = "bar:baz.boom.bim"
```

currently translates to

```python
from bar import baz.boom

if __name__ == '__main__':
    baz.boom.bim()
```

but should be

```python
from bar import baz  # <- notice the difference

if __name__ == '__main__':
    baz.boom.bim()
```

This is the case when, for instance, this is an entry point

```python
# file __init__.py in module bar
class baz:
    class boom:
        @classmethod
        def bim():
            #  ...
```

Also extended the tests to test sub-module import