### PR TITLE
Add a missing " to the post install message of `install-poetry.py`

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -267,7 +267,7 @@ You can test that everything is set up by executing:
 """
 
 POST_MESSAGE_CONFIGURE_UNIX = """
-Add `export PATH="{poetry_home_bin}:$PATH` to your shell configuration file.
+Add `export PATH="{poetry_home_bin}:$PATH"` to your shell configuration file.
 """
 
 POST_MESSAGE_CONFIGURE_FISH = """


### PR DESCRIPTION
Got annoyed when I tried to copy paste this multiple times and pressing enter just started a new line in Bash :D