### PR TITLE
Fix locked VCS dependencies always being updated

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -390,7 +390,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "poetry-core"
-version = "1.1.0a0"
+version = "1.1.0a1"
 description = "Poetry PEP 517 Build Backend"
 category = "main"
 optional = false
@@ -405,7 +405,7 @@ importlib-metadata = {version = "^1.7.0", markers = "python_version >= \"3.5\" a
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "master"
-resolved_reference = "c11cb9a6ebdda53d45dae78b45f6f73f5368e793"
+resolved_reference = "8d5e5c5d070940736ab72c5dec09cd7deab07cf3"
 
 [[package]]
 name = "pre-commit"

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -606,7 +606,12 @@ class Executor:
 
         git = Git()
         git.clone(package.source_url, src_dir)
-        git.checkout(package.source_resolved_reference, src_dir)
+
+        reference = package.source_resolved_reference
+        if not reference:
+            reference = package.source_reference
+
+        git.checkout(reference, src_dir)
 
         # Now we just need to install from the source directory
         original_url = package.source_url

--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -309,12 +309,6 @@ class Installer:
 
         pool.add_repository(repo)
 
-        # We whitelist all packages to be sure
-        # that the latest ones are picked up
-        whitelist = []
-        for pkg in locked_repository.packages:
-            whitelist.append(pkg.name)
-
         solver = Solver(
             root,
             pool,
@@ -323,9 +317,12 @@ class Installer:
             NullIO(),
             remove_untracked=self._remove_untracked,
         )
+        # Everything is resolved at this point, so we no longer need
+        # to load deferred dependencies (i.e. VCS, URL and path dependencies)
+        solver.provider.load_deferred(False)
 
         with solver.use_environment(self._env):
-            ops = solver.solve(use_latest=whitelist)
+            ops = solver.solve(use_latest=self._whitelist)
 
         # We need to filter operations so that packages
         # not compatible with the current system,

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -251,7 +251,12 @@ class PipInstaller(BaseInstaller):
 
         git = Git()
         git.clone(package.source_url, src_dir)
-        git.checkout(package.source_reference, src_dir)
+
+        reference = package.source_resolved_reference
+        if not reference:
+            reference = package.source_reference
+
+        git.checkout(reference, src_dir)
 
         # Now we just need to install from the source directory
         pkg = Package(package.name, package.version)

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -14,6 +14,7 @@ from cleo.io.outputs.buffered_output import BufferedOutput
 from cleo.io.outputs.output import Verbosity
 from deepdiff import DeepDiff
 
+from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.toml.file import TOMLFile
 from poetry.factory import Factory
@@ -1924,3 +1925,66 @@ def test_run_with_dependencies_quiet(installer, locker, repo, package, quiet):
         assert installer._io.output._buffer.read() == ""
     else:
         assert installer._io.output._buffer.read() != ""
+
+
+def test_installer_should_use_the_locked_version_of_git_dependencies(
+    installer, locker, package, repo
+):
+    locker.locked(True)
+    locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "demo",
+                    "version": "0.1.1",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"pendulum": ">=1.4.4"},
+                    "source": {
+                        "type": "git",
+                        "url": "https://github.com/demo/demo.git",
+                        "reference": "master",
+                        "resolved_reference": "123456",
+                    },
+                },
+                {
+                    "name": "pendulum",
+                    "version": "1.4.4",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {},
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"demo": [], "pendulum": []},
+            },
+        }
+    )
+
+    package.add_dependency(
+        Factory.create_dependency(
+            "demo", {"git": "https://github.com/demo/demo.git", "branch": "master"}
+        )
+    )
+
+    repo.add_package(get_package("pendulum", "1.4.4"))
+
+    installer.run()
+
+    assert installer.executor.installations[-1] == Package(
+        "demo",
+        "0.1.1",
+        source_type="git",
+        source_url="https://github.com/demo/demo.git",
+        source_reference="master",
+        source_resolved_reference="123456",
+    )


### PR DESCRIPTION
The issue was caused by multiple factors:

- Every package was marked as "use the latest version" which led to the packages not being retrieved from the locked repository. While this did not matter for "normal" packages this had the unintended side effect of pulling the latest revision of VCS dependencies regardless of the locked version. This was the main problem.
- Even when the locked version was used, Poetry would still clone VCS dependencies even though it was no longer needed. This is solved by using the `Provider.load_deferred(False)` since we already have all the information when installing from the lock file.

## Pull Request Check List

Resolves: #2921 

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
