### PR TITLE
pool: ensure sources are prioritised over PyPI

### DIFF
--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -70,7 +70,8 @@ class Factory(BaseFactory):
         )
 
         # Configuring sources
-        for source in poetry.local_config.get("source", []):
+        sources = poetry.local_config.get("source", [])
+        for source in sources:
             repository = self.create_legacy_repository(source, config)
             is_default = source.get("default", False)
             is_secondary = source.get("secondary", False)
@@ -90,7 +91,8 @@ class Factory(BaseFactory):
         # Always put PyPI last to prefer private repositories
         # but only if we have no other default source
         if not poetry.pool.has_default():
-            poetry.pool.add_repository(PyPiRepository(), True)
+            has_sources = bool(sources)
+            poetry.pool.add_repository(PyPiRepository(), not has_sources, has_sources)
         else:
             if io.is_debug():
                 io.write_line("Deactivating the PyPI repository")

--- a/tests/fixtures/with_non_default_source/pyproject.toml
+++ b/tests/fixtures/with_non_default_source/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "Some description."
+authors = [
+    "Your Name <you@example.com>"
+]
+license = "MIT"
+
+# Requirements
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+
+[tool.poetry.dev-dependencies]
+
+[[tool.poetry.source]]
+name = "foo"
+url = "https://foo.bar/simple/"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -6,6 +6,8 @@ import pytest
 
 from poetry.core.toml.file import TOMLFile
 from poetry.factory import Factory
+from poetry.repositories.legacy_repository import LegacyRepository
+from poetry.repositories.pypi_repository import PyPiRepository
 from poetry.utils._compat import PY2
 from poetry.utils._compat import Path
 
@@ -148,6 +150,31 @@ def test_poetry_with_default_source():
     poetry = Factory().create_poetry(fixtures_dir / "with_default_source")
 
     assert 1 == len(poetry.pool.repositories)
+
+
+def test_poetry_with_non_default_source():
+    poetry = Factory().create_poetry(fixtures_dir / "with_non_default_source")
+
+    assert len(poetry.pool.repositories) == 2
+
+    assert not poetry.pool.has_default()
+
+    assert poetry.pool.repositories[0].name == "foo"
+    assert isinstance(poetry.pool.repositories[0], LegacyRepository)
+
+    assert poetry.pool.repositories[1].name == "PyPI"
+    assert isinstance(poetry.pool.repositories[1], PyPiRepository)
+
+
+def test_poetry_with_no_default_source():
+    poetry = Factory().create_poetry(fixtures_dir / "sample_project")
+
+    assert len(poetry.pool.repositories) == 1
+
+    assert poetry.pool.has_default()
+
+    assert poetry.pool.repositories[0].name == "PyPI"
+    assert isinstance(poetry.pool.repositories[0], PyPiRepository)
 
 
 def test_poetry_with_two_default_sources():


### PR DESCRIPTION
When a project specifies non default sources, PyPI gets added as the
default source. This will prioritise packages available in PyPI when
the package exists in both index. This change ensures that PyPI is
only used as a default when no other sources are provided.

Resolves: #1677 #2564 #3238