### PR TITLE
Fix #3434: poetry init interactive dependency search is case sensitive

### DIFF
--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -255,18 +255,15 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 else:
                     choices = []
                     matches_names = [p.name for p in matches]
-                    exact_match = constraint["name"] in matches_names
+                    exact_match = constraint["name"].lower() in matches_names
                     if exact_match:
                         choices.append(
-                            matches[matches_names.index(constraint["name"])].pretty_name
+                            matches[matches_names.index(constraint["name"].lower())].pretty_name
                         )
 
                     for found_package in matches:
                         if len(choices) >= 10:
                             break
-
-                        if found_package.name.lower() == constraint["name"].lower():
-                            continue
 
                         choices.append(found_package.pretty_name)
 

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -258,7 +258,9 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     exact_match = constraint["name"].lower() in matches_names
                     if exact_match:
                         choices.append(
-                            matches[matches_names.index(constraint["name"].lower())].pretty_name
+                            matches[
+                                matches_names.index(constraint["name"].lower())
+                            ].pretty_name
                         )
 
                     for found_package in matches:

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -258,9 +258,9 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     exact_match = constraint["name"].lower() in matches_names
                     if exact_match:
                         choices.append(
-                            matches[
+                            matches.pop(
                                 matches_names.index(constraint["name"].lower())
-                            ].pretty_name
+                            ).pretty_name
                         )
 
                     for found_package in matches:

--- a/poetry/repositories/repository.py
+++ b/poetry/repositories/repository.py
@@ -102,7 +102,7 @@ class Repository(BaseRepository):
         results = []
 
         for package in self.packages:
-            if query in package.name:
+            if query.lower() in package.name:
                 results.append(package)
 
         return results

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -124,6 +124,44 @@ pytest = "^3.6.0"
     assert expected in tester.io.fetch_output()
 
 
+def test_interactive_with_dependencies_case_sensitivity(tester, repo):
+    repo.add_package(get_package("pygithub", "1.54.0"))
+
+    inputs = [
+        "my-package",  # Package name
+        "1.2.3",  # Version
+        "This is a description",  # Description
+        "n",  # Author
+        "MIT",  # License
+        "~2.7 || ^3.6",  # Python
+        "",  # Interactive packages
+        "PyGithub",  # Search for a package using capital letters
+        "0",  # First (and only) option is pygithub
+        "",  # Do not set constraint
+        "",  # Stop searching for packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+    tester.execute(inputs="\n".join(inputs))
+
+    expected = """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+pygithub = "^1.54.0"
+
+[tool.poetry.dev-dependencies]
+"""
+
+    assert expected in tester.io.fetch_output()
+
+
 def test_empty_license(tester):
     inputs = [
         "my-package",  # Package name


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3434

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

---

## Problem(s)

This PR fixes an issue with the `poetry init` command, more specifically the interactive dependency specification feature. When comparing a given package name against the matches in the pool, the names are considered to be an exact match if only if the casing matches. This behavior deviates from [PEP-426](https://www.python.org/dev/peps/pep-0426/#name) which states that comparisons of distribution names **must** be case insensitive.

This PR also removes some weird behavior where a case-insensitive match was purposely being _excluded_ from the list of package choices presented to the user. I assume that was to limit an exact match from appearing in the list twice. 🤷 

## Solution

I modified the exact match check to be case-insensitive.

## Testing

Added a pretty straight-forward test, `test_interactive_with_dependencies_case_sensitivity`, to cover the original issue. You can run the test against the first commit to see the failure and re-run the test against the head of this branch to see it pass. All existing tests continue to pass.

## Other Issue

In order to properly test this, I needed to modify the `search` method of the `Repository` class to also be case-insensitive. This is my first code contribution to `poetry` so I'm not sure of what the side-effects of that might be, if there are any. Any insight would be helpful!