### PR TITLE
Add azure keyring support

### DIFF
--- a/poetry/installation/authenticator.py
+++ b/poetry/installation/authenticator.py
@@ -152,9 +152,8 @@ class Authenticator(object):
                 continue
 
             parsed_url = urllib.parse.urlsplit(url)
-
             if netloc == parsed_url.netloc:
-                auth = self._password_manager.get_http_auth(repository_name)
+                auth = self._password_manager.get_http_auth(repository_name, url)
 
                 if auth is None:
                     continue

--- a/poetry/publishing/publisher.py
+++ b/poetry/publishing/publisher.py
@@ -45,7 +45,7 @@ class Publisher:
         password: Optional[str],
         cert: Optional[Path] = None,
         client_cert: Optional[Path] = None,
-        dry_run: Optional[bool] = False,
+        dry_run: bool = False,
     ) -> None:
         if not repository_name:
             url = "https://upload.pypi.org/legacy/"
@@ -66,7 +66,7 @@ class Publisher:
                 username = "__token__"
                 password = token
             else:
-                auth = self._password_manager.get_http_auth(repository_name)
+                auth = self._password_manager.get_http_auth(repository_name, url)
                 if auth:
                     logger.debug(
                         "Found authentication information for {}.".format(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3344 

I have added support for keyring lookup based on repository url via a `get_credentials` call, which is what `artifacts-keyring` seems to do. Every `get_credentials` call is at Microsoft speed, so I had to also add a cache on the keyring values.

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
