### PR TITLE
fix (utils.patterns): recognize one digit version in filename

### DIFF
--- a/poetry/utils/patterns.py
+++ b/poetry/utils/patterns.py
@@ -2,8 +2,11 @@ import re
 
 
 wheel_file_re = re.compile(
-    r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
-        ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
-        \.whl|\.dist-info)$""",
+    r"^(?P<namever>(?P<name>.+?)-(?P<ver>\d.*?))"
+    r"(-(?P<build>\d.*?))?"
+    r"-(?P<pyver>.+?)"
+    r"-(?P<abi>.+?)"
+    r"-(?P<plat>.+?)"
+    r"\.whl|\.dist-info$",
     re.VERBOSE,
 )

--- a/tests/utils/test_patterns.py
+++ b/tests/utils/test_patterns.py
@@ -1,0 +1,39 @@
+import pytest
+
+from poetry.utils import patterns
+
+
+@pytest.mark.parametrize(
+    ["filename", "expected"],
+    [
+        (
+            "markdown_captions-2-py3-none-any.whl",
+            {
+                "namever": "markdown_captions-2",
+                "name": "markdown_captions",
+                "ver": "2",
+                "build": None,
+                "pyver": "py3",
+                "abi": "none",
+                "plat": "any",
+            },
+        ),
+        (
+            "SQLAlchemy-1.3.20-cp27-cp27mu-manylinux2010_x86_64.whl",
+            {
+                "namever": "SQLAlchemy-1.3.20",
+                "name": "SQLAlchemy",
+                "ver": "1.3.20",
+                "build": None,
+                "pyver": "cp27",
+                "abi": "cp27mu",
+                "plat": "manylinux2010_x86_64",
+            },
+        ),
+    ],
+)
+def test_wheel_file_re(filename, expected):
+    match = patterns.wheel_file_re.match(filename)
+    groups = match.groupdict()
+
+    assert groups == expected


### PR DESCRIPTION
The current regex for wheel filename doesn't recognize one digit versions in the filename. This PR fixes this.

Furthermore the current regex makes the version part in the wheel name optional. According to PEP 491 this part is mandatory. This is fixed by this PR as well.

Feel free to provide more filenames for the tests :)

# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/3320

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
