### PR TITLE
Remove non-existing --path option, add missing options

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -257,9 +257,14 @@ poetry add "git+https://github.com/pallets/flask.git@1.1.1[dotenv,dev]"
 ### Options
 
 * `--dev (-D)`: Add package as development dependency.
-* `--optional` : Add as an optional dependency.
-* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
-* `--lock` : Do not perform install (only update the lockfile).
+* `--extras (-E)`: Extras to activate for the dependency.
+* `--optional`: Add as an optional dependency.
+* `--python`: Python version for which the dependency must be installed.
+* `--platform`: Platforms for which the dependency must be installed.
+* `--source`: Name of the source to use to install the package.
+* `---allow-prereleases`: Accept prereleases.
+* `--dry-run`: Outputs the operations but will not execute anything (implicitly enables --verbose).
+* `--lock`: Do not perform install (only update the lockfile).
 
 
 ## remove

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -257,7 +257,7 @@ poetry add "git+https://github.com/pallets/flask.git@1.1.1[dotenv,dev]"
 ### Options
 
 * `--dev (-D)`: Add package as development dependency.
-* `--extras (-E)`: Extras to activate for the dependency.
+* `--extras (-E)`: Extras to activate for the dependency. (multiple values allowed)
 * `--optional`: Add as an optional dependency.
 * `--python`: Python version for which the dependency must be installed.
 * `--platform`: Platforms for which the dependency must be installed.

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -257,7 +257,6 @@ poetry add "git+https://github.com/pallets/flask.git@1.1.1[dotenv,dev]"
 ### Options
 
 * `--dev (-D)`: Add package as development dependency.
-* `--path`: The path to a dependency.
 * `--optional` : Add as an optional dependency.
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
 * `--lock` : Do not perform install (only update the lockfile).


### PR DESCRIPTION
I can't see this option in `poetry add --help` and I've also tried to actually run the command `poetry add --path $PATH` and I get this:

```python
clikit.api.args.exceptions.NoSuchOptionException: The "--path" option does not exist.
```

I verified the above with both version 1.1.4 as well as latest master commit https://github.com/python-poetry/poetry/commit/2aab9bcd495e11e5f4491aa72a9510773cc4a90e.
