### PR TITLE
Fix incorrect import of the Dependency class

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -25,7 +25,7 @@ from tomlkit.exceptions import TOMLKitError
 import poetry.repositories
 
 from poetry.core.packages import dependency_from_pep_508
-from poetry.core.packages.package import Dependency
+from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.semver import parse_constraint
 from poetry.core.semver.version import Version


### PR DESCRIPTION
# Pull Request Check List

This PR fixes the import of the `Dependency` class (which should be imported from `poetry.core.packages.dependency` and not from `poetry.core.packages.package`)

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
