### PR TITLE
tests: add case for transitive markers propagation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -390,7 +390,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "poetry-core"
-version = "1.1.0a1"
+version = "1.1.0a2"
 description = "Poetry PEP 517 Build Backend"
 category = "main"
 optional = false
@@ -405,7 +405,7 @@ importlib-metadata = {version = "^1.7.0", markers = "python_version >= \"3.5\" a
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "master"
-resolved_reference = "8d5e5c5d070940736ab72c5dec09cd7deab07cf3"
+resolved_reference = "d3e60732ce9bd4f30dee3e594405fe6a80163b7e"
 
 [[package]]
 name = "pre-commit"


### PR DESCRIPTION
This change also upgrades poetry-core to use latest master version.

Relates-to: #3878