### PR TITLE
Add support for get-poetry.py --file using sdist

### DIFF
--- a/tests/scripts/test_get_poetry.py
+++ b/tests/scripts/test_get_poetry.py
@@ -1,0 +1,69 @@
+import os
+import shutil
+
+
+try:
+    # Python 3.5+
+    import importlib.util
+except ImportError:
+    # Python 2.7
+    import imp
+
+from pathlib import Path
+
+import pytest
+
+from poetry.core.masonry.builder import Builder
+from poetry.factory import Factory
+
+
+# We need to set the poetry home environment variable prior to importing the script since it gets set once at import
+# time.
+SOURCE_HOME = Path(__file__).parent.parent.parent
+GET_POETRY_PATH = SOURCE_HOME / "get-poetry.py"
+TMP_DIR = Path(__file__).parent / "tmp"
+POETRY_HOME = TMP_DIR / ".poetry"
+os.environ["POETRY_HOME"] = str(POETRY_HOME)
+try:
+    # Python 3.5+
+    spec = importlib.util.spec_from_file_location("getpoetry", GET_POETRY_PATH)
+    getpoetry = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(getpoetry)
+except ImportError:
+    # Python 2.7
+
+    getpoetry = imp.load_source("getpoetry", str(GET_POETRY_PATH))
+
+
+@pytest.fixture()
+def tmp_dir():
+    """
+    Use this in tests to actually set up and tear down the directory.
+    """
+    if TMP_DIR.exists():
+        shutil.rmtree(TMP_DIR)
+    TMP_DIR.mkdir(exist_ok=True, parents=False)
+    yield TMP_DIR
+    shutil.rmtree(TMP_DIR)
+
+
+@pytest.fixture()
+def poetry_home(tmp_dir):
+    return POETRY_HOME
+
+
+@pytest.fixture()
+def poetry_sdist_file(tmp_dir):
+    poetry = Factory().create_poetry(cwd=SOURCE_HOME)
+    builder = Builder(poetry)
+    builder.build("sdist")
+    dist_dir = SOURCE_HOME / "dist"
+    yield Path(next(dist_dir.glob("*.tar.gz")))
+
+
+def test_installer_file_sdist(poetry_home, poetry_sdist_file):
+    installer = getpoetry.Installer(file=str(poetry_sdist_file), accept_all=True)
+    installer.run()
+    assert poetry_home.is_dir()
+    assert (poetry_home / "bin" / "poetry").is_file()
+    assert (poetry_home / "lib" / "poetry" / "__init__.py").is_file()

--- a/tests/scripts/test_get_poetry.py
+++ b/tests/scripts/test_get_poetry.py
@@ -8,8 +8,12 @@ try:
 except ImportError:
     # Python 2.7
     import imp
-
-from pathlib import Path
+try:
+    # Python 2
+    from pathlib2 import Path
+except ImportError:
+    # Python 3
+    from pathlib import Path
 
 import pytest
 
@@ -31,7 +35,6 @@ try:
     spec.loader.exec_module(getpoetry)
 except ImportError:
     # Python 2.7
-
     getpoetry = imp.load_source("getpoetry", str(GET_POETRY_PATH))
 
 

--- a/tests/scripts/test_get_poetry.py
+++ b/tests/scripts/test_get_poetry.py
@@ -33,7 +33,7 @@ try:
     spec = importlib.util.spec_from_file_location("getpoetry", GET_POETRY_PATH)
     getpoetry = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(getpoetry)
-except ImportError:
+except NameError:
     # Python 2.7
     getpoetry = imp.load_source("getpoetry", str(GET_POETRY_PATH))
 
@@ -44,10 +44,10 @@ def tmp_dir():
     Use this in tests to actually set up and tear down the directory.
     """
     if TMP_DIR.exists():
-        shutil.rmtree(TMP_DIR)
+        shutil.rmtree(str(TMP_DIR))
     TMP_DIR.mkdir(exist_ok=True, parents=False)
     yield TMP_DIR
-    shutil.rmtree(TMP_DIR)
+    shutil.rmtree(str(TMP_DIR))
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3228

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

* This pull request adds support for install from an sdist file for the get-poetry script. Currently, the file structure of sdist vs the github releases is different due to the poetry package being nested one level deeper in the sdist file structure. Strictly speaking, this is a feature. However, the previous behavior may have resulted in a user experience that was difficult to distinguish from a bug.
* Check the library location and raise an error if the expected poetry library is not created from the file provided by the user.
* Added some unit tests for the new functionality in the get-poetry.py file. The test fixtures used and the import structure can be used for more unit tests of get-poetry.py in the future.