### PR TITLE
install only given dev dependency

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -116,6 +116,16 @@ by passing the `--dev-only` option. Note that `--no-dev` takes priority if both 
 poetry install --dev-only
 ```
 
+If not all development dependencies should be installed, but only a specific list, you can do this py passing
+ the `--dev` option. This option can be used multiple times. If only development dependencies should be used, you
+can use this option together with the `--dev-only` option.
+
+```bash
+poetry install --dev black
+poetry install --dev black --dev isort
+poetry install --dev-only --dev black
+```
+
 If you want to remove old dependencies no longer present in the lock file, use the
 `--remove-untracked` option.
 
@@ -156,6 +166,7 @@ option is passed.
 
 * `--no-dev`: Do not install dev dependencies.
 * `--dev-only`: Only install dev dependencies.
+* `--dev`: Only install listed development dependencies.
 * `--no-root`: Do not install the root package (your project).
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
 * `--remove-untracked`: Remove dependencies not presented in the lock file

--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -12,6 +12,13 @@ class InstallCommand(InstallerCommand):
         option("no-dev", None, "Do not install the development dependencies."),
         option("dev-only", None, "Only install the development dependencies."),
         option(
+            "dev",
+            None,
+            "Only install listed development dependencies.",
+            flag=False,
+            multiple=True,
+        ),
+        option(
             "no-root", None, "Do not install the root package (the current project)."
         ),
         option(
@@ -66,6 +73,7 @@ dependencies and not including the current project, run the command with the
         self._installer.extras(extras)
         self._installer.dev_mode(not self.option("no-dev"))
         self._installer.dev_only(self.option("dev-only"))
+        self._installer.dev_dependencies(self.option("dev"))
         self._installer.dry_run(self.option("dry-run"))
         self._installer.remove_untracked(self.option("remove-untracked"))
         self._installer.verbose(self._io.is_verbose())

--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -63,6 +63,8 @@ class Installer:
 
         self._extras = []
 
+        self._dev_dependencies = []
+
         if executor is None:
             executor = Executor(self._env, self._pool, config, self._io)
 
@@ -147,6 +149,11 @@ class Installer:
 
     def dev_only(self, dev_only=False):  # type: (bool) -> Installer
         self._dev_only = dev_only
+
+        return self
+
+    def dev_dependencies(self, dev_dependencies):  # type: (List[str]) -> Installer
+        self._dev_dependencies = dev_dependencies
 
         return self
 
@@ -290,6 +297,13 @@ class Installer:
         elif self.is_dev_only():
             root = root.clone()
             del root.requires[:]
+
+        if self._dev_dependencies:
+            root.dev_requires = [
+                package
+                for package in root.dev_requires
+                if package.name in self._dev_dependencies
+            ]
 
         if self._io.is_verbose():
             self._io.write_line("")


### PR DESCRIPTION
This PR introduce a new option `--dev` for the `poetry install` command. Instead of installing all development dependencies, one can use this option, to limit the installation to the given dev dependencies. `--dev` can be used together with `--dev-only` to decide, whether the dev dependencies should be installed together with the package or without.

Closes: https://github.com/python-poetry/poetry/issues/3570

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
