### PR TITLE
Mitigate exception due to non-matching regex

### DIFF
--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -711,20 +711,21 @@ class Provider:
         if message.startswith("fact:"):
             if "depends on" in message:
                 m = re.match(r"fact: (.+?) depends on (.+?) \((.+?)\)", message)
-                m2 = re.match(r"(.+?) \((.+?)\)", m.group(1))
-                if m2:
-                    name = m2.group(1)
-                    version = " (<c2>{}</c2>)".format(m2.group(2))
-                else:
-                    name = m.group(1)
-                    version = ""
+                if m:
+                    m2 = re.match(r"(.+?) \((.+?)\)", m.group(1))
+                    if m2:
+                        name = m2.group(1)
+                        version = " (<c2>{}</c2>)".format(m2.group(2))
+                    else:
+                        name = m.group(1)
+                        version = ""
 
-                message = (
-                    "<fg=blue>fact</>: <c1>{}</c1>{} "
-                    "depends on <c1>{}</c1> (<c2>{}</c2>)".format(
-                        name, version, m.group(2), m.group(3)
+                    message = (
+                        "<fg=blue>fact</>: <c1>{}</c1>{} "
+                        "depends on <c1>{}</c1> (<c2>{}</c2>)".format(
+                            name, version, m.group(2), m.group(3)
+                        )
                     )
-                )
             elif " is " in message:
                 message = re.sub(
                     "fact: (.+) is (.+)",


### PR DESCRIPTION
# Pull Request Check List

Resolves: exception when running poetry with -vv or -vvv verbosity

Running poetry update -vv results in the following exception:

  AttributeError

  'NoneType' object has no attribute 'group'

  at /usr/local/lib/python3.7/site-packages/poetry/puzzle/provider.py:699 in debug
      695│
      696│         if message.startswith("fact:"):
      697│             if "depends on" in message:
      698│                 m = re.match(r"fact: (.+?) depends on (.+?) \((.+?)\)", message)
  → 699│                 m2 = re.match(r"(.+?) \((.+?)\)", m.group(1))
      700│                 if m2:
      701│                     name = m2.group(1)
      702│                     version = " ({})".format(m2.group(2))
      703│                 else:
