### PR TITLE
Fix fallback to other interpreters when specifying a patchlevel.

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -847,7 +847,7 @@ class EnvManager:
                         supported_python
                     ):
                         continue
-                elif not supported_python.allows_all(
+                elif not supported_python.allows_any(
                     parse_constraint(python_to_try + ".*")
                 ):
                     continue

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1093,3 +1093,35 @@ def test_env_finds_fallback_executables_for_generic_env(tmp_dir, manager):
 
     assert Path(venv.python).name == expected_executable
     assert Path(venv.pip).name == expected_pip_executable
+
+
+def test_create_venv_accepts_fallback_version_w_nonzero_patchlevel(
+    manager, poetry, config, mocker, config_virtualenvs_path
+):
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
+
+    poetry.package.python_versions = "~3.5.1"
+    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
+
+    check_output = mocker.patch(
+        "subprocess.check_output",
+        side_effect=lambda cmd, *args, **kwargs: str(
+            "3.5.12" if "python3.5" in cmd else "3.7.1"
+        ),
+    )
+    m = mocker.patch(
+        "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
+    )
+
+    manager.create_venv(NullIO())
+
+    assert check_output.called
+    m.assert_called_with(
+        config_virtualenvs_path / "{}-py3.5".format(venv_name),
+        executable="python3.5",
+        flags={"always-copy": False, "system-site-packages": False},
+        with_pip=True,
+        with_setuptools=True,
+        with_wheel=True,
+    )


### PR DESCRIPTION
When a project specifies a narrow range for the supported python
versions, i.e. "python ~= 3.6.1" and the current interpreter falls
outside of that range, the fallback code fails to test an available
python3.6 interpreter because of a too strict a test.

# Pull Request Check List

Resolves: #3463

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [N/A] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
