### PR TITLE
fix(get-poetry): use exit code 1 with non-existing version

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -352,7 +352,7 @@ class Installer:
         version, current_version = self.get_version()
 
         if version is None:
-            return 0
+            return 1
 
         self.customize_install()
         self.display_pre_message()


### PR DESCRIPTION
`python get-poetry.py --version 0.12.34` should exit non-zero.

This apparently regressed in 23667d28a96cd [1].

1: https://github.com/python-poetry/poetry/commit/23667d28a96cdf62a83e944ac977e22d3ced7590#diff-952871ed95a893e0348aa1269bf15e689d18756657cfec5c7316d05e55eb6dc6R302

Ref: https://github.com/python-poetry/poetry/pull/378

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.