### PR TITLE
env: pass full path of python executable to virtualenv creation

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -730,7 +730,7 @@ class EnvManager(object):
 
                 if supported_python.allows(Version.parse(python_patch)):
                     io.write_line("Using <c1>{}</c1> ({})".format(python, python_patch))
-                    executable = python
+                    executable = shutil.which(python)
                     python_minor = ".".join(python_patch.split(".")[:2])
                     break
 

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -652,6 +652,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
         "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.7.5")),
     )
+    mocker.patch("shutil.which", return_value="/opt/bin/python3")
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
     )
@@ -660,7 +661,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
 
     m.assert_called_with(
         config_virtualenvs_path / "{}-py3.7".format(venv_name),
-        executable="python3",
+        executable="/opt/bin/python3",
         flags={"always-copy": False},
     )
 
@@ -676,6 +677,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
 
     mocker.patch("sys.version_info", (2, 7, 16))
     mocker.patch("subprocess.check_output", side_effect=["3.5.3", "3.9.0"])
+    mocker.patch("shutil.which", return_value="/opt/bin/python3.9")
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
     )
@@ -684,7 +686,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
 
     m.assert_called_with(
         config_virtualenvs_path / "{}-py3.9".format(venv_name),
-        executable="python3.9",
+        executable="/opt/bin/python3.9",
         flags={"always-copy": False},
     )
 


### PR DESCRIPTION
# Pull Request Check List

Closes #3284.

Let me know if this feels off.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Skipped docs since this is a bugfix? Also, didn't actually add tests, but rather updated the tests for create_env.
