### PR TITLE
[minor] Wrong name for `poetry-core` package in docs

### DIFF
--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -300,4 +300,4 @@ build-backend = "poetry.core.masonry.api"
 !!!note
 
     If your `pyproject.toml` file still references `poetry` directly as a build backend,
-    you should update it to reference `poetry_core` instead.
+    you should update it to reference `poetry-core` instead.

--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -288,7 +288,7 @@ it in the `build-system` section of the `pyproject.toml` file like so:
 
 ```toml
 [build-system]
-requires = ["poetry_core>=1.0.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 ```
 


### PR DESCRIPTION
Docs mention `poetry_core` in the `build_system` section for `pyproject.toml` syntax, but package's name is `poetry-core` (`-`, not `_`).

I assume it works either way. Just trying to be consistent.

# Pull Request Check List

- [X] ~~Added **tests** for changed code.~~ *irrelevant*
- [X] Updated **documentation** for changed code.
