### PR TITLE
Update CLI docs to include information about poetry lock --no-update

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -419,7 +419,9 @@ poetry search requests pendulum
 
 This command locks (without installing) the dependencies specified in `pyproject.toml`.
 
-By default, it will update all dependencies within their version constraints.
+!!!note
+
+     By default, this will lock all dependencies to the latest available compatible versions. To only refresh the lock file, use the `--no-update` option.
 
 ```bash
 poetry lock

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -419,9 +419,15 @@ poetry search requests pendulum
 
 This command locks (without installing) the dependencies specified in `pyproject.toml`.
 
+By default, it will update all dependencies within their version constraints.
+
 ```bash
 poetry lock
 ```
+
+### Options
+
+* `--no-update`: Avoid updating dependencies that already satisfy their version constraints.
 
 ## version
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -427,7 +427,7 @@ poetry lock
 
 ### Options
 
-* `--no-update`: Avoid updating dependencies that already satisfy their version constraints.
+* `--no-update`: Do not update locked versions, only refresh lock file.
 
 ## version
 


### PR DESCRIPTION
Adds an "options" section for the `lock` command, including documentation about the `--no-update` flag. Also adds a note regarding the default behavior of `poetry lock` to update dependencies.

# Pull Request Check List

Resolves: #1614

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
