### PR TITLE
Upgrade poetry core to 1.0.2 (1.1)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-1-snap
+  image_family: freebsd-12-2
 
 test_task:
   name: "Tests / FreeBSD / "

--- a/poetry.lock
+++ b/poetry.lock
@@ -552,7 +552,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "poetry-core"
-version = "1.0.0"
+version = "1.0.2"
 description = "Poetry PEP 517 Build Backend"
 category = "main"
 optional = false
@@ -974,7 +974,7 @@ testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~2.7 || ^3.5"
-content-hash = "1e774c9d8b7f6812d721cff08b51554f9a0cd051e2ae0e884421bcb56718d131"
+content-hash = "8c83ff77ac7763f13d4d0f73723b2cffe9236f8eb0a56e571c4e04cd3dc39f5a"
 
 [metadata.files]
 appdirs = [
@@ -1270,8 +1270,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 poetry-core = [
-    {file = "poetry-core-1.0.0.tar.gz", hash = "sha256:6a664ff389b9f45382536f8fa1611a0cb4d2de7c5a5c885db1f0c600cd11fbd5"},
-    {file = "poetry_core-1.0.0-py2.py3-none-any.whl", hash = "sha256:769288e0e1b88dfcceb3185728f0b7388b26d5f93d6c22d2dcae372da51d200d"},
+    {file = "poetry-core-1.0.2.tar.gz", hash = "sha256:ff505d656a6cf40ffbf84393d8b5bf37b78523a15def3ac473b6fad74261ee71"},
+    {file = "poetry_core-1.0.2-py2.py3-none-any.whl", hash = "sha256:ee0ed4164440eeab27d1b01bc7b9b3afdc3124f68d4ea28d0821a402a9c7c044"},
 ]
 pre-commit = [
     {file = "pre_commit-2.7.1-py2.py3-none-any.whl", hash = "sha256:810aef2a2ba4f31eed1941fc270e72696a1ad5590b9751839c90807d0fff6b9a"},

--- a/poetry/mixology/incompatibility.py
+++ b/poetry/mixology/incompatibility.py
@@ -434,7 +434,12 @@ class Incompatibility:
         if allow_every and term.constraint.is_any():
             return "every version of {}".format(term.dependency.complete_name)
 
-        return str(term.dependency)
+        if term.dependency.is_root:
+            return term.dependency.pretty_name
+
+        return "{} ({})".format(
+            term.dependency.pretty_name, term.dependency.pretty_constraint
+        )
 
     def _single_term_where(self, callable):  # type: (callable) -> Term
         found = None

--- a/poetry/mixology/term.py
+++ b/poetry/mixology/term.py
@@ -161,7 +161,11 @@ class Term(object):
         return Term(self.dependency.with_constraint(constraint), is_positive)
 
     def __str__(self):
-        return "{}{}".format("not " if not self.is_positive() else "", self._dependency)
+        return "{} {} ({})".format(
+            "not " if not self.is_positive() else "",
+            self._dependency.pretty_name,
+            self._dependency.pretty_constraint,
+        )
 
     def __repr__(self):
         return "<Term {}>".format(str(self))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"
 
-poetry-core = "^1.0.0"
+poetry-core = "^1.0.2"
 cleo = "^0.8.1"
 clikit = "^0.6.2"
 crashtest = { version = "^0.3.0", python = "^3.6" }


### PR DESCRIPTION
This PR upgrades `poetry-core` to `1.0.2` on the `1.1` branch.

Note that the representation of incompatibilities and terms needed to be changed in `mixology` due to changes in how dependencies are represented in `poetry-core`.
