### PR TITLE
tests: Add coverage for add and config commands

### DIFF
--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -722,6 +722,32 @@ Writing lock file
     }
 
 
+def test_add_constraint_with_multiple_extras_variadic_fails(app: PoetryTestApplication, repo: TestRepository, tester: CommandTester):
+    cachy2 = get_package("cachy", "0.2.0")
+
+    cachy2.extras = {
+        "msgpack": [get_dependency("msgpack-python")],
+        "toml": [get_dependency("tomlkit")],
+    }
+    msgpack_dep = get_dependency("msgpack-python", ">=0.5 <0.6", optional=True)
+    cachy2.add_dependency(msgpack_dep)
+
+    toml_dep = get_dependency("tomlkit", ">=0.5 <0.6", optional=True)
+    cachy2.add_dependency(toml_dep)
+
+    repo.add_package(get_package("cachy", "0.1.0"))
+    repo.add_package(cachy2)
+    repo.add_package(get_package("msgpack-python", "0.5.3"))
+    repo.add_package(get_package("tomlkit", "0.5.5"))
+
+    with pytest.raises(ValueError) as e:
+        tester.execute("cachy=0.2.0 --extras msgpack toml")
+
+    expected = "You can only specify one package when using the --extras option"
+
+    assert expected == str(e.value)
+
+
 def test_add_url_constraint_wheel(
     app: PoetryTestApplication,
     repo: TestRepository,


### PR DESCRIPTION
Relates-to: #3155

Added some tests to cover parts of the `add` and `config` commands that were not previously covered by tests.

# Pull Request Check List


<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
