### PR TITLE
Add root-only install option

### DIFF
--- a/docs/docs/basic-usage.md
+++ b/docs/docs/basic-usage.md
@@ -203,6 +203,15 @@ If you want to install the dependencies only, run the `install` command with the
 poetry install --no-root
 ```
 
+### Installing root package only
+
+If you want to install the current project only, without resolving any
+dependencies, run the `install` command with the `--root-only` flag:
+
+```bash
+poetry install --root-only
+```
+
 ## Updating dependencies to their latest versions
 
 As mentioned above, the `poetry.lock` file prevents you from automatically getting the latest versions

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -152,11 +152,20 @@ poetry install --no-root
 Installation of your project's package is also skipped when the `--dev-only`
 option is passed.
 
+
+If you only want to install your project's package, without resolving any
+dependencies, use the `--root-only` option.
+
+```bash
+poetry install --root-only
+```
+
 ### Options
 
 * `--no-dev`: Do not install dev dependencies.
 * `--dev-only`: Only install dev dependencies.
 * `--no-root`: Do not install the root package (your project).
+* `--root-only`: Only install the root package (your project).
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
 * `--remove-untracked`: Remove dependencies not presented in the lock file
 * `--extras (-E)`: Features to install (multiple values allowed).

--- a/poetry/console/commands/install.py
+++ b/poetry/console/commands/install.py
@@ -15,6 +15,9 @@ class InstallCommand(InstallerCommand):
             "no-root", None, "Do not install the root package (the current project)."
         ),
         option(
+            "root-only", None, "Only install the root package (the current project)."
+        ),
+        option(
             "dry-run",
             None,
             "Output the operations but do not execute anything "
@@ -54,28 +57,29 @@ dependencies and not including the current project, run the command with the
         from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
         from poetry.masonry.builders import EditableBuilder
 
-        self._installer.use_executor(
-            self.poetry.config.get("experimental.new-installer", False)
-        )
+        if not self.option("root-only"):
+            self._installer.use_executor(
+                self.poetry.config.get("experimental.new-installer", False)
+            )
 
-        extras = []
-        for extra in self.option("extras"):
-            if " " in extra:
-                extras += [e.strip() for e in extra.split(" ")]
-            else:
-                extras.append(extra)
+            extras = []
+            for extra in self.option("extras"):
+                if " " in extra:
+                    extras += [e.strip() for e in extra.split(" ")]
+                else:
+                    extras.append(extra)
 
-        self._installer.extras(extras)
-        self._installer.dev_mode(not self.option("no-dev"))
-        self._installer.dev_only(self.option("dev-only"))
-        self._installer.dry_run(self.option("dry-run"))
-        self._installer.remove_untracked(self.option("remove-untracked"))
-        self._installer.verbose(self._io.is_verbose())
+            self._installer.extras(extras)
+            self._installer.dev_mode(not self.option("no-dev"))
+            self._installer.dev_only(self.option("dev-only"))
+            self._installer.dry_run(self.option("dry-run"))
+            self._installer.remove_untracked(self.option("remove-untracked"))
+            self._installer.verbose(self._io.is_verbose())
 
-        return_code = self._installer.run()
+            return_code = self._installer.run()
 
-        if return_code != 0:
-            return return_code
+            if return_code != 0:
+                return return_code
 
         if self.option("no-root") or self.option("dev-only"):
             return 0


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2166

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

# Summary
Adds an option to skip any dependency resolution and just install the root package.

# Motivation
- When developing inside a docker container its common to install dependencies during the docker build process (which can be done using `poetry install --no-root`), and then install the root package at runtime (once the code has been mounted in to the container). At the moment the `poetry install` command can take a long time (~1 minute) to resolve even though all dependencies are installed and up to date. Adding a `--root-only` option would enable a quick install of the root package in situations where you are confident that the dependencies are already up to date. This would have big impact on development speed and is in keeping with the `no-dev` and `dev-only` commands that are already present.
- In the linked issue, others seem to have similar challenges with multistage docker builds. In particular in situations where there might not be network connectivity for all build steps or when developing extensions in other languages.

# Notes
- Happy to add tests, however, I couldn't see a `tests/console/command/test_install.py` so wasn't sure where to add them.
