### PR TITLE
Fix installation of pyyaml

### DIFF
--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -534,16 +534,20 @@ class PackageInfo:
             info = cls.from_metadata(path)
 
             if not info or info.requires_dist is None:
+                new_info = None
                 try:
                     if disable_build:
-                        info = cls.from_setup_files(path)
+                        new_info = cls.from_setup_files(path)
                     else:
-                        info = cls._pep517_metadata(path)
+                        new_info = cls._pep517_metadata(path)
                 except PackageInfoError:
                     if not info:
                         raise
 
-                    # we discovered PkgInfo but no requirements were listed
+                if new_info:
+                    info = new_info
+                elif not info:
+                    raise PackageInfoError(path, "Exhausted all metadata sources.")
 
         info._source_type = "directory"
         info._source_url = path.as_posix()


### PR DESCRIPTION
"poetry add pyyaml==5.3.1" was failing with:
   AttributeError: 'NoneType' object has no attribute '_source_type'

pyyaml doesn't have any dependencies and various code in PackageInfo() assumes
no dependencies means looking for other sources. from_directory() didn't handle
the case where none of the sources return something and would fail like noted above.

Instead of failing use the last valid result and return it.

Resolves: #3362