### PR TITLE
Make get-poetry.py compatible with Cygwin - fix #1383

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -569,6 +569,8 @@ class Installer:
 
         # We get the payload from the remote host
         platform = sys.platform
+        if platform == "cygwin":
+            platform = "win32"
         if platform == "linux2":
             platform = "linux"
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #1383

- ❌ Added **tests** for changed code: no, as including tests for the Cygwin platform would require adding Cygwin as part of the GitHub Actions pipeline OS matrix: https://github.com/python-poetry/poetry/blob/master/.github/workflows/main.yml#L24
- ❌ Updated **documentation** for changed code: no, as the documentation currently does not mention Cygwin, and merging this PR does not mean `poetry` wants to provide full support for Cygwin.

This is just a quick & easy fix, that allowed me to use the official `poetry` installation method with `curl | bash`.

In many Python libs I have worked on, considering a [Cygwin](https://www.cygwin.com) environment as just being Windows is the usual way to go with supporting it.
