### PR TITLE
Raise UploadError when HTTP 308 occurs when publishing

### DIFF
--- a/poetry/publishing/uploader.py
+++ b/poetry/publishing/uploader.py
@@ -272,7 +272,7 @@ class Uploader:
                         )
                     )
                     bar.finish()
-                elif resp.status_code == 301:
+                elif resp.status_code in (301, 308):
                     if self._io.output.supports_ansi():
                         self._io.overwrite(
                             " - Uploading <c1>{0}</c1> <error>{1}</>".format(

--- a/tests/publishing/test_uploader.py
+++ b/tests/publishing/test_uploader.py
@@ -46,6 +46,18 @@ def test_uploader_properly_handles_301_redirects(http):
     )
 
 
+def test_uploader_properly_handles_308_redirects(http):
+    http.register_uri(http.POST, "https://foo.com", status=308, body="Redirect")
+    uploader = Uploader(Factory().create_poetry(project("simple_project")), NullIO())
+
+    with pytest.raises(UploadError) as e:
+        uploader.upload("https://foo.com")
+
+    assert "Redirects are not supported. Is the URL missing a trailing slash?" == str(
+        e.value
+    )
+
+
 def test_uploader_registers_for_appropriate_400_errors(mocker, http):
     register = mocker.patch("poetry.publishing.uploader.Uploader._register")
     http.register_uri(


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/742
Related PR: https://github.com/python-poetry/poetry/pull/3083

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


I was experiencing HTTP redirect errors on poetry v1.14.0, even though 301 redirects are being handled properly. It appears I was getting a 308. I have added the 308 so that it will be caught and added a new test.

@ObserverOfTime You recently worked on this as well. Could you have a look and share your thoughts?
