### PR TITLE
update discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,4 +268,4 @@ At this point the rest of the resolution is straightforward since there is no mo
 
 * [Official Website](https://python-poetry.org)
 * [Issue Tracker](https://github.com/python-poetry/poetry/issues)
-* [Discord](https://discordapp.com/invite/awxPgve)
+* [Discord](https://discord.com/invite/awxPgve)


### PR DESCRIPTION
discordapp.com domain will go defunct very soon, everything has transitioned to discord.com now

https://support.discord.com/hc/en-us/articles/360042987951-Discordapp-com-is-now-Discord-com

fwiw I used the discord.com invite link to join the discord and it worked, so this works :)

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation**

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
^^not necessary here