### PR TITLE
Enable pip to reuse previously built wheel from cache when installing

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -19,6 +19,7 @@ from cleo.io.null_io import NullIO
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.utils.link import Link
 from poetry.core.pyproject.toml import PyProjectTOML
+from poetry.core.semver.version import Version
 from poetry.utils._compat import decode
 from poetry.utils.env import EnvCommandError
 from poetry.utils.helpers import safe_rmtree
@@ -475,7 +476,15 @@ class Executor(object):
         )
         self._write(operation, message)
 
-        args = ["install", "--no-deps", str(archive)]
+        if self._env.pip_version >= Version(19, 1, 0):
+            archive_path = str(archive)
+            if not archive_path.startswith("file://"):
+                archive_path = Path(archive_path).resolve().as_uri()
+
+            ref = "{} @ {}".format(package.name, archive_path)
+        else:
+            ref = str(archive)
+        args = ["install", "--no-deps", ref]
         if operation.job_type == "update":
             args.insert(2, "-U")
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -10,9 +10,11 @@ import pytest
 
 from cleo.formatters.style import Style
 from cleo.io.buffered_io import BufferedIO
+from cleo.io.null_io import NullIO
 
 from poetry.config.config import Config
 from poetry.core.packages.package import Package
+from poetry.core.semver.version import Version
 from poetry.installation.executor import Executor
 from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall
@@ -254,3 +256,66 @@ def test_executor_should_delete_incomplete_downloads(
         executor._download(Install(Package("tomlkit", "0.5.3")))
 
     assert not destination_fixture.exists()
+
+
+def test_executor_should_pip_run_direct_ref(
+    config, pool, tmp_dir, mock_file_downloads, env, mocker
+):
+    config = Config()
+    config.merge({"cache-dir": tmp_dir})
+
+    package = Package(
+        "demo",
+        "0.1.0",
+        source_type="file",
+        source_url=Path(__file__)
+        .parent.parent.joinpath("fixtures/distributions/demo-0.1.0.tar.gz")
+        .resolve()
+        .as_posix(),
+    )
+
+    type(env).pip_version = mocker.PropertyMock(return_value=Version(19, 1, 0))
+
+    executor = Executor(env, pool, config, NullIO())
+    executor.execute([Install(package)])
+
+    assert env.executed[0] == [
+        "python",
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        "demo @ {}".format(Path(package.source_url).as_uri()),
+    ]
+
+
+def test_executor_should_pip_run_path(
+    config, pool, tmp_dir, mock_file_downloads, env, mocker
+):
+    config = Config()
+    config.merge({"cache-dir": tmp_dir})
+
+    package = Package(
+        "demo",
+        "0.1.0",
+        source_type="file",
+        source_url=Path(__file__)
+        .parent.parent.joinpath("fixtures/distributions/demo-0.1.0.tar.gz")
+        .resolve()
+        .as_posix(),
+    )
+
+    type(env).pip_version = mocker.PropertyMock(return_value=Version(19, 0, 0))
+
+    executor = Executor(env, pool, config, NullIO())
+
+    executor.execute([Install(package)])
+
+    assert env.executed[0] == [
+        "python",
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        str(Path(package.source_url)),
+    ]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3439

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

The way poetry calls `pip install` causes pip to ignore its wheel cache of previously built packages. This patch fixes that by using a direct reference (supported since pip 19.1) `pip install --no-deps "package @ artifact/package.tar.gz"` instead of `pip install --no-deps artifact/package.tar.gz`. This causes pip to properly use its resolver to check its wheel cache to see if it had previously built that package before instead of rebuilding it every time.

This can substantially speed up `poetry install`, especially with CI systems that cache the pip cache directory between calls.

Edit: The previous version of this pull request created a temporary requirements.txt file, however pip can use a direct reference on the command line is cleaner.