### PR TITLE
Throw a RuntimeError on hash mismatch in Chooser._get_links

### DIFF
--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -106,6 +106,11 @@ class Chooser:
 
             selected_links.append(link)
 
+        if links and not selected_links:
+            raise RuntimeError(
+                f"Retrieved digest for link {link.filename}({h}) not in poetry.lock metadata {hashes}"
+            )
+
         return selected_links
 
     def _sort_key(self, package: Package, link: Link) -> Tuple:

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -208,3 +208,36 @@ def test_chooser_chooses_distributions_that_match_the_package_hashes(
     link = chooser.choose_for(package)
 
     assert "isort-4.3.4.tar.gz" == link.filename
+
+
+@pytest.mark.parametrize("source_type", ["", "legacy"])
+def test_chooser_throws_an_error_if_package_hashes_do_not_match(
+    env,
+    mock_pypi,
+    mock_legacy,
+    source_type,
+    pool,
+):
+    chooser = Chooser(pool, env)
+
+    package = Package("isort", "4.3.4")
+    files = [
+        {
+            "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "filename": "isort-4.3.4.tar.gz",
+        }
+    ]
+    if source_type == "legacy":
+        package = Package(
+            package.name,
+            package.version.text,
+            source_type="legacy",
+            source_reference="foo",
+            source_url="https://foo.bar/simple/",
+        )
+
+    package.files = files
+
+    with pytest.raises(RuntimeError) as e:
+        chooser.choose_for(package)
+    assert files[0]["hash"] in str(e)


### PR DESCRIPTION
Throw a specific exception in the case of finding a matching name+version, but none of the digests for a link matching the `poetry.lock` metadata.

Resolves: #2422

- [✅] Added **tests** for changed code.
- [✅] Updated **documentation** for changed code.
