### PR TITLE
Fix script entrypoints with extras

### DIFF
--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -102,6 +102,8 @@ dependencies and not including the current project, run the command with the
             self.line("")
             return 0
 
+        builder.extras(extras)
+
         builder.build()
 
         if self._io.supports_ansi() and not self.io.is_debug():

--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -36,6 +36,8 @@ class EditableBuilder(Builder):
         self._env = env
         self._io = io
 
+        self._extras = []
+
     def build(self):
         self._debug(
             "  - Building package <c1>{}</c1> in <info>editable</info> mode".format(
@@ -143,6 +145,12 @@ class EditableBuilder(Builder):
 
         scripts = entry_points.get("console_scripts", [])
         for script in scripts:
+            if script.endswith("]"):
+                script, extras = script[:-1].split("[")
+                extras = set(extras.split(","))
+                if extras - set(self._extras):
+                    continue
+
             name, script = script.split(" = ")
             module, callable_ = script.split(":")
             callable_holder = callable_.split(".", 1)[0]
@@ -255,3 +263,8 @@ class EditableBuilder(Builder):
     def _debug(self, msg):
         if self._io.is_debug():
             self._io.write_line(msg)
+
+    def extras(self, extras):  # type: (list) -> EditableBuilder
+        self._extras = extras
+
+        return self

--- a/tests/fixtures/project_with_extras/pyproject.toml
+++ b/tests/fixtures/project_with_extras/pyproject.toml
@@ -14,4 +14,7 @@ cachy = { version = ">=0.2.0", optional = true }
 extras_a = [ "pendulum" ]
 extras_b = [ "cachy" ]
 
+[tool.poetry.scripts]
+foo = { callable = "project_with_extras:foo", extras = ["extras_a"]}
+
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
---

- [x] Resolve invalid script entry point file when script has extras
- [x] Don't add script file when not all extras are selected

---
Consider this `pyproject.toml` file, which contains a script that has an extra (as implemented, but not yet documented -> https://github.com/python-poetry/poetry/pull/1181)
```toml
# pyproject.toml
# ...

[tool.poetry.extras]
my_extra = []

[tool.poetry.scripts]
foo = {callable = "my_package:foo", extras = ["my_extra"]}
```

Installing the above with `poetry install` givens you a script file including the 

```python
#!/path/to/python
from my_package import foo

if __name__ == '__main__':
    foo[my_extra]()
```

The last line is obviously incorrect. It should have been
```python
    foo()
```

In my opinion the file shouldn't have been installed at all in the first place, as those extras often go along with installing some optional packages to let them work. So I chose to skip the installation of the entrypoint as a whole if not all given extras are demanded. Note that I say "in my opinion", as this is different from setuptools. Setuptools will always install all script entrypoints.