### PR TITLE
utils: Fix FileNotFoundError in temporary_directory()

### DIFF
--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -48,7 +48,8 @@ def temporary_directory(*args, **kwargs):
 
     yield name
 
-    shutil.rmtree(name, onerror=_del_ro)
+    if os.path.exists(name):
+        shutil.rmtree(name, onerror=_del_ro)
 
 
 def get_cert(config, repository_name):  # type: (Config, str) -> Optional[Path]


### PR DESCRIPTION
Don't try to delete temporary directories that no longer exist.

Fixes: d22afa9d933529c01b74a6127fa41ce49bf0182b

# Pull Request Check List

This is a trivial change, and appears to be a corner case. I didn't find a matching Issue on github, and I'm not sure it's worth raising a new one.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
