### PR TITLE
[1.1] Fix locked VCS dependencies always being updated

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -567,7 +567,12 @@ class Executor(object):
 
         git = Git()
         git.clone(package.source_url, src_dir)
-        git.checkout(package.source_reference, src_dir)
+
+        reference = package.source_resolved_reference
+        if not reference:
+            reference = package.source_reference
+
+        git.checkout(reference, src_dir)
 
         # Now we just need to install from the source directory
         package._source_url = str(src_dir)

--- a/poetry/installation/installer.py
+++ b/poetry/installation/installer.py
@@ -289,12 +289,6 @@ class Installer:
 
         pool.add_repository(repo)
 
-        # We whitelist all packages to be sure
-        # that the latest ones are picked up
-        whitelist = []
-        for pkg in locked_repository.packages:
-            whitelist.append(pkg.name)
-
         solver = Solver(
             root,
             pool,
@@ -303,9 +297,12 @@ class Installer:
             NullIO(),
             remove_untracked=self._remove_untracked,
         )
+        # Everything is resolved at this point, so we no longer need
+        # to load deferred dependencies (i.e. VCS, URL and path dependencies)
+        solver.provider.load_deferred(False)
 
         with solver.use_environment(self._env):
-            ops = solver.solve(use_latest=whitelist)
+            ops = solver.solve(use_latest=self._whitelist)
 
         # We need to filter operations so that packages
         # not compatible with the current system,

--- a/poetry/installation/pip_installer.py
+++ b/poetry/installation/pip_installer.py
@@ -250,7 +250,12 @@ class PipInstaller(BaseInstaller):
 
         git = Git()
         git.clone(package.source_url, src_dir)
-        git.checkout(package.source_reference, src_dir)
+
+        reference = package.source_resolved_reference
+        if not reference:
+            reference = package.source_reference
+
+        git.checkout(reference, src_dir)
 
         # Now we just need to install from the source directory
         pkg = Package(package.name, package.version)


### PR DESCRIPTION
Backport of #3875 to the `1.1` branch
