### PR TITLE
tests: Fix incompatibility with pytest-mock>=3.3.0

### DIFF
--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import pytest
 
-from pytest_mock.plugin import MockFixture
+from pytest_mock import MockFixture
 
 from poetry.core.packages import Package
 from poetry.repositories.installed_repository import InstalledRepository


### PR DESCRIPTION
Version 3.3.0 of pytest mock renamed MockFixture into MockerFixture. There is
as alias available for backwards compatibility. The import path of this alias
is not pytest_mock.pluging though but just pytest_mock instead.

For reference: Check out this [diff between version 3.2.0 and 3.3.0 of pytest-mock](https://github.com/pytest-dev/pytest-mock/compare/v3.2.0...v3.3.0).  Unfortunately you have to expand the diff of `src/pytest_mock/plugin.py` to see the change. This makes it impossible to link to the appropriate line (which is line 43 in the newer version).

# Pull Request Check List

Resolves: #issue-number-here
I did not find any issues related to this as of creating this PR.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

I think non of the above check boxes apply.