### PR TITLE
POETRY_EXPERIMENTAL_NEW_INSTALLER is interpreted as a boolean

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -132,6 +132,7 @@ class Config:
             "virtualenvs.in-project",
             "virtualenvs.options.always-copy",
             "virtualenvs.options.system-site-packages",
+            "experimental.new-installer",
             "installer.parallel",
         }:
             return boolean_normalizer

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,6 +1,21 @@
 import os
+import re
 
 import pytest
+
+from poetry.config.config import Config
+
+
+def get_boolean_options(config=None):
+    if config is None:
+        config = Config.default_config
+
+    for k, v in config.items():
+        if isinstance(v, bool) or v is None:
+            yield k
+        if isinstance(v, dict):
+            for suboption in get_boolean_options(v):
+                yield "{}.{}".format(k, suboption)
 
 
 @pytest.mark.parametrize(
@@ -14,16 +29,19 @@ def test_config_get_processes_depended_on_values(config, config_cache_dir):
     assert str(config_cache_dir / "virtualenvs") == config.get("virtualenvs.path")
 
 
+def generate_environment_variable_tests():
+    for env_value, value in [("true", True), ("false", False)]:
+        for name in get_boolean_options():
+            env_var = "POETRY_{}".format(re.sub("[.-]+", "_", name).upper())
+            yield (name, env_var, env_value, value)
+
+
 @pytest.mark.parametrize(
-    ("name", "env_value", "value"),
-    [
-        ("installer.parallel", "true", True),
-        ("installer.parallel", "false", False),
-        ("virtualenvs.create", "true", True),
-        ("virtualenvs.create", "false", False),
-    ],
+    ("name", "env_var", "env_value", "value"),
+    list(generate_environment_variable_tests()),
 )
-def test_config_get_from_environment_variable(config, environ, name, env_value, value):
-    env_var = "POETRY_{}".format("_".join(k.upper() for k in name.split(".")))
+def test_config_get_from_environment_variable(
+    config, environ, name, env_var, env_value, value
+):
     os.environ[env_var] = env_value
     assert config.get(name) is value


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

The `POETRY_EXPERIMENTAL_NEW_INSTALLER` environment variable is not currently interpreted as a boolean value. This means that you have to set the value to an empty string to disable it.
This change adds the option to the list of options that are interpreted as booleans so that you can also disable it by setting it as anything other than "1" or "true".