### PR TITLE
Get poetry file doc

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-1
+  image_family: freebsd-12-1-snap
 
 test_task:
   name: "Tests / FreeBSD / "

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-1-snap
+  image_family: freebsd-12-1
 
 test_task:
   name: "Tests / FreeBSD / "

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -324,7 +324,8 @@ class Installer:
     )
 
     REPOSITORY_URL = "https://github.com/python-poetry/poetry"
-    BASE_URL = REPOSITORY_URL + "/releases/download/"
+    USER_BASE_URL = REPOSITORY_URL + "/releases"
+    BASE_URL = USER_BASE_URL + "/download/"
     FALLBACK_BASE_URL = "https://github.com/sdispater/poetry/releases/download/"
 
     def __init__(
@@ -1048,7 +1049,9 @@ def main():
         dest="file",
         action="store",
         help="Install from a local file instead of fetching the latest version "
-        "of Poetry available online.",
+        "of Poetry available online.  File shall be downloaded from the poetry source repository: {}.  ".format(
+            Installer.USER_BASE_URL
+        ),
     )
 
     args = parser.parse_args()

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -1058,12 +1058,10 @@ def main():
         "--file",
         dest="file",
         action="store",
-        help="Install from a local file instead of fetching the latest version "
-        "of Poetry available online.  File shall be downloaded from the poetry source repository: {}.  ".format(
-            Installer.USER_BASE_URL
-        ),
+        help="Install from a local file instead of fetching the latest "
+        "version of Poetry available online.  File shall be downloaded "
+        f"from the poetry source repository: {Installer.USER_BASE_URL}",
     )
-
     args = parser.parse_args()
 
     base_url = Installer.BASE_URL

--- a/tests/scripts/test_get_poetry.py
+++ b/tests/scripts/test_get_poetry.py
@@ -57,17 +57,16 @@ def poetry_source_file_bad(tmp_dir):
     return source_tar
 
 
-def test_installer_file_run(poetry_home, poetry_source_file, get_poetry):
+def test_installer_file_make_lib(poetry_home, poetry_source_file, get_poetry):
     installer = get_poetry.Installer(file=str(poetry_source_file), accept_all=True)
-    installer.run()
+    installer.make_lib(None)
     assert poetry_home.is_dir()
-    assert (poetry_home / "bin" / "poetry").is_file()
     assert (poetry_home / "lib" / "poetry" / "__init__.py").is_file()
 
 
-def test_installer_file_run_raises_source_file_error(
+def test_installer_file_make_lib_raises_source_file_error(
     poetry_home, poetry_source_file_bad, get_poetry
 ):
     installer = get_poetry.Installer(file=str(poetry_source_file_bad), accept_all=True)
     with pytest.raises(get_poetry.SourceFileError):
-        installer.run()
+        installer.make_lib(None)

--- a/tests/scripts/test_get_poetry.py
+++ b/tests/scripts/test_get_poetry.py
@@ -58,7 +58,9 @@ def poetry_source_file_bad(tmp_dir):
 
 
 def test_installer_file_make_lib(poetry_home, poetry_source_file, get_poetry):
-    installer = get_poetry.Installer(file=str(poetry_source_file), accept_all=True)
+    installer = get_poetry.Installer(
+        version=None, file=str(poetry_source_file), accept_all=True
+    )
     installer.make_lib(None)
     assert poetry_home.is_dir()
     assert (poetry_home / "lib" / "poetry" / "__init__.py").is_file()
@@ -67,6 +69,8 @@ def test_installer_file_make_lib(poetry_home, poetry_source_file, get_poetry):
 def test_installer_file_make_lib_raises_source_file_error(
     poetry_home, poetry_source_file_bad, get_poetry
 ):
-    installer = get_poetry.Installer(file=str(poetry_source_file_bad), accept_all=True)
+    installer = get_poetry.Installer(
+        version=None, file=str(poetry_source_file_bad), accept_all=True
+    )
     with pytest.raises(get_poetry.SourceFileError):
         installer.make_lib(None)

--- a/tests/scripts/test_get_poetry.py
+++ b/tests/scripts/test_get_poetry.py
@@ -1,0 +1,72 @@
+import os
+import shutil
+
+
+try:
+    # Python 3.5+
+    import importlib.util
+except ImportError:
+    # Python 2.7
+    import imp
+try:
+    # Python 2
+    from pathlib2 import Path
+except ImportError:
+    # Python 3
+    from pathlib import Path
+
+import pytest
+
+from poetry.core.masonry.builder import Builder
+from poetry.factory import Factory
+
+
+# We need to set the poetry home environment variable prior to importing the script since it gets set once at import
+# time.
+SOURCE_HOME = Path(__file__).parent.parent.parent
+GET_POETRY_PATH = SOURCE_HOME / "get-poetry.py"
+TMP_DIR = Path(__file__).parent / "tmp"
+POETRY_HOME = TMP_DIR / ".poetry"
+os.environ["POETRY_HOME"] = str(POETRY_HOME)
+try:
+    # Python 3.5+
+    spec = importlib.util.spec_from_file_location("getpoetry", GET_POETRY_PATH)
+    getpoetry = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(getpoetry)
+except NameError:
+    # Python 2.7
+    getpoetry = imp.load_source("getpoetry", str(GET_POETRY_PATH))
+
+
+@pytest.fixture()
+def tmp_dir():
+    """
+    Use this in tests to actually set up and tear down the directory.
+    """
+    if TMP_DIR.exists():
+        shutil.rmtree(str(TMP_DIR))
+    TMP_DIR.mkdir(exist_ok=True, parents=False)
+    yield TMP_DIR
+    shutil.rmtree(str(TMP_DIR))
+
+
+@pytest.fixture()
+def poetry_home(tmp_dir):
+    return POETRY_HOME
+
+
+@pytest.fixture()
+def poetry_sdist_file(tmp_dir):
+    poetry = Factory().create_poetry(cwd=SOURCE_HOME)
+    builder = Builder(poetry)
+    builder.build("sdist")
+    dist_dir = SOURCE_HOME / "dist"
+    yield Path(next(dist_dir.glob("*.tar.gz")))
+
+
+def test_installer_file_sdist(poetry_home, poetry_sdist_file):
+    installer = getpoetry.Installer(file=str(poetry_sdist_file), accept_all=True)
+    installer.run()
+    assert poetry_home.is_dir()
+    assert (poetry_home / "bin" / "poetry").is_file()
+    assert (poetry_home / "lib" / "poetry" / "__init__.py").is_file()

--- a/tests/scripts/test_get_poetry.py
+++ b/tests/scripts/test_get_poetry.py
@@ -47,7 +47,7 @@ def poetry_source_file(tmp_dir):
 def poetry_source_file_bad(tmp_dir):
     source = Path(tmp_dir) / "fake-source"
     source.mkdir()
-    poetry_dir = source / "poetry"
+    poetry_dir = source / "foo"
     poetry_dir.mkdir()
     source_tar = Path(tmp_dir) / "fake-source-bad.tar.gz"
     tar = tarfile.open(source_tar, "w:gz")
@@ -65,9 +65,9 @@ def test_installer_file_run(poetry_home, poetry_source_file, get_poetry):
     assert (poetry_home / "lib" / "poetry" / "__init__.py").is_file()
 
 
-def test_installer_file_run_raises_file_not_found(
+def test_installer_file_run_raises_source_file_error(
     poetry_home, poetry_source_file_bad, get_poetry
 ):
     installer = get_poetry.Installer(file=str(poetry_source_file_bad), accept_all=True)
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(get_poetry.SourceFileError):
         installer.run()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3228

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This pull request does the following.

1. Improve documentation for get-poetry --file to document where the source file is to be obtained.
2. Added basic validation of the source file to make sure it contains a directory named "poetry." 
3. Added tests for get-poetry.py Installer.make_lib.

This issue was discussed earlier in PR #3239. However, this solution was determined to be preferable to adding new support for the currently unsupported sdist format.