### PR TITLE
site: use importlib instead of adhoc file searches

### DIFF
--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -117,7 +117,9 @@ class PipInstaller(BaseInstaller):
             raise
 
         # This is a workaround for https://github.com/pypa/pip/issues/4176
-        for nspkg_pth_file in self._env.site_packages.find(f"{package.name}-nspkg.pth"):
+        for nspkg_pth_file in self._env.site_packages.find_distribution_nspkg_pth_files(
+            distribution_name=package.name
+        ):
             nspkg_pth_file.unlink()
 
         # If we have a VCS package, remove its source directory

--- a/poetry/repositories/installed_repository.py
+++ b/poetry/repositories/installed_repository.py
@@ -2,7 +2,6 @@ import itertools
 import json
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Set
 from typing import Tuple
 from typing import Union
@@ -18,9 +17,6 @@ from .repository import Repository
 
 
 _VENDORS = Path(__file__).parent.parent.joinpath("_vendor")
-
-if TYPE_CHECKING:
-    from importlib.metadata import Distribution
 
 
 try:
@@ -102,7 +98,7 @@ class InstalledRepository(Repository):
 
     @classmethod
     def create_package_from_distribution(
-        cls, distribution: "Distribution", env: "Env"
+        cls, distribution: metadata.Distribution, env: "Env"
     ) -> Package:
         # We first check for a direct_url.json file to determine
         # the type of package.
@@ -172,7 +168,7 @@ class InstalledRepository(Repository):
         return package
 
     @classmethod
-    def create_package_from_pep610(cls, distribution: "Distribution") -> Package:
+    def create_package_from_pep610(cls, distribution: metadata.Distribution) -> Package:
         path = Path(str(distribution._path))
         source_type = None
         source_url = None


### PR DESCRIPTION
This change replaces various cases in which installed distribution and
file look-ups used path searches with importlib.metadata backed 
look-ups.

This fixes issues with `dist-info` lookup for PEP610 implementation as 
well as `.pth` file look-up and `dist-info` removal.

Resolves: #2918