### PR TITLE
Remove Python2.7 specific code

### DIFF
--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Dict
 from typing import List
 

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import hashlib
 import os
 import re
@@ -28,7 +26,7 @@ if TYPE_CHECKING:
     from poetry.core.semver.version import Version
 
 
-BIN = """# -*- coding: utf-8 -*-
+BIN = """\
 import glob
 import sys
 import os

--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Dict

--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import hashlib
 import os
 import shutil

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -5,6 +5,7 @@ import urllib.parse
 import warnings
 
 from collections import defaultdict
+from html import unescape
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -12,6 +13,7 @@ from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
+from urllib.parse import quote
 
 import requests
 import requests.auth
@@ -42,23 +44,6 @@ from .pypi_repository import PyPiRepository
 
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
-
-try:
-    from html import unescape
-except ImportError:
-    try:
-        from html.parser import HTMLParser
-    except ImportError:
-        from HTMLParser import HTMLParser
-
-    unescape = HTMLParser().unescape
-
-
-try:
-    from urllib.parse import quote
-except ImportError:
-    from urllib import quote
-
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")

--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -4,6 +4,7 @@ import shutil
 import stat
 import tempfile
 
+from collections.abc import Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -17,12 +18,6 @@ import requests
 
 from poetry.config.config import Config
 from poetry.core.packages.package import Package
-
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
 
 
 _canonicalize_regex = re.compile("[-_]+")

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -57,7 +57,6 @@ def test_self_update_should_install_all_necessary_elements(
     assert script.exists()
 
     expected_script = """\
-# -*- coding: utf-8 -*-
 import glob
 import sys
 import os

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from tests.helpers import get_package

--- a/tests/fixtures/directory/project_with_transitive_directory_dependencies/setup.py
+++ b/tests/fixtures/directory/project_with_transitive_directory_dependencies/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from distutils.core import setup
 
 packages = ["project_with_extras"]

--- a/tests/fixtures/git/github.com/demo/demo/setup.py
+++ b/tests/fixtures/git/github.com/demo/demo/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/git/github.com/demo/no-dependencies/setup.py
+++ b/tests/fixtures/git/github.com/demo/no-dependencies/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/git/github.com/demo/no-version/setup.py
+++ b/tests/fixtures/git/github.com/demo/no-version/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ast
 import os
 

--- a/tests/fixtures/git/github.com/demo/non-canonical-name/setup.py
+++ b/tests/fixtures/git/github.com/demo/non-canonical-name/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/project_with_setup/setup.py
+++ b/tests/fixtures/project_with_setup/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from setuptools import setup
 
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import json
 import re
 import shutil

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import itertools
 import json
 import sys

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import itertools
 import sys
 

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os
 import shutil
 

--- a/tests/puzzle/conftest.py
+++ b/tests/puzzle/conftest.py
@@ -1,19 +1,14 @@
 import shutil
+import urllib.parse
 
 from pathlib import Path
 
 import pytest
 
 
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
-
-
 def mock_clone(self, source, dest):
     # Checking source to determine which folder we need to copy
-    parts = urlparse.urlparse(source)
+    parts = urllib.parse.urlparse(source)
 
     folder = (
         Path(__file__).parent.parent

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -1,4 +1,5 @@
 import shutil
+import urllib.parse
 
 from pathlib import Path
 
@@ -11,12 +12,6 @@ from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.legacy_repository import Page
-
-
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
 
 
 class MockRepository(LegacyRepository):
@@ -40,7 +35,7 @@ class MockRepository(LegacyRepository):
             return Page(self._url + endpoint, f.read(), {})
 
     def _download(self, url, dest):
-        filename = urlparse.urlparse(url).path.rsplit("/")[-1]
+        filename = urllib.parse.urlparse(url).path.rsplit("/")[-1]
         filepath = self.FIXTURES.parent / "pypi.org" / "dists" / filename
 
         shutil.copyfile(str(filepath), dest)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from pathlib import Path
 
 import pytest

--- a/tests/utils/fixtures/setups/ansible/setup.py
+++ b/tests/utils/fixtures/setups/ansible/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import os
 import os.path

--- a/tests/utils/fixtures/setups/flask/setup.py
+++ b/tests/utils/fixtures/setups/flask/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import io
 import re
 from collections import OrderedDict

--- a/tests/utils/fixtures/setups/pendulum/setup.py
+++ b/tests/utils/fixtures/setups/pendulum/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from distutils.core import setup
 
 from build import *


### PR DESCRIPTION
Related: #3318

- Remove `coding: utf8` header as utf8 is the default in python3.
- Remove urllib2 imports in favor of urllib
- Remove __future__ imports.
- Remove htmlparser import, unescape is available (Python 3.4).
- collections.abc.Mapping (Python 3.3)
- Remove unicode function in get-poetry.py
- Remove _winreg import in favor of winreg (renamed in python3)
- TemporaryDirectory available (Python 3.2)