### PR TITLE
Allow Wheel to work when no version is specified in filename

### DIFF
--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -24,7 +24,9 @@ class Wheel(object):
 
         self.filename = filename
         self.name = wheel_info.group("name").replace("_", "-")
-        self.version = wheel_info.group("ver").replace("_", "-")
+        self.version = wheel_info.group("ver")
+        if self.version:
+            self.version = self.version.replace("_", "-")
         self.build_tag = wheel_info.group("build")
         self.pyversions = wheel_info.group("pyver").split(".")
         self.abis = wheel_info.group("abi").split(".")

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -8,6 +8,7 @@ from packaging.tags import Tag
 
 from poetry.core.packages.package import Package
 from poetry.installation.chooser import Chooser
+from poetry.installation.chooser import Wheel
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool
 from poetry.repositories.pypi_repository import PyPiRepository
@@ -196,3 +197,7 @@ def test_chooser_chooses_distributions_that_match_the_package_hashes(
     link = chooser.choose_for(package)
 
     assert "isort-4.3.4.tar.gz" == link.filename
+
+
+def test_wheel_handles_no_version(env, pool):
+    Wheel("tiamat-6-py3-none-any.whl")


### PR DESCRIPTION
I hit a problem where poetry wasn't handling a package correctly.

It turns out that the wheel_file_re pattern correctly treats `version` as optional, but `Wheel` wasn't.

I've updated Wheel to properly handle this case and added a test using the exact package name that tripped me up.