### PR TITLE
Do not reuse requests sessions

### DIFF
--- a/poetry/installation/authenticator.py
+++ b/poetry/installation/authenticator.py
@@ -29,7 +29,6 @@ class Authenticator(object):
     def __init__(self, config, io=None):  # type: (Config, Optional[IO]) -> None
         self._config = config
         self._io = io
-        self._session = None
         self._credentials = {}
         self._password_manager = PasswordManager(self._config)
 
@@ -45,10 +44,7 @@ class Authenticator(object):
 
     @property
     def session(self):  # type: () -> requests.Session
-        if self._session is None:
-            self._session = requests.Session()
-
-        return self._session
+        return requests.Session()
 
     def request(
         self, method, url, **kwargs

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -70,15 +70,11 @@ class PyPiRepository(RemoteRepository):
         )
 
         self._cache_control_cache = FileCache(str(release_cache_dir / "_http"))
-        self._session = CacheControl(
-            requests.session(), cache=self._cache_control_cache
-        )
-
         self._name = "PyPI"
 
     @property
     def session(self):
-        return self._session
+        return CacheControl(requests.session(), cache=self._cache_control_cache)
 
     def find_packages(self, dependency):  # type: (Dependency) -> List[Package]
         """


### PR DESCRIPTION
When running under certain environment, reuse of request sessions maybe
causing network connectivity issues. This change ensures that request
sessions are not reused across requests.

Relates-to: #3219
