### PR TITLE
Issue #3483 Add cert retrieval for requests

### DIFF
--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -75,7 +75,7 @@ class Authenticator:
         if cert is not None:
             cert = str(cert)
 
-        if isinstance(verify, pathlib.PurePath):
+        if verify is not None:
             verify = str(verify)
 
         settings = session.merge_environment_settings(
@@ -193,7 +193,7 @@ class Authenticator:
 
         return credentials
 
-    def get_certs_for_url(self, url: str) -> Dict[str, pathlib.PosixPath]:
+    def get_certs_for_url(self, url: str) -> Dict[str, pathlib.Path]:
         parsed_url = urllib.parse.urlsplit(url)
 
         netloc = parsed_url.netloc

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -181,7 +181,7 @@ class Authenticator:
     ) -> Tuple[Optional[str], Optional[str]]:
         credentials = (None, None)
 
-        for (repository_name, repository_netloc) in self._get_repository_netlocs():
+        for (repository_name, _) in self._get_repository_netlocs():
             auth = self._get_http_auth(repository_name, netloc)
 
             if auth is None:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -6,10 +6,9 @@ import urllib.parse
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
+from typing import Generator
 from typing import Optional
 from typing import Tuple
-from typing import Dict
-from typing import Generator
 
 import requests
 import requests.auth

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -2,7 +2,6 @@ import logging
 import time
 import urllib.parse
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
@@ -21,6 +20,8 @@ from poetry.utils.password_manager import PasswordManager
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from cleo.io.io import IO
 
     from poetry.config.config import Config
@@ -191,7 +192,7 @@ class Authenticator:
 
         return credentials
 
-    def get_certs_for_url(self, url: str) -> Dict[str, Path]:
+    def get_certs_for_url(self, url: str) -> Dict[str, "Path"]:
         parsed_url = urllib.parse.urlsplit(url)
 
         netloc = parsed_url.netloc
@@ -237,8 +238,8 @@ class Authenticator:
 
         return None
 
-    def _get_certs_for_netloc_from_config(self, netloc: str) -> Dict[str, Path]:
-        certs = dict(cert=None, verify=None)
+    def _get_certs_for_netloc_from_config(self, netloc: str) -> Dict[str, "Path"]:
+        certs = {"cert": None, "verify": None}
 
         for (repository_name, repository_netloc) in self._get_repository_netlocs():
             if netloc == repository_netloc:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -16,8 +16,9 @@ import requests.auth
 import requests.exceptions
 
 from poetry.exceptions import PoetryException
+from poetry.utils.helpers import get_cert
+from poetry.utils.helpers import get_client_cert
 from poetry.utils.password_manager import PasswordManager
-from poetry.utils.helpers import get_cert, get_client_cert
 
 
 if TYPE_CHECKING:
@@ -187,16 +188,13 @@ class Authenticator:
 
         return credentials
 
-    def get_certs_for_url(
-        self, url: str
-    ) -> Dict[str, pathlib.PosixPath]:
+    def get_certs_for_url(self, url: str) -> Dict[str, pathlib.PosixPath]:
         parsed_url = urllib.parse.urlsplit(url)
 
         netloc = parsed_url.netloc
 
         return self._certs.setdefault(
-            netloc,
-            self._get_certs_for_netloc_from_config(netloc),
+            netloc, self._get_certs_for_netloc_from_config(netloc),
         )
 
     def _get_repository_netlocs(self) -> Generator[[str, str], None, None]:
@@ -244,8 +242,8 @@ class Authenticator:
 
         for (repository_name, repository_netloc) in self._get_repository_netlocs():
             if netloc == repository_netloc:
-                certs['cert'] = get_client_cert(self._config, repository_name)
-                certs['verify'] = get_cert(self._config, repository_name)
+                certs["cert"] = get_client_cert(self._config, repository_name)
+                certs["verify"] = get_cert(self._config, repository_name)
                 break
 
         return certs

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -200,7 +200,8 @@ class Authenticator:
         netloc = parsed_url.netloc
 
         return self._certs.setdefault(
-            netloc, self._get_certs_for_netloc_from_config(netloc),
+            netloc,
+            self._get_certs_for_netloc_from_config(netloc),
         )
 
     def _get_repository_netlocs(self) -> Generator[[str, str], None, None]:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -204,7 +204,7 @@ class Authenticator:
             self._get_certs_for_netloc_from_config(netloc),
         )
 
-    def _get_repository_netlocs(self) -> Generator[[str, str], None, None]:
+    def _get_repository_netlocs(self) -> Generator[Tuple[str, str], None, None]:
         for repository_name in self._config.get("repositories", []):
             auth = self._get_http_auth(repository_name, netloc)
 

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -72,7 +72,7 @@ class Authenticator:
         verify = kwargs.get("verify", certs.get("verify"))
         cert = kwargs.get("cert", certs.get("cert"))
 
-        if isinstance(cert, pathlib.PurePath):
+        if cert is not None:
             cert = str(cert)
 
         if isinstance(verify, pathlib.PurePath):
@@ -241,9 +241,7 @@ class Authenticator:
 
         return None
 
-    def _get_certs_for_netloc_from_config(
-        self, netloc: str
-    ) -> Dict[str, pathlib.PosixPath]:
+    def _get_certs_for_netloc_from_config(self, netloc: str) -> Dict[str, pathlib.Path]:
         certs = dict(cert=None, verify=None)
 
         for (repository_name, repository_netloc) in self._get_repository_netlocs():

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -69,8 +69,8 @@ class Authenticator:
         stream = kwargs.get("stream")
 
         certs = self.get_certs_for_url(url)
-        verify = kwargs.get("verify", certs.get("verify"))
-        cert = kwargs.get("cert", certs.get("cert"))
+        verify = kwargs.get("verify") or certs.get("verify")
+        cert = kwargs.get("cert") or certs.get("cert")
 
         if cert is not None:
             cert = str(cert)
@@ -179,19 +179,14 @@ class Authenticator:
     def _get_credentials_for_netloc(
         self, netloc: str
     ) -> Tuple[Optional[str], Optional[str]]:
-        credentials = (None, None)
-
         for (repository_name, repository_netloc) in self._get_repository_netlocs():
             if netloc == repository_netloc:
                 auth = self._password_manager.get_http_auth(repository_name)
 
                 if auth is None:
-                    continue
+                    return (auth["username"], auth["password"])
 
-                credentials = (auth["username"], auth["password"])
-                break
-
-        return credentials
+        return (None, None)
 
     def get_certs_for_url(self, url: str) -> Dict[str, pathlib.Path]:
         parsed_url = urllib.parse.urlsplit(url)

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -73,6 +73,12 @@ class Authenticator:
         verify = kwargs.get("verify", certs.get("verify"))
         cert = kwargs.get("cert", certs.get("cert"))
 
+        if isinstance(cert, pathlib.PurePath):
+            cert = str(cert)
+
+        if isinstance(verify, pathlib.PurePath):
+            verify = str(verify)
+
         settings = session.merge_environment_settings(
             prepared_request.url, proxies, stream, verify, cert
         )

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -1,8 +1,8 @@
 import logging
-import pathlib
 import time
 import urllib.parse
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
@@ -183,12 +183,12 @@ class Authenticator:
             if netloc == repository_netloc:
                 auth = self._password_manager.get_http_auth(repository_name)
 
-                if auth is None:
+                if auth is not None:
                     return (auth["username"], auth["password"])
 
         return (None, None)
 
-    def get_certs_for_url(self, url: str) -> Dict[str, pathlib.Path]:
+    def get_certs_for_url(self, url: str) -> Dict[str, Path]:
         parsed_url = urllib.parse.urlsplit(url)
 
         netloc = parsed_url.netloc
@@ -236,7 +236,7 @@ class Authenticator:
 
         return None
 
-    def _get_certs_for_netloc_from_config(self, netloc: str) -> Dict[str, pathlib.Path]:
+    def _get_certs_for_netloc_from_config(self, netloc: str) -> Dict[str, Path]:
         certs = dict(cert=None, verify=None)
 
         for (repository_name, repository_netloc) in self._get_repository_netlocs():

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -328,8 +328,8 @@ def test_authenticator_uses_certs_from_config_if_not_provided(
     session_send = mocker.patch.object(authenticator.session, "send")
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
     kwargs = session_send.call_args[1]
-    assert str(kwargs["verify"]) == str(pathlib.Path("/path/to/cert"))
-    assert str(kwargs["cert"]) == str(pathlib.Path("/path/to/client-cert"))
+    assert pathlib.Path(kwargs["verify"]) == pathlib.Path("/path/to/cert")
+    assert pathlib.Path(kwargs["cert"]) == pathlib.Path("/path/to/client-cert")
 
 
 def test_authenticator_uses_provided_certs_instead_of_config_certs(
@@ -354,5 +354,5 @@ def test_authenticator_uses_provided_certs_instead_of_config_certs(
         cert="/path/to/provided/client-cert",
     )
     kwargs = session_send.call_args[1]
-    assert str(kwargs["verify"]) == str(pathlib.Path("/path/to/provided/cert"))
-    assert str(kwargs["cert"]) == str(pathlib.Path("/path/to/provided/client-cert"))
+    assert pathlib.Path(kwargs["verify"]) == pathlib.Path("/path/to/provided/cert")
+    assert pathlib.Path(kwargs["cert"]) == pathlib.Path("/path/to/provided/client-cert")

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -1,3 +1,4 @@
+import pathlib
 import re
 import uuid
 
@@ -327,8 +328,8 @@ def test_authenticator_uses_certs_from_config_if_not_provided(
     session_send = mocker.patch.object(authenticator.session, "send")
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
     kwargs = session_send.call_args[1]
-    assert str(kwargs["verify"]) == "/path/to/cert"
-    assert str(kwargs["cert"]) == "/path/to/client-cert"
+    assert str(kwargs["verify"]) == str(pathlib.Path("/path/to/cert"))
+    assert str(kwargs["cert"]) == str(pathlib.Path("/path/to/client-cert"))
 
 
 def test_authenticator_uses_provided_certs_instead_of_config_certs(
@@ -353,5 +354,5 @@ def test_authenticator_uses_provided_certs_instead_of_config_certs(
         cert="/path/to/provided/client-cert",
     )
     kwargs = session_send.call_args[1]
-    assert str(kwargs["verify"]) == "/path/to/provided/cert"
-    assert str(kwargs["cert"]) == "/path/to/provided/client-cert"
+    assert str(kwargs["verify"]) == str(pathlib.Path("/path/to/provided/cert"))
+    assert str(kwargs["cert"]) == str(pathlib.Path("/path/to/provided/client-cert"))

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -315,6 +315,8 @@ def test_authenticator_uses_env_provided_credentials(
     "cert,client_cert",
     [
         (None, None),
+        (None, "path/to/provided/client-cert"),
+        ("/path/to/provided/cert", None),
         ("/path/to/provided/cert", "path/to/provided/client-cert"),
     ],
 )

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -318,10 +318,9 @@ def test_authenticator_uses_certs_from_config_if_not_provided(
         {
             "repositories": {"foo": {"url": "https://foo.bar/simple/"}},
             "http-basic": {"foo": {"username": "bar", "password": "baz"}},
-            "certificates": {"foo": {
-                "cert": "/path/to/cert",
-                "client-cert": "/path/to/client-cert",
-            }},
+            "certificates": {
+                "foo": {"cert": "/path/to/cert", "client-cert": "/path/to/client-cert"}
+            },
         }
     )
 
@@ -340,10 +339,9 @@ def test_authenticator_uses_provided_certs_instead_of_config_certs(
         {
             "repositories": {"foo": {"url": "https://foo.bar/simple/"}},
             "http-basic": {"foo": {"username": "bar", "password": "baz"}},
-            "certificates": {"foo": {
-                "cert": "/path/to/cert",
-                "client-cert": "/path/to/client-cert",
-            }},
+            "certificates": {
+                "foo": {"cert": "/path/to/cert", "client-cert": "/path/to/client-cert"}
+            },
         }
     )
 

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -1,4 +1,3 @@
-import pathlib
 import re
 import uuid
 
@@ -327,9 +326,9 @@ def test_authenticator_uses_certs_from_config_if_not_provided(
     authenticator = Authenticator(config, NullIO())
     session_send = mocker.patch.object(authenticator.session, "send")
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
-    call_args = session_send.call_args
-    call_args.kwargs["verify"] == pathlib.Path("/path/to/cert")
-    call_args.kwargs["cert"] == pathlib.Path("/path/to/client-cert")
+    kwargs = session_send.call_args[1]
+    assert str(kwargs["verify"]) == "/path/to/cert"
+    assert str(kwargs["cert"]) == "/path/to/client-cert"
 
 
 def test_authenticator_uses_provided_certs_instead_of_config_certs(
@@ -353,6 +352,6 @@ def test_authenticator_uses_provided_certs_instead_of_config_certs(
         verify="/path/to/provided/cert",
         cert="/path/to/provided/client-cert",
     )
-    call_args = session_send.call_args
-    call_args.kwargs["verify"] == pathlib.Path("/path/to/provided/cert")
-    call_args.kwargs["cert"] == pathlib.Path("/path/to/provided/client-cert")
+    kwargs = session_send.call_args[1]
+    assert str(kwargs["verify"]) == "/path/to/provided/cert"
+    assert str(kwargs["cert"]) == "/path/to/provided/client-cert"

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -1,13 +1,13 @@
 import re
 import uuid
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Type
 from typing import Union
-from pathlib import Path
 
 import httpretty
 import pytest
@@ -321,7 +321,12 @@ def test_authenticator_uses_env_provided_credentials(
     ],
 )
 def test_authenticator_uses_certs_from_config_if_not_provided(
-    config, mock_remote, http, mocker, cert, client_cert
+    config: "Config",
+    mock_remote: Type[httpretty.httpretty],
+    http: Type[httpretty.httpretty],
+    mocker: "MockerFixture",
+    cert: Union[str, None],
+    client_cert: Union[str, None],
 ):
     configured_cert = "/path/to/cert"
     configured_client_cert = "/path/to/client-cert"


### PR DESCRIPTION
The authenticator.py code already retrieves credentials from the config
for every request based on url matching. This change makes the
authenticator also retrieve certs from the config for each request based
on url matching.

Also includes unit tests.

# Pull Request Check List

Resolves: #3483 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
