### PR TITLE
Minor clean up of code for consistency and performance

### DIFF
--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -450,7 +450,9 @@ class PackageInfo:
         except PackageInfoError:
             pass
 
-        with ephemeral_environment(pip=True, wheel=True, setuptools=True) as venv:
+        with ephemeral_environment(
+            with_pip=True, with_wheel=True, with_setuptools=True
+        ) as venv:
             # TODO: cache PEP 517 build environment corresponding to each project venv
             dest_dir = venv.path.parent / "dist"
             dest_dir.mkdir()

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1458,9 +1458,10 @@ class NullEnv(SystemEnv):
 @contextmanager
 def ephemeral_environment(
     executable=None,
-    pip: bool = False,
-    wheel: Optional[bool] = None,
-    setuptools: Optional[bool] = None,
+    flags: Dict[str, bool] = None,
+    with_pip: bool = False,
+    with_wheel: Optional[bool] = None,
+    with_setuptools: Optional[bool] = None,
 ) -> ContextManager[VirtualEnv]:
     with temporary_directory() as tmp_dir:
         # TODO: cache PEP 517 build environment corresponding to each project venv
@@ -1468,9 +1469,10 @@ def ephemeral_environment(
         EnvManager.build_venv(
             path=venv_dir.as_posix(),
             executable=executable,
-            with_pip=pip,
-            with_wheel=wheel,
-            with_setuptools=setuptools,
+            flags=flags,
+            with_pip=with_pip,
+            with_wheel=with_wheel,
+            with_setuptools=with_setuptools,
         )
         yield VirtualEnv(venv_dir, venv_dir)
 

--- a/poetry/utils/pip.py
+++ b/poetry/utils/pip.py
@@ -47,7 +47,7 @@ def pip_install(
             # Under certain Python3.6 installs vendored pip wheel does not contain zip-safe
             # pep517 lib. In this cases we create an isolated ephemeral virtual environment.
             with ephemeral_environment(
-                executable=environment.python, pip=True, setuptools=True
+                executable=environment.python, with_pip=True, with_setuptools=True
             ) as env:
                 return environment.run(
                     env._bin("pip"),

--- a/poetry/utils/pip.py
+++ b/poetry/utils/pip.py
@@ -20,7 +20,10 @@ def pip_install(
     path = Path(path) if isinstance(path, str) else path
     is_wheel = path.suffix == ".whl"
 
-    args = ["install", "--prefix", str(environment.path)]
+    # We disable version check here as we are already pinning to version available in either the
+    # virtual environment or the virtualenv package embedded wheel. Version checks are a wasteful
+    # network call that adds a lot of wait time when installing a lot of packages.
+    args = ["install", "--disable-pip-version-check", "--prefix", str(environment.path)]
 
     if not is_wheel:
         args.insert(1, "--use-pep517")


### PR DESCRIPTION
1. Make `ephemeral_environment` arguments aligned with `build_env`.
2. Disable pip version check when when using `pip_install`.