### PR TITLE
Use same python executable to run scripts

### DIFF
--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -1,3 +1,5 @@
+import sys
+
 from cleo import argument
 
 from .env_command import EnvCommand
@@ -35,9 +37,13 @@ class RunCommand(EnvCommand):
 
         module, callable_ = script.split(":")
 
-        src_in_sys_path = "sys.path.append('src'); " if self._module.is_in_src() else ""
+        # TODO Check during PR if this is necessary or if we can drop the whole block use of self._module
+        src_in_sys_path = ""
+        if hasattr(self, "_module") and self._module.is_in_src():
+            src_in_sys_path = "sys.path.append('src'); "
 
-        cmd = ["python", "-c"]
+        python_executable = sys.executable or "python"
+        cmd = [python_executable, "-c"]
 
         cmd += [
             "import sys; "

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 
@@ -14,3 +16,18 @@ def patches(mocker, env):
 def test_run_passes_all_args(tester, env):
     tester.execute("python -V")
     assert [["python", "-V"]] == env.executed
+
+
+def test_run_script_uses_current_python_executable(tester, env):
+    status_code = tester.execute("foo")
+    assert status_code == 0
+    assert env.executed == [
+        [
+            sys.executable,
+            "-c",
+            "import sys; "
+            "from importlib import import_module; "
+            "sys.argv = ['foo']; "
+            "import_module('foo').bar()",
+        ]
+    ]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3592

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
   - Note: `run` for `scripts` had no coverage so far
- [x] Updated **documentation** for changed code.
  - Nothing to be changed

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

- [ ] Remove TODO from the PR
  - When creating `test_run_script_uses_current_python_executable()` which was the first test for `run_script()` I noticed that `masonry` sets `self._module` to the `RunCommand` class during runtime which does not happen during the tests. It may be possible to define this `_module` inside the `command_tester_factory()` from `contest.py`. I'd be more than happy to get any pointers on how to improve this part of PR. One idea was to simply remove completely the `self._module.is_in_src()` statement and add some parameter in `pyproject.toml` that defines this `src` value. I feel it might improve code clarity and remove a bit of the black magic to have this `self._module` defines at runtime.