### PR TITLE
Add PEP 610 support

### DIFF
--- a/tests/fixtures/simple_project/pyproject.toml
+++ b/tests/fixtures/simple_project/pyproject.toml
@@ -28,3 +28,8 @@ python = "~2.7 || ^3.4"
 foo = "foo:bar"
 baz = "bar:baz.boom.bim"
 fox = "fuz.foo:bar.baz"
+
+
+[build-system]
+requires = ["poetry-core>=1.0.2"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/directory_pep_610-1.2.3.dist-info/METADATA
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/directory_pep_610-1.2.3.dist-info/METADATA
@@ -1,0 +1,6 @@
+Metadata-Version: 2.1
+Name: directory-pep-610
+Version: 1.2.3
+Summary: Foo
+License: MIT
+Requires-Python: >=3.6

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/directory_pep_610-1.2.3.dist-info/direct_url.json
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/directory_pep_610-1.2.3.dist-info/direct_url.json
@@ -1,0 +1,4 @@
+{
+  "url": "file:///path/to/distributions/directory-pep-610",
+  "dir_info": {}
+}

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/editable_directory_pep_610-1.2.3.dist-info/METADATA
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/editable_directory_pep_610-1.2.3.dist-info/METADATA
@@ -1,0 +1,6 @@
+Metadata-Version: 2.1
+Name: editable-directory-pep-610
+Version: 1.2.3
+Summary: Foo
+License: MIT
+Requires-Python: >=3.6

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/editable_directory_pep_610-1.2.3.dist-info/direct_url.json
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/editable_directory_pep_610-1.2.3.dist-info/direct_url.json
@@ -1,0 +1,6 @@
+{
+  "url": "file:///path/to/distributions/directory-pep-610",
+  "dir_info": {
+    "editable": true
+  }
+}

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/file_pep_610-1.2.3.dist-info/METADATA
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/file_pep_610-1.2.3.dist-info/METADATA
@@ -1,0 +1,6 @@
+Metadata-Version: 2.1
+Name: file-pep-610
+Version: 1.2.3
+Summary: Foo
+License: MIT
+Requires-Python: >=3.6

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/file_pep_610-1.2.3.dist-info/direct_url.json
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/file_pep_610-1.2.3.dist-info/direct_url.json
@@ -1,0 +1,6 @@
+{
+  "url": "file:///path/to/distributions/file-pep-610-1.2.3.tar.gz",
+  "archive_info": {
+    "hash": "sha256=2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+  }
+}

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/git_pep_610-1.2.3.dist-info/METADATA
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/git_pep_610-1.2.3.dist-info/METADATA
@@ -1,0 +1,6 @@
+Metadata-Version: 2.1
+Name: git-pep-610
+Version: 1.2.3
+Summary: Foo
+License: MIT
+Requires-Python: >=3.6

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/git_pep_610-1.2.3.dist-info/direct_url.json
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/git_pep_610-1.2.3.dist-info/direct_url.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://github.com/demo/git-pep-610.git",
+  "vcs_info": {
+    "vcs": "git",
+    "requested_revision": "my-branch",
+    "commit_id": "123456"
+  }
+}

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/url_pep_610-1.2.3.dist-info/METADATA
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/url_pep_610-1.2.3.dist-info/METADATA
@@ -1,0 +1,6 @@
+Metadata-Version: 2.1
+Name: url-pep-610
+Version: 1.2.3
+Summary: Foo
+License: MIT
+Requires-Python: >=3.6

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/url_pep_610-1.2.3.dist-info/direct_url.json
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/url_pep_610-1.2.3.dist-info/direct_url.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://python-poetry.org/distributions/url-pep-610-1.2.3.tar.gz",
+  "archive_info": {}
+}

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -30,6 +30,13 @@ INSTALLED_RESULTS = [
     metadata.PathDistribution(SITE_PURELIB / "editable-with-import-2.3.4.dist-info"),
     metadata.PathDistribution(SITE_PLATLIB / "lib64-2.3.4.dist-info"),
     metadata.PathDistribution(SITE_PLATLIB / "bender-2.0.5.dist-info"),
+    metadata.PathDistribution(SITE_PURELIB / "git_pep_610-1.2.3.dist-info"),
+    metadata.PathDistribution(SITE_PURELIB / "url_pep_610-1.2.3.dist-info"),
+    metadata.PathDistribution(SITE_PURELIB / "file_pep_610-1.2.3.dist-info"),
+    metadata.PathDistribution(SITE_PURELIB / "directory_pep_610-1.2.3.dist-info"),
+    metadata.PathDistribution(
+        SITE_PURELIB / "editable_directory_pep_610-1.2.3.dist-info"
+    ),
 ]
 
 
@@ -165,3 +172,60 @@ def test_load_standard_package_with_pth_file(repository):
     assert standard.version.text == "1.2.3"
     assert standard.source_type is None
     assert standard.source_url is None
+
+
+def test_load_pep_610_compliant_git_packages(repository):
+    package = get_package_from_repository("git-pep-610", repository)
+
+    assert package is not None
+    assert package.name == "git-pep-610"
+    assert package.version.text == "1.2.3"
+    assert package.source_type == "git"
+    assert package.source_url == "https://github.com/demo/git-pep-610.git"
+    assert package.source_reference == "my-branch"
+    assert package.source_resolved_reference == "123456"
+
+
+def test_load_pep_610_compliant_url_packages(repository):
+    package = get_package_from_repository("url-pep-610", repository)
+
+    assert package is not None
+    assert package.name == "url-pep-610"
+    assert package.version.text == "1.2.3"
+    assert package.source_type == "url"
+    assert (
+        package.source_url
+        == "https://python-poetry.org/distributions/url-pep-610-1.2.3.tar.gz"
+    )
+
+
+def test_load_pep_610_compliant_file_packages(repository):
+    package = get_package_from_repository("file-pep-610", repository)
+
+    assert package is not None
+    assert package.name == "file-pep-610"
+    assert package.version.text == "1.2.3"
+    assert package.source_type == "file"
+    assert package.source_url == "/path/to/distributions/file-pep-610-1.2.3.tar.gz"
+
+
+def test_load_pep_610_compliant_directory_packages(repository):
+    package = get_package_from_repository("directory-pep-610", repository)
+
+    assert package is not None
+    assert package.name == "directory-pep-610"
+    assert package.version.text == "1.2.3"
+    assert package.source_type == "directory"
+    assert package.source_url == "/path/to/distributions/directory-pep-610"
+    assert not package.develop
+
+
+def test_load_pep_610_compliant_editable_directory_packages(repository):
+    package = get_package_from_repository("editable-directory-pep-610", repository)
+
+    assert package is not None
+    assert package.name == "editable-directory-pep-610"
+    assert package.version.text == "1.2.3"
+    assert package.source_type == "directory"
+    assert package.source_url == "/path/to/distributions/directory-pep-610"
+    assert package.develop


### PR DESCRIPTION
This PR adds support for [PEP-610](https://www.python.org/dev/peps/pep-0610/) which introduced a standard way of recording the origin of direct URL packages (i.e. file, directory, url and VCS packages).

Two things needed to be done for Poetry to be fully compliant:

- Write the `direct_url.json` file to record the origin of the package
- Read the `direct_url.json` file in `InstalledRepository.load()` to retrieve the origin of the information. This also avoids some of the heuristics we are currently doing to guess the origin of the installed packages.

One thing of note is that existing environments will see updates for all their "standard" packages due to the fact that `pip` already supports PEP-610 and since we are installing wheels from our own cache, `pip` consider them as file packages. That's also why we need to remove the `direct_url.json` file generated by `pip` when installing packages. This will be a one-time thing to set the current environments right. New environments will not be affected.

## Pull Request Check List

Resolves: #2452 

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
