### PR TITLE
Make test_installer.py test suite pass when run from any directory

### DIFF
--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1186,8 +1186,15 @@ def test_run_installs_with_local_file(
     package: ProjectPackage,
     fixture_dir: FixtureDirGetter,
 ):
+    root_dir = Path(__file__).parent.parent.parent
+    package.root_dir = root_dir
+    locker.set_lock_path(root_dir)
     file_path = fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl")
-    package.add_dependency(Factory.create_dependency("demo", {"file": str(file_path)}))
+    package.add_dependency(
+        Factory.create_dependency(
+            "demo", {"file": str(file_path.relative_to(root_dir))}, root_dir=root_dir
+        )
+    )
 
     repo.add_package(get_package("pendulum", "1.4.4"))
 
@@ -1206,10 +1213,17 @@ def test_run_installs_wheel_with_no_requires_dist(
     package: ProjectPackage,
     fixture_dir: FixtureDirGetter,
 ):
+    root_dir = Path(__file__).parent.parent.parent
+    package.root_dir = root_dir
+    locker.set_lock_path(root_dir)
     file_path = fixture_dir(
         "wheel_with_no_requires_dist/demo-0.1.0-py2.py3-none-any.whl"
     )
-    package.add_dependency(Factory.create_dependency("demo", {"file": str(file_path)}))
+    package.add_dependency(
+        Factory.create_dependency(
+            "demo", {"file": str(file_path.relative_to(root_dir))}, root_dir=root_dir
+        )
+    )
 
     installer.run()
 
@@ -1228,10 +1242,15 @@ def test_run_installs_with_local_poetry_directory_and_extras(
     tmpdir: Path,
     fixture_dir: FixtureDirGetter,
 ):
+    root_dir = Path(__file__).parent.parent.parent
+    package.root_dir = root_dir
+    locker.set_lock_path(root_dir)
     file_path = fixture_dir("project_with_extras")
     package.add_dependency(
         Factory.create_dependency(
-            "project-with-extras", {"path": str(file_path), "extras": ["extras_a"]}
+            "project-with-extras",
+            {"path": str(file_path.relative_to(root_dir)), "extras": ["extras_a"]},
+            root_dir=root_dir,
         )
     )
 
@@ -1319,9 +1338,16 @@ def test_run_installs_with_local_setuptools_directory(
     tmpdir: Path,
     fixture_dir: FixtureDirGetter,
 ):
+    root_dir = Path(__file__).parent.parent.parent
+    package.root_dir = root_dir
+    locker.set_lock_path(root_dir)
     file_path = fixture_dir("project_with_setup/")
     package.add_dependency(
-        Factory.create_dependency("project-with-setup", {"path": str(file_path)})
+        Factory.create_dependency(
+            "project-with-setup",
+            {"path": str(file_path.relative_to(root_dir))},
+            root_dir=root_dir,
+        )
     )
 
     repo.add_package(get_package("pendulum", "1.4.4"))


### PR DESCRIPTION
# Pull Request Check List

Relates-to: #3155

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- (N/A) Added **tests** for changed code.
- (N/A) Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This relates to one of the low-hanging targets outlined in #3155:

> Make test_installer.py test suite pass when run from any directory. Currently, tests expect that they be executed from the project root. There are file path comparisions that will fail since they use hard coded paths, eg: tests/fixture/dist/some.whl.

I followed the example from other tests in `test_installer.py` to ensure the paths in the resulting lockfile are relative to the project root. This involves:

- Setting `package.root_dir` to the project root
- Calling `locker.set_lock_path(root_dir)`
- Calling `.relative_to(root_dir)` on the absolute path returned by `fixture_dir`
- Passing `root_dir` to `Factory.create_dependency()`
