### PR TITLE
Tests for ansi and no-ansi installs + bugfix for ansi install

### DIFF
--- a/tests/utils/test_pip.py
+++ b/tests/utils/test_pip.py
@@ -1,0 +1,20 @@
+import subprocess
+
+import pytest
+
+from poetry.utils.pip import pip_install
+
+
+def test_pip_install_successful(tmp_dir, tmp_venv, fixture_dir):
+    file_path = fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl")
+    result = pip_install(file_path, tmp_venv)
+
+    assert "Successfully installed demo-0.1.0" in result
+
+
+def test_pip_install_with_keyboard_interrupt(tmp_dir, tmp_venv, fixture_dir, mocker):
+    file_path = fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl")
+    mocker.patch("subprocess.run", side_effect=KeyboardInterrupt())
+    with pytest.raises(KeyboardInterrupt):
+        pip_install(file_path, tmp_venv)
+    subprocess.run.assert_called_once()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2922 (sort of, more context below)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

#2922 is mostly fixed on the `master` branch (but not in v1.1.5) because of the cleo upgrade, but there's been a regression on the `--ansi` part of things because of some other changes with how you're doing pip installs. Pip installation should emit an integer "return code" and not the output to stdout of the pip install command. Fixing that allows [this line in executor.py](https://github.com/python-poetry/poetry/blob/master/poetry/installation/executor.py#L298-L299) to work properly and resolves the new ansi bug.

I have confirmed that the tests I wrote fail on `master` but pass on my branch, and I've linted my code.