### PR TITLE
Fix reverting the pyproject.toml content in the remove command

### DIFF
--- a/poetry/console/commands/remove.py
+++ b/poetry/console/commands/remove.py
@@ -32,7 +32,6 @@ list of installed packages
         packages = self.argument("packages")
         is_dev = self.option("dev")
 
-        original_content = self.poetry.file.read()
         content = self.poetry.file.read()
         poetry_content = content["tool"]["poetry"]
         section = "dependencies"
@@ -75,14 +74,9 @@ list of installed packages
         self._installer.update(True)
         self._installer.whitelist(requirements)
 
-        try:
-            status = self._installer.run()
-        except Exception:
-            self.poetry.file.write(original_content)
+        status = self._installer.run()
 
-            raise
-
-        if not self.option("dry-run"):
+        if not self.option("dry-run") and status == 0:
             self.poetry.file.write(content)
 
         return status

--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -1,0 +1,24 @@
+import pytest
+
+from poetry.core.packages.package import Package
+
+
+@pytest.fixture()
+def tester(command_tester_factory):
+    return command_tester_factory("remove")
+
+
+def test_remove_command_should_not_write_changes_upon_installer_errors(
+    tester, app, repo, command_tester_factory, mocker
+):
+    repo.add_package(Package("foo", "2.0.0"))
+
+    command_tester_factory("add").execute("foo")
+
+    mocker.patch("poetry.installation.installer.Installer.run", return_value=1)
+
+    original_content = app.poetry.file.read().as_string()
+
+    tester.execute("foo")
+
+    assert app.poetry.file.read().as_string() == original_content


### PR DESCRIPTION
The status code of the installer was not used to ensure that the content of the `pyproject.toml` file was reverted in case of errors.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
