### PR TITLE
Add a special error message for missing commands

### DIFF
--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -28,7 +28,15 @@ class RunCommand(EnvCommand):
         if scripts and script in scripts:
             return self.run_script(scripts[script], args)
 
-        return self.env.execute(*args)
+        try:
+            return self.env.execute(*args)
+        except FileNotFoundError:
+            self.line_error("")
+            self.line_error(
+                "<error>Error: Command {} is not found.</error>".format(script)
+            )
+            self.line_error("")
+            return 1
 
     @property
     def _module(self) -> "Module":

--- a/poetry/console/commands/run.py
+++ b/poetry/console/commands/run.py
@@ -31,11 +31,7 @@ class RunCommand(EnvCommand):
         try:
             return self.env.execute(*args)
         except FileNotFoundError:
-            self.line_error("")
-            self.line_error(
-                "<error>Error: Command {} is not found.</error>".format(script)
-            )
-            self.line_error("")
+            self.line_error(f "<error><c1>{script}</c1>: command not found.</error>")
             return 1
 
     @property


### PR DESCRIPTION
If a given command is missing, `poetry run` would result in an exception being printed out.

This pull request adds an error message describing what the issue is.

closes #3883

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
