### PR TITLE
recognize one digit version in filename (port from 1.1)

### DIFF
--- a/poetry/utils/patterns.py
+++ b/poetry/utils/patterns.py
@@ -2,8 +2,11 @@ import re
 
 
 wheel_file_re = re.compile(
-    r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
-        ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
-        \.whl|\.dist-info)$""",
+    r"^(?P<namever>(?P<name>.+?)-(?P<ver>\d.*?))"
+    r"(-(?P<build>\d.*?))?"
+    r"-(?P<pyver>.+?)"
+    r"-(?P<abi>.+?)"
+    r"-(?P<plat>.+?)"
+    r"\.whl|\.dist-info$",
     re.VERBOSE,
 )

--- a/tests/utils/test_patterns.py
+++ b/tests/utils/test_patterns.py
@@ -1,0 +1,39 @@
+import pytest
+
+from poetry.utils import patterns
+
+
+@pytest.mark.parametrize(
+    ["filename", "expected"],
+    [
+        (
+            "markdown_captions-2-py3-none-any.whl",
+            {
+                "namever": "markdown_captions-2",
+                "name": "markdown_captions",
+                "ver": "2",
+                "build": None,
+                "pyver": "py3",
+                "abi": "none",
+                "plat": "any",
+            },
+        ),
+        (
+            "SQLAlchemy-1.3.20-cp27-cp27mu-manylinux2010_x86_64.whl",
+            {
+                "namever": "SQLAlchemy-1.3.20",
+                "name": "SQLAlchemy",
+                "ver": "1.3.20",
+                "build": None,
+                "pyver": "cp27",
+                "abi": "cp27mu",
+                "plat": "manylinux2010_x86_64",
+            },
+        ),
+    ],
+)
+def test_wheel_file_re(filename, expected):
+    match = patterns.wheel_file_re.match(filename)
+    groups = match.groupdict()
+
+    assert groups == expected


### PR DESCRIPTION
This is a port from the 1.1 branch: https://github.com/python-poetry/poetry/pull/3338

* fix (utils.patterns): recognize one digit version in filename
* fix (utils.patterns): version part in filename must be present according PEP491
