### PR TITLE
fix(shell): quote spacing before activating env

### DIFF
--- a/poetry/utils/shell.py
+++ b/poetry/utils/shell.py
@@ -65,6 +65,8 @@ class Shell:
         if WINDOWS:
             return env.execute(self.path)
 
+        import shlex
+
         terminal = Terminal()
         with env.temp_environ():
             c = pexpect.spawn(
@@ -77,7 +79,9 @@ class Shell:
         activate_script = self._get_activate_script()
         bin_dir = "Scripts" if WINDOWS else "bin"
         activate_path = env.path / bin_dir / activate_script
-        c.sendline("{} {}".format(self._get_source_command(), activate_path))
+        c.sendline(
+            "{} {}".format(self._get_source_command(), shlex.quote(str(activate_path)))
+        )
 
         def resize(sig, data):  # type: (Any, Any) -> None
             terminal = Terminal()


### PR DESCRIPTION
Signed-off-by: Pablo Woolvett <pablowoolvett@gmail.com>

# Pull Request Check List

Resolves: #3630

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
