### PR TITLE
Bump pkginfo requirement from ^1.4 to ^1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requests = "^2.18"
 cachy = "^0.3.0"
 requests-toolbelt = "^0.9.1"
 cachecontrol = { version = "^0.12.4", extras = ["filecache"] }
-pkginfo = "^1.4"
+pkginfo = "^1.5"
 html5lib = "^1.0"
 shellingham = "^1.1"
 tomlkit = ">=0.7.0,<1.0.0"


### PR DESCRIPTION
1.4.2 is shipped by default in Ubuntu 20.10 and pip installing
poetry will lead to the old system version being used.

Turns out poetry doesn't work with that old version, see #3362
and updating to 1.5.0 fixes things.

Resolves: #3362