### PR TITLE
poetry lock --no-update always generated a invalid lock file

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -525,6 +525,18 @@ class Locker(object):
             if not dependency.marker.is_any():
                 constraint["markers"] = str(dependency.marker)
 
+            if dependency.is_vcs():
+                # vcs constarint doesn't need version
+                del constraint["version"]
+
+                constraint["git"] = dependency.source
+                if dependency.branch:
+                    constraint["branch"] = dependency.branch
+                elif dependency.tag:
+                    constraint["tag"] = dependency.tag
+                else:
+                    constraint["rev"] = dependency.rev
+
             dependencies[dependency.pretty_name].append(constraint)
 
         # All the constraints should have the same type,

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -54,6 +54,49 @@ python-versions = "*"
 develop = true
 
 [package.dependencies]
+git_package = {git = "https://github.com/ota42y/dummy.git", rev = "abcdefg"}
+
+[package.source]
+type = "directory"
+url = "../dummy"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "*"
+content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
+
+[metadata.files]
+git_package = []
+local_package = []
+"""
+
+
+LOCK_FILE_WITH_GIT_PACKAGE_FOR_OLD_VERSION = """
+[[package]]
+name = "git_package"
+version = "0.1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = true
+
+[package.source]
+type = "git"
+url = "https://github.com/ota42y/dummy.git"
+reference = "abcdefg"
+resolved_reference = "abcdefg"
+
+[[package]]
+name = "local_package"
+version = "0.1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = true
+
+[package.dependencies]
 git_package = "rev abcdefg"
 
 [package.source]
@@ -105,6 +148,24 @@ def test_saving_lock_file_with_git_package(locker, root):
 
 def test_locker_properly_loads_rev_package(locker):
     locker.lock.write(tomlkit.parse(LOCK_FILE_WITH_GIT_PACKAGE))
+
+    packages = locker.locked_repository().packages
+
+    assert 2 == len(packages)
+
+    package = packages[1]
+    assert "local-package" == package.name
+    assert 1 == len(package.requires)
+
+    git_package_dependency = package.requires[0]  # this is Dependency not VCSDependency
+    assert git_package_dependency.is_vcs()
+    assert "rev abcdefg" == git_package_dependency.pretty_constraint
+    assert "abcdefg" == git_package_dependency.rev
+    assert "https://github.com/ota42y/dummy.git" == git_package_dependency.source
+
+
+def test_locker_properly_loads_rev_package_for_old_version(locker):
+    locker.lock.write(tomlkit.parse(LOCK_FILE_WITH_GIT_PACKAGE_FOR_OLD_VERSION))
 
     packages = locker.locked_repository().packages
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/3548

- [x] Added **tests** for changed code.
  - I want to check if the implementation is correct.
- [x] Updated **documentation** for changed code.

# summary

I found a bug where `poetry lock --no-update` always generated a invalid lock file.
When we use the package depends on git repository,
`poetry lock` correctly registers packages to lock file.
But when we use `poetry lock --no-update` command, which deletes the registered packages.

This is because the poetry ommitted data to saving poetry.core.Package which have VCSDependency 
So Locker#locked_repository load VCSDependency as Dependency and it caused bug.

I add information when we use VCSDependency, and I know this fix solved this bug.
But I'm not familiar with poetry, so it can cause unexpected bugs.
We would appreciate it if you could help us fix this bug.


# Bug codes
I added a repository here that can reproduce the bug.
https://github.com/ota42y/poetry_local_package_bug

This repository include invalid pyproject and which depends on local package (ota42y_python_package_test).
The local package depends on [absl-py](https://pypi.org/project/absl-py/) by git commit (c99edd8e3dffe3667a9f086db86aa259927ac429).
The absl-py depends on six.
(local_package->ota42y_python_package_test->absl-py->six)

The poetry delete `six` from lock file when `poetry lock --no-update` after `poetry lock`.

You can get bug after `git clone`

```
git submodule init
git submodule update

cd local_package
poetry lock
# generate correct lock file
poetry install
# no error

cp poetry.lock poetry.lock_correct

poetry lock --no-update
# generate invalit lock file
poetry install
# get error

diff poetry.lock poetry.lock_correct
# delete six from poetry.lock
````


# Causing
`poetry lock` generate Package object corresponding to local package(ota42y_python_package_test).
This object's ([package.requires](https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/packages/locker.py#L499) is array.
And this array have VCSDependency object corresponding to `absl-py`.

When poetry save lock file, poetry do this code.
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/packages/locker.py#L501-L507

```
constraint["version"] = str(dependency.pretty_constraint)
```
This line call [VCSDependency#pretty_constraint](https://github.com/python-poetry/poetry-core/blob/79bc4cb632df299d6604f866b1a96ad25a58ac52/poetry/core/packages/vcs_dependency.py#L83).
And save `"rev c99edd8e3dffe3667a9f086db86aa259927ac429"` to version.

So poetry save `absl-py = "rev c99edd8e3dffe3667a9f086db86aa259927ac429"` to local package's dependency 
And save `absl-py` and `six` to 'package'

```poetry.lock
[[package]]
name = "absl-py"
version = "0.11.0"
......

[package.dependencies]
six = "*"

[package.source]
type = "git"
url = "https://github.com/abseil/abseil-py.git"
reference = "c99edd8e3dffe3667a9f086db86aa259927ac429"
resolved_reference = "c99edd8e3dffe3667a9f086db86aa259927ac429"

[[package]]
name = "ota42y-python-package-test"
version = "0.1.0"
......

[package.dependencies]
absl-py = "rev c99edd8e3dffe3667a9f086db86aa259927ac429"

[package.source]
type = "directory"
url = "../ota42y_python_package_test"

[[package]]
name = "six"
......
```

`poetry lock --no-update` load dependency from lock file using this method
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/installation/installer.py#L188

This method is Locker#locked_repository.
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/packages/locker.py#L87

In this method, local package's data is loaded and load dependency by this line
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/packages/locker.py#L187

When load local package(ota42y_python_package_test), poetry call create_dependency method with dep_name="absl-py", constraint="rev c99edd8e3dffe3667a9f086db86aa259927ac429".

In Factory#create_dependency method, constraint isn't dict (string ) so poetry create Dependency by this line.
https://github.com/python-poetry/poetry-core/blob/79bc4cb632df299d6604f866b1a96ad25a58ac52/poetry/core/factory.py#L301
So poetry create local package with Dependency object corresponding to absl-py.

But when we use `poetry lock`, poetry create local package with VCSDependency, and this changes caused bug.


The bug occurred by this line when we use `poetry lock --no-update`
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/mixology/partial_solution.py#L143-L145

First, poetry register Term object which create from Dependency("absl-py") object which included in local package's dependency.
Next, poetry call this method with VCSDependency("absl'py") from this line
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/mixology/version_solver.py#L412

The poetry get Term which crate from Dependency as `old_positive` in this line.
`old_positive = self._positive.get(name)`
and call `intersect` method.
`self._positive[name] = old_positive.intersect(assignment)`.

So poetry execute this method
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/mixology/term.py#L109

The poetry call _compatible_dependency method and execute `other.is_same_package_as(self.dependency)`
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/mixology/term.py#L154

In this method, poetry called `self._source_type != other.source_type` (L72)
https://github.com/python-poetry/poetry-core/blob/master/poetry/core/packages/specification.py#L67-L73

self is VCSDependency("absl-py") and _souce_type return `"git"`.
But other is Dependency("absl-py") and _source_type is None.
So this method return False.

Term#intersect execute this line but self and others is positive so this method return None
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/mixology/term.py#L138

PartialSolution._positive
https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/mixology/partial_solution.py#L145

execute as `self._positive['absl-py'] = None`

But when we use `poetry lock`, loca packaged`s dependency is VCSDependency so `old_positive` is VCSDependency.
This difference causes a bug which deleting `six` package.

This changes save dict to lock file  when we saving VCSDependency.
So when we use `poetry lock --no-update`, we can create VCSDependency object in Factory#create_dependency.