### PR TITLE
Fix relative paths for cache-dir

### DIFF
--- a/poetry/installation/chef.py
+++ b/poetry/installation/chef.py
@@ -81,7 +81,7 @@ class Chef:
         links = []
         for archive_type in archive_types:
             for archive in cache_dir.glob("*.{}".format(archive_type)):
-                links.append(Link(archive.as_uri()))
+                links.append(Link(archive.resolve().as_uri()))
 
         return links
 


### PR DESCRIPTION
Resolves: #3049

This PR addresses an issue with having relative paths on the cache-dir, AFAIK it only happens on python3.7 and up. I'm not sure of the internals of Poetry so the maintainers should take a look at this to make sure it doesn't introduce undesired behaviors.

All the credit goes to @matejcik since he came up with the fix. I'm just opening the PR since I really need this fixed and the issue where he reported this has been quiet for about 2 weeks.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

