### PR TITLE
Make the dependency on poetry-core more restrictive

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -974,7 +974,7 @@ testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~2.7 || ^3.5"
-content-hash = "8c83ff77ac7763f13d4d0f73723b2cffe9236f8eb0a56e571c4e04cd3dc39f5a"
+content-hash = "70e35c602ca490dcb9a13e83f8d9403990491b6ea258e4e4d44eecbc06bb8bff"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"
 
-poetry-core = "^1.0.2"
+poetry-core = "~1.0.2"
 cleo = "^0.8.1"
 clikit = "^0.6.2"
 crashtest = { version = "^0.3.0", python = "^3.6" }


### PR DESCRIPTION
Since `poetry-core` will see some changes in order to modernize its codebase it's better to be prudent here by restricting it to `~1.0.2` for the `1.1` branch of Poetry until we can be sure we can loosen it.

Note that it does change anything regarding the constraint in the `build-system` section since the high level API is unlikely to change for the foreseeable future.

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
