### PR TITLE
Use global fixture_dir instead of defining one on each test file

### DIFF
--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -12,23 +12,19 @@ from poetry.utils.env import EnvCommandError
 from poetry.utils.env import VirtualEnv
 
 
-FIXTURE_DIR_BASE = Path(__file__).parent.parent / "fixtures"
-FIXTURE_DIR_INSPECTIONS = FIXTURE_DIR_BASE / "inspection"
-
-
 @pytest.fixture(autouse=True)
 def pep517_metadata_mock():
     pass
 
 
 @pytest.fixture
-def demo_sdist():  # type: () -> Path
-    return FIXTURE_DIR_BASE / "distributions" / "demo-0.1.0.tar.gz"
+def demo_sdist(fixture_dir):  # type: () -> Path
+    return fixture_dir("distributions/demo-0.1.0.tar.gz")
 
 
 @pytest.fixture
-def demo_wheel():  # type: () -> Path
-    return FIXTURE_DIR_BASE / "distributions" / "demo-0.1.0-py2.py3-none-any.whl"
+def demo_wheel(fixture_dir):  # type: () -> Path
+    return fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl")
 
 
 @pytest.fixture
@@ -120,16 +116,16 @@ def test_info_from_bdist(demo_wheel):
     demo_check_info(info)
 
 
-def test_info_from_poetry_directory():
+def test_info_from_poetry_directory(fixture_dir):
     info = PackageInfo.from_directory(
-        FIXTURE_DIR_INSPECTIONS / "demo", disable_build=True
+        fixture_dir("inspection/demo"), disable_build=True
     )
     demo_check_info(info)
 
 
-def test_info_from_requires_txt():
+def test_info_from_requires_txt(fixture_dir):
     info = PackageInfo.from_metadata(
-        FIXTURE_DIR_INSPECTIONS / "demo_only_requires_txt.egg-info"
+        fixture_dir("inspection/demo_only_requires_txt.egg-info")
     )
     demo_check_info(info)
 
@@ -146,9 +142,9 @@ def test_info_from_setup_cfg(demo_setup_cfg):
     demo_check_info(info, requires_dist={"package"})
 
 
-def test_info_no_setup_pkg_info_no_deps():
+def test_info_no_setup_pkg_info_no_deps(fixture_dir):
     info = PackageInfo.from_directory(
-        FIXTURE_DIR_INSPECTIONS / "demo_no_setup_pkg_info_no_deps", disable_build=True,
+        fixture_dir("inspection/demo_no_setup_pkg_info_no_deps"), disable_build=True,
     )
     assert info.name == "demo"
     assert info.version == "0.1.0"
@@ -237,8 +233,8 @@ def test_info_setup_missing_mandatory_should_trigger_pep517(
         assert spy.call_count == 2
 
 
-def test_info_prefer_poetry_config_over_egg_info():
+def test_info_prefer_poetry_config_over_egg_info(fixture_dir):
     info = PackageInfo.from_directory(
-        FIXTURE_DIR_INSPECTIONS / "demo_with_obsolete_egg_info"
+        fixture_dir("inspection/demo_with_obsolete_egg_info")
     )
     demo_check_info(info)

--- a/tests/publishing/test_uploader.py
+++ b/tests/publishing/test_uploader.py
@@ -4,19 +4,13 @@ from poetry.factory import Factory
 from poetry.io.null_io import NullIO
 from poetry.publishing.uploader import Uploader
 from poetry.publishing.uploader import UploadError
-from poetry.utils._compat import Path
 
 
-fixtures_dir = Path(__file__).parent.parent / "fixtures"
-
-
-def project(name):
-    return fixtures_dir / name
-
-
-def test_uploader_properly_handles_400_errors(http):
+def test_uploader_properly_handles_400_errors(http, fixture_dir):
     http.register_uri(http.POST, "https://foo.com", status=400, body="Bad request")
-    uploader = Uploader(Factory().create_poetry(project("simple_project")), NullIO())
+    uploader = Uploader(
+        Factory().create_poetry(fixture_dir("simple_project")), NullIO()
+    )
 
     with pytest.raises(UploadError) as e:
         uploader.upload("https://foo.com")
@@ -24,9 +18,11 @@ def test_uploader_properly_handles_400_errors(http):
     assert "HTTP Error 400: Bad Request" == str(e.value)
 
 
-def test_uploader_properly_handles_403_errors(http):
+def test_uploader_properly_handles_403_errors(http, fixture_dir):
     http.register_uri(http.POST, "https://foo.com", status=403, body="Unauthorized")
-    uploader = Uploader(Factory().create_poetry(project("simple_project")), NullIO())
+    uploader = Uploader(
+        Factory().create_poetry(fixture_dir("simple_project")), NullIO()
+    )
 
     with pytest.raises(UploadError) as e:
         uploader.upload("https://foo.com")
@@ -34,9 +30,11 @@ def test_uploader_properly_handles_403_errors(http):
     assert "HTTP Error 403: Forbidden" == str(e.value)
 
 
-def test_uploader_properly_handles_301_redirects(http):
+def test_uploader_properly_handles_301_redirects(http, fixture_dir):
     http.register_uri(http.POST, "https://foo.com", status=301, body="Redirect")
-    uploader = Uploader(Factory().create_poetry(project("simple_project")), NullIO())
+    uploader = Uploader(
+        Factory().create_poetry(fixture_dir("simple_project")), NullIO()
+    )
 
     with pytest.raises(UploadError) as e:
         uploader.upload("https://foo.com")
@@ -46,12 +44,14 @@ def test_uploader_properly_handles_301_redirects(http):
     )
 
 
-def test_uploader_registers_for_appropriate_400_errors(mocker, http):
+def test_uploader_registers_for_appropriate_400_errors(mocker, http, fixture_dir):
     register = mocker.patch("poetry.publishing.uploader.Uploader._register")
     http.register_uri(
         http.POST, "https://foo.com", status=400, body="No package was ever registered"
     )
-    uploader = Uploader(Factory().create_poetry(project("simple_project")), NullIO())
+    uploader = Uploader(
+        Factory().create_poetry(fixture_dir("simple_project")), NullIO()
+    )
 
     with pytest.raises(UploadError):
         uploader.upload("https://foo.com")

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -7,14 +7,10 @@ import pytest
 from poetry.core.toml.file import TOMLFile
 from poetry.factory import Factory
 from poetry.utils._compat import PY2
-from poetry.utils._compat import Path
 
 
-fixtures_dir = Path(__file__).parent / "fixtures"
-
-
-def test_create_poetry():
-    poetry = Factory().create_poetry(fixtures_dir / "sample_project")
+def test_create_poetry(fixture_base, fixture_dir):
+    poetry = Factory().create_poetry(fixture_dir("sample_project"))
 
     package = poetry.package
 
@@ -24,7 +20,7 @@ def test_create_poetry():
     assert package.authors == ["Sébastien Eustace <sebastien@eustace.io>"]
     assert package.license.id == "MIT"
     assert (
-        package.readme.relative_to(fixtures_dir).as_posix()
+        package.readme.relative_to(fixture_base).as_posix()
         == "sample_project/README.rst"
     )
     assert package.homepage == "https://python-poetry.org"
@@ -113,8 +109,8 @@ def test_create_poetry():
     ]
 
 
-def test_create_poetry_with_packages_and_includes():
-    poetry = Factory().create_poetry(fixtures_dir / "with-include")
+def test_create_poetry_with_packages_and_includes(fixture_dir):
+    poetry = Factory().create_poetry(fixture_dir("with-include"))
 
     package = poetry.package
 
@@ -134,9 +130,9 @@ def test_create_poetry_with_packages_and_includes():
     ]
 
 
-def test_create_poetry_with_multi_constraints_dependency():
+def test_create_poetry_with_multi_constraints_dependency(fixture_dir):
     poetry = Factory().create_poetry(
-        fixtures_dir / "project_with_multi_constraints_dependency"
+        fixture_dir("project_with_multi_constraints_dependency")
     )
 
     package = poetry.package
@@ -144,28 +140,28 @@ def test_create_poetry_with_multi_constraints_dependency():
     assert len(package.requires) == 2
 
 
-def test_poetry_with_default_source():
-    poetry = Factory().create_poetry(fixtures_dir / "with_default_source")
+def test_poetry_with_default_source(fixture_dir):
+    poetry = Factory().create_poetry(fixture_dir("with_default_source"))
 
     assert 1 == len(poetry.pool.repositories)
 
 
-def test_poetry_with_two_default_sources():
+def test_poetry_with_two_default_sources(fixture_dir):
     with pytest.raises(ValueError) as e:
-        Factory().create_poetry(fixtures_dir / "with_two_default_sources")
+        Factory().create_poetry(fixture_dir("with_two_default_sources"))
 
     assert "Only one repository can be the default" == str(e.value)
 
 
-def test_validate():
-    complete = TOMLFile(fixtures_dir / "complete.toml")
+def test_validate(fixture_dir):
+    complete = TOMLFile(fixture_dir("complete.toml"))
     content = complete.read()["tool"]["poetry"]
 
     assert Factory.validate(content) == {"errors": [], "warnings": []}
 
 
-def test_validate_fails():
-    complete = TOMLFile(fixtures_dir / "complete.toml")
+def test_validate_fails(fixture_dir):
+    complete = TOMLFile(fixture_dir("complete.toml"))
     content = complete.read()["tool"]["poetry"]
     content["this key is not in the schema"] = ""
 
@@ -183,11 +179,9 @@ def test_validate_fails():
     assert Factory.validate(content) == {"errors": [expected], "warnings": []}
 
 
-def test_create_poetry_fails_on_invalid_configuration():
+def test_create_poetry_fails_on_invalid_configuration(fixture_dir):
     with pytest.raises(RuntimeError) as e:
-        Factory().create_poetry(
-            Path(__file__).parent / "fixtures" / "invalid_pyproject" / "pyproject.toml"
-        )
+        Factory().create_poetry(fixture_dir("invalid_pyproject/pyproject.toml"))
 
     if PY2:
         expected = """\


### PR DESCRIPTION
# Pull Request Check List

Relates-to: https://github.com/python-poetry/poetry/issues/3155

There exists `fixture_dir` in conftest visible to all test suites. So we might as well use it in our tests.
There are actually more other files that we can update, I will continue updating them in other PRs.

Risk: maybe i'm oversimplifying? 😅 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
