### PR TITLE
Remove python 2.7/3.5 compatibility code 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -626,7 +626,7 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psu
 
 [[package]]
 name = "urllib3"
-version = "1.26.2"
+version = "1.25.10"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -634,7 +634,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -688,7 +688,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "a4389e2b377905d43c47b5cb616276db55530b2ebf08afe931fb48658d8067cd"
+content-hash = "077bd512e57f2e31d9f8b72b9a8b3a918f6844afdd3c7e25c2babc7f95fdfc4e"
 
 [metadata.files]
 appdirs = [
@@ -1024,8 +1024,8 @@ tox = [
     {file = "tox-3.20.1.tar.gz", hash = "sha256:4321052bfe28f9d85082341ca8e233e3ea901fdd14dab8a5d3fbd810269fbaf6"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
-    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
+    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
+    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 virtualenv = [
     {file = "virtualenv-20.2.1-py2.py3-none-any.whl", hash = "sha256:07cff122e9d343140366055f31be4dcd61fd598c69d11cd33a9d9c8df4546dd7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,29 +16,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "20.2.0"
+version = "20.3.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
-
-[[package]]
-name = "backports.functools-lru-cache"
-version = "1.6.1"
-description = "Backport of functools.lru_cache"
-category = "dev"
-optional = false
-python-versions = ">=2.6"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov"]
 
 [[package]]
 name = "cachecontrol"
@@ -72,7 +60,7 @@ msgpack = ["msgpack-python (>=0.5,<0.6)"]
 
 [[package]]
 name = "certifi"
-version = "2020.6.20"
+version = "2020.11.8"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -126,39 +114,16 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
 crashtest = {version = ">=0.3.0,<0.4.0", markers = "python_version >= \"3.6\" and python_version < \"4.0\""}
-enum34 = {version = ">=1.1,<2.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
 pastel = ">=0.2.0,<0.3.0"
 pylev = ">=1.3,<2.0"
-typing = {version = ">=3.6,<4.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\" or python_version >= \"3.4\" and python_version < \"3.5\""}
-typing-extensions = {version = ">=3.6,<4.0", markers = "python_version >= \"3.5\" and python_full_version < \"3.5.4\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.3"
+version = "0.4.4"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "configparser"
-version = "4.0.2"
-description = "Updated configparser from Python 3.7 for Python 2.6+."
-category = "main"
-optional = false
-python-versions = ">=2.6"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2)", "pytest-flake8", "pytest-black-multipy"]
-
-[[package]]
-name = "contextlib2"
-version = "0.6.0.post1"
-description = "Backports and enhancements for the contextlib module"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "coverage"
@@ -181,7 +146,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "cryptography"
-version = "3.1.1"
+version = "3.2.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -189,16 +154,14 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.dependencies]
 cffi = ">=1.8,<1.11.3 || >1.11.3"
-enum34 = {version = "*", markers = "python_version < \"3\""}
-ipaddress = {version = "*", markers = "python_version < \"3\""}
 six = ">=1.4.1"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,<1.8.0 || >1.8.0,<3.1.0 || >3.1.0,<3.1.1 || >3.1.1)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
+test = ["pytest (>=3.6.0,!=3.9.0,!=3.9.1,!=3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
 name = "distlib"
@@ -209,60 +172,9 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "entrypoints"
-version = "0.3"
-description = "Discover and load entry points from installed packages."
-category = "main"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-configparser = {version = ">=3.5", markers = "python_version == \"2.7\""}
-
-[[package]]
-name = "enum34"
-version = "1.1.10"
-description = "Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "filelock"
 version = "3.0.12"
 description = "A platform independent file lock."
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "funcsigs"
-version = "1.0.2"
-description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "functools32"
-version = "3.2.3-2"
-description = "Backport of the functools module from Python 3.2.3 for use on 2.7 and PyPy."
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "futures"
-version = "3.3.0"
-description = "Backport of the concurrent.futures package from Python 3"
-category = "main"
-optional = false
-python-versions = ">=2.6, <3"
-
-[[package]]
-name = "glob2"
-version = "0.6"
-description = "Version of the glob module that can capture patterns and supports recursive wildcards"
 category = "main"
 optional = false
 python-versions = "*"
@@ -287,18 +199,15 @@ lxml = ["lxml"]
 
 [[package]]
 name = "httpretty"
-version = "0.9.7"
+version = "1.0.2"
 description = "HTTP client mock for Python"
 category = "dev"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = "*"
+python-versions = ">=3"
 
 [[package]]
 name = "identify"
-version = "1.5.5"
+version = "1.5.10"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -324,9 +233,6 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
-configparser = {version = ">=3.5", markers = "python_version < \"3\""}
-contextlib2 = {version = "*", markers = "python_version < \"3\""}
-pathlib2 = {version = "*", markers = "python_version < \"3\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -335,92 +241,46 @@ testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
-version = "3.0.0"
+version = "3.3.0"
 description = "Read resources from Python packages"
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
 [package.dependencies]
-contextlib2 = {version = "*", markers = "python_version < \"3\""}
-pathlib2 = {version = "*", markers = "python_version < \"3\""}
-singledispatch = {version = "*", markers = "python_version < \"3.4\""}
-typing = {version = "*", markers = "python_version < \"3.5\""}
 zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "rst.linker", "jaraco.packaging"]
 
 [[package]]
-name = "ipaddress"
-version = "1.0.23"
-description = "IPv4/IPv6 manipulation library"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "jeepney"
-version = "0.4.3"
+version = "0.6.0"
 description = "Low-level, pure Python DBus protocol wrapper."
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.extras]
-dev = ["testpath"]
+test = ["pytest", "pytest-trio", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
 name = "keyring"
-version = "18.0.1"
-description = "Store and access your passwords safely."
-category = "main"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-entrypoints = "*"
-pywin32-ctypes = {version = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1", markers = "sys_platform == \"win32\""}
-secretstorage = {version = "<3", markers = "(sys_platform == \"linux2\" or sys_platform == \"linux\") and python_version < \"3.5\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs", "pytest-flake8"]
-
-[[package]]
-name = "keyring"
-version = "20.0.1"
-description = "Store and access your passwords safely."
-category = "main"
-optional = false
-python-versions = ">=3.5"
-
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-pywin32-ctypes = {version = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1", markers = "sys_platform == \"win32\""}
-secretstorage = {version = "*", markers = "sys_platform == \"linux\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov"]
-
-[[package]]
-name = "keyring"
-version = "21.4.0"
+version = "21.5.0"
 description = "Store and access your passwords safely."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=1", markers = "python_version < \"3.8\""}
 jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
 pywin32-ctypes = {version = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1", markers = "sys_platform == \"win32\""}
-SecretStorage = {version = ">=3", markers = "sys_platform == \"linux\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black (>=0.3.7)", "pytest-cov", "pytest-mypy"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "lockfile"
@@ -431,36 +291,8 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "mock"
-version = "3.0.5"
-description = "Rolling backport of unittest.mock for all Pythons"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-funcsigs = {version = ">=1", markers = "python_version < \"3.3\""}
-six = "*"
-
-[package.extras]
-build = ["twine", "wheel", "blurb"]
-docs = ["sphinx"]
-test = ["pytest", "pytest-cov"]
-
-[[package]]
 name = "more-itertools"
-version = "5.0.0"
-description = "More routines for operating on iterables, beyond itertools"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = ">=1.0.0,<2.0.0"
-
-[[package]]
-name = "more-itertools"
-version = "8.5.0"
+version = "8.6.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
@@ -503,18 +335,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "pathlib2"
-version = "2.3.5"
-description = "Object-oriented filesystem paths"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-scandir = {version = "*", markers = "python_version < \"3.5\""}
-six = "*"
-
-[[package]]
 name = "pexpect"
 version = "4.8.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -527,7 +347,7 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "pkginfo"
-version = "1.5.0.1"
+version = "1.6.1"
 description = "Query metadatdata from sdists / bdists / installed packages."
 category = "main"
 optional = false
@@ -559,15 +379,11 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-enum34 = {version = ">=1.1.10,<2.0.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
-functools32 = {version = ">=3.2.3-2,<4.0.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
 importlib-metadata = {version = ">=1.7.0,<2.0.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\" or python_version >= \"3.5\" and python_version < \"3.8\""}
-pathlib2 = {version = ">=2.3.5,<3.0.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
-typing = {version = ">=3.7.4.1,<4.0.0.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
 
 [[package]]
 name = "pre-commit"
-version = "2.7.1"
+version = "2.9.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -625,34 +441,6 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "4.6.11"
-description = "pytest: simple powerful testing with Python"
-category = "dev"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-
-[package.dependencies]
-atomicwrites = ">=1.0"
-attrs = ">=17.4.0"
-colorama = {version = "*", markers = "sys_platform == \"win32\" and python_version != \"3.4\""}
-funcsigs = {version = ">=1.0", markers = "python_version < \"3.0\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-more-itertools = [
-    {version = ">=4.0.0,<6.0.0", markers = "python_version <= \"2.7\""},
-    {version = ">=4.0.0", markers = "python_version > \"2.7\""},
-]
-packaging = "*"
-pathlib2 = {version = ">=2.2.0", markers = "python_version < \"3.6\""}
-pluggy = ">=0.12,<1.0"
-py = ">=1.5.0"
-six = ">=1.10.0"
-wcwidth = "*"
-
-[package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "nose", "requests", "mock"]
-
-[[package]]
-name = "pytest"
 version = "5.4.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
@@ -666,13 +454,12 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 more-itertools = ">=4.0.0"
 packaging = "*"
-pathlib2 = {version = ">=2.2.0", markers = "python_version < \"3.6\""}
 pluggy = ">=0.12,<1.0"
 py = ">=1.5.0"
 wcwidth = "*"
 
 [package.extras]
-checkqa-mypy = ["mypy (v0.761)"]
+checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
@@ -688,7 +475,7 @@ coverage = ">=4.4"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-mock"
@@ -699,7 +486,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
-mock = {version = "*", markers = "python_version < \"3.0\""}
 pytest = ">=2.7"
 
 [package.extras]
@@ -736,7 +522,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "requests"
-version = "2.24.0"
+version = "2.25.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
@@ -746,11 +532,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<4"
 idna = ">=2.5,<3"
-urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -764,37 +550,15 @@ python-versions = "*"
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
-name = "scandir"
-version = "1.10.0"
-description = "scandir, a better directory iterator and faster os.walk()"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "secretstorage"
-version = "2.3.1"
-description = "Python bindings to FreeDesktop.org Secret Service API"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-cryptography = "*"
-
-[package.extras]
-dbus-python = ["dbus-python"]
-
-[[package]]
-name = "secretstorage"
-version = "3.1.2"
+version = "3.2.0"
 description = "Python bindings to FreeDesktop.org Secret Service API"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-cryptography = "*"
+cryptography = ">=2.0"
 jeepney = ">=0.4.2"
 
 [[package]]
@@ -806,31 +570,12 @@ optional = false
 python-versions = "!=3.0,!=3.1,!=3.2,!=3.3,>=2.6"
 
 [[package]]
-name = "singledispatch"
-version = "3.4.0.3"
-description = "This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3."
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = "*"
-
-[[package]]
 name = "six"
 version = "1.15.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
-name = "subprocess32"
-version = "3.5.4"
-description = "A backport of the subprocess module from Python 3 for use on 2.x."
-category = "main"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
 
 [[package]]
 name = "termcolor"
@@ -842,11 +587,11 @@ python-versions = "*"
 
 [[package]]
 name = "toml"
-version = "0.10.1"
+version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomlkit"
@@ -856,14 +601,9 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
-[package.dependencies]
-enum34 = {version = ">=1.1,<2.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
-functools32 = {version = ">=3.2.3,<4.0.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
-typing = {version = ">=3.6,<4.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\" or python_version >= \"3.4\" and python_version < \"3.5\""}
-
 [[package]]
 name = "tox"
-version = "3.20.0"
+version = "3.20.1"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
@@ -872,7 +612,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [package.dependencies]
 colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
 filelock = ">=3.0.0"
-importlib-metadata = {version = ">=0.12,<2", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=0.12,<3", markers = "python_version < \"3.8\""}
 packaging = ">=14"
 pluggy = ">=0.12.0"
 py = ">=1.4.17"
@@ -885,27 +625,8 @@ docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-a
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)"]
 
 [[package]]
-name = "typing"
-version = "3.7.4.3"
-description = "Type Hints for Python"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "typing-extensions"
-version = "3.7.4.3"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-typing = {version = ">=3.7.4", markers = "python_version < \"3.5\""}
-
-[[package]]
 name = "urllib3"
-version = "1.25.10"
+version = "1.26.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -913,12 +634,12 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.0.31"
+version = "20.2.1"
 description = "Virtual Python Environment builder"
 category = "main"
 optional = false
@@ -928,14 +649,13 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 appdirs = ">=1.4.3,<2"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
-importlib-metadata = {version = ">=0.12,<2", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
-pathlib2 = {version = ">=2.3.3,<3", markers = "python_version < \"3.4\" and sys_platform != \"win32\""}
 six = ">=1.9.0,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
-testing = ["coverage (>=5)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
 name = "wcwidth"
@@ -944,9 +664,6 @@ description = "Measures the displayed width of unicode strings in a terminal"
 category = "dev"
 optional = false
 python-versions = "*"
-
-[package.dependencies]
-"backports.functools-lru-cache" = {version = ">=1.2.1", markers = "python_version < \"3.2\""}
 
 [[package]]
 name = "webencodings"
@@ -958,23 +675,20 @@ python-versions = "*"
 
 [[package]]
 name = "zipp"
-version = "1.2.0"
+version = "3.4.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-contextlib2 = {version = "*", markers = "python_version < \"3.4\""}
+python-versions = ">=3.6"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "~2.7 || ^3.5"
-content-hash = "1e774c9d8b7f6812d721cff08b51554f9a0cd051e2ae0e884421bcb56718d131"
+python-versions = "^3.6"
+content-hash = "a4389e2b377905d43c47b5cb616276db55530b2ebf08afe931fb48658d8067cd"
 
 [metadata.files]
 appdirs = [
@@ -986,12 +700,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
-    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
-]
-"backports.functools-lru-cache" = [
-    {file = "backports.functools_lru_cache-1.6.1-py2.py3-none-any.whl", hash = "sha256:0bada4c2f8a43d533e4ecb7a12214d9420e66eb206d54bf2d682581ca4b80848"},
-    {file = "backports.functools_lru_cache-1.6.1.tar.gz", hash = "sha256:8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a"},
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 cachecontrol = [
     {file = "CacheControl-0.12.6-py2.py3-none-any.whl", hash = "sha256:10d056fa27f8563a271b345207402a6dcce8efab7e5b377e270329c62471b10d"},
@@ -1002,8 +712,8 @@ cachy = [
     {file = "cachy-0.3.0.tar.gz", hash = "sha256:186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1"},
 ]
 certifi = [
-    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
-    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
+    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 cffi = [
     {file = "cffi-1.14.3-2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3eeeb0405fd145e714f7633a5173318bd88d8bbfc3dd0a5751f8c4f70ae629bc"},
@@ -1060,16 +770,8 @@ clikit = [
     {file = "clikit-0.6.2.tar.gz", hash = "sha256:442ee5db9a14120635c5990bcdbfe7c03ada5898291f0c802f77be71569ded59"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
-]
-configparser = [
-    {file = "configparser-4.0.2-py2.py3-none-any.whl", hash = "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c"},
-    {file = "configparser-4.0.2.tar.gz", hash = "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"},
-]
-contextlib2 = [
-    {file = "contextlib2-0.6.0.post1-py2.py3-none-any.whl", hash = "sha256:3355078a159fbb44ee60ea80abd0d87b80b78c248643b49aa6d94673b413609b"},
-    {file = "contextlib2-0.6.0.post1.tar.gz", hash = "sha256:01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
     {file = "coverage-5.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270"},
@@ -1112,71 +814,47 @@ crashtest = [
     {file = "crashtest-0.3.1.tar.gz", hash = "sha256:42ca7b6ce88b6c7433e2ce47ea884e91ec93104a4b754998be498a8e6c3d37dd"},
 ]
 cryptography = [
-    {file = "cryptography-3.1.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:65beb15e7f9c16e15934569d29fb4def74ea1469d8781f6b3507ab896d6d8719"},
-    {file = "cryptography-3.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:983c0c3de4cb9fcba68fd3f45ed846eb86a2a8b8d8bc5bb18364c4d00b3c61fe"},
-    {file = "cryptography-3.1.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:e97a3b627e3cb63c415a16245d6cef2139cca18bb1183d1b9375a1c14e83f3b3"},
-    {file = "cryptography-3.1.1-cp27-cp27m-win32.whl", hash = "sha256:cb179acdd4ae1e4a5a160d80b87841b3d0e0be84af46c7bb2cd7ece57a39c4ba"},
-    {file = "cryptography-3.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:b372026ebf32fe2523159f27d9f0e9f485092e43b00a5adacf732192a70ba118"},
-    {file = "cryptography-3.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:680da076cad81cdf5ffcac50c477b6790be81768d30f9da9e01960c4b18a66db"},
-    {file = "cryptography-3.1.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:5d52c72449bb02dd45a773a203196e6d4fae34e158769c896012401f33064396"},
-    {file = "cryptography-3.1.1-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:f0e099fc4cc697450c3dd4031791559692dd941a95254cb9aeded66a7aa8b9bc"},
-    {file = "cryptography-3.1.1-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:a7597ffc67987b37b12e09c029bd1dc43965f75d328076ae85721b84046e9ca7"},
-    {file = "cryptography-3.1.1-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:4549b137d8cbe3c2eadfa56c0c858b78acbeff956bd461e40000b2164d9167c6"},
-    {file = "cryptography-3.1.1-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:89aceb31cd5f9fc2449fe8cf3810797ca52b65f1489002d58fe190bfb265c536"},
-    {file = "cryptography-3.1.1-cp35-cp35m-win32.whl", hash = "sha256:559d622aef2a2dff98a892eef321433ba5bc55b2485220a8ca289c1ecc2bd54f"},
-    {file = "cryptography-3.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:451cdf60be4dafb6a3b78802006a020e6cd709c22d240f94f7a0696240a17154"},
-    {file = "cryptography-3.1.1-cp36-abi3-win32.whl", hash = "sha256:762bc5a0df03c51ee3f09c621e1cee64e3a079a2b5020de82f1613873d79ee70"},
-    {file = "cryptography-3.1.1-cp36-abi3-win_amd64.whl", hash = "sha256:b12e715c10a13ca1bd27fbceed9adc8c5ff640f8e1f7ea76416352de703523c8"},
-    {file = "cryptography-3.1.1-cp36-cp36m-win32.whl", hash = "sha256:21b47c59fcb1c36f1113f3709d37935368e34815ea1d7073862e92f810dc7499"},
-    {file = "cryptography-3.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:48ee615a779ffa749d7d50c291761dc921d93d7cf203dca2db663b4f193f0e49"},
-    {file = "cryptography-3.1.1-cp37-cp37m-win32.whl", hash = "sha256:b2bded09c578d19e08bd2c5bb8fed7f103e089752c9cf7ca7ca7de522326e921"},
-    {file = "cryptography-3.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f99317a0fa2e49917689b8cf977510addcfaaab769b3f899b9c481bbd76730c2"},
-    {file = "cryptography-3.1.1-cp38-cp38-win32.whl", hash = "sha256:ab010e461bb6b444eaf7f8c813bb716be2d78ab786103f9608ffd37a4bd7d490"},
-    {file = "cryptography-3.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:99d4984aabd4c7182050bca76176ce2dbc9fa9748afe583a7865c12954d714ba"},
-    {file = "cryptography-3.1.1.tar.gz", hash = "sha256:9d9fc6a16357965d282dd4ab6531013935425d0dc4950df2e0cf2a1b1ac1017d"},
+    {file = "cryptography-3.2.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:6dc59630ecce8c1f558277ceb212c751d6730bd12c80ea96b4ac65637c4f55e7"},
+    {file = "cryptography-3.2.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:75e8e6684cf0034f6bf2a97095cb95f81537b12b36a8fedf06e73050bb171c2d"},
+    {file = "cryptography-3.2.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4e7268a0ca14536fecfdf2b00297d4e407da904718658c1ff1961c713f90fd33"},
+    {file = "cryptography-3.2.1-cp27-cp27m-win32.whl", hash = "sha256:7117319b44ed1842c617d0a452383a5a052ec6aa726dfbaffa8b94c910444297"},
+    {file = "cryptography-3.2.1-cp27-cp27m-win_amd64.whl", hash = "sha256:a733671100cd26d816eed39507e585c156e4498293a907029969234e5e634bc4"},
+    {file = "cryptography-3.2.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:a75f306a16d9f9afebfbedc41c8c2351d8e61e818ba6b4c40815e2b5740bb6b8"},
+    {file = "cryptography-3.2.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:5849d59358547bf789ee7e0d7a9036b2d29e9a4ddf1ce5e06bb45634f995c53e"},
+    {file = "cryptography-3.2.1-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:bd717aa029217b8ef94a7d21632a3bb5a4e7218a4513d2521c2a2fd63011e98b"},
+    {file = "cryptography-3.2.1-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:efe15aca4f64f3a7ea0c09c87826490e50ed166ce67368a68f315ea0807a20df"},
+    {file = "cryptography-3.2.1-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:32434673d8505b42c0de4de86da8c1620651abd24afe91ae0335597683ed1b77"},
+    {file = "cryptography-3.2.1-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:7b8d9d8d3a9bd240f453342981f765346c87ade811519f98664519696f8e6ab7"},
+    {file = "cryptography-3.2.1-cp35-cp35m-win32.whl", hash = "sha256:d3545829ab42a66b84a9aaabf216a4dce7f16dbc76eb69be5c302ed6b8f4a29b"},
+    {file = "cryptography-3.2.1-cp35-cp35m-win_amd64.whl", hash = "sha256:a4e27ed0b2504195f855b52052eadcc9795c59909c9d84314c5408687f933fc7"},
+    {file = "cryptography-3.2.1-cp36-abi3-win32.whl", hash = "sha256:13b88a0bd044b4eae1ef40e265d006e34dbcde0c2f1e15eb9896501b2d8f6c6f"},
+    {file = "cryptography-3.2.1-cp36-abi3-win_amd64.whl", hash = "sha256:07ca431b788249af92764e3be9a488aa1d39a0bc3be313d826bbec690417e538"},
+    {file = "cryptography-3.2.1-cp36-cp36m-win32.whl", hash = "sha256:a035a10686532b0587d58a606004aa20ad895c60c4d029afa245802347fab57b"},
+    {file = "cryptography-3.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:d26a2557d8f9122f9bf445fc7034242f4375bd4e95ecda007667540270965b13"},
+    {file = "cryptography-3.2.1-cp37-cp37m-win32.whl", hash = "sha256:545a8550782dda68f8cdc75a6e3bf252017aa8f75f19f5a9ca940772fc0cb56e"},
+    {file = "cryptography-3.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:55d0b896631412b6f0c7de56e12eb3e261ac347fbaa5d5e705291a9016e5f8cb"},
+    {file = "cryptography-3.2.1-cp38-cp38-win32.whl", hash = "sha256:3cd75a683b15576cfc822c7c5742b3276e50b21a06672dc3a800a2d5da4ecd1b"},
+    {file = "cryptography-3.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:d25cecbac20713a7c3bc544372d42d8eafa89799f492a43b79e1dfd650484851"},
+    {file = "cryptography-3.2.1.tar.gz", hash = "sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3"},
 ]
 distlib = [
     {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
     {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
 ]
-entrypoints = [
-    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
-    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
-]
-enum34 = [
-    {file = "enum34-1.1.10-py2-none-any.whl", hash = "sha256:a98a201d6de3f2ab3db284e70a33b0f896fbf35f8086594e8c9e74b909058d53"},
-    {file = "enum34-1.1.10-py3-none-any.whl", hash = "sha256:c3858660960c984d6ab0ebad691265180da2b43f07e061c0f8dca9ef3cffd328"},
-    {file = "enum34-1.1.10.tar.gz", hash = "sha256:cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248"},
-]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
-]
-funcsigs = [
-    {file = "funcsigs-1.0.2-py2.py3-none-any.whl", hash = "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca"},
-    {file = "funcsigs-1.0.2.tar.gz", hash = "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"},
-]
-functools32 = [
-    {file = "functools32-3.2.3-2.tar.gz", hash = "sha256:f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"},
-    {file = "functools32-3.2.3-2.zip", hash = "sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0"},
-]
-futures = [
-    {file = "futures-3.3.0-py2-none-any.whl", hash = "sha256:49b3f5b064b6e3afc3316421a3f25f66c137ae88f068abbf72830170033c5e16"},
-    {file = "futures-3.3.0.tar.gz", hash = "sha256:7e033af76a5e35f58e56da7a91e687706faf4e7bdfb2cbc3f2cca6b9bcda9794"},
-]
-glob2 = [
-    {file = "glob2-0.6.tar.gz", hash = "sha256:f5b0a686ff21f820c4d3f0c4edd216704cea59d79d00fa337e244a2f2ff83ed6"},
 ]
 html5lib = [
     {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
     {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
 ]
 httpretty = [
-    {file = "httpretty-0.9.7.tar.gz", hash = "sha256:66216f26b9d2c52e81808f3e674a6fb65d4bf719721394a1a9be926177e55fbe"},
+    {file = "httpretty-1.0.2.tar.gz", hash = "sha256:24a6fd2fe1c76e94801b74db8f52c0fb42718dc4a199a861b305b1a492b9d868"},
 ]
 identify = [
-    {file = "identify-1.5.5-py2.py3-none-any.whl", hash = "sha256:da683bfb7669fa749fc7731f378229e2dbf29a1d1337cbde04106f02236eb29d"},
-    {file = "identify-1.5.5.tar.gz", hash = "sha256:7c22c384a2c9b32c5cc891d13f923f6b2653aa83e2d75d8f79be240d6c86c4f4"},
+    {file = "identify-1.5.10-py2.py3-none-any.whl", hash = "sha256:cc86e6a9a390879dcc2976cef169dd9cc48843ed70b7380f321d1b118163c60e"},
+    {file = "identify-1.5.10.tar.gz", hash = "sha256:943cd299ac7f5715fcb3f684e2fc1594c1e0f22a90d15398e5888143bd4144b5"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1187,39 +865,24 @@ importlib-metadata = [
     {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-3.0.0-py2.py3-none-any.whl", hash = "sha256:d028f66b66c0d5732dae86ba4276999855e162a749c92620a38c1d779ed138a7"},
-    {file = "importlib_resources-3.0.0.tar.gz", hash = "sha256:19f745a6eca188b490b1428c8d1d4a0d2368759f32370ea8fb89cad2ab1106c3"},
-]
-ipaddress = [
-    {file = "ipaddress-1.0.23-py2.py3-none-any.whl", hash = "sha256:6e0f4a39e66cb5bb9a137b00276a2eff74f93b71dcbdad6f10ff7df9d3557fcc"},
-    {file = "ipaddress-1.0.23.tar.gz", hash = "sha256:b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2"},
+    {file = "importlib_resources-3.3.0-py2.py3-none-any.whl", hash = "sha256:a3d34a8464ce1d5d7c92b0ea4e921e696d86f2aa212e684451cb1482c8d84ed5"},
+    {file = "importlib_resources-3.3.0.tar.gz", hash = "sha256:7b51f0106c8ec564b1bef3d9c588bc694ce2b92125bbb6278f4f2f5b54ec3592"},
 ]
 jeepney = [
-    {file = "jeepney-0.4.3-py3-none-any.whl", hash = "sha256:d6c6b49683446d2407d2fe3acb7a368a77ff063f9182fe427da15d622adc24cf"},
-    {file = "jeepney-0.4.3.tar.gz", hash = "sha256:3479b861cc2b6407de5188695fa1a8d57e5072d7059322469b62628869b8e36e"},
+    {file = "jeepney-0.6.0-py3-none-any.whl", hash = "sha256:aec56c0eb1691a841795111e184e13cad504f7703b9a64f63020816afa79a8ae"},
+    {file = "jeepney-0.6.0.tar.gz", hash = "sha256:7d59b6622675ca9e993a6bd38de845051d315f8b0c72cca3aef733a20b648657"},
 ]
 keyring = [
-    {file = "keyring-18.0.1-py2.py3-none-any.whl", hash = "sha256:7b29ebfcf8678c4da531b2478a912eea01e80007e5ddca9ee0c7038cb3489ec6"},
-    {file = "keyring-18.0.1.tar.gz", hash = "sha256:67d6cc0132bd77922725fae9f18366bb314fd8f95ff4d323a4df41890a96a838"},
-    {file = "keyring-20.0.1-py2.py3-none-any.whl", hash = "sha256:c674f032424b4bffc62abeac5523ec49cc84aed07a480c3233e0baf618efc15c"},
-    {file = "keyring-20.0.1.tar.gz", hash = "sha256:963bfa7f090269d30bdc5e25589e5fd9dad2cf2a7c6f176a7f2386910e5d0d8d"},
-    {file = "keyring-21.4.0-py3-none-any.whl", hash = "sha256:4e34ea2fdec90c1c43d6610b5a5fafa1b9097db1802948e90caf5763974b8f8d"},
-    {file = "keyring-21.4.0.tar.gz", hash = "sha256:9aeadd006a852b78f4b4ef7c7556c2774d2432bbef8ee538a3e9089ac8b11466"},
+    {file = "keyring-21.5.0-py3-none-any.whl", hash = "sha256:12de23258a95f3b13e5b167f7a641a878e91eab8ef16fafc077720a95e6115bb"},
+    {file = "keyring-21.5.0.tar.gz", hash = "sha256:207bd66f2a9881c835dad653da04e196c678bf104f8252141d2d3c4f31051579"},
 ]
 lockfile = [
     {file = "lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa"},
     {file = "lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"},
 ]
-mock = [
-    {file = "mock-3.0.5-py2.py3-none-any.whl", hash = "sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"},
-    {file = "mock-3.0.5.tar.gz", hash = "sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3"},
-]
 more-itertools = [
-    {file = "more-itertools-5.0.0.tar.gz", hash = "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4"},
-    {file = "more_itertools-5.0.0-py2-none-any.whl", hash = "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc"},
-    {file = "more_itertools-5.0.0-py3-none-any.whl", hash = "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"},
-    {file = "more-itertools-8.5.0.tar.gz", hash = "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20"},
-    {file = "more_itertools-8.5.0-py3-none-any.whl", hash = "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"},
+    {file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"},
+    {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
 ]
 msgpack = [
     {file = "msgpack-1.0.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:cec8bf10981ed70998d98431cd814db0ecf3384e6b113366e7f36af71a0fca08"},
@@ -1253,17 +916,13 @@ pastel = [
     {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
     {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
 ]
-pathlib2 = [
-    {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
-    {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
-]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
     {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
 ]
 pkginfo = [
-    {file = "pkginfo-1.5.0.1-py2.py3-none-any.whl", hash = "sha256:a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32"},
-    {file = "pkginfo-1.5.0.1.tar.gz", hash = "sha256:7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb"},
+    {file = "pkginfo-1.6.1-py2.py3-none-any.whl", hash = "sha256:ce14d7296c673dc4c61c759a0b6c14bae34e34eb819c0017bb6ca5b7292c56e9"},
+    {file = "pkginfo-1.6.1.tar.gz", hash = "sha256:a6a4ac943b496745cec21f14f021bbd869d5e9b4f6ec06918cffea5a2f4b9193"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -1274,8 +933,8 @@ poetry-core = [
     {file = "poetry_core-1.0.0-py2.py3-none-any.whl", hash = "sha256:769288e0e1b88dfcceb3185728f0b7388b26d5f93d6c22d2dcae372da51d200d"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.7.1-py2.py3-none-any.whl", hash = "sha256:810aef2a2ba4f31eed1941fc270e72696a1ad5590b9751839c90807d0fff6b9a"},
-    {file = "pre_commit-2.7.1.tar.gz", hash = "sha256:c54fd3e574565fe128ecc5e7d2f91279772ddb03f8729645fa812fe809084a70"},
+    {file = "pre_commit-2.9.0-py2.py3-none-any.whl", hash = "sha256:4aee0db4808fa48d2458cedd5b9a084ef24dda1a0fa504432a11977a4d1cfd0a"},
+    {file = "pre_commit-2.9.0.tar.gz", hash = "sha256:b2d106d51c6ba6217e859d81774aae33fd825fe7de0dcf0c46e2586333d7a92e"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.6.0-py2.py3-none-any.whl", hash = "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"},
@@ -1298,8 +957,6 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-4.6.11-py2.py3-none-any.whl", hash = "sha256:a00a7d79cbbdfa9d21e7d0298392a8dd4123316bfac545075e6f8f24c94d8c97"},
-    {file = "pytest-4.6.11.tar.gz", hash = "sha256:50fa82392f2120cc3ec2ca0a75ee615be4c479e66669789771f1758332be4353"},
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
 ]
@@ -1332,78 +989,47 @@ pyyaml = [
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 requests = [
-    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
-    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+    {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
+    {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
 ]
 requests-toolbelt = [
     {file = "requests-toolbelt-0.9.1.tar.gz", hash = "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"},
     {file = "requests_toolbelt-0.9.1-py2.py3-none-any.whl", hash = "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f"},
 ]
-scandir = [
-    {file = "scandir-1.10.0-cp27-cp27m-win32.whl", hash = "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"},
-    {file = "scandir-1.10.0-cp27-cp27m-win_amd64.whl", hash = "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"},
-    {file = "scandir-1.10.0-cp34-cp34m-win32.whl", hash = "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f"},
-    {file = "scandir-1.10.0-cp34-cp34m-win_amd64.whl", hash = "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e"},
-    {file = "scandir-1.10.0-cp35-cp35m-win32.whl", hash = "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f"},
-    {file = "scandir-1.10.0-cp35-cp35m-win_amd64.whl", hash = "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32"},
-    {file = "scandir-1.10.0-cp36-cp36m-win32.whl", hash = "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022"},
-    {file = "scandir-1.10.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4"},
-    {file = "scandir-1.10.0-cp37-cp37m-win32.whl", hash = "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173"},
-    {file = "scandir-1.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d"},
-    {file = "scandir-1.10.0.tar.gz", hash = "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"},
-]
 secretstorage = [
-    {file = "SecretStorage-2.3.1.tar.gz", hash = "sha256:3af65c87765323e6f64c83575b05393f9e003431959c9395d1791d51497f29b6"},
-    {file = "SecretStorage-3.1.2-py3-none-any.whl", hash = "sha256:b5ec909dde94d4ae2fa26af7c089036997030f0cf0a5cb372b4cccabd81c143b"},
-    {file = "SecretStorage-3.1.2.tar.gz", hash = "sha256:15da8a989b65498e29be338b3b279965f1b8f09b9668bd8010da183024c8bff6"},
+    {file = "SecretStorage-3.2.0-py3-none-any.whl", hash = "sha256:ed5279d788af258e4676fa26b6efb6d335a31f1f9f529b6f1e200f388fac33e1"},
+    {file = "SecretStorage-3.2.0.tar.gz", hash = "sha256:46305c3847ee3f7252b284e0eee5590fa6341c891104a2fd2313f8798c615a82"},
 ]
 shellingham = [
     {file = "shellingham-1.3.2-py2.py3-none-any.whl", hash = "sha256:7f6206ae169dc1a03af8a138681b3f962ae61cc93ade84d0585cca3aaf770044"},
     {file = "shellingham-1.3.2.tar.gz", hash = "sha256:576c1982bea0ba82fb46c36feb951319d7f42214a82634233f58b40d858a751e"},
 ]
-singledispatch = [
-    {file = "singledispatch-3.4.0.3-py2.py3-none-any.whl", hash = "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"},
-    {file = "singledispatch-3.4.0.3.tar.gz", hash = "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c"},
-]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
-]
-subprocess32 = [
-    {file = "subprocess32-3.5.4-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:88e37c1aac5388df41cc8a8456bb49ebffd321a3ad4d70358e3518176de3a56b"},
-    {file = "subprocess32-3.5.4.tar.gz", hash = "sha256:eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
 toml = [
-    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
-    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomlkit = [
     {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
     {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
 ]
 tox = [
-    {file = "tox-3.20.0-py2.py3-none-any.whl", hash = "sha256:e6318f404aff16522ff5211c88cab82b39af121735a443674e4e2e65f4e4637b"},
-    {file = "tox-3.20.0.tar.gz", hash = "sha256:eb629ddc60e8542fd4a1956b2462e3b8771d49f1ff630cecceacaa0fbfb7605a"},
-]
-typing = [
-    {file = "typing-3.7.4.3-py2-none-any.whl", hash = "sha256:283d868f5071ab9ad873e5e52268d611e851c870a2ba354193026f2dfb29d8b5"},
-    {file = "typing-3.7.4.3.tar.gz", hash = "sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9"},
-]
-typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "tox-3.20.1-py2.py3-none-any.whl", hash = "sha256:42ce19ce5dc2f6d6b1fdc5666c476e1f1e2897359b47e0aa3a5b774f335d57c2"},
+    {file = "tox-3.20.1.tar.gz", hash = "sha256:4321052bfe28f9d85082341ca8e233e3ea901fdd14dab8a5d3fbd810269fbaf6"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
-    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
+    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
+    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.31-py2.py3-none-any.whl", hash = "sha256:e0305af10299a7fb0d69393d8f04cb2965dda9351140d11ac8db4e5e3970451b"},
-    {file = "virtualenv-20.0.31.tar.gz", hash = "sha256:43add625c53c596d38f971a465553f6318decc39d98512bc100fa1b1e839c8dc"},
+    {file = "virtualenv-20.2.1-py2.py3-none-any.whl", hash = "sha256:07cff122e9d343140366055f31be4dcd61fd598c69d11cd33a9d9c8df4546dd7"},
+    {file = "virtualenv-20.2.1.tar.gz", hash = "sha256:e0aac7525e880a429764cefd3aaaff54afb5d9f25c82627563603f5d7de5a6e5"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
@@ -1414,6 +1040,6 @@ webencodings = [
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 zipp = [
-    {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},
-    {file = "zipp-1.2.0.tar.gz", hash = "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1"},
+    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
+    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
 ]

--- a/poetry/config/config.py
+++ b/poetry/config/config.py
@@ -4,14 +4,13 @@ import os
 import re
 
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Optional
 
 from poetry.locations import CACHE_DIR
-from poetry.utils._compat import Path
-from poetry.utils._compat import basestring
 
 from .config_source import ConfigSource
 from .dict_config_source import DictConfigSource
@@ -131,7 +130,7 @@ class Config(object):
         return self.process(value)
 
     def process(self, value):  # type: (Any) -> Any
-        if not isinstance(value, basestring):
+        if not isinstance(value, str):
             return value
 
         return re.sub(r"{(.+?)}", lambda m: self.get(m.group(1)), value)

--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -60,8 +60,9 @@ class Application(BaseApplication):
 
     @property
     def poetry(self):
+        from pathlib import Path
+
         from poetry.factory import Factory
-        from poetry.utils._compat import Path
 
         if self._poetry is not None:
             return self._poetry

--- a/poetry/console/commands/check.py
+++ b/poetry/console/commands/check.py
@@ -1,6 +1,7 @@
+from pathlib import Path
+
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.factory import Factory
-from poetry.utils._compat import Path
 
 from .command import Command
 

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -41,10 +41,11 @@ To remove a repository (repo is a short alias for repositories):
 
     @property
     def unique_config_values(self):
+        from pathlib import Path
+
         from poetry.config.config import boolean_normalizer
         from poetry.config.config import boolean_validator
         from poetry.locations import CACHE_DIR
-        from poetry.utils._compat import Path
 
         unique_config_values = {
             "cache-dir": (
@@ -75,10 +76,10 @@ To remove a repository (repo is a short alias for repositories):
         return unique_config_values
 
     def handle(self):
+        from pathlib import Path
+
         from poetry.config.file_config_source import FileConfigSource
         from poetry.locations import CONFIG_DIR
-        from poetry.utils._compat import Path
-        from poetry.utils._compat import basestring
 
         config = Factory.create_config(self.io)
         config_file = TOMLFile(Path(CONFIG_DIR) / "config.toml")
@@ -134,7 +135,7 @@ To remove a repository (repo is a short alias for repositories):
 
                 value = config.get(setting_key)
 
-                if not isinstance(value, basestring):
+                if not isinstance(value, str):
                     value = json.dumps(value)
 
                 self.line(value)
@@ -267,8 +268,6 @@ To remove a repository (repo is a short alias for repositories):
         return 0
 
     def _list_configuration(self, config, raw, k=""):
-        from poetry.utils._compat import basestring
-
         orig_k = k
         for key, value in sorted(config.items()):
             if k + key in self.LIST_PROHIBITED_SETTINGS:
@@ -293,7 +292,7 @@ To remove a repository (repo is a short alias for repositories):
                 message = "<c1>{}</c1> = <c2>{}</c2>".format(
                     k + key, json.dumps(raw_val)
                 )
-            elif isinstance(raw_val, basestring) and raw_val != value:
+            elif isinstance(raw_val, str) and raw_val != value:
                 message = "<c1>{}</c1> = <c2>{}</c2>  # {}".format(
                     k + key, json.dumps(raw_val), value
                 )

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 import os
 import re
 import sys
+import urllib.parse
 
+from pathlib import Path
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -15,9 +17,6 @@ from tomlkit import inline_table
 
 from poetry.core.pyproject import PyProjectException
 from poetry.core.pyproject.toml import PyProjectTOML
-from poetry.utils._compat import OrderedDict
-from poetry.utils._compat import Path
-from poetry.utils._compat import urlparse
 
 from .command import Command
 from .env_command import EnvCommand
@@ -63,9 +62,10 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         self._pool = None
 
     def handle(self):
+        from pathlib import Path
+
         from poetry.core.vcs.git import GitConfig
         from poetry.layouts import layout
-        from poetry.utils._compat import Path
         from poetry.utils.env import SystemEnv
 
         pyproject = PyProjectTOML(Path.cwd() / "pyproject.toml")
@@ -390,7 +390,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 extras = [e.strip() for e in extras_m.group(1).split(",")]
                 requirement, _ = requirement.split("[")
 
-            url_parsed = urlparse.urlparse(requirement)
+            url_parsed = urllib.parse.urlparse(requirement)
             if url_parsed.scheme and url_parsed.netloc:
                 # Url
                 if url_parsed.scheme in ["git+https", "git+ssh"]:
@@ -400,7 +400,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     parsed = ParsedUrl.parse(requirement)
                     url = Git.normalize_url(requirement)
 
-                    pair = OrderedDict([("name", parsed.name), ("git", url.url)])
+                    pair = dict([("name", parsed.name), ("git", url.url)])
                     if parsed.rev:
                         pair["rev"] = url.revision
 
@@ -417,9 +417,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 elif url_parsed.scheme in ["http", "https"]:
                     package = Provider.get_package_from_url(requirement)
 
-                    pair = OrderedDict(
-                        [("name", package.name), ("url", package.source_url)]
-                    )
+                    pair = dict([("name", package.name), ("url", package.source_url)])
                     if extras:
                         pair["extras"] = extras
 
@@ -435,7 +433,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     package = Provider.get_package_from_directory(path)
 
                 result.append(
-                    OrderedDict(
+                    dict(
                         [
                             ("name", package.name),
                             ("path", path.relative_to(cwd).as_posix()),
@@ -451,7 +449,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             )
             pair = pair.strip()
 
-            require = OrderedDict()
+            require = dict()
             if " " in pair:
                 name, version = pair.split(" ", 2)
                 extras_m = re.search(r"\[([\w\d,-_]+)\]$", name)

--- a/poetry/console/commands/new.py
+++ b/poetry/console/commands/new.py
@@ -20,10 +20,11 @@ class NewCommand(Command):
     ]
 
     def handle(self):
+        from pathlib import Path
+
         from poetry.core.semver import parse_constraint
         from poetry.core.vcs.git import GitConfig
         from poetry.layouts import layout
-        from poetry.utils._compat import Path
         from poetry.utils.env import SystemEnv
 
         if self.option("src"):

--- a/poetry/console/commands/publish.py
+++ b/poetry/console/commands/publish.py
@@ -1,6 +1,6 @@
-from cleo import option
+from pathlib import Path
 
-from poetry.utils._compat import Path
+from cleo import option
 
 from .command import Command
 

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -62,7 +62,7 @@ class SelfUpdateCommand(Command):
 
     @property
     def home(self):
-        from poetry.utils._compat import Path
+        from pathlib import Path
 
         return Path(os.environ.get("POETRY_HOME", "~/.poetry")).expanduser()
 
@@ -239,7 +239,7 @@ class SelfUpdateCommand(Command):
         return subprocess.check_output(list(args), stderr=subprocess.STDOUT)
 
     def _check_recommended_installation(self):
-        from poetry.utils._compat import Path
+        from pathlib import Path
 
         current = Path(__file__)
         try:

--- a/poetry/console/config/application_config.py
+++ b/poetry/console/config/application_config.py
@@ -30,7 +30,7 @@ from poetry.console.commands.env_command import EnvCommand
 from poetry.console.commands.installer_command import InstallerCommand
 from poetry.console.logging.io_formatter import IOFormatter
 from poetry.console.logging.io_handler import IOHandler
-from poetry.utils._compat import PY36
+from poetry.mixology.solutions.providers import PythonRequirementSolutionProvider
 
 
 class ApplicationConfig(BaseApplicationConfig):
@@ -55,14 +55,9 @@ class ApplicationConfig(BaseApplicationConfig):
         self.add_event_listener(PRE_HANDLE, self.set_env)
         self.add_event_listener(PRE_HANDLE, self.set_installer)
 
-        if PY36:
-            from poetry.mixology.solutions.providers import (
-                PythonRequirementSolutionProvider,
-            )
-
-            self._solution_provider_repository.register_solution_providers(
-                [PythonRequirementSolutionProvider]
-            )
+        self._solution_provider_repository.register_solution_providers(
+            [PythonRequirementSolutionProvider]
+        )
 
     def register_command_loggers(
         self, event, event_name, _

--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from pathlib import Path
 from typing import Dict
 from typing import Optional
 
@@ -16,7 +17,6 @@ from .locations import CONFIG_DIR
 from .packages.locker import Locker
 from .poetry import Poetry
 from .repositories.pypi_repository import PyPiRepository
-from .utils._compat import Path
 
 
 class Factory(BaseFactory):

--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -4,6 +4,7 @@ import os
 import tarfile
 import zipfile
 
+from pathlib import Path
 from typing import Dict
 from typing import Iterator
 from typing import List
@@ -17,8 +18,6 @@ from poetry.core.packages import Package
 from poetry.core.packages import ProjectPackage
 from poetry.core.packages import dependency_from_pep_508
 from poetry.core.pyproject.toml import PyProjectTOML
-from poetry.core.utils._compat import PY35
-from poetry.core.utils._compat import Path
 from poetry.core.utils.helpers import parse_requires
 from poetry.core.utils.helpers import temporary_directory
 from poetry.core.version.markers import InvalidMarker
@@ -364,13 +363,10 @@ class PackageInfo:
         :param path: Path to search.
         """
         pattern = "**/*.*-info"
-        if PY35:
-            # Sometimes pathlib will fail on recursive symbolic links, so we need to workaround it
-            # and use the glob module instead. Note that this does not happen with pathlib2
-            # so it's safe to use it for Python < 3.4.
-            directories = glob.iglob(path.joinpath(pattern).as_posix(), recursive=True)
-        else:
-            directories = path.glob(pattern)
+        # Sometimes pathlib will fail on recursive symbolic links, so we need to workaround it
+        # and use the glob module instead. Note that this does not happen with pathlib2
+        # so it's safe to use it for Python < 3.4.
+        directories = glob.iglob(path.joinpath(pattern).as_posix(), recursive=True)
 
         for d in directories:
             yield Path(d)

--- a/poetry/installation/authenticator.py
+++ b/poetry/installation/authenticator.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import urllib.parse
 
 from typing import TYPE_CHECKING
 
@@ -8,7 +9,6 @@ import requests.auth
 import requests.exceptions
 
 from poetry.exceptions import PoetryException
-from poetry.utils._compat import urlparse
 from poetry.utils.password_manager import PasswordManager
 
 
@@ -107,7 +107,7 @@ class Authenticator(object):
     def get_credentials_for_url(
         self, url
     ):  # type: (str) -> Tuple[Optional[str], Optional[str]]
-        parsed_url = urlparse.urlsplit(url)
+        parsed_url = urllib.parse.urlsplit(url)
 
         netloc = parsed_url.netloc
 
@@ -130,7 +130,7 @@ class Authenticator(object):
                     credentials = auth, None
 
                 credentials = tuple(
-                    None if x is None else urlparse.unquote(x) for x in credentials
+                    None if x is None else urllib.parse.unquote(x) for x in credentials
                 )
 
         if credentials[0] is not None or credentials[1] is not None:
@@ -156,7 +156,7 @@ class Authenticator(object):
             if not url:
                 continue
 
-            parsed_url = urlparse.urlsplit(url)
+            parsed_url = urllib.parse.urlsplit(url)
 
             if netloc == parsed_url.netloc:
                 auth = self._password_manager.get_http_auth(repository_name)

--- a/poetry/installation/chef.py
+++ b/poetry/installation/chef.py
@@ -1,10 +1,10 @@
 import hashlib
 import json
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from poetry.core.packages.utils.link import Link
-from poetry.utils._compat import Path
 
 from .chooser import InvalidWheelName
 from .chooser import Wheel

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import urllib.parse
 
 from subprocess import CalledProcessError
 
@@ -12,12 +13,6 @@ from poetry.utils.env import Env
 from poetry.utils.helpers import safe_rmtree
 
 from .base_installer import BaseInstaller
-
-
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
 
 
 class PipInstaller(BaseInstaller):
@@ -44,7 +39,7 @@ class PipInstaller(BaseInstaller):
             and package.source_url
         ):
             repository = self._pool.repository(package.source_reference)
-            parsed = urlparse.urlparse(package.source_url)
+            parsed = urllib.parse.urlparse(package.source_url)
             if parsed.scheme == "http":
                 self._io.error(
                     "    <warning>Installing from unsecure host: {}</warning>".format(

--- a/poetry/locations.py
+++ b/poetry/locations.py
@@ -1,4 +1,5 @@
-from .utils._compat import Path
+from pathlib import Path
+
 from .utils.appdirs import user_cache_dir
 from .utils.appdirs import user_config_dir
 

--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -5,13 +5,13 @@ import os
 import shutil
 
 from base64 import urlsafe_b64encode
+from pathlib import Path
 
 from poetry.core.masonry.builders.builder import Builder
 from poetry.core.masonry.builders.sdist import SdistBuilder
 from poetry.core.masonry.utils.package_include import PackageInclude
 from poetry.core.semver.version import Version
 from poetry.utils._compat import WINDOWS
-from poetry.utils._compat import Path
 from poetry.utils._compat import decode
 from poetry.utils.helpers import is_dir_writable
 

--- a/poetry/mixology/partial_solution.py
+++ b/poetry/mixology/partial_solution.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import Dict
 from typing import List
 
@@ -26,13 +25,13 @@ class PartialSolution:
         self._assignments = []  # type: List[Assignment]
 
         # The decisions made for each package.
-        self._decisions = OrderedDict()  # type: Dict[str, Package]
+        self._decisions = dict()  # type: Dict[str, Package]
 
         # The intersection of all positive Assignments for each package, minus any
         # negative Assignments that refer to that package.
         #
         # This is derived from self._assignments.
-        self._positive = OrderedDict()  # type: Dict[str, Term]
+        self._positive = dict()  # type: Dict[str, Term]
 
         # The union of all negative Assignments for each package.
         #
@@ -40,7 +39,7 @@ class PartialSolution:
         # map.
         #
         # This is derived from self._assignments.
-        self._negative = OrderedDict()  # type: Dict[str, Dict[str, Term]]
+        self._negative = dict()  # type: Dict[str, Dict[str, Term]]
 
         # The number of distinct solutions that have been attempted so far.
         self._attempted_solutions = 1

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -5,6 +5,7 @@ import re
 
 from copy import deepcopy
 from hashlib import sha256
+from pathlib import Path
 from typing import Dict
 from typing import Iterable
 from typing import Iterator
@@ -33,8 +34,6 @@ from poetry.core.toml.file import TOMLFile
 from poetry.core.version.markers import parse_marker
 from poetry.core.version.requirements import InvalidRequirement
 from poetry.packages import DependencyPackage
-from poetry.utils._compat import OrderedDict
-from poetry.utils._compat import Path
 from poetry.utils.extras import get_extra_package_names
 
 
@@ -412,7 +411,7 @@ class Locker(object):
                 for extra, deps in sorted(root.extras.items())
             }
 
-        lock["metadata"] = OrderedDict(
+        lock["metadata"] = dict(
             [
                 ("lock-version", self._VERSION),
                 ("python-versions", root.python_versions),
@@ -525,7 +524,7 @@ class Locker(object):
                     constraint["version"] for constraint in constraints
                 ]
 
-        data = OrderedDict(
+        data = dict(
             [
                 ("name", package.pretty_name),
                 ("version", package.pretty_version),
@@ -569,7 +568,7 @@ class Locker(object):
                     )
                 ).as_posix()
 
-            data["source"] = OrderedDict()
+            data["source"] = dict()
 
             if package.source_type:
                 data["source"]["type"] = package.source_type

--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from pathlib import Path
+
 from poetry.core.packages import ProjectPackage
 from poetry.core.poetry import Poetry as BasePoetry
 
@@ -8,7 +10,6 @@ from .__version__ import __version__
 from .config.config import Config
 from .packages import Locker
 from .repositories.pool import Pool
-from .utils._compat import Path
 
 
 class Poetry(BasePoetry):

--- a/poetry/publishing/publisher.py
+++ b/poetry/publishing/publisher.py
@@ -1,8 +1,8 @@
 import logging
 
+from pathlib import Path
 from typing import Optional
 
-from poetry.utils._compat import Path
 from poetry.utils.helpers import get_cert
 from poetry.utils.helpers import get_client_cert
 from poetry.utils.password_manager import PasswordManager

--- a/poetry/publishing/uploader.py
+++ b/poetry/publishing/uploader.py
@@ -1,6 +1,7 @@
 import hashlib
 import io
 
+from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
@@ -21,7 +22,6 @@ from poetry.__version__ import __version__
 from poetry.core.masonry.metadata import Metadata
 from poetry.core.masonry.utils.helpers import escape_name
 from poetry.core.masonry.utils.helpers import escape_version
-from poetry.utils._compat import Path
 from poetry.utils.helpers import normalize_version
 from poetry.utils.patterns import wheel_file_re
 

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import re
+import urllib.parse
 
 from contextlib import contextmanager
+from pathlib import Path
 from tempfile import mkdtemp
 from typing import Any
 from typing import List
@@ -30,9 +32,6 @@ from poetry.packages import DependencyPackage
 from poetry.packages.package_collection import PackageCollection
 from poetry.puzzle.exceptions import OverrideNeeded
 from poetry.repositories import Pool
-from poetry.utils._compat import OrderedDict
-from poetry.utils._compat import Path
-from poetry.utils._compat import urlparse
 from poetry.utils.env import Env
 from poetry.utils.helpers import download_file
 from poetry.utils.helpers import safe_rmtree
@@ -324,7 +323,7 @@ class Provider:
     def get_package_from_url(cls, url):  # type: (str) -> Package
         with temporary_directory() as temp_dir:
             temp_dir = Path(temp_dir)
-            file_name = os.path.basename(urlparse.urlparse(url).path)
+            file_name = os.path.basename(urllib.parse.urlparse(url).path)
             download_file(url, str(temp_dir / file_name))
 
             package = cls.get_package_from_file(temp_dir / file_name)
@@ -517,7 +516,7 @@ class Provider:
         # An example of this is:
         #   - pypiwin32 (220); sys_platform == "win32" and python_version >= "3.6"
         #   - pypiwin32 (219); sys_platform == "win32" and python_version < "3.6"
-        duplicates = OrderedDict()
+        duplicates = dict()
         for dep in dependencies:
             if dep.name not in duplicates:
                 duplicates[dep.name] = []
@@ -533,7 +532,7 @@ class Provider:
             self.debug("<debug>Duplicate dependencies for {}</debug>".format(dep_name))
 
             # Regrouping by constraint
-            by_constraint = OrderedDict()
+            by_constraint = dict()
             for dep in deps:
                 if dep.constraint not in by_constraint:
                     by_constraint[dep.constraint] = []

--- a/poetry/repositories/installed_repository.py
+++ b/poetry/repositories/installed_repository.py
@@ -1,11 +1,11 @@
 import itertools
 
+from pathlib import Path
 from typing import Set
 from typing import Union
 
 from poetry.core.packages import Package
 from poetry.core.utils.helpers import module_name
-from poetry.utils._compat import Path
 from poetry.utils._compat import metadata
 from poetry.utils.env import Env
 

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -1,8 +1,10 @@
 import cgi
 import re
+import urllib.parse
 import warnings
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Generator
 from typing import Optional
 from typing import Union
@@ -21,7 +23,6 @@ from poetry.core.semver import VersionConstraint
 from poetry.core.semver import VersionRange
 from poetry.core.semver import parse_constraint
 from poetry.locations import REPOSITORY_CACHE_DIR
-from poetry.utils._compat import Path
 from poetry.utils.helpers import canonicalize_name
 from poetry.utils.patterns import wheel_file_re
 
@@ -32,11 +33,6 @@ from .exceptions import PackageNotFound
 from .exceptions import RepositoryError
 from .pypi_repository import PyPiRepository
 
-
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
 
 try:
     from html import unescape
@@ -115,7 +111,7 @@ class Page:
         for anchor in self._parsed.findall(".//a"):
             if anchor.get("href"):
                 href = anchor.get("href")
-                url = self.clean_link(urlparse.urljoin(self._url, href))
+                url = self.clean_link(urllib.parse.urljoin(self._url, href))
                 pyrequire = anchor.get("data-requires-python")
                 pyrequire = unescape(pyrequire) if pyrequire else None
 
@@ -219,7 +215,7 @@ class LegacyRepository(PyPiRepository):
         if not self._session.auth:
             return self.url
 
-        parsed = urlparse.urlparse(self.url)
+        parsed = urllib.parse.urlparse(self.url)
 
         return "{scheme}://{username}:{password}@{netloc}{path}".format(
             scheme=parsed.scheme,

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -1,7 +1,9 @@
 import logging
 import os
+import urllib.parse
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Dict
 from typing import List
 from typing import Union
@@ -24,7 +26,6 @@ from poetry.core.semver import parse_constraint
 from poetry.core.semver.exceptions import ParseVersionError
 from poetry.core.version.markers import parse_marker
 from poetry.locations import REPOSITORY_CACHE_DIR
-from poetry.utils._compat import Path
 from poetry.utils._compat import to_str
 from poetry.utils.helpers import download_file
 from poetry.utils.helpers import temporary_directory
@@ -33,12 +34,6 @@ from poetry.utils.patterns import wheel_file_re
 from ..inspection.info import PackageInfo
 from .exceptions import PackageNotFound
 from .remote_repository import RemoteRepository
-
-
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
 
 
 cache_control_logger.setLevel(logging.ERROR)
@@ -424,11 +419,13 @@ class PyPiRepository(RemoteRepository):
 
     def _get_info_from_wheel(self, url):  # type: (str) -> PackageInfo
         self._log(
-            "Downloading wheel: {}".format(urlparse.urlparse(url).path.rsplit("/")[-1]),
+            "Downloading wheel: {}".format(
+                urllib.parse.urlparse(url).path.rsplit("/")[-1]
+            ),
             level="debug",
         )
 
-        filename = os.path.basename(urlparse.urlparse(url).path.rsplit("/")[-1])
+        filename = os.path.basename(urllib.parse.urlparse(url).path.rsplit("/")[-1])
 
         with temporary_directory() as temp_dir:
             filepath = Path(temp_dir) / filename
@@ -438,11 +435,13 @@ class PyPiRepository(RemoteRepository):
 
     def _get_info_from_sdist(self, url):  # type: (str) -> PackageInfo
         self._log(
-            "Downloading sdist: {}".format(urlparse.urlparse(url).path.rsplit("/")[-1]),
+            "Downloading sdist: {}".format(
+                urllib.parse.urlparse(url).path.rsplit("/")[-1]
+            ),
             level="debug",
         )
 
-        filename = os.path.basename(urlparse.urlparse(url).path)
+        filename = os.path.basename(urllib.parse.urlparse(url).path)
 
         with temporary_directory() as temp_dir:
             filepath = Path(temp_dir) / filename

--- a/poetry/utils/_compat.py
+++ b/poetry/utils/_compat.py
@@ -2,236 +2,16 @@ import sys
 
 
 try:
-    from functools32 import lru_cache
-except ImportError:
-    from functools import lru_cache
-
-try:
-    from glob2 import glob
-except ImportError:
-    from glob import glob
-
-try:
-    import zipfile as zipp
-
     from importlib import metadata
 except ImportError:
-    import importlib_metadata as metadata
-    import zipp
-
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
-
-try:
-    from os import cpu_count
-except ImportError:  # Python 2
-    from multiprocessing import cpu_count
-
-try:  # Python 2
-    long = long
-    unicode = unicode
-    basestring = basestring
-except NameError:  # Python 3
-    long = int
-    unicode = str
-    basestring = str
-
-
-PY2 = sys.version_info[0] == 2
-PY34 = sys.version_info >= (3, 4)
-PY35 = sys.version_info >= (3, 5)
-PY36 = sys.version_info >= (3, 6)
+    # compatibility for python <3.8
+    import importlib_metadata as metadata  # noqa
 
 WINDOWS = sys.platform == "win32"
 
-try:
-    from shlex import quote
-except ImportError:
-    # PY2
-    from pipes import quote  # noqa
-
-if PY34:
-    from importlib.machinery import EXTENSION_SUFFIXES
-else:
-    from imp import get_suffixes
-
-    EXTENSION_SUFFIXES = [suffix[0] for suffix in get_suffixes()]
-
-
-if PY35:
-    from pathlib import Path
-else:
-    from pathlib2 import Path
-
-if not PY36:
-    from collections import OrderedDict
-else:
-    OrderedDict = dict
-
-
-if PY35:
-    import subprocess as subprocess
-
-    from subprocess import CalledProcessError
-else:
-    import subprocess32 as subprocess
-
-    from subprocess32 import CalledProcessError
-
-
-if PY34:
-    # subprocess32 pass the calls directly to subprocess
-    # on Python 3.3+ but Python 3.4 does not provide run()
-    # so we backport it
-    import signal
-
-    from subprocess import PIPE
-    from subprocess import Popen
-    from subprocess import SubprocessError
-    from subprocess import TimeoutExpired
-
-    class CalledProcessError(SubprocessError):
-        """Raised when run() is called with check=True and the process
-        returns a non-zero exit status.
-
-        Attributes:
-          cmd, returncode, stdout, stderr, output
-        """
-
-        def __init__(self, returncode, cmd, output=None, stderr=None):
-            self.returncode = returncode
-            self.cmd = cmd
-            self.output = output
-            self.stderr = stderr
-
-        def __str__(self):
-            if self.returncode and self.returncode < 0:
-                try:
-                    return "Command '%s' died with %r." % (
-                        self.cmd,
-                        signal.Signals(-self.returncode),
-                    )
-                except ValueError:
-                    return "Command '%s' died with unknown signal %d." % (
-                        self.cmd,
-                        -self.returncode,
-                    )
-            else:
-                return "Command '%s' returned non-zero exit status %d." % (
-                    self.cmd,
-                    self.returncode,
-                )
-
-        @property
-        def stdout(self):
-            """Alias for output attribute, to match stderr"""
-            return self.output
-
-        @stdout.setter
-        def stdout(self, value):
-            # There's no obvious reason to set this, but allow it anyway so
-            # .stdout is a transparent alias for .output
-            self.output = value
-
-    class CompletedProcess(object):
-        """A process that has finished running.
-        This is returned by run().
-        Attributes:
-          args: The list or str args passed to run().
-          returncode: The exit code of the process, negative for signals.
-          stdout: The standard output (None if not captured).
-          stderr: The standard error (None if not captured).
-        """
-
-        def __init__(self, args, returncode, stdout=None, stderr=None):
-            self.args = args
-            self.returncode = returncode
-            self.stdout = stdout
-            self.stderr = stderr
-
-        def __repr__(self):
-            args = [
-                "args={!r}".format(self.args),
-                "returncode={!r}".format(self.returncode),
-            ]
-            if self.stdout is not None:
-                args.append("stdout={!r}".format(self.stdout))
-            if self.stderr is not None:
-                args.append("stderr={!r}".format(self.stderr))
-            return "{}({})".format(type(self).__name__, ", ".join(args))
-
-        def check_returncode(self):
-            """Raise CalledProcessError if the exit code is non-zero."""
-            if self.returncode:
-                raise CalledProcessError(
-                    self.returncode, self.args, self.stdout, self.stderr
-                )
-
-    def run(*popenargs, **kwargs):
-        """Run command with arguments and return a CompletedProcess instance.
-        The returned instance will have attributes args, returncode, stdout and
-        stderr. By default, stdout and stderr are not captured, and those attributes
-        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.
-        If check is True and the exit code was non-zero, it raises a
-        CalledProcessError. The CalledProcessError object will have the return code
-        in the returncode attribute, and output & stderr attributes if those streams
-        were captured.
-        If timeout is given, and the process takes too long, a TimeoutExpired
-        exception will be raised.
-        There is an optional argument "input", allowing you to
-        pass a string to the subprocess's stdin.  If you use this argument
-        you may not also use the Popen constructor's "stdin" argument, as
-        it will be used internally.
-        The other arguments are the same as for the Popen constructor.
-        If universal_newlines=True is passed, the "input" argument must be a
-        string and stdout/stderr in the returned object will be strings rather than
-        bytes.
-        """
-        input = kwargs.pop("input", None)
-        timeout = kwargs.pop("timeout", None)
-        check = kwargs.pop("check", False)
-        if input is not None:
-            if "stdin" in kwargs:
-                raise ValueError("stdin and input arguments may not both be used.")
-            kwargs["stdin"] = PIPE
-
-        process = Popen(*popenargs, **kwargs)
-        try:
-            process.__enter__()  # No-Op really... illustrate "with in 2.4"
-            try:
-                stdout, stderr = process.communicate(input, timeout=timeout)
-            except TimeoutExpired:
-                process.kill()
-                stdout, stderr = process.communicate()
-                raise TimeoutExpired(
-                    process.args, timeout, output=stdout, stderr=stderr
-                )
-            except:
-                process.kill()
-                process.wait()
-                raise
-            retcode = process.poll()
-            if check and retcode:
-                raise CalledProcessError(
-                    retcode, process.args, output=stdout, stderr=stderr
-                )
-        finally:
-            # None because our context manager __exit__ does not use them.
-            process.__exit__(None, None, None)
-
-        return CompletedProcess(process.args, retcode, stdout, stderr)
-
-    subprocess.run = run
-    subprocess.CalledProcessError = CalledProcessError
-
 
 def decode(string, encodings=None):
-    if not PY2 and not isinstance(string, bytes):
-        return string
-
-    if PY2 and isinstance(string, unicode):
+    if not isinstance(string, bytes):
         return string
 
     encodings = encodings or ["utf-8", "latin1", "ascii"]
@@ -246,10 +26,7 @@ def decode(string, encodings=None):
 
 
 def encode(string, encodings=None):
-    if not PY2 and isinstance(string, bytes):
-        return string
-
-    if PY2 and isinstance(string, str):
+    if isinstance(string, bytes):
         return string
 
     encodings = encodings or ["utf-8", "latin1", "ascii"]
@@ -264,23 +41,7 @@ def encode(string, encodings=None):
 
 
 def to_str(string):
-    if isinstance(string, str) or not isinstance(string, (unicode, bytes)):
-        return string
-
-    if PY2:
-        method = "encode"
-    else:
-        method = "decode"
-
-    encodings = ["utf-8", "latin1", "ascii"]
-
-    for encoding in encodings:
-        try:
-            return getattr(string, method)(encoding)
-        except (UnicodeEncodeError, UnicodeDecodeError):
-            pass
-
-    return getattr(string, method)(encodings[0], errors="ignore")
+    return decode(string)
 
 
 def list_to_shell_command(cmd):

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -5,11 +5,14 @@ import os
 import platform
 import re
 import shutil
+import subprocess
 import sys
 import sysconfig
 import textwrap
 
 from contextlib import contextmanager
+from pathlib import Path
+from subprocess import CalledProcessError
 from typing import Any
 from typing import Dict
 from typing import List
@@ -33,12 +36,9 @@ from poetry.core.toml.file import TOMLFile
 from poetry.core.version.markers import BaseMarker
 from poetry.locations import CACHE_DIR
 from poetry.poetry import Poetry
-from poetry.utils._compat import CalledProcessError
-from poetry.utils._compat import Path
 from poetry.utils._compat import decode
 from poetry.utils._compat import encode
 from poetry.utils._compat import list_to_shell_command
-from poetry.utils._compat import subprocess
 from poetry.utils.helpers import is_dir_writable
 from poetry.utils.helpers import paths_csv
 

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -1,3 +1,6 @@
+import urllib.parse
+
+from pathlib import Path
 from typing import Optional
 from typing import Sequence
 from typing import Union
@@ -5,9 +8,7 @@ from typing import Union
 from clikit.api.io import IO
 
 from poetry.poetry import Poetry
-from poetry.utils._compat import Path
 from poetry.utils._compat import decode
-from poetry.utils._compat import urlparse
 
 
 class Exporter(object):
@@ -140,7 +141,7 @@ class Exporter(object):
                 url = (
                     repository.authenticated_url if with_credentials else repository.url
                 )
-                parsed_url = urlparse.urlsplit(url)
+                parsed_url = urllib.parse.urlsplit(url)
                 if parsed_url.scheme == "http":
                     indexes_header += "--trusted-host {}\n".format(parsed_url.netloc)
                 indexes_header += "--extra-index-url {}\n".format(url)

--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -5,6 +5,7 @@ import stat
 import tempfile
 
 from contextlib import contextmanager
+from pathlib import Path
 from typing import List
 from typing import Optional
 
@@ -13,7 +14,6 @@ import requests
 from poetry.config.config import Config
 from poetry.core.packages.package import Package
 from poetry.core.version import Version
-from poetry.utils._compat import Path
 
 
 try:

--- a/poetry/utils/setup_reader.py
+++ b/poetry/utils/setup_reader.py
@@ -1,5 +1,7 @@
 import ast
 
+from configparser import ConfigParser
+from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -9,16 +11,6 @@ from typing import Tuple
 from typing import Union
 
 from poetry.core.semver import Version
-
-from ._compat import PY35
-from ._compat import Path
-from ._compat import basestring
-
-
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from ConfigParser import ConfigParser
 
 
 class SetupReader(object):
@@ -39,8 +31,8 @@ class SetupReader(object):
     @classmethod
     def read_from_directory(
         cls, directory
-    ):  # type: (Union[basestring, Path]) -> Dict[str, Union[List, Dict]]
-        if isinstance(directory, basestring):
+    ):  # type: (Union[str, Path]) -> Dict[str, Union[List, Dict]]
+        if isinstance(directory, str):
             directory = Path(directory)
 
         result = cls.DEFAULT.copy()
@@ -61,11 +53,8 @@ class SetupReader(object):
 
     def read_setup_py(
         self, filepath
-    ):  # type: (Union[basestring, Path]) -> Dict[str, Union[List, Dict]]
-        if not PY35:
-            return self.DEFAULT
-
-        if isinstance(filepath, basestring):
+    ):  # type: (Union[str, Path]) -> Dict[str, Union[List, Dict]]
+        if isinstance(filepath, str):
             filepath = Path(filepath)
 
         with filepath.open(encoding="utf-8") as f:
@@ -92,7 +81,7 @@ class SetupReader(object):
 
     def read_setup_cfg(
         self, filepath
-    ):  # type: (Union[basestring, Path]) -> Dict[str, Union[List, Dict]]
+    ):  # type: (Union[str, Path]) -> Dict[str, Union[List, Dict]]
         parser = ConfigParser()
 
         parser.read(str(filepath))

--- a/poetry/utils/shell.py
+++ b/poetry/utils/shell.py
@@ -2,6 +2,8 @@ import os
 import signal
 import sys
 
+from pathlib import Path
+
 import pexpect
 
 from clikit.utils.terminal import Terminal
@@ -9,7 +11,6 @@ from shellingham import ShellDetectionFailure
 from shellingham import detect_shell
 
 from ._compat import WINDOWS
-from ._compat import Path
 from .env import VirtualEnv
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ tox = "^3.0"
 pytest-sugar = "^0.9.2"
 httpretty = "^1.0"
 zipp = { version = "^3.4", python = "<3.8"}
+# temporary workaround for https://github.com/python-poetry/poetry/issues/3404
+urllib3 = "1.25.10"
 
 [tool.poetry.scripts]
 poetry = "poetry.console:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,12 @@ classifiers = [
 
 # Requirements
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.5"
+python = "^3.6"
 
 poetry-core = "^1.0.0"
 cleo = "^0.8.1"
 clikit = "^0.6.2"
-crashtest = { version = "^0.3.0", python = "^3.6" }
+crashtest = "^0.3.0"
 requests = "^2.18"
 cachy = "^0.3.0"
 requests-toolbelt = "^0.9.1"
@@ -39,38 +39,18 @@ tomlkit = ">=0.7.0,<1.0.0"
 pexpect = "^4.7.0"
 packaging = "^20.4"
 virtualenv = { version = "^20.0.26" }
-
-# The typing module is not in the stdlib in Python 2.7
-typing = { version = "^3.6", python = "~2.7" }
-
-# Use pathlib2 for Python 2.7
-pathlib2 = { version = "^2.3", python = "~2.7" }
-# Use futures on Python 2.7
-futures = { version = "^3.3.0", python = "~2.7" }
-# Use glob2 for Python 2.7 and 3.4
-glob2 = { version = "^0.6", python = "~2.7" }
-# functools32 is needed for Python 2.7
-functools32 = { version = "^3.2.3", python = "~2.7" }
-keyring = [
-    { version = "^18.0.1", python = "~2.7" },
-    { version = "^20.0.1", python = "~3.5" },
-    { version = "^21.2.0", python = "^3.6" }
-]
-# Use subprocess32 for Python 2.7
-subprocess32 = { version = "^3.5", python = "~2.7" }
+keyring = "^21.2.0"
 importlib-metadata = {version = "^1.6.0", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
-pytest = [
-    {version = "^4.1", python = "<3.5"},
-    {version = "^5.4.3", python = ">=3.5"}
-]
+pytest = "^5.4.3"
 pytest-cov = "^2.5"
 pytest-mock = "^1.9"
 pre-commit = { version = "^2.6", python = "^3.6.1" }
 tox = "^3.0"
 pytest-sugar = "^0.9.2"
-httpretty = "^0.9.6"
+httpretty = "^1.0"
+zipp = { version = "^3.4", python = "<3.8"}
 
 [tool.poetry.scripts]
 poetry = "poetry.console:main"

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,0 +1,4 @@
+try:
+    import zipp
+except ImportError:
+    import zipfile as zipp  # noqa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import tempfile
 
+from pathlib import Path
 from typing import Any
 from typing import Dict
 
@@ -21,7 +22,6 @@ from poetry.installation import Installer
 from poetry.layouts import layout
 from poetry.repositories import Pool
 from poetry.repositories import Repository
-from poetry.utils._compat import Path
 from poetry.utils.env import EnvManager
 from poetry.utils.env import SystemEnv
 from poetry.utils.env import VirtualEnv
@@ -184,7 +184,7 @@ def mocked_open_files(mocker):
             return mocker.MagicMock()
         return original(self, *args, **kwargs)
 
-    mocker.patch("poetry.utils._compat.Path.open", mocked_open)
+    mocker.patch("pathlib.Path.open", mocked_open)
 
     yield files
 

--- a/tests/console/commands/env/conftest.py
+++ b/tests/console/commands/env/conftest.py
@@ -1,8 +1,9 @@
 import os
 
+from pathlib import Path
+
 import pytest
 
-from poetry.utils._compat import Path
 from poetry.utils.env import EnvManager
 
 

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -1,8 +1,8 @@
+from pathlib import Path
 from typing import Optional
 from typing import Union
 
 from poetry.core.semver import Version
-from poetry.utils._compat import Path
 
 
 def build_venv(

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -1,6 +1,7 @@
+from pathlib import Path
+
 import pytest
 
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 
 

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -13,7 +13,7 @@ def test_remove_by_python_version(
     mocker, tester, venvs_in_cache_dirs, venv_name, venv_cache
 ):
     check_output = mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
 

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -1,11 +1,12 @@
 import os
 
+from pathlib import Path
+
 import pytest
 import tomlkit
 
 from poetry.core.semver import Version
 from poetry.core.toml.file import TOMLFile
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 from tests.console.commands.env.helpers import build_venv
 from tests.console.commands.env.helpers import check_output_wrapper
@@ -21,11 +22,11 @@ def setup(mocker):
 @pytest.fixture(autouse=True)
 def mock_subprocess_calls(setup, current_python, mocker):
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version(*current_python)),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
+        "subprocess.Popen.communicate",
         side_effect=[("/prefix", None), ("/prefix", None), ("/prefix", None)],
     )
 
@@ -39,8 +40,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     mocker, tester, venv_cache, venv_name, venvs_in_cache_config
 ):
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
 
     mock_build_env = mocker.patch(

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -1,12 +1,13 @@
 import os
 
+from pathlib import Path
+
 import pytest
 
 from poetry.__version__ import __version__
 from poetry.core.packages.package import Package
 from poetry.core.semver.version import Version
 from poetry.utils._compat import WINDOWS
-from poetry.utils._compat import Path
 
 
 FIXTURES = Path(__file__).parent.joinpath("fixtures")

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -3,11 +3,12 @@ from __future__ import unicode_literals
 
 import sys
 
+from pathlib import Path
+
 import pytest
 
 from poetry.core.semver import Version
 from poetry.repositories.legacy_repository import LegacyRepository
-from poetry.utils._compat import Path
 from tests.helpers import get_dependency
 from tests.helpers import get_package
 
@@ -279,7 +280,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 
 
 def test_add_directory_constraint(app, repo, tester, mocker):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__).parent
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -313,7 +314,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 
 
 def test_add_directory_with_poetry(app, repo, tester, mocker):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__) / ".."
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -341,7 +342,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 
 
 def test_add_file_constraint_wheel(app, repo, tester, mocker, poetry):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = poetry.file.parent
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -376,7 +377,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 
 
 def test_add_file_constraint_sdist(app, repo, tester, mocker):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__) / ".."
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -448,7 +449,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 
 
 def test_add_url_constraint_wheel(app, repo, tester, mocker):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__) / ".."
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -1069,7 +1070,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 def test_add_directory_constraint_old_installer(
     app, repo, installer, mocker, old_tester
 ):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__) / ".."
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -1106,7 +1107,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 def test_add_directory_with_poetry_old_installer(
     app, repo, installer, mocker, old_tester
 ):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__) / ".."
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -1137,7 +1138,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 def test_add_file_constraint_wheel_old_installer(
     app, repo, installer, mocker, old_tester
 ):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__) / ".."
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -1175,7 +1176,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 def test_add_file_constraint_sdist_old_installer(
     app, repo, installer, mocker, old_tester
 ):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__) / ".."
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -1253,7 +1254,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 def test_add_url_constraint_wheel_old_installer(
     app, repo, installer, mocker, old_tester
 ):
-    p = mocker.patch("poetry.utils._compat.Path.cwd")
+    p = mocker.patch("pathlib.Path.cwd")
     p.return_value = Path(__file__) / ".."
 
     repo.add_package(get_package("pendulum", "1.4.4"))

--- a/tests/console/commands/test_cache.py
+++ b/tests/console/commands/test_cache.py
@@ -5,9 +5,9 @@ import pytest
 
 @pytest.fixture
 def repository_cache_dir(monkeypatch, tmpdir):
-    import poetry.locations
+    from pathlib import Path
 
-    from poetry.utils._compat import Path
+    import poetry.locations
 
     path = Path(str(tmpdir))
     monkeypatch.setattr(poetry.locations, "REPOSITORY_CACHE_DIR", path)

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -1,7 +1,6 @@
-import pytest
+from pathlib import Path
 
-from poetry.utils._compat import PY2
-from poetry.utils._compat import Path
+import pytest
 
 
 @pytest.fixture()
@@ -30,14 +29,7 @@ def test_check_invalid(mocker, tester):
 
     tester.execute()
 
-    if PY2:
-        expected = """\
-Error: u'description' is a required property
-Warning: A wildcard Python dependency is ambiguous. Consider specifying a more explicit one.
-Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.
-"""
-    else:
-        expected = """\
+    expected = """\
 Error: 'description' is a required property
 Warning: A wildcard Python dependency is ambiguous. Consider specifying a more explicit one.
 Warning: The "pendulum" dependency specifies the "allows-prereleases" property, which is deprecated. Use "allow-prereleases" instead.

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -6,8 +6,6 @@ import pytest
 from poetry.config.config_source import ConfigSource
 from poetry.core.pyproject import PyProjectException
 from poetry.factory import Factory
-from poetry.utils._compat import PY2
-from poetry.utils._compat import WINDOWS
 
 
 @pytest.fixture()
@@ -136,15 +134,13 @@ def test_set_cert(tester, auth_config_source, mocker):
 
 
 def test_config_installer_parallel(tester, command_tester_factory):
-    serial_enforced = PY2 and WINDOWS
-
     tester.execute("--local installer.parallel")
     assert tester.io.fetch_output().strip() == "true"
 
     workers = command_tester_factory(
         "install"
     )._command._installer._executor._max_workers
-    assert workers > 1 or (serial_enforced and workers == 1)
+    assert workers > 1
 
     tester.io.clear_output()
     tester.execute("--local installer.parallel false")

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -2,12 +2,13 @@ import os
 import shutil
 import sys
 
+from pathlib import Path
+
 import pytest
 
 from cleo import CommandTester
 
 from poetry.repositories import Pool
-from poetry.utils._compat import Path
 from poetry.utils._compat import decode
 from tests.helpers import TestApplication
 from tests.helpers import get_package
@@ -26,7 +27,7 @@ def source_dir(tmp_path):  # type: (...) -> Path
 
 @pytest.fixture
 def patches(mocker, source_dir, repo):
-    mocker.patch("poetry.utils._compat.Path.cwd", return_value=source_dir)
+    mocker.patch("pathlib.Path.cwd", return_value=source_dir)
     mocker.patch(
         "poetry.console.commands.init.InitCommand._get_pool", return_value=Pool([repo])
     )

--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -1,7 +1,8 @@
+from pathlib import Path
+
 import pytest
 
 from poetry.packages import Locker
-from poetry.utils._compat import Path
 from tests.helpers import get_package
 
 

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -1,14 +1,10 @@
-import pytest
+from pathlib import Path
+
 import requests
 
 from poetry.publishing.uploader import UploadError
-from poetry.utils._compat import PY36
-from poetry.utils._compat import Path
 
 
-@pytest.mark.skipif(
-    not PY36, reason="Improved error rendering is only available on Python >=3.6"
-)
 def test_publish_returns_non_zero_code_for_upload_errors(app, app_tester, http):
     http.register_uri(
         http.POST, "https://upload.pypi.org/legacy/", status=400, body="Bad Request"
@@ -45,32 +41,6 @@ def test_publish_returns_non_zero_code_for_connection_errors(app, app_tester, ht
     expected = str(UploadError(error=requests.ConnectionError()))
 
     assert expected in app_tester.io.fetch_output()
-
-
-@pytest.mark.skipif(
-    PY36, reason="Improved error rendering is not available on Python <3.6"
-)
-def test_publish_returns_non_zero_code_for_upload_errors_older_python(
-    app, app_tester, http
-):
-    http.register_uri(
-        http.POST, "https://upload.pypi.org/legacy/", status=400, body="Bad Request"
-    )
-
-    exit_code = app_tester.execute("publish --username foo --password bar")
-
-    assert 1 == exit_code
-
-    expected = """
-Publishing simple-project (1.2.3) to PyPI
-
-
-UploadError
-
-HTTP Error 400: Bad Request
-"""
-
-    assert app_tester.io.fetch_output() == expected
 
 
 def test_publish_with_cert(app_tester, mocker):

--- a/tests/console/commands/test_search.py
+++ b/tests/console/commands/test_search.py
@@ -1,6 +1,6 @@
-import pytest
+from pathlib import Path
 
-from poetry.utils._compat import Path
+import pytest
 
 
 TESTS_DIRECTORY = Path(__file__).parent.parent.parent

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -1,5 +1,7 @@
 import os
 
+from pathlib import Path
+
 import pytest
 
 from cleo import ApplicationTester
@@ -8,7 +10,6 @@ from poetry.factory import Factory
 from poetry.installation.noop_installer import NoopInstaller
 from poetry.io.null_io import NullIO
 from poetry.repositories import Pool
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 from tests.helpers import TestApplication
 from tests.helpers import TestExecutor

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,8 @@
 import os
 import shutil
+import urllib.parse
+
+from pathlib import Path
 
 from poetry.console import Application
 from poetry.core.masonry.utils.helpers import escape_name
@@ -14,10 +17,7 @@ from poetry.installation.executor import Executor
 from poetry.packages import Locker
 from poetry.repositories import Repository
 from poetry.repositories.exceptions import PackageNotFound
-from poetry.utils._compat import PY2
 from poetry.utils._compat import WINDOWS
-from poetry.utils._compat import Path
-from poetry.utils._compat import urlparse
 
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures"
@@ -59,19 +59,13 @@ def copy_or_symlink(source, dest):
     # os.symlink requires either administrative privileges or developer mode on Win10,
     # throwing an OSError if neither is active.
     if WINDOWS:
-        if PY2:
+        try:
+            os.symlink(str(source), str(dest), target_is_directory=source.is_dir())
+        except OSError:
             if source.is_dir():
                 shutil.copytree(str(source), str(dest))
             else:
                 shutil.copyfile(str(source), str(dest))
-        else:
-            try:
-                os.symlink(str(source), str(dest), target_is_directory=source.is_dir())
-            except OSError:
-                if source.is_dir():
-                    shutil.copytree(str(source), str(dest))
-                else:
-                    shutil.copyfile(str(source), str(dest))
     else:
         os.symlink(str(source), str(dest))
 
@@ -92,7 +86,7 @@ def mock_clone(_, source, dest):
 
 
 def mock_download(url, dest, **__):
-    parts = urlparse.urlparse(url)
+    parts = urllib.parse.urlparse(url)
 
     fixtures = Path(__file__).parent / "fixtures"
     fixture = fixtures / parts.path.lstrip("/")

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -1,12 +1,11 @@
+from pathlib import Path
+from subprocess import CalledProcessError
 from typing import Set
 
 import pytest
 
 from poetry.inspection.info import PackageInfo
 from poetry.inspection.info import PackageInfoError
-from poetry.utils._compat import PY35
-from poetry.utils._compat import CalledProcessError
-from poetry.utils._compat import Path
 from poetry.utils._compat import decode
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import VirtualEnv
@@ -134,13 +133,11 @@ def test_info_from_requires_txt():
     demo_check_info(info)
 
 
-@pytest.mark.skipif(not PY35, reason="Parsing of setup.py is skipped for Python < 3.5")
 def test_info_from_setup_py(demo_setup):
     info = PackageInfo.from_setup_files(demo_setup)
     demo_check_info(info, requires_dist={"package"})
 
 
-@pytest.mark.skipif(not PY35, reason="Parsing of setup.cfg is skipped for Python < 3.5")
 def test_info_from_setup_cfg(demo_setup_cfg):
     info = PackageInfo.from_setup_files(demo_setup_cfg)
     demo_check_info(info, requires_dist={"package"})
@@ -155,7 +152,6 @@ def test_info_no_setup_pkg_info_no_deps():
     assert info.requires_dist is None
 
 
-@pytest.mark.skipif(not PY35, reason="Parsing of setup.py is skipped for Python < 3.5")
 def test_info_setup_simple(mocker, demo_setup):
     spy = mocker.spy(VirtualEnv, "run")
     info = PackageInfo.from_directory(demo_setup)
@@ -163,18 +159,6 @@ def test_info_setup_simple(mocker, demo_setup):
     demo_check_info(info, requires_dist={"package"})
 
 
-@pytest.mark.skipif(
-    PY35,
-    reason="For projects with setup.py using Python < 3.5 fallback to pep517 build",
-)
-def test_info_setup_simple_py2(mocker, demo_setup):
-    spy = mocker.spy(VirtualEnv, "run")
-    info = PackageInfo.from_directory(demo_setup)
-    assert spy.call_count == 2
-    demo_check_info(info, requires_dist={"package"})
-
-
-@pytest.mark.skipif(not PY35, reason="Parsing of setup.cfg is skipped for Python < 3.5")
 def test_info_setup_cfg(mocker, demo_setup_cfg):
     spy = mocker.spy(VirtualEnv, "run")
     info = PackageInfo.from_directory(demo_setup_cfg)
@@ -203,7 +187,6 @@ def test_info_setup_complex_pep517_legacy(demo_setup_complex_pep517_legacy):
     demo_check_info(info, requires_dist={"package"})
 
 
-@pytest.mark.skipif(not PY35, reason="Parsing of setup.py is skipped for Python < 3.5")
 def test_info_setup_complex_disable_build(mocker, demo_setup_complex):
     spy = mocker.spy(VirtualEnv, "run")
     info = PackageInfo.from_directory(demo_setup_complex, disable_build=True)
@@ -213,7 +196,6 @@ def test_info_setup_complex_disable_build(mocker, demo_setup_complex):
     assert info.requires_dist is None
 
 
-@pytest.mark.skipif(not PY35, reason="Parsing of setup.py is skipped for Python < 3.5")
 @pytest.mark.parametrize("missing", ["version", "name", "install_requires"])
 def test_info_setup_missing_mandatory_should_trigger_pep517(
     mocker, source_dir, missing

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -1,8 +1,9 @@
+from pathlib import Path
+
 from packaging.tags import Tag
 
 from poetry.core.packages.utils.link import Link
 from poetry.installation.chef import Chef
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 
 

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -1,5 +1,7 @@
 import re
 
+from pathlib import Path
+
 import pytest
 
 from packaging.tags import Tag
@@ -9,7 +11,6 @@ from poetry.installation.chooser import Chooser
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool
 from poetry.repositories.pypi_repository import PyPiRepository
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import re
 import shutil
 
+from pathlib import Path
+
 import pytest
 
 from clikit.api.formatter.style import Style
@@ -16,8 +18,6 @@ from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall
 from poetry.installation.operations import Update
 from poetry.repositories.pool import Pool
-from poetry.utils._compat import PY36
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 from tests.repositories.test_pypi_repository import MockRepository
 
@@ -155,9 +155,6 @@ Package operations: 0 installs, 0 updates, 0 removals, 1 skipped
     assert 0 == len(env.executed)
 
 
-@pytest.mark.skipif(
-    not PY36, reason="Improved error rendering is only available on Python >=3.6"
-)
 def test_execute_should_show_errors(config, mocker, io, env):
     executor = Executor(env, pool, config, io)
     executor.verbose()

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import json
 import sys
 
+from pathlib import Path
+
 import pytest
 
 from clikit.io import NullIO
@@ -17,8 +19,6 @@ from poetry.packages import Locker as BaseLocker
 from poetry.repositories import Pool
 from poetry.repositories import Repository
 from poetry.repositories.installed_repository import InstalledRepository
-from poetry.utils._compat import PY2
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 from poetry.utils.env import NullEnv
 from tests.helpers import get_dependency
@@ -112,15 +112,6 @@ class Locker(BaseLocker):
     def _write_lock_data(self, data):
         for package in data["package"]:
             python_versions = str(package["python-versions"])
-            if PY2:
-                python_versions = python_versions.decode()
-                if "requirements" in package:
-                    requirements = {}
-                    for key, value in package["requirements"].items():
-                        requirements[key.decode()] = value.decode()
-
-                    package["requirements"] = requirements
-
             package["python-versions"] = python_versions
 
         self._written_data = json.loads(json.dumps(data))
@@ -1583,7 +1574,7 @@ def test_installer_required_extras_should_not_be_removed_when_updating_single_de
     installer.whitelist(["pytest"])
     installer.run()
 
-    assert (6 if not PY2 else 7) == installer.executor.installations_count
+    assert 6 == installer.executor.installations_count
     assert 0 == installer.executor.updates_count
     assert 0 == installer.executor.removals_count
 

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 import sys
 
+from pathlib import Path
+
 import pytest
 
 from clikit.io import NullIO
@@ -15,8 +17,6 @@ from poetry.packages import Locker as BaseLocker
 from poetry.repositories import Pool
 from poetry.repositories import Repository
 from poetry.repositories.installed_repository import InstalledRepository
-from poetry.utils._compat import PY2
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 from poetry.utils.env import NullEnv
 from tests.helpers import get_dependency
@@ -74,15 +74,6 @@ class Locker(BaseLocker):
     def _write_lock_data(self, data):
         for package in data["package"]:
             python_versions = str(package["python-versions"])
-            if PY2:
-                python_versions = python_versions.decode()
-                if "requirements" in package:
-                    requirements = {}
-                    for key, value in package["requirements"].items():
-                        requirements[key.decode()] = value.decode()
-
-                    package["requirements"] = requirements
-
             package["python-versions"] = python_versions
 
         self._written_data = data
@@ -1514,7 +1505,7 @@ def test_installer_required_extras_should_not_be_removed_when_updating_single_de
     installer.whitelist(["pytest"])
     installer.run()
 
-    assert len(installer.installer.installs) == 6 if not PY2 else 7
+    assert len(installer.installer.installs) == 6
     assert len(installer.installer.updates) == 0
     assert len(installer.installer.removals) == 0
 

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -1,5 +1,7 @@
 import shutil
 
+from pathlib import Path
+
 import pytest
 
 from poetry.core.packages.package import Package
@@ -7,7 +9,6 @@ from poetry.installation.pip_installer import PipInstaller
 from poetry.io.null_io import NullIO
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool
-from poetry.utils._compat import Path
 from poetry.utils.env import NullEnv
 
 

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -4,12 +4,13 @@ from __future__ import unicode_literals
 import os
 import shutil
 
+from pathlib import Path
+
 import pytest
 
 from poetry.factory import Factory
 from poetry.io.null_io import NullIO
 from poetry.masonry.builders.editable import EditableBuilder
-from poetry.utils._compat import Path
 from poetry.utils.env import EnvManager
 from poetry.utils.env import MockEnv
 from poetry.utils.env import VirtualEnv

--- a/tests/mixology/solutions/providers/test_python_requirement_solution_provider.py
+++ b/tests/mixology/solutions/providers/test_python_requirement_solution_provider.py
@@ -1,5 +1,3 @@
-import pytest
-
 from poetry.core.packages.dependency import Dependency
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.incompatibility import Incompatibility
@@ -7,12 +5,8 @@ from poetry.mixology.incompatibility_cause import NoVersionsCause
 from poetry.mixology.incompatibility_cause import PythonCause
 from poetry.mixology.term import Term
 from poetry.puzzle.exceptions import SolverProblemError
-from poetry.utils._compat import PY36
 
 
-@pytest.mark.skipif(
-    not PY36, reason="Error solutions are only available for Python ^3.6"
-)
 def test_it_can_solve_python_incompatibility_solver_errors():
     from poetry.mixology.solutions.providers import PythonRequirementSolutionProvider
     from poetry.mixology.solutions.solutions import PythonRequirementSolution
@@ -27,9 +21,6 @@ def test_it_can_solve_python_incompatibility_solver_errors():
     assert isinstance(provider.get_solutions(exception)[0], PythonRequirementSolution)
 
 
-@pytest.mark.skipif(
-    not PY36, reason="Error solutions are only available for Python ^3.6"
-)
 def test_it_cannot_solve_other_solver_errors():
     from poetry.mixology.solutions.providers import PythonRequirementSolutionProvider
 

--- a/tests/mixology/solutions/solutions/test_python_requirement_solution.py
+++ b/tests/mixology/solutions/solutions/test_python_requirement_solution.py
@@ -1,5 +1,3 @@
-import pytest
-
 from clikit.io.buffered_io import BufferedIO
 
 from poetry.core.packages.dependency import Dependency
@@ -8,12 +6,8 @@ from poetry.mixology.incompatibility import Incompatibility
 from poetry.mixology.incompatibility_cause import PythonCause
 from poetry.mixology.term import Term
 from poetry.puzzle.exceptions import SolverProblemError
-from poetry.utils._compat import PY36
 
 
-@pytest.mark.skipif(
-    not PY36, reason="Error solutions are only available for Python ^3.6"
-)
 def test_it_provides_the_correct_solution():
     from poetry.mixology.solutions.solutions import PythonRequirementSolution
 

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -1,5 +1,7 @@
 import os
 
+from pathlib import Path
+
 import pytest
 
 from cleo.io import BufferedIO
@@ -7,7 +9,6 @@ from cleo.io import BufferedIO
 from poetry.factory import Factory
 from poetry.io.null_io import NullIO
 from poetry.publishing.publisher import Publisher
-from poetry.utils._compat import Path
 
 
 def test_publish_publishes_to_pypi_by_default(fixture_dir, mocker, config):

--- a/tests/publishing/test_uploader.py
+++ b/tests/publishing/test_uploader.py
@@ -1,10 +1,11 @@
+from pathlib import Path
+
 import pytest
 
 from poetry.factory import Factory
 from poetry.io.null_io import NullIO
 from poetry.publishing.uploader import Uploader
 from poetry.publishing.uploader import UploadError
-from poetry.utils._compat import Path
 
 
 fixtures_dir = Path(__file__).parent.parent / "fixtures"

--- a/tests/puzzle/conftest.py
+++ b/tests/puzzle/conftest.py
@@ -1,8 +1,8 @@
 import shutil
 
-import pytest
+from pathlib import Path
 
-from poetry.utils._compat import Path
+import pytest
 
 
 try:

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from subprocess import CalledProcessError
 
 import pytest
@@ -12,8 +13,6 @@ from poetry.inspection.info import PackageInfo
 from poetry.puzzle.provider import Provider
 from poetry.repositories.pool import Pool
 from poetry.repositories.repository import Repository
-from poetry.utils._compat import PY35
-from poetry.utils._compat import Path
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import MockEnv as BaseMockEnv
 from tests.helpers import get_dependency
@@ -94,7 +93,6 @@ def test_search_for_vcs_setup_egg_info_with_extras(provider):
     }
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_vcs_read_setup(provider, mocker):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
@@ -115,7 +113,6 @@ def test_search_for_vcs_read_setup(provider, mocker):
     }
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_vcs_read_setup_with_extras(provider, mocker):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
@@ -241,7 +238,6 @@ def test_search_for_directory_setup_with_base(provider, directory):
     )
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_directory_setup_read_setup(provider, mocker):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
@@ -270,7 +266,6 @@ def test_search_for_directory_setup_read_setup(provider, mocker):
     }
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_directory_setup_read_setup_with_extras(provider, mocker):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
@@ -300,7 +295,6 @@ def test_search_for_directory_setup_read_setup_with_extras(provider, mocker):
     }
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_search_for_directory_setup_read_setup_with_no_dependencies(provider):
     dependency = DirectoryDependency(
         "demo",

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from clikit.io import NullIO
@@ -13,7 +15,6 @@ from poetry.puzzle.provider import Provider as BaseProvider
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.repositories.pool import Pool
 from poetry.repositories.repository import Repository
-from poetry.utils._compat import Path
 from poetry.utils.env import MockEnv
 from tests.helpers import get_dependency
 from tests.helpers import get_package

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -6,11 +7,9 @@ from pytest_mock.plugin import MockFixture
 
 from poetry.core.packages import Package
 from poetry.repositories.installed_repository import InstalledRepository
-from poetry.utils._compat import PY36
-from poetry.utils._compat import Path
 from poetry.utils._compat import metadata
-from poetry.utils._compat import zipp
 from poetry.utils.env import MockEnv as BaseMockEnv
+from tests.compat import zipp
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -135,9 +134,6 @@ def test_load_platlib_package(repository):
     assert lib64.version.text == "2.3.4"
 
 
-@pytest.mark.skipif(
-    not PY36, reason="pathlib.resolve() does not support strict argument"
-)
 def test_load_editable_package(repository):
     # test editable package with text .pth file
     editable = get_package_from_repository("editable", repository)

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -1,5 +1,7 @@
 import shutil
 
+from pathlib import Path
+
 import pytest
 
 from poetry.core.packages import Dependency
@@ -8,8 +10,6 @@ from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.legacy_repository import Page
-from poetry.utils._compat import PY35
-from poetry.utils._compat import Path
 
 
 try:
@@ -94,16 +94,6 @@ def test_get_package_information_fallback_read_setup():
         package.description
         == "Jupyter metapackage. Install all the Jupyter components in one go."
     )
-
-    if PY35:
-        assert package.requires == [
-            Dependency("notebook", "*"),
-            Dependency("qtconsole", "*"),
-            Dependency("jupyter-console", "*"),
-            Dependency("nbconvert", "*"),
-            Dependency("ipykernel", "*"),
-            Dependency("ipywidgets", "*"),
-        ]
 
 
 def test_get_package_information_skips_dependencies_with_invalid_constraints():

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -2,6 +2,7 @@ import json
 import shutil
 
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 
@@ -11,8 +12,6 @@ from requests.models import Response
 from poetry.core.packages import Dependency
 from poetry.factory import Factory
 from poetry.repositories.pypi_repository import PyPiRepository
-from poetry.utils._compat import PY35
-from poetry.utils._compat import Path
 from poetry.utils._compat import encode
 
 
@@ -136,7 +135,6 @@ def test_fallback_inspects_sdist_first_if_no_matching_wheels_can_be_found():
     assert dep.python_versions == "~2.7"
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_fallback_can_read_setup_to_get_dependencies():
     repo = MockRepository(fallback=True)
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -2,14 +2,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from pathlib import Path
+
 import pytest
 
 from poetry.core.toml.file import TOMLFile
 from poetry.factory import Factory
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pypi_repository import PyPiRepository
-from poetry.utils._compat import PY2
-from poetry.utils._compat import Path
 
 
 fixtures_dir = Path(__file__).parent / "fixtures"
@@ -196,16 +196,10 @@ def test_validate_fails():
     content = complete.read()["tool"]["poetry"]
     content["this key is not in the schema"] = ""
 
-    if PY2:
-        expected = (
-            "Additional properties are not allowed "
-            "(u'this key is not in the schema' was unexpected)"
-        )
-    else:
-        expected = (
-            "Additional properties are not allowed "
-            "('this key is not in the schema' was unexpected)"
-        )
+    expected = (
+        "Additional properties are not allowed "
+        "('this key is not in the schema' was unexpected)"
+    )
 
     assert Factory.validate(content) == {"errors": [expected], "warnings": []}
 
@@ -216,13 +210,7 @@ def test_create_poetry_fails_on_invalid_configuration():
             Path(__file__).parent / "fixtures" / "invalid_pyproject" / "pyproject.toml"
         )
 
-    if PY2:
-        expected = """\
-The Poetry configuration is invalid:
-  - u'description' is a required property
-"""
-    else:
-        expected = """\
+    expected = """\
 The Poetry configuration is invalid:
   - 'description' is a required property
 """

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 
+from pathlib import Path
 from typing import Optional
 from typing import Union
 
@@ -13,8 +14,6 @@ from clikit.io import NullIO
 from poetry.core.semver import Version
 from poetry.core.toml.file import TOMLFile
 from poetry.factory import Factory
-from poetry.utils._compat import PY2
-from poetry.utils._compat import Path
 from poetry.utils.env import GET_BASE_PREFIX
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import EnvManager
@@ -145,11 +144,10 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
+        "subprocess.Popen.communicate",
         side_effect=[("/prefix", None), ("/prefix", None)],
     )
     m = mocker.patch("poetry.utils.env.EnvManager.build_venv", side_effect=build_venv)
@@ -186,12 +184,10 @@ def test_activate_activates_existing_virtualenv_no_envs_file(
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
-        side_effect=[("/prefix", None)],
+        "subprocess.Popen.communicate", side_effect=[("/prefix", None)],
     )
     m = mocker.patch("poetry.utils.env.EnvManager.build_venv", side_effect=build_venv)
 
@@ -227,12 +223,10 @@ def test_activate_activates_same_virtualenv_with_envs_file(
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
-        side_effect=[("/prefix", None)],
+        "subprocess.Popen.communicate", side_effect=[("/prefix", None)],
     )
     m = mocker.patch("poetry.utils.env.EnvManager.create_venv")
 
@@ -266,11 +260,11 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
+        "subprocess.Popen.communicate",
         side_effect=[("/prefix", None), ("/prefix", None), ("/prefix", None)],
     )
     m = mocker.patch("poetry.utils.env.EnvManager.build_venv", side_effect=build_venv)
@@ -309,11 +303,10 @@ def test_activate_activates_recreates_for_different_patch(
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
+        "subprocess.Popen.communicate",
         side_effect=[
             ("/prefix", None),
             ('{"version_info": [3, 7, 0]}', None),
@@ -366,11 +359,11 @@ def test_activate_does_not_recreate_when_switching_minor(
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
+        "subprocess.Popen.communicate",
         side_effect=[("/prefix", None), ("/prefix", None), ("/prefix", None)],
     )
     build_venv_m = mocker.patch(
@@ -411,8 +404,7 @@ def test_deactivate_non_activated_but_existing(
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
 
     manager.deactivate(NullIO())
@@ -450,8 +442,7 @@ def test_deactivate_activated(tmp_dir, manager, poetry, config, mocker):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
 
     manager.deactivate(NullIO())
@@ -482,12 +473,10 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     envs_file.write(doc)
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
-        side_effect=[("/prefix", None)],
+        "subprocess.Popen.communicate", side_effect=[("/prefix", None)],
     )
 
     env = manager.get()
@@ -518,7 +507,7 @@ def test_remove_by_python_version(tmp_dir, manager, poetry, config, mocker):
     (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
 
@@ -536,7 +525,7 @@ def test_remove_by_name(tmp_dir, manager, poetry, config, mocker):
     (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
 
@@ -554,7 +543,7 @@ def test_remove_also_deactivates(tmp_dir, manager, poetry, config, mocker):
     (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
 
@@ -591,7 +580,7 @@ def test_remove_keeps_dir_if_not_deleteable(tmp_dir, manager, poetry, config, mo
     file2_path.touch(exist_ok=False)
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
 
@@ -619,9 +608,7 @@ def test_remove_keeps_dir_if_not_deleteable(tmp_dir, manager, poetry, config, mo
     m.side_effect = original_rmtree  # Avoid teardown using `err_on_rm_venv_only`
 
 
-@pytest.mark.skipif(
-    os.name == "nt" or PY2, reason="Symlinks are not support for Windows"
-)
+@pytest.mark.skipif(os.name == "nt", reason="Symlinks are not support for Windows")
 def test_env_has_symlinks_on_nix(tmp_dir, tmp_venv):
     assert os.path.islink(tmp_venv.python)
 
@@ -652,7 +639,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
 
     mocker.patch("sys.version_info", (2, 7, 16))
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.7.5")),
     )
     m = mocker.patch(
@@ -678,9 +665,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     mocker.patch("sys.version_info", (2, 7, 16))
-    mocker.patch(
-        "poetry.utils._compat.subprocess.check_output", side_effect=["3.5.3", "3.9.0"]
-    )
+    mocker.patch("subprocess.check_output", side_effect=["3.5.3", "3.9.0"])
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
     )
@@ -702,9 +687,7 @@ def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
 
     poetry.package.python_versions = "^4.8"
 
-    mocker.patch(
-        "poetry.utils._compat.subprocess.check_output", side_effect=["", "", "", ""]
-    )
+    mocker.patch("subprocess.check_output", side_effect=["", "", "", ""])
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
     )
@@ -730,7 +713,7 @@ def test_create_venv_does_not_try_to_find_compatible_versions_with_executable(
 
     poetry.package.python_versions = "^4.8"
 
-    mocker.patch("poetry.utils._compat.subprocess.check_output", side_effect=["3.8.0"])
+    mocker.patch("subprocess.check_output", side_effect=["3.8.0"])
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
     )
@@ -762,7 +745,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
 
     mocker.patch("sys.version_info", (version.major, version.minor, version.patch + 1))
     check_output = mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.9")),
     )
     m = mocker.patch(
@@ -793,7 +776,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility_with_executable(
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     check_output = mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
+        "subprocess.check_output",
         side_effect=check_output_wrapper(
             Version.parse("{}.{}.0".format(version.major, version.minor - 1))
         ),
@@ -831,11 +814,10 @@ def test_activate_with_in_project_setting_does_not_fail_if_no_venvs_dir(
     )
 
     mocker.patch(
-        "poetry.utils._compat.subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        "subprocess.check_output", side_effect=check_output_wrapper(),
     )
     mocker.patch(
-        "poetry.utils._compat.subprocess.Popen.communicate",
+        "subprocess.Popen.communicate",
         side_effect=[("/prefix", None), ("/prefix", None)],
     )
     m = mocker.patch("poetry.utils.env.EnvManager.build_venv")

--- a/tests/utils/test_env_site.py
+++ b/tests/utils/test_env_site.py
@@ -1,13 +1,14 @@
 import uuid
 
-from poetry.utils._compat import Path
+from pathlib import Path
+
 from poetry.utils._compat import decode
 from poetry.utils.env import SitePackages
 
 
 def test_env_site_simple(tmp_dir, mocker):
     # emulate permission error when creating directory
-    mocker.patch("poetry.utils._compat.Path.mkdir", side_effect=OSError())
+    mocker.patch("pathlib.Path.mkdir", side_effect=OSError())
     site_packages = SitePackages(Path("/non-existent"), fallbacks=[Path(tmp_dir)])
     candidates = site_packages.make_candidates(Path("hello.txt"), writable_only=True)
     hello = Path(tmp_dir) / "hello.txt"

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -1,5 +1,7 @@
 import sys
 
+from pathlib import Path
+
 import pytest
 
 from poetry.core.packages import dependency_from_pep_508
@@ -7,7 +9,6 @@ from poetry.core.toml.file import TOMLFile
 from poetry.factory import Factory
 from poetry.packages import Locker as BaseLocker
 from poetry.repositories.legacy_repository import LegacyRepository
-from poetry.utils._compat import Path
 from poetry.utils.exporter import Exporter
 
 
@@ -42,9 +43,7 @@ def working_directory():
 
 @pytest.fixture(autouse=True)
 def mock_path_cwd(mocker, working_directory):
-    yield mocker.patch(
-        "poetry.core.utils._compat.Path.cwd", return_value=working_directory
-    )
+    yield mocker.patch("pathlib.Path.cwd", return_value=working_directory)
 
 
 @pytest.fixture()

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,5 +1,6 @@
+from pathlib import Path
+
 from poetry.core.utils.helpers import parse_requires
-from poetry.utils._compat import Path
 from poetry.utils.helpers import get_cert
 from poetry.utils.helpers import get_client_cert
 

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 from poetry.core.semver.exceptions import ParseVersionError
-from poetry.utils._compat import PY35
 from poetry.utils.setup_reader import SetupReader
 
 
@@ -15,7 +14,6 @@ def setup():
     return _setup
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_setup_reader_read_first_level_setup_call_with_direct_types(setup):
     result = SetupReader.read_from_directory(setup("flask"))
 
@@ -48,7 +46,6 @@ def test_setup_reader_read_first_level_setup_call_with_direct_types(setup):
     assert expected_python_requires == result["python_requires"]
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_setup_reader_read_first_level_setup_call_with_variables(setup):
     result = SetupReader.read_from_directory(setup("requests"))
 
@@ -74,7 +71,6 @@ def test_setup_reader_read_first_level_setup_call_with_variables(setup):
     assert expected_python_requires == result["python_requires"]
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_setup_reader_read_sub_level_setup_call_with_direct_types(setup):
     result = SetupReader.read_from_directory(setup("sqlalchemy"))
 
@@ -123,7 +119,6 @@ def test_setup_reader_read_setup_cfg_with_attr(setup):
         SetupReader.read_from_directory(setup("with-setup-cfg-attr"))
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_setup_reader_read_setup_kwargs(setup):
     result = SetupReader.read_from_directory(setup("pendulum"))
 
@@ -140,7 +135,6 @@ def test_setup_reader_read_setup_kwargs(setup):
     assert expected_python_requires == result["python_requires"]
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_setup_reader_read_setup_call_in_main(setup):
     result = SetupReader.read_from_directory(setup("pyyaml"))
 
@@ -157,7 +151,6 @@ def test_setup_reader_read_setup_call_in_main(setup):
     assert expected_python_requires == result["python_requires"]
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_setup_reader_read_extras_require_with_variables(setup):
     result = SetupReader.read_from_directory(setup("extras_require_with_vars"))
 
@@ -174,7 +167,6 @@ def test_setup_reader_read_extras_require_with_variables(setup):
     assert expected_python_requires == result["python_requires"]
 
 
-@pytest.mark.skipif(not PY35, reason="AST parsing does not work for Python <3.4")
 def test_setup_reader_setuptools(setup):
     result = SetupReader.read_from_directory(setup("setuptools_setup"))
 


### PR DESCRIPTION
This change removes code, dependencies and tests related to python 2.7
and 3.5 compatibility. The minimum supported runtime python version
for poetry is now 3.6.

Additionally this change also mitigates httpretty urllib incompatibility (#3404).
