### PR TITLE
Skip path update prompt if --no-modify-path CLI arg was used

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -476,7 +476,7 @@ class Installer:
         return version, current_version
 
     def customize_install(self):
-        if not self._accept_all:
+        if self._modify_path and not self._accept_all:
             print("Before we start, please answer the following questions.")
             print("You may simply press the Enter key to leave unchanged.")
 


### PR DESCRIPTION
Fixes #3703.

# Pull Request Check List

Resolves: #3703

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

There don't appear to be any tests for get-poetry.py, and there is no documentation to update as this just makes get-poetry.py act as it is already documented. :man_shrugging: 