### PR TITLE
Use configured CA certificate when downloading packages

### DIFF
--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -82,7 +82,7 @@ class Chooser:
 
         return chosen
 
-    def _get_links(self, package):  # type: (Package) -> List[Link]
+    def _get_repository(self, package):
         if not package.source_type:
             if not self._pool.has_repository("pypi"):
                 repository = self._pool.repositories[0]
@@ -90,6 +90,10 @@ class Chooser:
                 repository = self._pool.repository("pypi")
         else:
             repository = self._pool.repository(package.source_reference)
+        return repository
+
+    def _get_links(self, package):  # type: (Package) -> List[Link]
+        repository = self._get_repository(package)
 
         links = repository.find_links_for_package(package)
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: possibly #3110 #2593 #1012 (I haven't looked into the nuances)

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

It seems that #1325 tried to add support to supply custom CA certificates for custom 3rd party repositories (via `poetry config certificates.$repo.cert`).

But the implementation was incomplete: `poetry lock` properly uses the correct CA certs for custom repository access, but `poetry install` still fails with a cert error because the package download code path does not use the configured CA certificates.

This issue surfaced for us when upgrading Poetry from 1.1.3 to 1.1.4, the minor release had change #3251 that gave our custom repository priority (it was ignored previously); the root cause was challenging to track down.

This PR is a hack to make artifact downloads use configured CA file too. I wanted to submit this first to get feedback whether I'm on the right track.

Error that occurs without this patch:
```
% poetry install
Installing dependencies from lock file

Package operations: 1 install, 0 updates, 0 removals

  • Installing django (3.1.3): Pending...
Retrying HTTP request in 0.5 seconds.
Retrying HTTP request in 1.0 seconds.
Retrying HTTP request in 1.5 seconds.
Retrying HTTP request in 2.0 seconds.
  • Installing django (3.1.3): Failed

  SSLError

  HTTPSConnectionPool(host='***', port=443): Max retries exceeded with url: /api/pypi/pypi/packages/packages/7f/17/16267e782a30ea2ce08a9a452c1db285afb0ff226cfe3753f484d3d65662/Django-3.1.3-py3-none-any.whl (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1122)')))

  at /usr/local/Cellar/poetry/1.1.4/libexec/vendor/lib/python3.9/site-packages/requests/adapters.py:514 in send
      510│                 raise ProxyError(e, request=request)
      511│ 
      512│             if isinstance(e.reason, _SSLError):
      513│                 # This branch is for urllib3 v1.22 and later.
    → 514│                 raise SSLError(e, request=request)
      515│ 
      516│             raise ConnectionError(e, request=request)
      517│ 
      518│         except ClosedPoolError as e:
```
