### PR TITLE
Move multiple constraints note in dependency-specification.md

### DIFF
--- a/docs/docs/dependency-specification.md
+++ b/docs/docs/dependency-specification.md
@@ -185,6 +185,11 @@ foo = [
 ]
 ```
 
+!!!note
+
+    The constraints **must** have different requirements (like `python`)
+    otherwise it will cause an error when resolving dependencies.
+
 ## Expanded dependency specification syntax
 
 In the case of more complex dependency specifications, you may find that you
@@ -212,8 +217,3 @@ markers = "platform_python_implementation == 'CPython'"
 All of the same information is still present, and ends up providing the exact
 same specification. It's simply split into multiple, slightly more readable,
 lines.
-
-!!!note
-
-    The constraints **must** have different requirements (like `python`)
-    otherwise it will cause an error when resolving dependencies.


### PR DESCRIPTION
I think the "Expanded dependency specification syntax" paragraph added in
commit c94c34c813060abfaebc2632c58abe063e40efd3 was inserted in the wrong place
and cut the note from its corresponding block.

# Pull Request Check List

This does not resolve any open issue, I just found this while browsing the documentation so I figured I could just fix it now and then ^^
