### PR TITLE
Cleanup hash checking

### DIFF
--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -95,24 +95,7 @@ class Chooser:
             repository = self._pool.repository(package.source_reference)
 
         links = repository.find_links_for_package(package)
-
-        hashes = [f["hash"] for f in package.files]
-        if not hashes:
-            return links
-
-        selected_links = []
-        for link in links:
-            if not link.hash:
-                selected_links.append(link)
-                continue
-
-            h = link.hash_name + ":" + link.hash
-            if h not in hashes:
-                continue
-
-            selected_links.append(link)
-
-        return selected_links
+        return [link for link in links if self._is_link_hash_allowed_for_package(link, package)]
 
     def _sort_key(self, package, link):  # type: (Package, Link) -> Tuple
         """

--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -104,13 +104,6 @@ class Chooser:
         Returns a tuple such that tuples sorting as greater using Python's
         default comparison operator are more preferred.
         The preference is as follows:
-        First and foremost, candidates with allowed (matching) hashes are
-        always preferred over candidates without matching hashes. This is
-        because e.g. if the only candidate with an allowed hash is yanked,
-        we still want to use that candidate.
-        Second, excepting hash considerations, candidates that have been
-        yanked (in the sense of PEP 592) are always less preferred than
-        candidates that haven't been yanked. Then:
         If not finding wheels, they are sorted by version only.
         If finding wheels, then the sort order is by version, then:
           1. existing installs
@@ -141,14 +134,7 @@ class Chooser:
         else:  # sdist
             pri = -support_num
 
-        has_allowed_hash = int(self._is_link_hash_allowed_for_package(link, package))
-
-        # TODO: Proper yank value
-        yank_value = 0
-
         return (
-            has_allowed_hash,
-            yank_value,
             binary_preference,
             package.version,
             build_tag,

--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -1,5 +1,5 @@
 import re
-
+import logging
 from typing import List
 from typing import Tuple
 
@@ -10,6 +10,9 @@ from poetry.core.packages.utils.link import Link
 from poetry.repositories.pool import Pool
 from poetry.utils.env import Env
 from poetry.utils.patterns import wheel_file_re
+
+
+logger = logging.getLogger(__name__)
 
 
 class InvalidWheelName(Exception):
@@ -175,6 +178,13 @@ class Chooser:
         if not link.hash:
             return True
 
-        h = link.hash_name + ":" + link.hash
+        named_hash = link.hash_name + ":" + link.hash
 
-        return h in {f["hash"] for f in package.files}
+        for source in package.files:
+            if source["file"] == link.filename:
+                if named_hash == source["hash"]:
+                    return True
+                else:
+                    logger.warn("Disregarding download url %s because of mismatching hash with stored hash", link)
+        
+        return False

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -599,8 +599,17 @@ class Executor(object):
                 archive = self._chef.prepare(archive)
 
         if package.files:
-            archive_hash = "sha256:" + FileDependency(package.name, archive).hash()
-            if archive_hash not in {f["hash"] for f in package.files}:
+            for f in package.files:
+                if source["file"] == link.filename:
+                    hash_type, reference_hash = source["hash"].split(":")
+                    break
+            else:
+                raise RuntimeError(
+                    "Filename {} not found in lock".format(link.filename)
+            )
+            
+            archive_hash = FileDependency(package.name, archive).hash(hash_type)
+            if archive_hash != reference_hash:
                 raise RuntimeError(
                     "Invalid hash for {} using archive {}".format(package, archive.name)
                 )


### PR DESCRIPTION
# Pull Request Check List

Depends on https://github.com/python-poetry/poetry-core/pull/113
Further improves: #2422 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

# What is this about

There are two points where checksum are (supposed to be*) validated in poetry:

1. When choosing a download link the hash sum is queried from the repo and checked against a list of known hashes
2. After downloading the downloaded package is checked to have one of the known hashes

This MR changes a few things:

1. Only check against the hash for the corresponding file name instead of all hashes - this improves security and makes it possible to improve output to the user.
2. Improve output: I the current version* if the hash mismatches this could be for two reasons, the hash is for a different file (e.g. the lock file was created for the .tar.gz but it was deleted and a wheel was uploaded instead) or because the hash of the file does not match. These are two different scenarios which the user cannot differentiate. This MR makes it transparent for the user what is actually happening.
3. Code Clean-up: When selecting which link to use for download, if a matching hash exists for the link is considered. But the code filters out all links with mismatching hashes before the sorting is even reached. So that part was removed.

```
* The current version does not validate hashes at all. I am referring to how the code is intended to do it.
```

# Open TODOs
1. This really needs proper tests - and I am willing to contribute them but I had some difficulties, [see other MR](https://github.com/python-poetry/poetry-core/pull/113)
2. I am not sure about how to properly handle the error/warning output when a mismatching hash occurs. I python logging - which I guess is okay but not as nice to look at as the usual poetry output. On the other hand, mismatching hashes means something ugly is going on... :man_shrugging: 
3. Docs need to be added - but I would welcome input on code and CLI output before updating the docs.