### PR TITLE
Use per-package --index-url in export command (3269)

### DIFF
--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -29,6 +29,7 @@ class ExportCommand(Command):
             multiple=True,
         ),
         option("with-credentials", None, "Include credentials for extra indices."),
+        option("with-indexes", None, "Include --index-url per each package."),
     ]
 
     def handle(self):
@@ -71,4 +72,5 @@ class ExportCommand(Command):
             dev=self.option("dev"),
             extras=self.option("extras"),
             with_credentials=self.option("with-credentials"),
+            with_indexes=self.option("with-indexes"),
         )

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -32,6 +32,7 @@ class Exporter(object):
         dev=False,
         extras=None,
         with_credentials=False,
+        with_indexes=False,
     ):  # type: (str, Path, Union[IO, str], bool, bool, Optional[Union[bool, Sequence[str]]], bool) -> None
         if fmt not in self.ACCEPTED_FORMATS:
             raise ValueError("Invalid export format: {}".format(fmt))
@@ -43,6 +44,7 @@ class Exporter(object):
             dev=dev,
             extras=extras,
             with_credentials=with_credentials,
+            with_indexes=with_indexes,
         )
 
     def _export_requirements_txt(
@@ -53,6 +55,7 @@ class Exporter(object):
         dev=False,
         extras=None,
         with_credentials=False,
+        with_indexes=False,
     ):  # type: (Path, Union[IO, str], bool, bool, Optional[Union[bool, Sequence[str]]], bool) -> None
         indexes = set()
         content = ""
@@ -87,6 +90,8 @@ class Exporter(object):
                         line += "; {}".format(markers)
 
             if not is_direct_reference and package.source_url:
+                if with_indexes:
+                    line = f"--index-url {package.source_url} " + line
                 indexes.add(package.source_url)
 
             if package.files and with_hashes:

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -1028,6 +1028,68 @@ foo==1.2.3 \\
     assert expected == content
 
 
+def test_exporter_exports_requirements_txt_with_legacy_packages_indexes(
+    tmp_dir, poetry
+):
+    poetry.pool.add_repository(
+        LegacyRepository("custom", "https://example.com/simple",)
+    )
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                },
+                {
+                    "name": "bar",
+                    "version": "4.5.6",
+                    "category": "dev",
+                    "optional": False,
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://example.com/simple",
+                        "reference": "",
+                    },
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo": ["12345"], "bar": ["67890"]},
+            },
+        }
+    )
+    set_package_requires(poetry)
+
+    exporter = Exporter(poetry)
+
+    exporter.export(
+        "requirements.txt",
+        Path(tmp_dir),
+        "requirements.txt",
+        dev=True,
+        with_indexes=True,
+    )
+
+    with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """\
+--extra-index-url https://example.com/simple
+
+--index-url https://example.com/simple bar==4.5.6 \\
+    --hash=sha256:67890
+foo==1.2.3 \\
+    --hash=sha256:12345
+"""
+    assert expected == content
+
+
 def test_exporter_exports_requirements_txt_with_legacy_packages_trusted_host(
     tmp_dir, poetry
 ):


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3269 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Add `--with-indexes` option to the export command in order to add `--index-url` per each package.


FYI this PR is related to Hacktoberfest :)
