### PR TITLE
Fix tests due to new poetry-core

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -366,7 +366,7 @@ importlib-metadata = {version = "^1.7.0", markers = "python_version >= \"3.5\" a
 type = "git"
 url = "https://github.com/python-poetry/poetry-core"
 reference = "master"
-resolved_reference = "d0b8f3ff1d2ec94e317d8ec20920f32a5d4992ef"
+resolved_reference = "5d5251c427aacedcf54f9743635a8124e5a26151"
 
 [[package]]
 name = "pre-commit"

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -131,7 +131,7 @@ Package operations: 4 installs, 1 update, 1 removal
     expected = set(expected.splitlines())
     output = set(io.fetch_output().splitlines())
     assert expected == output
-    assert 5 == len(env.executed)
+    assert 6 == len(env.executed)
     assert 0 == return_code
 
 

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -73,7 +73,7 @@ description = ""
 category = "main"
 optional = false
 python-versions = "*"
-develop = true
+develop = false
 
 [package.source]
 type = "git"


### PR DESCRIPTION
This fixes some tests that no longer work due to the new version of poetry-core.

One test related to the executor seems like it was erroneous from the start (testing that 5 operations were executed while there was actually 6) and we might have fixed this along the way. If that's the case I am not sure where that changed.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
