### PR TITLE
Don't change poetry.lock during `poetry update --dry-run`

### DIFF
--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -355,7 +355,7 @@ class Installer:
         # Execute operations
         return self._execute(ops)
 
-    def _write_lock_file(self, repo: Repository, force: bool = True) -> None:
+    def _write_lock_file(self, repo: Repository, force: bool = False) -> None:
         if force or (self._update and self._write_lock):
             updated_lock = self._locker.set_lock_data(self._package, repo.packages)
 

--- a/tests/console/commands/plugin/test_remove.py
+++ b/tests/console/commands/plugin/test_remove.py
@@ -120,8 +120,6 @@ def test_remove_installed_package_dry_run(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 0 installs, 0 updates, 1 removal
 
   • Removing poetry-plugin (1.2.3)

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from poetry.packages import Locker
+from tests.helpers import get_package
+
+
+if TYPE_CHECKING:
+    from poetry.poetry import Poetry
+    from tests.helpers import TestRepository
+    from tests.types import CommandTesterFactory
+    from tests.types import FixtureDirGetter
+    from tests.types import ProjectFactory
+
+
+@pytest.fixture
+def source_dir(tmp_path: Path) -> Path:
+    return Path(tmp_path.as_posix())
+
+
+@pytest.fixture
+def poetry_with_old_lockfile(
+    project_factory: "ProjectFactory", fixture_dir: "FixtureDirGetter"
+) -> "Poetry":
+    source = fixture_dir("old_lock")
+    pyproject_content = (source / "pyproject.toml").read_text(encoding="utf-8")
+    poetry_lock_content = (source / "poetry.lock").read_text(encoding="utf-8")
+    return project_factory(
+        name="foobar",
+        pyproject_content=pyproject_content,
+        poetry_lock_content=poetry_lock_content,
+    )
+
+
+def test_dry_run_update(
+    command_tester_factory: "CommandTesterFactory",
+    poetry_with_old_lockfile: "Poetry",
+    repo: "TestRepository",
+) -> None:
+    repo.add_package(get_package("sampleproject", "1.3.1"))
+    repo.add_package(get_package("sampleproject", "2.0.0"))
+
+    lock = poetry_with_old_lockfile.pyproject.file.path.parent / "poetry.lock"
+    locker = Locker(
+        lock=lock,
+        local_config=poetry_with_old_lockfile.locker._local_config,
+    )
+    poetry_with_old_lockfile.set_locker(locker)
+
+    lock_content_before = lock.read_text(encoding="utf-8")
+
+    tester = command_tester_factory("update", poetry=poetry_with_old_lockfile)
+    tester.execute("--dry-run")
+
+    assert lock.read_text(encoding="utf-8") == lock_content_before


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3766

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

AFAIK, there is no relevant documentation to be changed, am I right?