### PR TITLE
Run test lock no update on windows environments

### DIFF
--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -1,5 +1,4 @@
 import shutil
-import sys
 
 import pytest
 
@@ -26,9 +25,6 @@ def poetry_with_old_lockfile(fixture_dir, source_dir):
     return poetry
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="does not work on windows under ci environments"
-)
 def test_lock_no_update(command_tester_factory, poetry_with_old_lockfile, http):
     http.disable()
 


### PR DESCRIPTION
# Pull Request Check List

Relates-to: #3155 

- Currently, `test_lock_no_update` is being skipped on windows environments.
- This PR will run the test on the said environments. And no test errors were found.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
