### PR TITLE
Upgrade poetry-core to 1.0.2 (master)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-1-snap
+  image_family: freebsd-12-2
 
 test_task:
   name: "Tests / FreeBSD / "

--- a/poetry.lock
+++ b/poetry.lock
@@ -352,7 +352,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "poetry-core"
-version = "1.0.0"
+version = "1.0.2"
 description = "Poetry PEP 517 Build Backend"
 category = "main"
 optional = false
@@ -668,7 +668,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "c495920c853f794d4046d2d4cc47410ea076d4647e54fd3364e46051d5f18da3"
+content-hash = "3061627bdc17958f2b0d1dfc86e448e167ff3e97639e6f3c8f67bf0b06d9995c"
 
 [metadata.files]
 appdirs = [
@@ -901,8 +901,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 poetry-core = [
-    {file = "poetry-core-1.0.0.tar.gz", hash = "sha256:6a664ff389b9f45382536f8fa1611a0cb4d2de7c5a5c885db1f0c600cd11fbd5"},
-    {file = "poetry_core-1.0.0-py2.py3-none-any.whl", hash = "sha256:769288e0e1b88dfcceb3185728f0b7388b26d5f93d6c22d2dcae372da51d200d"},
+    {file = "poetry-core-1.0.2.tar.gz", hash = "sha256:ff505d656a6cf40ffbf84393d8b5bf37b78523a15def3ac473b6fad74261ee71"},
+    {file = "poetry_core-1.0.2-py2.py3-none-any.whl", hash = "sha256:ee0ed4164440eeab27d1b01bc7b9b3afdc3124f68d4ea28d0821a402a9c7c044"},
 ]
 pre-commit = [
     {file = "pre_commit-2.9.0-py2.py3-none-any.whl", hash = "sha256:4aee0db4808fa48d2458cedd5b9a084ef24dda1a0fa504432a11977a4d1cfd0a"},

--- a/poetry/mixology/incompatibility.py
+++ b/poetry/mixology/incompatibility.py
@@ -454,7 +454,12 @@ class Incompatibility:
         if allow_every and term.constraint.is_any():
             return "every version of {}".format(term.dependency.complete_name)
 
-        return str(term.dependency)
+        if term.dependency.is_root:
+            return term.dependency.pretty_name
+
+        return "{} ({})".format(
+            term.dependency.pretty_name, term.dependency.pretty_constraint
+        )
 
     def _single_term_where(self, callable: callable) -> Optional[Term]:
         found = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 
-poetry-core = "^1.0.0"
+poetry-core = "^1.0.2"
 cleo = "^1.0.0a1"
 crashtest = "^0.3.0"
 requests = "^2.18"


### PR DESCRIPTION
This PR upgrades `poetry-core` to `1.0.2` on the `master` branch.

Note that the representation of incompatibilities and terms needed to be changed in `mixology` due to changes in how dependencies are represented in `poetry-core`.

