### PR TITLE
fix: debug message may break due to no dep version

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -710,7 +710,7 @@ class Provider:
 
         if message.startswith("fact:"):
             if "depends on" in message:
-                m = re.match(r"fact: (.+?) depends on (.+?) \((.+?)\)", message)
+                m = re.match(r"fact: (.+?) depends on (.+?)( \((.+?)\))?", message)
                 m2 = re.match(r"(.+?) \((.+?)\)", m.group(1))
                 if m2:
                     name = m2.group(1)

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -710,7 +710,7 @@ class Provider:
 
         if message.startswith("fact:"):
             if "depends on" in message:
-                m = re.match(r"fact: (.+?) depends on (.+?)( \((.+?)\))?", message)
+                m = re.match(r"fact: (.+?) depends on ([^( ]+)(?: \((.+?)\))?", message)
                 m2 = re.match(r"(.+?) \((.+?)\)", m.group(1))
                 if m2:
                     name = m2.group(1)
@@ -722,7 +722,7 @@ class Provider:
                 message = (
                     "<fg=blue>fact</>: <c1>{}</c1>{} "
                     "depends on <c1>{}</c1> (<c2>{}</c2>)".format(
-                        name, version, m.group(2), m.group(3)
+                        name, version, m.group(2), m.group(3) or "*"
                     )
                 )
             elif " is " in message:


### PR DESCRIPTION
When colorizing the debug message, a depended package without version
constraint may fail regex match. This PR makes the version info part
optional.

# Pull Request Check List

Resolves: #3663

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
