### PR TITLE
env: make pip/setuptools/wheel configurable

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -35,6 +35,9 @@ cache-dir = "/path/to/cache/directory"
 virtualenvs.create = true
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = true
+virtualenvs.options.no-pip = true
+virtualenvs.options.no-setuptools = false
+virtualenvs.options.no-wheel = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = "{cache-dir}/virtualenvs"  # /path/to/cache/directory/virtualenvs
 ```
@@ -144,6 +147,25 @@ Defaults to `{cache-dir}/virtualenvs` (`{cache-dir}\virtualenvs` on Windows).
 ### `virtualenvs.options.always-copy`: boolean
 
 If set to `true` the `--always-copy` parameter is passed to `virtualenv` on creation of the venv. Thus all needed files are copied into the venv instead of symlinked.
+Defaults to `false`.
+
+### `virtualenvs.options.no-pip`: boolean
+
+If set to `true` the `--no-pip` parameter is passed to `virtualenv` on creation of the venv. Thus all needed files are copied into the venv instead of symlinked.
+Defaults to `false`.
+
+!!!note
+
+    If set to `true`, `poetry run pip` will use pip embedded in poetry's virtualenv dependency.
+
+### `virtualenvs.options.no-setuptools`: boolean
+
+If set to `true` the `--no-setuptools` parameter is passed to `virtualenv` on creation of the venv. Thus all needed files are copied into the venv instead of symlinked.
+Defaults to `false`.
+
+### `virtualenvs.options.no-wheel`: boolean
+
+If set to `true` the `--no-wheel parameter is passed to `virtualenv` on creation of the venv. Thus all needed files are copied into the venv instead of symlinked.
 Defaults to `false`.
 
 ### `virtualenvs.options.system-site-packages`: boolean

--- a/poetry.lock
+++ b/poetry.lock
@@ -161,7 +161,7 @@ python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "deepdiff"
-version = "5.2.3"
+version = "5.5.0"
 description = "Deep Difference and Search of any Python object/data."
 category = "dev"
 optional = false
@@ -171,7 +171,7 @@ python-versions = ">=3.6"
 ordered-set = "4.0.2"
 
 [package.extras]
-cli = ["click (==7.1.2)", "pyyaml (==5.3.1)", "toml (==0.10.2)", "clevercsv (==0.6.6)"]
+cli = ["click (==7.1.2)", "pyyaml (==5.4)", "toml (==0.10.2)", "clevercsv (==0.6.7)"]
 
 [[package]]
 name = "distlib"
@@ -225,7 +225,7 @@ python-versions = ">=3"
 
 [[package]]
 name = "identify"
-version = "2.2.1"
+version = "2.2.4"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -327,7 +327,7 @@ python-versions = "*"
 
 [[package]]
 name = "nodeenv"
-version = "1.5.0"
+version = "1.6.0"
 description = "Node.js virtual environment builder"
 category = "dev"
 optional = false
@@ -390,7 +390,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "poetry-core"
-version = "1.1.0a2"
+version = "1.1.0a3"
 description = "Poetry PEP 517 Build Backend"
 category = "main"
 optional = false
@@ -398,18 +398,18 @@ python-versions = "^3.6"
 develop = false
 
 [package.dependencies]
-dataclasses = {version = "^0.8", markers = "python_version >= \"3.6\" and python_version < \"3.7\""}
-importlib-metadata = {version = "^1.7.0", markers = "python_version >= \"3.5\" and python_version < \"3.8\""}
+dataclasses = {version = ">=0.8", markers = "python_version >= \"3.6\" and python_version < \"3.7\""}
+importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
 
 [package.source]
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "master"
-resolved_reference = "d3e60732ce9bd4f30dee3e594405fe6a80163b7e"
+resolved_reference = "3f718c55fcda63d9bd88b8fc612970c24fc9af25"
 
 [[package]]
 name = "pre-commit"
-version = "2.11.1"
+version = "2.12.1"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -665,7 +665,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.4.3"
+version = "20.4.4"
 description = "Virtual Python Environment builder"
 category = "main"
 optional = false
@@ -873,8 +873,8 @@ dataclasses = [
     {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 deepdiff = [
-    {file = "deepdiff-5.2.3-py3-none-any.whl", hash = "sha256:3d3da4bd7e01fb5202088658ed26427104c748dda56a0ecfac9ce9a1d2d00844"},
-    {file = "deepdiff-5.2.3.tar.gz", hash = "sha256:ae2cb98353309f93fbfdda4d77adb08fb303314d836bb6eac3d02ed71a10b40e"},
+    {file = "deepdiff-5.5.0-py3-none-any.whl", hash = "sha256:e054fed9dfe0d83d622921cbb3a3d0b3a6dd76acd2b6955433a0a2d35147774a"},
+    {file = "deepdiff-5.5.0.tar.gz", hash = "sha256:dd79b81c2d84bfa33aa9d94d456b037b68daff6bb87b80dfaa1eca04da68b349"},
 ]
 distlib = [
     {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
@@ -896,8 +896,8 @@ httpretty = [
     {file = "httpretty-1.0.5.tar.gz", hash = "sha256:e53c927c4d3d781a0761727f1edfad64abef94e828718e12b672a678a8b3e0b5"},
 ]
 identify = [
-    {file = "identify-2.2.1-py2.py3-none-any.whl", hash = "sha256:9cc5f58996cd359b7b72f0a5917d8639de5323917e6952a3bfbf36301b576f40"},
-    {file = "identify-2.2.1.tar.gz", hash = "sha256:1cfb05b578de996677836d5a2dde14b3dffde313cf7d2b3e793a0787a36e26dd"},
+    {file = "identify-2.2.4-py2.py3-none-any.whl", hash = "sha256:ad9f3fa0c2316618dc4d840f627d474ab6de106392a4f00221820200f490f5a8"},
+    {file = "identify-2.2.4.tar.gz", hash = "sha256:9bcc312d4e2fa96c7abebcdfb1119563b511b5e3985ac52f60d9116277865b2e"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -958,8 +958,8 @@ msgpack = [
     {file = "msgpack-1.0.2.tar.gz", hash = "sha256:fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984"},
 ]
 nodeenv = [
-    {file = "nodeenv-1.5.0-py2.py3-none-any.whl", hash = "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9"},
-    {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
+    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
+    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
 ordered-set = [
     {file = "ordered-set-4.0.2.tar.gz", hash = "sha256:ba93b2df055bca202116ec44b9bead3df33ea63a7d5827ff8e16738b97f33a95"},
@@ -982,8 +982,8 @@ pluggy = [
 ]
 poetry-core = []
 pre-commit = [
-    {file = "pre_commit-2.11.1-py2.py3-none-any.whl", hash = "sha256:94c82f1bf5899d56edb1d926732f4e75a7df29a0c8c092559c77420c9d62428b"},
-    {file = "pre_commit-2.11.1.tar.gz", hash = "sha256:de55c5c72ce80d79106e48beb1b54104d16495ce7f95b0c7b13d4784193a00af"},
+    {file = "pre_commit-2.12.1-py2.py3-none-any.whl", hash = "sha256:70c5ec1f30406250b706eda35e868b87e3e4ba099af8787e3e8b4b01e84f4712"},
+    {file = "pre_commit-2.12.1.tar.gz", hash = "sha256:900d3c7e1bf4cf0374bb2893c24c23304952181405b4d88c9c40b72bda1bb8a9"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -1087,8 +1087,8 @@ urllib3 = [
     {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.4.3-py2.py3-none-any.whl", hash = "sha256:83f95875d382c7abafe06bd2a4cdd1b363e1bb77e02f155ebe8ac082a916b37c"},
-    {file = "virtualenv-20.4.3.tar.gz", hash = "sha256:49ec4eb4c224c6f7dd81bb6d0a28a09ecae5894f4e593c89b0db0885f565a107"},
+    {file = "virtualenv-20.4.4-py2.py3-none-any.whl", hash = "sha256:a935126db63128861987a7d5d30e23e8ec045a73840eeccb467c148514e29535"},
+    {file = "virtualenv-20.4.4.tar.gz", hash = "sha256:09c61377ef072f43568207dc8e46ddeac6bcdcaf288d49011bda0e7f4d38c4a2"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/poetry/config/config.py
+++ b/poetry/config/config.py
@@ -33,7 +33,13 @@ class Config:
             "create": True,
             "in-project": None,
             "path": os.path.join("{cache-dir}", "virtualenvs"),
-            "options": {"always-copy": False, "system-site-packages": False},
+            "options": {
+                "always-copy": False,
+                "system-site-packages": False,
+                "no-pip": False,
+                "no-setuptools": False,
+                "no-wheel": False,
+            },
         },
         "experimental": {"new-installer": True},
         "installer": {"parallel": True},
@@ -139,6 +145,9 @@ class Config:
             "virtualenvs.in-project",
             "virtualenvs.options.always-copy",
             "virtualenvs.options.system-site-packages",
+            "virtualenvs.options.no-pip",
+            "virtualenvs.options.no-setuptools",
+            "virtualenvs.options.no-wheel",
             "installer.parallel",
         }:
             return boolean_normalizer

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -72,6 +72,21 @@ To remove a repository (repo is a short alias for repositories):
                 boolean_normalizer,
                 False,
             ),
+            "virtualenvs.options.no-pip": (
+                boolean_validator,
+                boolean_normalizer,
+                False,
+            ),
+            "virtualenvs.options.no-setuptools": (
+                boolean_validator,
+                boolean_normalizer,
+                False,
+            ),
+            "virtualenvs.options.no-wheel": (
+                boolean_validator,
+                boolean_normalizer,
+                False,
+            ),
             "virtualenvs.path": (
                 str,
                 lambda val: str(Path(val)),

--- a/poetry/console/commands/debug/resolve.py
+++ b/poetry/console/commands/debug/resolve.py
@@ -84,7 +84,14 @@ class DebugResolveCommand(InitCommand):
 
         pool = self.poetry.pool
 
-        solver = Solver(package, pool, Repository(), Repository(), self._io)
+        solver = Solver(
+            package,
+            pool,
+            Repository(),
+            Repository(),
+            self._io,
+            config=self.poetry.config,
+        )
 
         ops = solver.solve()
 
@@ -121,7 +128,9 @@ class DebugResolveCommand(InitCommand):
 
             pool.add_repository(locked_repository)
 
-            solver = Solver(package, pool, Repository(), Repository(), NullIO())
+            solver = Solver(
+                package, pool, Repository(), Repository(), NullIO(), poetry=self.poetry
+            )
             with solver.use_environment(env):
                 ops = solver.solve()
 

--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -90,6 +90,7 @@ lists all packages available."""
             installed=Repository(),
             locked=locked_repo,
             io=NullIO(),
+            config=self.poetry.config,
         )
         solver.provider.load_deferred(False)
         with solver.use_environment(self.env):

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -670,7 +670,13 @@ class Executor:
                 archive = self._chef.prepare(archive)
 
         if package.files:
-            archive_hash = "sha256:" + FileDependency(package.name, archive).hash()
+            archive_hash = (
+                "sha256:"
+                + FileDependency(
+                    package.name,
+                    Path(archive.path) if isinstance(archive, Link) else archive,
+                ).hash()
+            )
             if archive_hash not in {f["hash"] for f in package.files}:
                 raise RuntimeError(
                     f"Invalid hash for {package} using archive {archive.name}"

--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -74,6 +74,7 @@ class Installer:
             installed = self._get_installed()
 
         self._installed_repository = installed
+        self._poetry_config = config
 
     @property
     def executor(self) -> Executor:
@@ -209,6 +210,7 @@ class Installer:
             locked_repository,
             locked_repository,
             self._io,
+            config=self._poetry_config,
         )
 
         ops = solver.solve(use_latest=[])
@@ -247,6 +249,7 @@ class Installer:
                 locked_repository,
                 self._io,
                 remove_untracked=self._remove_untracked,
+                config=self._poetry_config,
             )
 
             ops = solver.solve(use_latest=self._whitelist)
@@ -316,6 +319,7 @@ class Installer:
             locked_repository,
             NullIO(),
             remove_untracked=self._remove_untracked,
+            config=self._poetry_config,
         )
         # Everything is resolved at this point, so we no longer need
         # to load deferred dependencies (i.e. VCS, URL and path dependencies)

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1245,6 +1245,7 @@ class Env:
         """
         call = kwargs.pop("call", False)
         input_ = kwargs.pop("input_", None)
+        env = kwargs.pop("env", {k: v for k, v in os.environ.items()})
 
         try:
             if self._is_windows:
@@ -1263,10 +1264,10 @@ class Env:
                     **kwargs,
                 ).stdout
             elif call:
-                return subprocess.call(cmd, stderr=subprocess.STDOUT, **kwargs)
+                return subprocess.call(cmd, stderr=subprocess.STDOUT, env=env, **kwargs)
             else:
                 output = subprocess.check_output(
-                    cmd, stderr=subprocess.STDOUT, **kwargs
+                    cmd, stderr=subprocess.STDOUT, env=env, **kwargs
                 )
         except CalledProcessError as e:
             raise EnvCommandError(e, input=input_)

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -927,11 +927,28 @@ class EnvManager:
         path: Union[Path, str],
         executable: Optional[Union[str, Path]] = None,
         flags: Dict[str, bool] = None,
-        with_pip: bool = False,
+        with_pip: Optional[bool] = None,
         with_wheel: Optional[bool] = None,
         with_setuptools: Optional[bool] = None,
     ) -> virtualenv.run.session.Session:
         flags = flags or {}
+
+        flags["no-pip"] = (
+            not with_pip if with_pip is not None else flags.pop("no-pip", True)
+        )
+
+        flags["no-setuptools"] = (
+            not with_setuptools
+            if with_setuptools is not None
+            else flags.pop("no-setuptools", True)
+        )
+
+        # we want wheels to be enabled when pip is required and it has not been explicitly disabled
+        flags["no-wheel"] = (
+            not with_wheel
+            if with_wheel is not None
+            else flags.pop("no-wheel", flags["no-pip"])
+        )
 
         if isinstance(executable, Path):
             executable = executable.resolve().as_posix()
@@ -942,20 +959,6 @@ class EnvManager:
             "--python",
             executable or sys.executable,
         ]
-
-        if not with_pip:
-            args.append("--no-pip")
-        else:
-            if with_wheel is None:
-                # we want wheels to be enabled when pip is required and it has
-                # not been explicitly disabled
-                with_wheel = True
-
-        if with_wheel is None or not with_wheel:
-            args.append("--no-wheel")
-
-        if with_setuptools is None or not with_setuptools:
-            args.append("--no-setuptools")
 
         for flag, value in flags.items():
             if value is True:
@@ -1039,6 +1042,8 @@ class Env:
         self._platlib = None
         self._script_dirs = None
 
+        self._embedded_pip_path = None
+
     @property
     def path(self) -> Path:
         return self._path
@@ -1075,6 +1080,12 @@ class Env:
         ).path
 
     @property
+    def pip_embedded(self) -> str:
+        if self._embedded_pip_path is None:
+            self._embedded_pip_path = str(self.get_embedded_wheel("pip") / "pip")
+        return self._embedded_pip_path
+
+    @property
     def pip(self) -> str:
         """
         Path to current pip executable
@@ -1082,7 +1093,7 @@ class Env:
         # we do not use as_posix() here due to issues with windows pathlib2 implementation
         path = self._bin("pip")
         if not Path(path).exists():
-            return str(self.get_embedded_wheel("pip") / "pip")
+            return str(self.pip_embedded)
         return path
 
     @property
@@ -1187,7 +1198,7 @@ class Env:
     def get_marker_env(self) -> Dict[str, Any]:
         raise NotImplementedError()
 
-    def get_pip_command(self) -> List[str]:
+    def get_pip_command(self, embedded: bool = False) -> List[str]:
         raise NotImplementedError()
 
     def get_supported_tags(self) -> List[Tag]:
@@ -1208,16 +1219,20 @@ class Env:
         """
         return True
 
-    def run(self, bin: str, *args: str, **kwargs: Any) -> Union[str, int]:
+    def get_command_from_bin(self, bin: str) -> List[str]:
         if bin == "pip":
-            return self.run_pip(*args, **kwargs)
+            # when pip is required we need to ensure that we fallback to
+            # embedded pip when pip is not available in the environment
+            return self.get_pip_command()
 
-        bin = self._bin(bin)
-        cmd = [bin] + list(args)
+        return [self._bin(bin)]
+
+    def run(self, bin: str, *args: str, **kwargs: Any) -> Union[str, int]:
+        cmd = self.get_command_from_bin(bin) + list(args)
         return self._run(cmd, **kwargs)
 
     def run_pip(self, *args: str, **kwargs: Any) -> Union[int, str]:
-        pip = self.get_pip_command()
+        pip = self.get_pip_command(embedded=True)
         cmd = pip + list(args)
         return self._run(cmd, **kwargs)
 
@@ -1259,17 +1274,13 @@ class Env:
         return decode(output)
 
     def execute(self, bin: str, *args: str, **kwargs: Any) -> Optional[int]:
-        if bin == "pip":
-            return self.run_pip(*args, **kwargs)
-
-        bin = self._bin(bin)
+        command = self.get_command_from_bin(bin) + list(args)
         env = kwargs.pop("env", {k: v for k, v in os.environ.items()})
 
         if not self._is_windows:
-            args = [bin] + list(args)
-            return os.execvpe(bin, args, env=env)
+            return os.execvpe(command[0], command, env=env)
         else:
-            exe = subprocess.Popen([bin] + list(args), env=env, **kwargs)
+            exe = subprocess.Popen([command[0]] + command[1:], env=env, **kwargs)
             exe.communicate()
             return exe.returncode
 
@@ -1337,10 +1348,10 @@ class SystemEnv(Env):
     def get_python_implementation(self) -> str:
         return platform.python_implementation()
 
-    def get_pip_command(self) -> List[str]:
+    def get_pip_command(self, embedded: bool = False) -> List[str]:
         # If we're not in a venv, assume the interpreter we're running on
         # has a pip and use that
-        return [sys.executable, self.pip]
+        return [sys.executable, self.pip_embedded if embedded else self.pip]
 
     def get_paths(self) -> Dict[str, str]:
         # We can't use sysconfig.get_paths() because
@@ -1444,10 +1455,10 @@ class VirtualEnv(Env):
     def get_python_implementation(self) -> str:
         return self.marker_env["platform_python_implementation"]
 
-    def get_pip_command(self) -> List[str]:
+    def get_pip_command(self, embedded: bool = False) -> List[str]:
         # We're in a virtualenv that is known to be sane,
         # so assume that we have a functional pip
-        return [self._bin("python"), self.pip]
+        return [self._bin("python"), self.pip_embedded if embedded else self.pip]
 
     def get_supported_tags(self) -> List[Tag]:
         file_path = Path(packaging.tags.__file__)
@@ -1559,8 +1570,8 @@ class NullEnv(SystemEnv):
         self._execute = execute
         self.executed = []
 
-    def get_pip_command(self) -> List[str]:
-        return [self._bin("python"), self.pip]
+    def get_pip_command(self, embedded: bool = False) -> List[str]:
+        return [self._bin("python"), self.pip_embedded if embedded else self.pip]
 
     def _run(self, cmd: List[str], **kwargs: Any) -> int:
         self.executed.append(cmd)

--- a/poetry/utils/pip.py
+++ b/poetry/utils/pip.py
@@ -53,7 +53,7 @@ def pip_install(
                 executable=environment.python, with_pip=True, with_setuptools=True
             ) as env:
                 return environment.run(
-                    env._bin("pip"),
+                    *env.get_pip_command(),
                     *args,
                     env={**os.environ, "PYTHONPATH": str(env.purelib)},
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,15 @@ def config(config_source, auth_config_source, mocker):
 
 
 @pytest.fixture(autouse=True)
+def mock_user_config_dir(mocker):
+    config_dir = tempfile.mkdtemp(prefix="poetry_config_")
+    mocker.patch("poetry.locations.CONFIG_DIR", new=config_dir)
+    mocker.patch("poetry.factory.CONFIG_DIR", new=config_dir)
+    yield
+    shutil.rmtree(config_dir, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
 def download_mock(mocker):
     # Patch download to not download anything but to just copy from fixtures
     mocker.patch("poetry.utils.helpers.download_file", new=mock_download)

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -54,7 +54,13 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     mock_build_env.assert_called_with(
         venv_py37,
         executable="python3.7",
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
 
     envs_file = TOMLFile(venv_cache / "envs.toml")

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -32,6 +32,9 @@ installer.parallel = true
 virtualenvs.create = true
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
+virtualenvs.options.no-pip = false
+virtualenvs.options.no-setuptools = false
+virtualenvs.options.no-wheel = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {path}  # {virtualenvs}
 """.format(
@@ -54,6 +57,9 @@ installer.parallel = true
 virtualenvs.create = false
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
+virtualenvs.options.no-pip = false
+virtualenvs.options.no-setuptools = false
+virtualenvs.options.no-wheel = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {path}  # {virtualenvs}
 """.format(
@@ -98,6 +104,9 @@ installer.parallel = true
 virtualenvs.create = false
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
+virtualenvs.options.no-pip = false
+virtualenvs.options.no-setuptools = false
+virtualenvs.options.no-wheel = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {path}  # {virtualenvs}
 """.format(

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -217,7 +217,7 @@ def test_info_setup_missing_mandatory_should_trigger_pep517(
     except PackageInfoError:
         assert spy.call_count == 3
     else:
-        assert spy.call_count == 1
+        assert spy.call_count == 2
 
 
 def test_info_prefer_poetry_config_over_egg_info():

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -153,7 +153,7 @@ from bar import baz
 if __name__ == '__main__':
     baz.boom.bim()
 """.format(
-        python=tmp_venv._bin("python")
+        python=tmp_venv.python
     )
 
     assert baz_script == tmp_venv._bin_dir.joinpath("baz").read_text()
@@ -165,7 +165,7 @@ from foo import bar
 if __name__ == '__main__':
     bar()
 """.format(
-        python=tmp_venv._bin("python")
+        python=tmp_venv.python
     )
 
     assert foo_script == tmp_venv._bin_dir.joinpath("foo").read_text()
@@ -177,7 +177,7 @@ from fuz.foo import bar
 if __name__ == '__main__':
     bar.baz()
 """.format(
-        python=tmp_venv._bin("python")
+        python=tmp_venv.python
     )
 
     assert fox_script == tmp_venv._bin_dir.joinpath("fox").read_text()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -292,6 +292,9 @@ def test_create_poetry_with_local_config(fixture_dir):
     assert not poetry.config.get("virtualenvs.create")
     assert not poetry.config.get("virtualenvs.options.always-copy")
     assert not poetry.config.get("virtualenvs.options.system-site-packages")
+    assert not poetry.config.get("virtualenvs.options.no-pip")
+    assert not poetry.config.get("virtualenvs.options.no-setuptools")
+    assert not poetry.config.get("virtualenvs.options.no-wheel")
 
 
 def test_create_poetry_with_plugins(mocker):

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -160,7 +160,13 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     m.assert_called_with(
         Path(tmp_dir) / "{}-py3.7".format(venv_name),
         executable="python3.7",
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
 
     envs_file = TOMLFile(Path(tmp_dir) / "envs.toml")
@@ -280,7 +286,13 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     m.assert_called_with(
         Path(tmp_dir) / "{}-py3.6".format(venv_name),
         executable="python3.6",
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
 
     assert envs_file.exists()
@@ -334,7 +346,13 @@ def test_activate_activates_recreates_for_different_patch(
     build_venv_m.assert_called_with(
         Path(tmp_dir) / "{}-py3.7".format(venv_name),
         executable="python3.7",
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
     remove_venv_m.assert_called_with(Path(tmp_dir) / "{}-py3.7".format(venv_name))
 
@@ -714,7 +732,13 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
     m.assert_called_with(
         config_virtualenvs_path / "{}-py3.7".format(venv_name),
         executable="python3",
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
 
 
@@ -738,7 +762,13 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     m.assert_called_with(
         config_virtualenvs_path / "{}-py3.9".format(venv_name),
         executable="python3.9",
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
 
 
@@ -822,7 +852,13 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
         config_virtualenvs_path
         / "{}-py{}.{}".format(venv_name, version.major, version.minor),
         executable=None,
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
 
 
@@ -857,7 +893,13 @@ def test_create_venv_uses_patch_version_to_detect_compatibility_with_executable(
         config_virtualenvs_path
         / "{}-py{}.{}".format(venv_name, version.major, version.minor - 1),
         executable="python{}.{}".format(version.major, version.minor - 1),
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
 
 
@@ -891,7 +933,13 @@ def test_activate_with_in_project_setting_does_not_fail_if_no_venvs_dir(
     m.assert_called_with(
         poetry.file.parent / ".venv",
         executable="python3.7",
-        flags={"always-copy": False, "system-site-packages": False},
+        flags={
+            "always-copy": False,
+            "system-site-packages": False,
+            "no-pip": False,
+            "no-setuptools": False,
+            "no-wheel": False,
+        },
     )
 
     envs_file = TOMLFile(Path(tmp_dir) / "virtualenvs" / "envs.toml")


### PR DESCRIPTION
This change introduces the following configuration options:

- `virtualenvs.options.no-pip` (Default: `false`)
- `virtualenvs.options.no-wheel` (Default: `false`)
- `virtualenvs.options.no-setuptools` (Default: `false`)

With these options, we allow, the user to control the inclusion of
`pip`, `wheel` and `setuptools` packages in new virtual environments.
The defaults used retain existing behaviour as of `1.1.5`.

In addition the following now holds true.

- projects can define `pip`, `wheel` and `setuptools` as dependencies
- if any of these packages are in the project's dependency tree, poetry
  will manage their versions
- all poetry internal commands will use pip embedded in virtualenv
  irrespective of pip beig available in the environment
- if `poetry run pip` is executed, pip installed in the virtualenv will
  be prioritsed
- `poetry install --remove-untracked` will ignore these packages if
  they are not present in the project's and the options are not set to `true` dependency tree

Relates-to: #2826
Relates-to: #3916

## Testing
### Using pipx
```sh
pipx install --suffix=@3920 'poetry @ git+https://github.com/python-poetry/poetry.git@refs/pull/3920/head'
alias poetry=poetry@3920
poetry config virtualenvs.options.no-setuptools false
poetry lock
poetry run pip list
poetry add -D setuptools
poetry config virtualenvs.options.no-setuptools true
poetry install --remove-untracked
poetry run pip list
```

### Using a container (podman | docker)
```sh
podman run --rm -i --entrypoint bash python:3.8 <<EOF
set -x
python -m pip install -q git+https://github.com/python-poetry/poetry.git@refs/pull/3920/head
poetry new foobar
pushd foobar
sed -i /pytest/d pyproject.toml
poetry config virtualenvs.options.no-setuptools false
poetry lock
poetry run pip list
poetry add -D setuptools
poetry config virtualenvs.options.no-setuptools true
poetry install --remove-untracked
poetry run pip list
EOF
```
