### PR TITLE
Remove unused functions

### DIFF
--- a/poetry/config/config.py
+++ b/poetry/config/config.py
@@ -136,18 +136,6 @@ class Config(object):
 
         return re.sub(r"{(.+?)}", lambda m: self.get(m.group(1)), value)
 
-    def _get_validator(self, name):  # type: (str) -> Callable
-        if name in {
-            "virtualenvs.create",
-            "virtualenvs.in-project",
-            "virtualenvs.options.always-copy",
-            "installer.parallel",
-        }:
-            return boolean_validator
-
-        if name == "virtualenvs.path":
-            return str
-
     def _get_normalizer(self, name):  # type: (str) -> Callable
         if name in {
             "virtualenvs.create",

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -302,14 +302,6 @@ To remove a repository (repo is a short alias for repositories):
 
             self.line(message)
 
-    def _list_setting(self, contents, setting=None, k=None, default=None):
-        values = self._get_setting(contents, setting, k, default)
-
-        for value in values:
-            self.line(
-                "<comment>{}</comment> = <info>{}</info>".format(value[0], value[1])
-            )
-
     def _get_setting(self, contents, setting=None, k=None, default=None):
         orig_k = k
 
@@ -351,11 +343,3 @@ To remove a repository (repo is a short alias for repositories):
                 values.append(((k or "") + key, value))
 
             return values
-
-    def _get_formatted_value(self, value):
-        if isinstance(value, list):
-            value = [json.dumps(val) if isinstance(val, list) else val for val in value]
-
-            value = "[{}]".format(", ".join(value))
-
-        return json.dumps(value)

--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -47,14 +47,3 @@ class RunCommand(EnvCommand):
         ]
 
         return self.env.execute(*cmd)
-
-    @property
-    def _module(self):
-        from poetry.core.masonry.utils.module import Module
-
-        poetry = self.poetry
-        package = poetry.package
-        path = poetry.file.parent
-        module = Module(package.name, path.as_posix(), package.packages)
-
-        return module

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -257,14 +257,6 @@ class SelfUpdateCommand(Command):
 
         return "poetry-{}-{}".format(version, platform)
 
-    def _bin_path(self, base_path, bin):
-        from poetry.utils._compat import WINDOWS
-
-        if WINDOWS:
-            return (base_path / "Scripts" / bin).with_suffix(".exe")
-
-        return base_path / "bin" / bin
-
     def make_bin(self):
         from poetry.utils._compat import WINDOWS
 

--- a/poetry/mixology/version_solver.py
+++ b/poetry/mixology/version_solver.py
@@ -2,7 +2,6 @@
 import time
 
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import Dict
 from typing import List
 from typing import Union
@@ -10,8 +9,6 @@ from typing import Union
 from poetry.core.packages import Dependency
 from poetry.core.packages import Package
 from poetry.core.packages import ProjectPackage
-from poetry.core.semver import Version
-from poetry.core.semver import VersionRange
 
 from .failure import SolveFailure
 from .incompatibility import Incompatibility
@@ -422,9 +419,6 @@ class VersionSolver:
             )
 
         return dependency.complete_name
-
-    def _excludes_single_version(self, constraint):  # type: (Any) -> bool
-        return isinstance(VersionRange().difference(constraint), Version)
 
     def _result(self):  # type: () -> SolverResult
         """

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import time
 
 from contextlib import contextmanager
 from tempfile import mkdtemp
@@ -44,10 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 class Indicator(ProgressIndicator):
-    def _formatter_elapsed(self):
-        elapsed = time.time() - self._start_time
-
-        return "{:.1f}s".format(elapsed)
+    pass
 
 
 class Provider:

--- a/poetry/utils/setup_reader.py
+++ b/poetry/utils/setup_reader.py
@@ -59,14 +59,6 @@ class SetupReader(object):
 
         return result
 
-    @classmethod
-    def _is_empty_result(cls, result):  # type: (Dict[str, Any]) -> bool
-        return (
-            not result["install_requires"]
-            and not result["extras_require"]
-            and not result["python_requires"]
-        )
-
     def read_setup_py(
         self, filepath
     ):  # type: (Union[basestring, Path]) -> Dict[str, Union[List, Dict]]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3236 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

\#3236 states that some functions are defined but never used, thus this
PR remove then. While removing them, this also makes sure that there is
no trouble with:
```bash
$ poetry run pytest tests/
$ poetry run pre-commit run --all-files
```
as stated at `CONTRIBUTING.md`.

The functions removed were:

- `poetry/config/config.py`:
  + `_get_validator`

- `poetry/console/commands/config.py`:
  + `_list_setting`
  + `_get_formatted_value`

- `poetry/console/commands/run.py` :
  + `_module`

- `poetry/console/commands/self/update.py :
  + `_bin_path`

- `poetry/mixology/version_solver.py`:
  + `_excludes_single_version`

- `poetry/puzzle/provider.py`:
  + `_formatter_elapsed`

- `poetry/utils/setup_reader.py`:
  + `_is_empty_result`

By removing some of those functions Flack announced that there is no
more need to do some includes, so they were removed too:
- `poetry/mixology/version_solver.py`:
  + `from typing import Any`
  + `from poetry.core.semver import Version`
  + `from poetry.core.semver import VersionRange`
- `poetry/puzzle/provider.py`:
  + `import time`


