### PR TITLE
Make test suites  pass when run from any directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,11 @@ def fixture_dir(fixture_base):
 
 
 @pytest.fixture
+def poetry_root_dir():
+    return Path(__file__).parent.parent
+
+
+@pytest.fixture
 def tmp_dir():
     dir_ = tempfile.mkdtemp(prefix="poetry_")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,13 @@ def poetry_root_dir():
     return Path(__file__).parent.parent
 
 
+@pytest.fixture(autouse=True)
+def mock_path_cwd(mocker, poetry_root_dir):
+    yield mocker.patch(
+        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
+    )
+
+
 @pytest.fixture
 def tmp_dir():
     dir_ = tempfile.mkdtemp(prefix="poetry_")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,13 +158,6 @@ def poetry_root_dir():
     return Path(__file__).parent.parent
 
 
-@pytest.fixture(autouse=True)
-def mock_path_cwd(mocker, poetry_root_dir):
-    yield mocker.patch(
-        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
-    )
-
-
 @pytest.fixture
 def tmp_dir():
     dir_ = tempfile.mkdtemp(prefix="poetry_")

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -76,15 +76,10 @@ class CustomInstalledRepository(InstalledRepository):
         return cls()
 
 
-@pytest.fixture
-def working_directory():
-    return Path(__file__).parent.parent.parent
-
-
 @pytest.fixture(autouse=True)
-def mock_path_cwd(mocker, working_directory):
+def mock_path_cwd(mocker, poetry_root_dir):
     yield mocker.patch(
-        "poetry.core.utils._compat.Path.cwd", return_value=working_directory
+        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
     )
 
 

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -76,6 +76,13 @@ class CustomInstalledRepository(InstalledRepository):
         return cls()
 
 
+@pytest.fixture(autouse=True)
+def mock_path_cwd(mocker, poetry_root_dir):
+    yield mocker.patch(
+        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
+    )
+
+
 class Locker(BaseLocker):
     def __init__(self):
         self._lock = TOMLFile(Path.cwd().joinpath("poetry.lock"))

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -76,6 +76,18 @@ class CustomInstalledRepository(InstalledRepository):
         return cls()
 
 
+@pytest.fixture
+def working_directory():
+    return Path(__file__).parent.parent.parent
+
+
+@pytest.fixture(autouse=True)
+def mock_path_cwd(mocker, working_directory):
+    yield mocker.patch(
+        "poetry.core.utils._compat.Path.cwd", return_value=working_directory
+    )
+
+
 class Locker(BaseLocker):
     def __init__(self):
         self._lock = TOMLFile(Path.cwd().joinpath("poetry.lock"))

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -76,13 +76,6 @@ class CustomInstalledRepository(InstalledRepository):
         return cls()
 
 
-@pytest.fixture(autouse=True)
-def mock_path_cwd(mocker, poetry_root_dir):
-    yield mocker.patch(
-        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
-    )
-
-
 class Locker(BaseLocker):
     def __init__(self):
         self._lock = TOMLFile(Path.cwd().joinpath("poetry.lock"))

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -27,13 +27,6 @@ from tests.repositories.test_legacy_repository import (
 from tests.repositories.test_pypi_repository import MockRepository
 
 
-@pytest.fixture(autouse=True)
-def mock_path_cwd(mocker, poetry_root_dir):
-    yield mocker.patch(
-        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
-    )
-
-
 class Installer(BaseInstaller):
     def _get_installer(self):
         return NoopInstaller()

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -27,15 +27,10 @@ from tests.repositories.test_legacy_repository import (
 from tests.repositories.test_pypi_repository import MockRepository
 
 
-@pytest.fixture
-def working_directory():
-    return Path(__file__).parent.parent.parent
-
-
 @pytest.fixture(autouse=True)
-def mock_path_cwd(mocker, working_directory):
+def mock_path_cwd(mocker, poetry_root_dir):
     yield mocker.patch(
-        "poetry.core.utils._compat.Path.cwd", return_value=working_directory
+        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
     )
 
 

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -27,6 +27,18 @@ from tests.repositories.test_legacy_repository import (
 from tests.repositories.test_pypi_repository import MockRepository
 
 
+@pytest.fixture
+def working_directory():
+    return Path(__file__).parent.parent.parent
+
+
+@pytest.fixture(autouse=True)
+def mock_path_cwd(mocker, working_directory):
+    yield mocker.patch(
+        "poetry.core.utils._compat.Path.cwd", return_value=working_directory
+    )
+
+
 class Installer(BaseInstaller):
     def _get_installer(self):
         return NoopInstaller()

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -27,6 +27,13 @@ from tests.repositories.test_legacy_repository import (
 from tests.repositories.test_pypi_repository import MockRepository
 
 
+@pytest.fixture(autouse=True)
+def mock_path_cwd(mocker, poetry_root_dir):
+    yield mocker.patch(
+        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
+    )
+
+
 class Installer(BaseInstaller):
     def _get_installer(self):
         return NoopInstaller()

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -35,6 +35,13 @@ class Locker(BaseLocker):
         return "123456789"
 
 
+@pytest.fixture(autouse=True)
+def mock_path_cwd(mocker, poetry_root_dir):
+    yield mocker.patch(
+        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
+    )
+
+
 @pytest.fixture()
 def locker():
     return Locker()

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -35,15 +35,10 @@ class Locker(BaseLocker):
         return "123456789"
 
 
-@pytest.fixture
-def working_directory():
-    return Path(__file__).parent.parent.parent
-
-
 @pytest.fixture(autouse=True)
-def mock_path_cwd(mocker, working_directory):
+def mock_path_cwd(mocker, poetry_root_dir):
     yield mocker.patch(
-        "poetry.core.utils._compat.Path.cwd", return_value=working_directory
+        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
     )
 
 
@@ -740,7 +735,7 @@ foo @ git+https://github.com/foo/foo.git@123456 ; python_version < "3.7"
 
 
 def test_exporter_can_export_requirements_txt_with_directory_packages(
-    tmp_dir, poetry, working_directory
+    tmp_dir, poetry, poetry_root_dir
 ):
     poetry.locker.mock_lock_data(
         {
@@ -777,14 +772,14 @@ def test_exporter_can_export_requirements_txt_with_directory_packages(
     expected = """\
 foo @ {}/tests/fixtures/sample_project
 """.format(
-        working_directory.as_posix()
+        poetry_root_dir.as_posix()
     )
 
     assert expected == content
 
 
 def test_exporter_can_export_requirements_txt_with_directory_packages_and_markers(
-    tmp_dir, poetry, working_directory
+    tmp_dir, poetry, poetry_root_dir
 ):
     poetry.locker.mock_lock_data(
         {
@@ -822,14 +817,14 @@ def test_exporter_can_export_requirements_txt_with_directory_packages_and_marker
     expected = """\
 foo @ {}/tests/fixtures/sample_project; python_version < "3.7"
 """.format(
-        working_directory.as_posix()
+        poetry_root_dir.as_posix()
     )
 
     assert expected == content
 
 
 def test_exporter_can_export_requirements_txt_with_file_packages(
-    tmp_dir, poetry, working_directory
+    tmp_dir, poetry, poetry_root_dir
 ):
     poetry.locker.mock_lock_data(
         {
@@ -866,14 +861,14 @@ def test_exporter_can_export_requirements_txt_with_file_packages(
     expected = """\
 foo @ {}/tests/fixtures/distributions/demo-0.1.0.tar.gz
 """.format(
-        working_directory.as_uri()
+        poetry_root_dir.as_uri()
     )
 
     assert expected == content
 
 
 def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
-    tmp_dir, poetry, working_directory
+    tmp_dir, poetry, poetry_root_dir
 ):
     poetry.locker.mock_lock_data(
         {
@@ -911,7 +906,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
     expected = """\
 foo @ {}/tests/fixtures/distributions/demo-0.1.0.tar.gz; python_version < "3.7"
 """.format(
-        working_directory.as_uri()
+        poetry_root_dir.as_uri()
     )
 
     assert expected == content

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -35,13 +35,6 @@ class Locker(BaseLocker):
         return "123456789"
 
 
-@pytest.fixture(autouse=True)
-def mock_path_cwd(mocker, poetry_root_dir):
-    yield mocker.patch(
-        "poetry.core.utils._compat.Path.cwd", return_value=poetry_root_dir
-    )
-
-
 @pytest.fixture()
 def locker():
     return Locker()


### PR DESCRIPTION
# Pull Request Check List

Relates-to: #3155 

Currently,  `test_installer.py` and `test_installer_old.py` expect that they be executed from the project root. 
Example running test on tests/installation directory produces:
<img width="680" alt="Screen Shot 2020-10-17 at 2 46 01 PM" src="https://user-images.githubusercontent.com/743526/96330631-56566a80-1089-11eb-8d96-5749ff49a78d.png">

This PR patches current working directory `Path.cwd` to be always on project root. 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
