### PR TITLE
poetry-core update with lark pep440 implementation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -134,7 +134,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "cryptography"
-version = "3.4.6"
+version = "3.4.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -225,7 +225,7 @@ python-versions = ">=3"
 
 [[package]]
 name = "identify"
-version = "2.2.0"
+version = "2.2.1"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -855,18 +855,18 @@ crashtest = [
     {file = "crashtest-0.3.1.tar.gz", hash = "sha256:42ca7b6ce88b6c7433e2ce47ea884e91ec93104a4b754998be498a8e6c3d37dd"},
 ]
 cryptography = [
-    {file = "cryptography-3.4.6-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:57ad77d32917bc55299b16d3b996ffa42a1c73c6cfa829b14043c561288d2799"},
-    {file = "cryptography-3.4.6-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:4169a27b818de4a1860720108b55a2801f32b6ae79e7f99c00d79f2a2822eeb7"},
-    {file = "cryptography-3.4.6-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:93cfe5b7ff006de13e1e89830810ecbd014791b042cbe5eec253be11ac2b28f3"},
-    {file = "cryptography-3.4.6-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:5ecf2bcb34d17415e89b546dbb44e73080f747e504273e4d4987630493cded1b"},
-    {file = "cryptography-3.4.6-cp36-abi3-manylinux2014_x86_64.whl", hash = "sha256:fec7fb46b10da10d9e1d078d1ff8ed9e05ae14f431fdbd11145edd0550b9a964"},
-    {file = "cryptography-3.4.6-cp36-abi3-win32.whl", hash = "sha256:df186fcbf86dc1ce56305becb8434e4b6b7504bc724b71ad7a3239e0c9d14ef2"},
-    {file = "cryptography-3.4.6-cp36-abi3-win_amd64.whl", hash = "sha256:66b57a9ca4b3221d51b237094b0303843b914b7d5afd4349970bb26518e350b0"},
-    {file = "cryptography-3.4.6-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:066bc53f052dfeda2f2d7c195cf16fb3e5ff13e1b6b7415b468514b40b381a5b"},
-    {file = "cryptography-3.4.6-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:600cf9bfe75e96d965509a4c0b2b183f74a4fa6f5331dcb40fb7b77b7c2484df"},
-    {file = "cryptography-3.4.6-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:0923ba600d00718d63a3976f23cab19aef10c1765038945628cd9be047ad0336"},
-    {file = "cryptography-3.4.6-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:9e98b452132963678e3ac6c73f7010fe53adf72209a32854d55690acac3f6724"},
-    {file = "cryptography-3.4.6.tar.gz", hash = "sha256:2d32223e5b0ee02943f32b19245b61a62db83a882f0e76cc564e1cec60d48f87"},
+    {file = "cryptography-3.4.7-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1"},
+    {file = "cryptography-3.4.7-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250"},
+    {file = "cryptography-3.4.7-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2"},
+    {file = "cryptography-3.4.7-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6"},
+    {file = "cryptography-3.4.7-cp36-abi3-manylinux2014_x86_64.whl", hash = "sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959"},
+    {file = "cryptography-3.4.7-cp36-abi3-win32.whl", hash = "sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d"},
+    {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
+    {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
+    {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
+    {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
@@ -896,8 +896,8 @@ httpretty = [
     {file = "httpretty-1.0.5.tar.gz", hash = "sha256:e53c927c4d3d781a0761727f1edfad64abef94e828718e12b672a678a8b3e0b5"},
 ]
 identify = [
-    {file = "identify-2.2.0-py2.py3-none-any.whl", hash = "sha256:39c0b110c9d0cd2391b6c38cd0ff679ee4b4e98f8db8b06c5d9d9e502711a1e1"},
-    {file = "identify-2.2.0.tar.gz", hash = "sha256:efbf090a619255bc31c4fbba709e2805f7d30913fd4854ad84ace52bd276e2f6"},
+    {file = "identify-2.2.1-py2.py3-none-any.whl", hash = "sha256:9cc5f58996cd359b7b72f0a5917d8639de5323917e6952a3bfbf36301b576f40"},
+    {file = "identify-2.2.1.tar.gz", hash = "sha256:1cfb05b578de996677836d5a2dde14b3dffde313cf7d2b3e793a0787a36e26dd"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -152,6 +152,14 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
+name = "dataclasses"
+version = "0.8"
+description = "A backport of the dataclasses module for Python 3.6"
+category = "main"
+optional = false
+python-versions = ">=3.6, <3.7"
+
+[[package]]
 name = "deepdiff"
 version = "5.2.3"
 description = "Deep Difference and Search of any Python object/data."
@@ -390,13 +398,14 @@ python-versions = "^3.6"
 develop = false
 
 [package.dependencies]
+dataclasses = {version = "^0.8", markers = "python_version >= \"3.6\" and python_version < \"3.7\""}
 importlib-metadata = {version = "^1.7.0", markers = "python_version >= \"3.5\" and python_version < \"3.8\""}
 
 [package.source]
 type = "git"
-url = "https://github.com/python-poetry/poetry-core"
+url = "https://github.com/python-poetry/poetry-core.git"
 reference = "master"
-resolved_reference = "5d5251c427aacedcf54f9743635a8124e5a26151"
+resolved_reference = "c11cb9a6ebdda53d45dae78b45f6f73f5368e793"
 
 [[package]]
 name = "pre-commit"
@@ -705,7 +714,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "c72b0807603d4902cff83901d0e65165e243937b5be90b05c17d3c92a06b4fc8"
+content-hash = "8442060c68d80744b05aac3a07818a1e04e457c05b0e481d717cb44721009566"
 
 [metadata.files]
 appdirs = [
@@ -858,6 +867,10 @@ cryptography = [
     {file = "cryptography-3.4.6-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:0923ba600d00718d63a3976f23cab19aef10c1765038945628cd9be047ad0336"},
     {file = "cryptography-3.4.6-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:9e98b452132963678e3ac6c73f7010fe53adf72209a32854d55690acac3f6724"},
     {file = "cryptography-3.4.6.tar.gz", hash = "sha256:2d32223e5b0ee02943f32b19245b61a62db83a882f0e76cc564e1cec60d48f87"},
+]
+dataclasses = [
+    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
+    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 deepdiff = [
     {file = "deepdiff-5.2.3-py3-none-any.whl", hash = "sha256:3d3da4bd7e01fb5202088658ed26427104c748dda56a0ecfac9ce9a1d2d00844"},

--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -87,31 +87,22 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
             raise ValueError("The project's version doesn't seem to follow semver")
 
         if rule in {"major", "premajor"}:
-            new = version.next_major
+            new = version.next_major()
             if rule == "premajor":
-                new = new.first_prerelease
+                new = new.first_prerelease()
         elif rule in {"minor", "preminor"}:
-            new = version.next_minor
+            new = version.next_minor()
             if rule == "preminor":
-                new = new.first_prerelease
+                new = new.first_prerelease()
         elif rule in {"patch", "prepatch"}:
-            new = version.next_patch
+            new = version.next_patch()
             if rule == "prepatch":
-                new = new.first_prerelease
+                new = new.first_prerelease()
         elif rule == "prerelease":
-            if version.is_prerelease():
-                pre = version.prerelease
-                new_prerelease = int(pre[1]) + 1
-                new = Version.parse(
-                    "{}.{}.{}-{}".format(
-                        version.major,
-                        version.minor,
-                        version.patch,
-                        ".".join([pre[0], str(new_prerelease)]),
-                    )
-                )
+            if version.is_unstable():
+                new = Version(version.epoch, version.release, version.pre.next())
             else:
-                new = version.next_patch.first_prerelease
+                new = version.next_patch().first_prerelease()
         else:
             new = Version.parse(rule)
 

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -543,8 +543,9 @@ class Executor(object):
             # some versions of pip (< 19.0.0) don't understand it
             # so we need to check the version of pip to know
             # if we can rely on the build system
-            legacy_pip = self._env.pip_version < self._env.pip_version.__class__(
-                19, 0, 0
+            legacy_pip = (
+                self._env.pip_version
+                < self._env.pip_version.__class__.from_parts(19, 0, 0)
             )
             package_poetry = Factory().create_poetry(pyproject.file.path.parent)
 

--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -84,7 +84,7 @@ class EditableBuilder(Builder):
                 f.write(decode(builder.build_setup()))
 
         try:
-            if self._env.pip_version < Version(19, 0):
+            if self._env.pip_version < Version.from_parts(19, 0):
                 pip_editable_install(self._path, self._env)
             else:
                 # Temporarily rename pyproject.toml

--- a/poetry/mixology/version_solver.py
+++ b/poetry/mixology/version_solver.py
@@ -339,7 +339,7 @@ class VersionSolver:
             if locked and (
                 dependency.constraint.allows(locked.version)
                 or locked.is_prerelease()
-                and dependency.constraint.allows(locked.version.next_patch)
+                and dependency.constraint.allows(locked.version.next_patch())
             ):
                 return 1
 

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -478,7 +478,7 @@ class Locker(object):
         # We expect the locker to be able to read lock files
         # from the same semantic versioning range
         accepted_versions = parse_constraint(
-            "^{}".format(Version(current_version.major, 0))
+            "^{}".format(Version.from_parts(current_version.major, 0))
         )
         lock_version_allowed = accepted_versions.allows(lock_version)
         if lock_version_allowed and current_version < lock_version:

--- a/poetry/publishing/uploader.py
+++ b/poetry/publishing/uploader.py
@@ -24,7 +24,7 @@ from poetry.__version__ import __version__
 from poetry.core.masonry.metadata import Metadata
 from poetry.core.masonry.utils.helpers import escape_name
 from poetry.core.masonry.utils.helpers import escape_version
-from poetry.utils.helpers import normalize_version
+from poetry.core.utils.helpers import normalize_version
 from poetry.utils.patterns import wheel_file_re
 
 

--- a/poetry/puzzle/solver.py
+++ b/poetry/puzzle/solver.py
@@ -437,7 +437,7 @@ class PackageNode(DFSNode):
                 if pkg.complete_name == dependency.complete_name and (
                     dependency.constraint.allows(pkg.version)
                     or dependency.allows_prereleases()
-                    and pkg.version.is_prerelease()
+                    and pkg.version.is_unstable()
                     and dependency.constraint.allows(pkg.version.stable)
                 ):
                     # If there is already a child with this name

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -254,9 +254,9 @@ class LegacyRepository(PyPiRepository):
         if isinstance(constraint, VersionRange):
             if (
                 constraint.max is not None
-                and constraint.max.is_prerelease()
+                and constraint.max.is_unstable()
                 or constraint.min is not None
-                and constraint.min.is_prerelease()
+                and constraint.min.is_unstable()
             ):
                 allow_prereleases = True
 
@@ -275,7 +275,7 @@ class LegacyRepository(PyPiRepository):
 
             versions = []
             for version in page.versions:
-                if version.is_prerelease() and not allow_prereleases:
+                if version.is_unstable() and not allow_prereleases:
                     if constraint.is_any():
                         # we need this when all versions of the package are pre-releases
                         ignored_pre_release_versions.append(version)

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -20,10 +20,10 @@ from html5lib.html5parser import parse
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
-from poetry.core.semver.exceptions import ParseVersionError
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version_constraint import VersionConstraint
 from poetry.core.semver.version_range import VersionRange
+from poetry.core.version.exceptions import InvalidVersion
 from poetry.core.version.markers import parse_marker
 from poetry.locations import REPOSITORY_CACHE_DIR
 from poetry.utils._compat import to_str
@@ -98,9 +98,9 @@ class PyPiRepository(RemoteRepository):
         if isinstance(constraint, VersionRange):
             if (
                 constraint.max is not None
-                and constraint.max.is_prerelease()
+                and constraint.max.is_unstable()
                 or constraint.min is not None
-                and constraint.min.is_prerelease()
+                and constraint.min.is_unstable()
             ):
                 allow_prereleases = True
 
@@ -129,7 +129,7 @@ class PyPiRepository(RemoteRepository):
 
             try:
                 package = Package(info["info"]["name"], version)
-            except ParseVersionError:
+            except InvalidVersion:
                 self._log(
                     'Unable to parse version "{}" for the {} package, skipping'.format(
                         version, dependency.name
@@ -186,7 +186,7 @@ class PyPiRepository(RemoteRepository):
                 result = Package(name, version, description)
                 result.description = to_str(description.strip())
                 results.append(result)
-            except ParseVersionError:
+            except InvalidVersion:
                 self._log(
                     'Unable to parse version "{}" for the {} package, skipping'.format(
                         version, name

--- a/poetry/repositories/repository.py
+++ b/poetry/repositories/repository.py
@@ -55,9 +55,9 @@ class Repository(BaseRepository):
         if isinstance(constraint, VersionRange):
             if (
                 constraint.max is not None
-                and constraint.max.is_prerelease()
+                and constraint.max.is_unstable()
                 or constraint.min is not None
-                and constraint.min.is_prerelease()
+                and constraint.min.is_unstable()
             ):
                 allow_prereleases = True
 
@@ -77,7 +77,7 @@ class Repository(BaseRepository):
 
                 if constraint.allows(package.version) or (
                     package.is_prerelease()
-                    and constraint.allows(package.version.next_patch)
+                    and constraint.allows(package.version.next_patch())
                 ):
                     packages.append(package)
 

--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -17,7 +17,6 @@ import requests
 
 from poetry.config.config import Config
 from poetry.core.packages.package import Package
-from poetry.core.version import Version
 
 
 try:
@@ -35,10 +34,6 @@ def canonicalize_name(name: str) -> str:
 
 def module_name(name: str) -> str:
     return canonicalize_name(name).replace(".", "_").replace("-", "_")
-
-
-def normalize_version(version: str) -> str:
-    return str(Version(version))
 
 
 def _del_ro(action: Callable, name: str, exc: Exception) -> None:

--- a/poetry/version/version_selector.py
+++ b/poetry/version/version_selector.py
@@ -36,7 +36,7 @@ class VersionSelector(object):
             },
         )
         candidates = self._pool.find_packages(dependency)
-        only_prereleases = all([c.version.is_prerelease() for c in candidates])
+        only_prereleases = all([c.version.is_unstable() for c in candidates])
 
         if not candidates:
             return False
@@ -77,7 +77,7 @@ class VersionSelector(object):
             version = pretty_version
         else:
             version = ".".join(str(p) for p in parts)
-            if parsed.is_prerelease():
-                version += "-{}".format(".".join(str(p) for p in parsed.prerelease))
+            if parsed.is_unstable():
+                version += "-{}".format(parsed.pre.to_string())
 
         return "^{}".format(version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ generate-setup-file = false
 [tool.poetry.dependencies]
 python = "^3.6"
 
-poetry-core = { git = "https://github.com/python-poetry/poetry-core", branch = "master"}
+poetry-core = { git = "https://github.com/python-poetry/poetry-core.git", branch = "master"}
 cleo = "^1.0.0a1"
 crashtest = "^0.3.0"
 requests = "^2.18"

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -23,7 +23,7 @@ def setup(mocker):
 def mock_subprocess_calls(setup, current_python, mocker):
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(Version(*current_python)),
+        side_effect=check_output_wrapper(Version.from_parts(*current_python)),
     )
     mocker.patch(
         "subprocess.Popen.communicate",

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -25,7 +25,7 @@ def test_self_update_should_install_all_necessary_elements(
 
     command = tester.command
 
-    version = Version.parse(__version__).next_minor.text
+    version = Version.parse(__version__).next_minor().text
     mocker.patch(
         "poetry.repositories.pypi_repository.PyPiRepository.find_packages",
         return_value=[Package("poetry", version)],

--- a/tests/mixology/version_solver/test_backtracking.py
+++ b/tests/mixology/version_solver/test_backtracking.py
@@ -99,7 +99,7 @@ def test_backjump_to_nearer_unsatisfied_package(root, provider, repo):
     root.add_dependency(Factory.create_dependency("b", "*"))
 
     add_to_repo(repo, "a", "1.0.0", deps={"c": "1.0.0"})
-    add_to_repo(repo, "a", "2.0.0", deps={"c": "2.0.0-nonexistent"})
+    add_to_repo(repo, "a", "2.0.0", deps={"c": "2.0.0-1"})
     add_to_repo(repo, "b", "1.0.0")
     add_to_repo(repo, "b", "2.0.0")
     add_to_repo(repo, "b", "3.0.0")

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -428,7 +428,9 @@ content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77
 
 [metadata.files]
 """.format(
-        version=".".join(Version.parse(Locker._VERSION).next_minor.text.split(".")[:2])
+        version=".".join(
+            Version.parse(Locker._VERSION).next_minor().text.split(".")[:2]
+        )
     )
     caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
 

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -429,7 +429,7 @@ def test_deactivate_activated(tmp_dir, manager, poetry, config, mocker):
 
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     version = Version.parse(".".join(str(c) for c in sys.version_info[:3]))
-    other_version = Version.parse("3.4") if version.major == 2 else version.next_minor
+    other_version = Version.parse("3.4") if version.major == 2 else version.next_minor()
     (
         Path(tmp_dir) / "{}-py{}.{}".format(venv_name, version.major, version.minor)
     ).mkdir()

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from poetry.core.semver.exceptions import ParseVersionError
+from poetry.core.version.exceptions import InvalidVersion
 from poetry.utils.setup_reader import SetupReader
 
 
@@ -115,7 +115,7 @@ def test_setup_reader_read_setup_cfg(setup):
 
 
 def test_setup_reader_read_setup_cfg_with_attr(setup):
-    with pytest.raises(ParseVersionError):
+    with pytest.raises(InvalidVersion):
         SetupReader.read_from_directory(setup("with-setup-cfg-attr"))
 
 


### PR DESCRIPTION
This change consumes the upstream changes to semver `Version` class implementation.

Relates-to: python-poetry/poetry-core#140
Relates-to: python-poetry/poetry#2543
Relates-to: python-poetry/poetry#1151
Relates-to: python-poetry/poetry#892