### PR TITLE
pip installer: fix incorrect method call

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -229,7 +229,7 @@ class PipInstaller(BaseInstaller):
 
                     args.append(req)
 
-                    return self.run_pip(*args)
+                    return self.run(*args)
 
         if package.develop:
             args.append("-e")


### PR DESCRIPTION
Resolves: #3272