### PR TITLE
doc: change bash completions to user directory

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -176,7 +176,8 @@ See `poetry help completions` for full details, but the gist is as simple as usi
 
 ```bash
 # Bash
-poetry completions bash > /etc/bash_completion.d/poetry.bash-completion
+mkdir -p ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions
+poetry completions bash > ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions/poetry.bash-completions
 
 # Bash (Homebrew)
 poetry completions bash > $(brew --prefix)/etc/bash_completion.d/poetry.bash-completion
@@ -197,6 +198,16 @@ poetry completions zsh > $ZSH_CUSTOM/plugins/poetry/_poetry
 # prezto
 poetry completions zsh > ~/.zprezto/modules/completion/external/src/_poetry
 
+```
+
+The commands above create static completions that need to be manually updated when
+Poetry is updated. Alternatly, you can dynamically create the completions each time
+you open a terminal. However, this doesn't happen instantly, so it will add some
+delay before the terminal is ready.
+
+```
+# Bash
+echo '. <(poetry completions bash) >> ~/.bashrc
 ```
 
 !!! note

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -201,7 +201,7 @@ poetry completions zsh > ~/.zprezto/modules/completion/external/src/_poetry
 ```
 
 The commands above create static completions that need to be manually updated when
-Poetry is updated. Alternatly, you can dynamically create the completions each time
+Poetry is updated. Alternatively, you can dynamically create the completions each time
 you open a terminal. However, this doesn't happen instantly, so it will add some
 delay before the terminal is ready.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -207,7 +207,7 @@ delay before the terminal is ready.
 
 ```
 # Bash
-echo '. <(poetry completions bash) >> ~/.bashrc
+echo '. <(poetry completions bash)' >> ~/.bashrc
 ```
 
 !!! note

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -175,10 +175,13 @@ See `poetry help completions` for full details, but the gist is as simple as usi
 
 
 ```bash
-# Bash
+# Bash (single user)
 BASH_COMPLETION_USER_DIR=${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions
 mkdir -p ${BASH_COMPLETION_USER_DIR}
 poetry completions bash > ${BASH_COMPLETION_USER_DIR}/poetry
+
+# Bash (all users)
+poetry completions bash > /etc/bash_completion.d/poetry.bash-completion
 
 # Bash (Homebrew)
 poetry completions bash > $(brew --prefix)/etc/bash_completion.d/poetry.bash-completion

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -176,8 +176,9 @@ See `poetry help completions` for full details, but the gist is as simple as usi
 
 ```bash
 # Bash
-mkdir -p ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions
-poetry completions bash > ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions/poetry
+BASH_COMPLETION_USER_DIR=${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions
+mkdir -p ${BASH_COMPLETION_USER_DIR}
+poetry completions bash > ${BASH_COMPLETION_USER_DIR}/poetry
 
 # Bash (Homebrew)
 poetry completions bash > $(brew --prefix)/etc/bash_completion.d/poetry.bash-completion

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -177,7 +177,7 @@ See `poetry help completions` for full details, but the gist is as simple as usi
 ```bash
 # Bash
 mkdir -p ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions
-poetry completions bash > ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions/poetry.bash-completions
+poetry completions bash > ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions/poetry
 
 # Bash (Homebrew)
 poetry completions bash > $(brew --prefix)/etc/bash_completion.d/poetry.bash-completion


### PR DESCRIPTION
This changes the recommendation for bash completions to install in the user's home directory instead of the global `/etc` which would require root access.

The expression is exactly how bash completions looks for the directory. Comes from: https://github.com/scop/bash-completion/blob/9e98e2558c0625340013b123880ebb6bedc0d1b3/bash_completion#L2262

Also a section is added about how to dynamically add the completions instead of creating a static file and describes the pros and cons of doing it that way instead.

Fixes #2295

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
