### PR TITLE
Fix regression for file dependencies on networked drives

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -561,12 +561,11 @@ class Locker(object):
         if package.source_url:
             url = package.source_url
             if package.source_type in ["file", "directory"]:
-                # The lock file should only store paths relative to the root project
-                url = Path(
-                    os.path.relpath(
-                        Path(url).as_posix(), self._lock.path.parent.as_posix()
-                    )
-                ).as_posix()
+                # For all local paths, the lock file should store the relative path from the root folder
+                url = Path(url).as_posix()
+                package_root = self._lock.path.parent
+                if url.startswith(".") or Path(url).anchor == package_root.anchor:
+                    url = Path(os.path.relpath(url, package_root.as_posix())).as_posix()
 
             data["source"] = dict()
 


### PR DESCRIPTION
## Summary

Starting in `Poetry 1.1.0a2`, the step that formats the relative path for the lock file doesn't properly handle networked or other external drives which should lock the user-specified absolute path. This PR fixes that regression and adds tests for the various combinations of file or directory dependency paths

I would be happy to make any improvements or changes or answer any questions to help get this merged, thanks for reviewing!

## Pull Request Check List

Resolves: #2643 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code. {N/A}

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->