### PR TITLE
locker: handle nested extras requirement

### DIFF
--- a/tests/installation/fixtures/with-dependencies-nested-extras.test
+++ b/tests/installation/fixtures/with-dependencies-nested-extras.test
@@ -6,6 +6,12 @@ category = "main"
 optional = false
 python-versions = "*"
 
+[package.dependencies]
+B = {version = "^1.0", optional = true, extras = ["C"]}
+
+[package.extras]
+B = ["B[C] (>=1.0,<2.0)"]
+
 [[package]]
 name = "B"
 version = "1.0"
@@ -18,7 +24,7 @@ python-versions = "*"
 C = {version = "^1.0", optional = true}
 
 [package.extras]
-foo = ["C (>=1.0,<2.0)"]
+C = ["C (>=1.0,<2.0)"]
 
 [[package]]
 name = "C"


### PR DESCRIPTION
Previously, when using locked repository, incorrect dependency instance
was created when a dependency's extra requirement activated a
nested extra. This change ensures that these are correctly
loaded.

As part of this change new lock files write PEP 508 serialised form of
extra dependencies in order to reuse core logic to parse specification
of extra requirement.

Resolves: #3224
