### PR TITLE
Docs: adding a note about being able to specify a package's source repository

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -352,7 +352,7 @@ about dependency groups.
 
 ### Options
 
-* `--group (-D)`: The group to add the dependency to.
+* `--group (-G)`: The group to add the dependency to.
 * `--dev (-D)`: Add package as development dependency. (**Deprecated**)
 * `--editable (-e)`: Add vcs/path dependencies as editable.
 * `--extras (-E)`: Extras to activate for the dependency. (multiple values allowed)
@@ -360,8 +360,8 @@ about dependency groups.
 * `--python`: Python version for which the dependency must be installed.
 * `--platform`: Platforms for which the dependency must be installed.
 * `--source`: Name of the source to use to install the package.
-* `---allow-prereleases`: Accept prereleases.
-* `--dry-run`: Outputs the operations but will not execute anything (implicitly enables --verbose).
+* `--allow-prereleases`: Accept prereleases.
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
 * `--lock`: Do not perform install (only update the lockfile).
 
 

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -216,8 +216,15 @@ you can add it to your `pyproject.toml` file, like so:
 
 ```toml
 [[tool.poetry.source]]
-name = 'private'
-url = 'http://example.com/simple'
+name = "private"
+url = "http://example.com/simple"
+```
+
+If you have multiple repositories configured, you can explicitly tell poetry where to look for a specific package:
+
+```toml
+[tool.poetry.dependencies]
+requests = { version = "^2.13.0", source = "private" }
 ```
 
 {{% note %}}


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3476

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code. (N/A)
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

---

Adding a little note to the documentation about the ability to specify the source repository for a dependency.

As mentioned in the linked issue, poetry's dependency resolution was failing because the first private repository poetry looked in for a specified dependency returned a 404. Whether or not that's the right behavior is a different discussion, but the problem can immediately be solved using the `source` property.