### PR TITLE
Account for symlinked .venv when removing

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -834,13 +834,16 @@ class EnvManager(object):
             return
         except OSError as e:
             # Continue only if e.errno == 16
-            if e.errno != 16:  # ERRNO 16: Device or resource busy
+            if (
+                e.errno != 16 and e.errno != 20
+            ):  # ERRNO 16: Device or resource busy, # ERRNO 20: Not a directory
                 raise e
 
         # Delete all files and folders but the toplevel one. This is because sometimes
-        # the venv folder is mounted by the OS, such as in a docker volume. In such
+        # the venv folder is mounted or symlinked by the OS, such as in a docker volume, codebuild, etc. In such
         # cases, an attempt to delete the folder itself will result in an `OSError`.
         # See https://github.com/python-poetry/poetry/pull/2064
+        # See https://bugs.python.org/issue1669
         for file_path in path.iterdir():
             if file_path.is_file() or file_path.is_symlink():
                 file_path.unlink()


### PR DESCRIPTION
# Pull Request Check List

Resolves: Sometimes the `.venv` is a symlink, such as in caching strategies for CI/CD environments (codebuild, etc)  
Related: https://github.com/python-poetry/poetry/pull/2064

We are already asserting the file path is a directory, so if OS Error 20 is triggered, which is "Not a directory" we simply delete everything but the top level folder.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ X] Added **tests** for changed code.
- [ X] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
