### PR TITLE
show --tree: stop ignoring --no-dev

### DIFF
--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -55,7 +55,9 @@ lists all packages available."""
 
         # Show tree view if requested
         if self.option("tree") and not package:
-            requires = self.poetry.package.requires + self.poetry.package.dev_requires
+            requires = self.poetry.package.requires
+            if include_dev:
+                requires += self.poetry.package.dev_requires
             packages = locked_repo.packages
             for package in packages:
                 for require in requires:

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1152,3 +1152,70 @@ cachy 0.2.0
 """
 
     assert expected == tester.io.fetch_output()
+
+
+def test_show_tree_no_dev(tester, poetry, installed):
+    poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.2.0"))
+    poetry.package.add_dependency(
+        Factory.create_dependency("pytest", "^6.1.0", category="dev")
+    )
+
+    cachy2 = get_package("cachy", "0.2.0")
+    cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
+    installed.add_package(cachy2)
+
+    pytest = get_package("pytest", "6.1.1")
+    installed.add_package(pytest)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.2.0",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"msgpack-python": ">=0.5 <0.6"},
+                },
+                {
+                    "name": "msgpack-python",
+                    "version": "0.5.1",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pytest",
+                    "version": "6.1.1",
+                    "description": "",
+                    "category": "dev",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"cachy": [], "msgpack-python": [], "pytest": []},
+            },
+        }
+    )
+
+    tester.execute("--tree --no-dev")
+
+    expected = """\
+cachy 0.2.0
+`-- msgpack-python >=0.5 <0.6
+"""
+
+    assert expected == tester.io.fetch_output()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3295

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.  -> *not applicable, since we're updating the code to match the documentation :)*

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

---

I have tested this with the `pyproject.toml` from #3295 and it behaves as intended:
```
$ poetry show --tree --no-dev  # 1.1.4
pytest 6.1.1 pytest: simple powerful testing with Python
├── atomicwrites >=1.0
├── attrs >=17.4.0
├── colorama *
├── iniconfig *
├── packaging *
│   ├── pyparsing >=2.0.2
│   └── six *
├── pluggy >=0.12,<1.0
├── py >=1.8.2
└── toml *
xarray 0.16.1 N-D labeled arrays and datasets in Python
├── numpy >=1.15
└── pandas >=0.25
    ├── numpy >=1.15.4
    ├── python-dateutil >=2.7.3
    │   └── six >=1.5
    └── pytz >=2017.2
```
```
$ ~/.bin/poetry show --tree --no-dev  # git version from this PR
xarray 0.16.1 N-D labeled arrays and datasets in Python
├── numpy >=1.15
└── pandas >=0.25
    ├── numpy >=1.15.4
    ├── python-dateutil >=2.7.3
    │   └── six >=1.5
    └── pytz >=2017.2
```

I tried adding a formal test, but I wouldn't be surprised if I did something wrong as I'm only just discovering the poetry codebase :upside_down_face:

You can run the tests on the first commit and see that it fails, and that it passes after the second commit :+1: