### PR TITLE
Prefer 'python3' executables over 'python' during install

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -638,7 +638,7 @@ class Installer:
 
     def _which_python(self):
         """Decides which python executable we'll embed in the launcher script."""
-        allowed_executables = ["python", "python3"]
+        allowed_executables = ["python3", "python"]
         if WINDOWS:
             allowed_executables += ["py.exe -3", "py.exe -2"]
 


### PR DESCRIPTION
Currently the setup script uses `python` first, and falls back to `python3`. This means python2 is often picked up on systems that have Python3 installed.

This MR swiches the check order to use `python3` first, then `python`.

In the future when Poetry drops python2 support, without this change the install script will be broken on any system that has Python2 installed as `python`, regardless of `python3` being present.