### PR TITLE
Issue 3220 add develop flag for add command

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -174,6 +174,7 @@ update the constraint, for example `^2.3`. You can do this using the `add` comma
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
 * `--no-dev` : Do not install dev dependencies.
 * `--lock` : Do not perform install (only update the lockfile).
+* `--editable`: "Add as dependency in editable mode. Only permissible for non path or VCS dependencies!"
 
 ## add
 
@@ -230,7 +231,13 @@ poetry add ../my-package/dist/my-package-0.1.0.tar.gz
 poetry add ../my-package/dist/my_package-0.1.0.whl
 ```
 
-If you want the dependency to be installed in editable mode you can specify it in the `pyproject.toml` file. It means that changes in the local directory will be reflected directly in environment.
+If you want the dependency to be installed in editable mode you can pass the `--editable` flag or specify it in the `pyproject.toml` file. It means that changes in the local directory will be reflected directly in environment.
+
+```bash
+poetry add --editable ../my/path
+```
+
+or
 
 ```toml
 [tool.poetry.dependencies]
@@ -241,6 +248,14 @@ my-package = {path = "../my/path", develop = true}
 
     Before poetry 1.1 path dependencies were installed in editable mode by default. You should always set the `develop` attribute explicit,
     to make sure the behavior is the same for all poetry versions.
+
+!!!note
+
+    We are working on resolving the inconsistency in the naming of the `--editable` flag and the `develop` attribute. In future the `develop` attribute will be deprecated!
+
+!!!note
+
+    Currently passing the `--editable` flag with a non path or VCS dependency will result in a nonintuitive runtime error. We are currently working on providing a better error message.
 
 If the package(s) you want to install provide extras, you can specify them
 when adding the package:

--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -50,7 +50,11 @@ class AddCommand(InstallerCommand, InitCommand):
             "Output the operations but do not execute anything (implicitly enables --verbose).",
         ),
         option("lock", None, "Do not perform operations (only update the lockfile)."),
-        option("editable", None, "Add as dependency in editable mode."),
+        option(
+            "editable",
+            None,
+            "Add as dependency in editable mode. Will cause command to fail for non path or VCS dependencies!",
+        ),
     ]
     help = (
         "The add command adds required packages to your <comment>pyproject.toml</> and installs them.\n\n"

--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -50,6 +50,7 @@ class AddCommand(InstallerCommand, InitCommand):
             "Output the operations but do not execute anything (implicitly enables --verbose).",
         ),
         option("lock", None, "Do not perform operations (only update the lockfile)."),
+        option("develop", None, "Add as dependency in editable mode."),
     ]
     help = (
         "The add command adds required packages to your <comment>pyproject.toml</> and installs them.\n\n"
@@ -145,6 +146,9 @@ class AddCommand(InstallerCommand, InitCommand):
 
             if self.option("source"):
                 constraint["source"] = self.option("source")
+
+            if self.option("develop"):
+                constraint["develop"] = True
 
             if len(constraint) == 1 and "version" in constraint:
                 constraint = constraint["version"]

--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -50,7 +50,7 @@ class AddCommand(InstallerCommand, InitCommand):
             "Output the operations but do not execute anything (implicitly enables --verbose).",
         ),
         option("lock", None, "Do not perform operations (only update the lockfile)."),
-        option("develop", None, "Add as dependency in editable mode."),
+        option("editable", None, "Add as dependency in editable mode."),
     ]
     help = (
         "The add command adds required packages to your <comment>pyproject.toml</> and installs them.\n\n"
@@ -147,7 +147,7 @@ class AddCommand(InstallerCommand, InitCommand):
             if self.option("source"):
                 constraint["source"] = self.option("source")
 
-            if self.option("develop"):
+            if self.option("editable"):
                 constraint["develop"] = True
 
             if len(constraint) == 1 and "version" in constraint:

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -811,11 +811,11 @@ Writing lock file
     assert content_hash != app.poetry.locker.lock_data["metadata"]["content-hash"]
 
 
-def test_add_with_develop_fails_for_schema_without_develop(app, repo, tester):
+def test_add_with_editable_fails_for_schema_without_develop(app, repo, tester):
     repo.add_package(get_package("cachy", "0.2.0"))
 
     with pytest.raises(RuntimeError) as e:
-        tester.execute("cachy --develop")
+        tester.execute("cachy --editable")
     # TODO: Provide better error message.
     # `Develop` attribute is only supported by directory
     # https://github.com/python-poetry/poetry-core/blob/master/poetry/core/packages/directory_dependency.py
@@ -830,7 +830,7 @@ The Poetry configuration is invalid:
     )
 
 
-def test_add_with_develop(app, repo, tester, mocker):
+def test_add_with_editable(app, repo, tester, mocker):
     p = mocker.patch("poetry.utils._compat.Path.cwd")
     p.return_value = Path(__file__).parent
 
@@ -838,7 +838,7 @@ def test_add_with_develop(app, repo, tester, mocker):
     repo.add_package(get_package("cleo", "0.6.5"))
 
     path = "../git/github.com/demo/demo"
-    tester.execute("{} --develop".format(path))
+    tester.execute("{} --editable".format(path))
 
     expected = """\
 
@@ -1710,7 +1710,7 @@ def test_dry_run_restore_original_content(app, repo, installer, tester):
     assert original_content == app.poetry.file.read()
 
 
-def test_add_with_develop_old_installer(app, repo, old_tester, mocker):
+def test_add_with_editable_old_installer(app, repo, old_tester, mocker):
     p = mocker.patch("poetry.utils._compat.Path.cwd")
     p.return_value = Path(__file__).parent
 
@@ -1718,7 +1718,7 @@ def test_add_with_develop_old_installer(app, repo, old_tester, mocker):
     repo.add_package(get_package("cleo", "0.6.5"))
 
     path = "../git/github.com/demo/demo"
-    old_tester.execute("{} --develop".format(path))
+    old_tester.execute("{} --editable".format(path))
 
     expected = """\
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3220

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Simply adding the `develop` attribute causes the following [issue](https://github.com/python-poetry/poetry/issues/3220#issuecomment-712486145) however - only [directory](https://github.com/python-poetry/poetry-core/blob/fa522603bc2aff99127adaf585046f0ad50db973/poetry/core/packages/directory_dependency.py#L11-L21) and [vcs dependencies](https://github.com/python-poetry/poetry-core/blob/fa522603bc2aff99127adaf585046f0ad50db973/poetry/core/packages/vcs_dependency.py#L10-L28) support the `develop` attribute. 

If we add `develop = true` without checking the `source_type` first then the follow unintuitive error message is raised for dependencies that do not support it
```
RuntimeError

  The Poetry configuration is invalid:
    - [dependencies.<dependency>] {'version': '<version>', 'develop': True} is not valid under any of the given schemas
```
It would be better to raise an explicit error such as `The develop flag is not supported for dependencies of type <source_type>`
Unfortunately I don't see an elegant way of doing this without changing how `poetry-core` dependencies handle the `develop` parameter.
<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
