### PR TITLE
utils/envs: fix envs in MSYS2 always broken

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -879,9 +879,13 @@ class Env(object):
 
     def __init__(self, path: Path, base: Optional[Path] = None) -> None:
         self._is_windows = sys.platform == "win32"
+        self._is_mingw = sysconfig.get_platform() == "mingw"
 
+        if not self._is_windows or self._is_mingw:
+            bin_dir = "bin"
+        else:
+            bin_dir = "Scripts"
         self._path = path
-        bin_dir = "bin" if not self._is_windows else "Scripts"
         self._bin_dir = self._path / bin_dir
 
         self._base = base or path


### PR DESCRIPTION
When running poetry in MSYS2 it gives a warning that the virtual environment found seems to be broken messages. This change detects when in MSYS2 in order to use the bin directory for the virtualenv instead of Scripts which is normally used in Windows.

# Pull Request Check List

Resolves: #2867

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
