### PR TITLE
Fixed missing space in env activation 'one-liner'

### DIFF
--- a/docs/docs/basic-usage.md
+++ b/docs/docs/basic-usage.md
@@ -120,7 +120,7 @@ To deactivate this virtual environment simply use `deactivate`.
 |-------------------|------------------------------------------------|---------------------------------------------|-----------------|
 | New Shell         | `poetry shell`                                 | `poetry shell`                              | `exit`          |
 | Manual Activation | `source {path_to_venv}/bin/activate`           | `source {path_to_venv}\Scripts\activate.bat`| `deactivate`    |
-| One-liner         | ```source`poetry env info --path`/bin/activate```|                                             | `deactivate`    |
+| One-liner         | ```source `poetry env info --path`/bin/activate```|                                             | `deactivate`    |
 
 
 ### Version constraints


### PR DESCRIPTION
`source`poetry env info --path`/bin/activate`
replaced with:
`source `poetry env info --path`/bin/activate`

Was resulting in error like:
```
`source`poetry env info --path`/bin/activate
zsh: no such file or directory: source/Users/Voltron/Library/Caches/pypoetry/virtualenvs/some-project-RqqT3xfp-py3.8/bin/activate`
```
