### PR TITLE
hash check when installing packages from cache

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -232,6 +232,7 @@ class Application(BaseApplication):  # type: ignore[misc]
         io = event.io
 
         loggers = [
+            "poetry.installation.chef",
             "poetry.packages.locker",
             "poetry.packages.package",
             "poetry.utils.password_manager",

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import io
 import os
 import re
 import shutil
@@ -156,6 +158,18 @@ def is_dir_writable(path: Path, create: bool = False) -> bool:
         return False
     else:
         return True
+
+
+def get_file_hash(filepath: Path, hash_name: str) -> str:
+    block_size = io.DEFAULT_BUFFER_SIZE
+    with open(filepath, "rb") as f:
+        res_hash = hashlib.new(hash_name)
+        while True:
+            buffer = f.read(block_size)
+            if not buffer:
+                break
+            res_hash.update(buffer)
+        return res_hash.hexdigest()
 
 
 def pluralize(count: int, word: str = "") -> str:


### PR DESCRIPTION
When installing packages, poetry uses cache to avoid redownloading files. 
If cached package file is corrupted (due to failed download, etc), poetry will not work until you delete this file from cache directory manually.

This PR adds hash check when installing packages from cache: if hash is incorrect, the file will be redownloaded.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
