### PR TITLE
pip installer: fix installed script executable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os: [Ubuntu, MacOS, Windows]
         python-version: [3.6, 3.7, 3.8, 3.9]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -697,7 +697,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "fa762bec451ef26021b1882a6f657ca2c0b3eeff514e28f805dfa7dfc1a02495"
+content-hash = "6cbc07e5853bcf1280421b77b6fca85f2f7eb5a6ff12049f65ea116b256d94ea"
 
 [metadata.files]
 appdirs = [

--- a/poetry/utils/pip.py
+++ b/poetry/utils/pip.py
@@ -1,8 +1,12 @@
+import os
+import sys
+
 from pathlib import Path
 from typing import Union
 
 from poetry.exceptions import PoetryException
 from poetry.utils.env import Env
+from poetry.utils.env import EnvCommandError
 from poetry.utils.env import ephemeral_environment
 
 
@@ -14,8 +18,12 @@ def pip_install(
     upgrade: bool = False,
 ) -> Union[int, str]:
     path = Path(path) if isinstance(path, str) else path
+    is_wheel = path.suffix == ".whl"
 
     args = ["install", "--prefix", str(environment.path)]
+
+    if not is_wheel:
+        args.insert(1, "--use-pep517")
 
     if upgrade:
         args.append("--upgrade")
@@ -32,16 +40,21 @@ def pip_install(
 
     args.append(str(path))
 
-    if path.is_file() and path.suffix == ".whl":
+    try:
         return environment.run_pip(*args)
-
-    with ephemeral_environment(
-        executable=environment.python, pip=True, setuptools=True
-    ) as env:
-        return env.run(
-            "pip",
-            *args,
-        )
+    except EnvCommandError as e:
+        if sys.version_info < (3, 7) and not is_wheel:
+            # Under certain Python3.6 installs vendored pip wheel does not contain zip-safe
+            # pep517 lib. In this cases we create an isolated ephemeral virtual environment.
+            with ephemeral_environment(
+                executable=environment.python, pip=True, setuptools=True
+            ) as env:
+                return environment.run(
+                    env._bin("pip"),
+                    *args,
+                    env={**os.environ, "PYTHONPATH": str(env.purelib)},
+                )
+        raise PoetryException(f"Failed to install {path.as_posix()}") from e
 
 
 def pip_editable_install(directory: Path, environment: Env) -> Union[int, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ shellingham = "^1.1"
 tomlkit = ">=0.7.0,<1.0.0"
 pexpect = "^4.7.0"
 packaging = "^20.4"
-virtualenv = { version = "^20.0.26" }
+virtualenv = "^20.4.3"
 keyring = "^21.2.0"
 importlib-metadata = {version = "^1.6.0", python = "<3.8"}
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -137,7 +137,7 @@ Package operations: 4 installs, 1 update, 1 removal
     expected = set(expected.splitlines())
     output = set(io.fetch_output().splitlines())
     assert expected == output
-    assert 4 == len(env.executed)
+    assert 5 == len(env.executed)
     assert 0 == return_code
     pip_editable_install.assert_called_once()
 


### PR DESCRIPTION
When pip installs into an alternate prefix, it uses the current executable
when writing package scripts during install (eg: black, pytest etc.).

With this change, we:
1. Use the active environment to trigger pip embedded virtual environment.
2. Enforcing the use of `--pep-517` when installing non-wheel packages.
3. Handle zip-unsafe bug in pip's vendored pep517 under python3.6.