### PR TITLE
Handle 403 response from secondary repos

### DIFF
--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -120,6 +120,10 @@ a custom certificate authority or client certificates, similarly refer to the ex
 `certificates` section. Poetry will use these values to authenticate to your private repository when downloading or
 looking for packages.
 
+401 or 403 responses from secondary repositories will generate a warning
+message but are not considered as fatal, as some types of private repository
+servers may return a 403 if a request is made for a package not present on the
+server.
 
 ### Disabling the PyPI repository
 

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -395,6 +395,7 @@ class LegacyRepository(PyPiRepository):
             response = self.session.get(url)
             if response.status_code == 404:
                 return
+
             response.raise_for_status()
         except requests.HTTPError as e:
             raise RepositoryError(e)

--- a/tests/repositories/test_pool.py
+++ b/tests/repositories/test_pool.py
@@ -1,9 +1,49 @@
+import shutil
+
+from pathlib import Path
+from urllib.parse import urlparse
+
 import pytest
 
+from poetry.factory import Factory
 from poetry.repositories import Pool
 from poetry.repositories import Repository
 from poetry.repositories.exceptions import PackageNotFound
+from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.legacy_repository import LegacyRepository
+from poetry.repositories.legacy_repository import Page
+
+
+class MockRepository(LegacyRepository):
+
+    FIXTURES = Path(__file__).parent / "fixtures" / "legacy"
+
+    def __init__(self):
+        super(MockRepository, self).__init__(
+            "legacy", url="http://legacy.foo.bar", disable_cache=True
+        )
+
+    def _get(self, endpoint):
+        parts = endpoint.split("/")
+        name = parts[1]
+
+        fixture = self.FIXTURES / (name + ".html")
+        if not fixture.exists():
+            return
+
+        with fixture.open(encoding="utf-8") as f:
+            return Page(self._url + endpoint, f.read(), {})
+
+    def _download(self, url, dest):
+        filename = urlparse(url).path.rsplit("/")[-1]
+        filepath = self.FIXTURES.parent / "pypi.org" / "dists" / filename
+
+        shutil.copyfile(str(filepath), dest)
+
+
+class ErrorRepository(MockRepository):
+    def _get(self, endpoint):
+        raise RepositoryError()
 
 
 def test_pool_raises_package_not_found_when_no_package_is_found():
@@ -69,3 +109,26 @@ def test_repository_with_normal_default_and_secondary_repositories():
     assert pool.repository("foo") is repo1
     assert pool.repository("bar") is repo2
     assert pool.has_default()
+
+
+def test_default_repository_failure():
+    default = ErrorRepository()
+    secondary = MockRepository()
+    pool = Pool()
+    pool.add_repository(secondary, secondary=True)
+    pool.add_repository(default, default=True)
+
+    with pytest.raises(RepositoryError):
+        pool.find_packages(Factory.create_dependency("pyyaml", "*"))
+
+
+def test_secondary_repository_failure():
+    secondary = ErrorRepository()
+    default = MockRepository()
+    pool = Pool()
+    pool.add_repository(secondary, secondary=True)
+    pool.add_repository(default, default=True)
+
+    packages = pool.find_packages(Factory.create_dependency("pyyaml", "*"))
+
+    assert len(packages) == 1


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2783

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Hi all- this is my first PR for the project and thus I'm still somewhat clueless about the architecture as well as the teams practices, so begging your pardon in advance. Although this fixes the issue I've been encountering, I'm not confident that it's the ideal fix. I'm consulting with our Artifactory admins now to see if its possible to modify the behavior of the repo. Also I suspect that a few other open bugs related to failures when using secondary repositories may be the result of the same issue.

