### PR TITLE
Add direct_url.json to RECORD upon creation

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -777,8 +777,9 @@ class Executor:
                     encoding="utf-8",
                 )
 
-                with dist._path.joinpath("RECORD").open(mode="a") as record:
-                    record.write(str(dist._path.joinpath("direct_url.json")))
+                if dist._path.joinpath("RECORD").exists():
+                    with dist._path.joinpath("RECORD").open(mode="a") as record:
+                        record.write(str(dist._path.joinpath("direct_url.json")))
 
     def _create_git_url_reference(
         self, package: "Package"

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -783,7 +783,15 @@ class Executor:
                     with record.open(mode="a") as f:
                         writer = csv.writer(f)
                         writer.writerow(
-                            [str(dist._path.joinpath("direct_url.json").relative_to(record.parent.parent)), "", ""]
+                            [
+                                str(
+                                    dist._path.joinpath("direct_url.json").relative_to(
+                                        record.parent.parent
+                                    )
+                                ),
+                                "",
+                                "",
+                            ]
                         )
 
     def _create_git_url_reference(

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -1,3 +1,4 @@
+import csv
 import itertools
 import json
 import os

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -777,6 +777,9 @@ class Executor:
                     encoding="utf-8",
                 )
 
+                with dist._path.joinpath("RECORD").open(mode="a") as record:
+                    record.write(str(dist._path.joinpath("direct_url.json")))
+
     def _create_git_url_reference(
         self, package: "Package"
     ) -> Dict[str, Union[str, Dict[str, str]]]:

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -780,7 +780,7 @@ class Executor:
 
                 record = dist._path.joinpath("RECORD")
                 if record.exists():
-                    with record.open(mode="a") as f:
+                    with record.open(mode="a", encoding='utf-8') as f:
                         writer = csv.writer(f)
                         writer.writerow(
                             [

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -777,9 +777,13 @@ class Executor:
                     encoding="utf-8",
                 )
 
-                if dist._path.joinpath("RECORD").exists():
-                    with dist._path.joinpath("RECORD").open(mode="a") as record:
-                        record.write(str(dist._path.joinpath("direct_url.json")))
+                record = dist._path.joinpath("RECORD")
+                if record.exists():
+                    with record.open(mode="a") as f:
+                        writer = csv.writer(f)
+                        writer.writerow(
+                            [str(dist._path.joinpath("direct_url.json").relative_to(record.parent.parent)), "", ""]
+                        )
 
     def _create_git_url_reference(
         self, package: "Package"

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -780,7 +780,7 @@ class Executor:
 
                 record = dist._path.joinpath("RECORD")
                 if record.exists():
-                    with record.open(mode="a", encoding='utf-8') as f:
+                    with record.open(mode="a", encoding="utf-8") as f:
                         writer = csv.writer(f)
                         writer.writerow(
                             [

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -361,7 +361,8 @@ def verify_installed_distribution(venv, package, url_reference=None):
         direct_url_entry = direct_url_file.relative_to(record_file.parent.parent)
         assert direct_url_file.exists()
         assert str(direct_url_entry) in {
-            row.split(",")[0] for row in record_file.read_text(encoding="utf-8").splitlines()
+            row.split(",")[0]
+            for row in record_file.read_text(encoding="utf-8").splitlines()
         }
         assert json.loads(direct_url_file.read_text(encoding="utf-8")) == url_reference
     else:

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -356,14 +356,13 @@ def verify_installed_distribution(venv, package, url_reference=None):
 
     direct_url_file = distribution._path.joinpath("direct_url.json")
 
-    record_file = distribution._path.joinpath("RECORD")
-    direct_url_entry = direct_url_file.relative_to(record_file.parent.parent)
-    with open(record_file, "r") as f:
-        records_first_column = [row.split(",")[0] for row in f]
-
     if url_reference is not None:
+        record_file = distribution._path.joinpath("RECORD")
+        direct_url_entry = direct_url_file.relative_to(record_file.parent.parent)
         assert direct_url_file.exists()
-        assert str(direct_url_entry) in records_first_column
+        assert str(direct_url_entry) in {
+            row.split(",")[0] for row in record.read_text(encoding="utf-8").splitlines()
+        }
         assert json.loads(direct_url_file.read_text(encoding="utf-8")) == url_reference
     else:
         assert not direct_url_file.exists()

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -355,9 +355,15 @@ def verify_installed_distribution(venv, package, url_reference=None):
     assert metadata["Version"] == package.version.text
 
     direct_url_file = distribution._path.joinpath("direct_url.json")
+    
+    record_file = distribution._path.joinpath("RECORD")
+    with open(record_file, "r") as f:
+        record_file_contents = f.read().splitlines()
+    direct_url_entry = direct_url_file.relative_to(record_file.parent.parent)
 
     if url_reference is not None:
         assert direct_url_file.exists()
+        assert [r for r in record_file_contents if r.startswith(str(direct_url_entry))]
         assert json.loads(direct_url_file.read_text(encoding="utf-8")) == url_reference
     else:
         assert not direct_url_file.exists()

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -361,7 +361,7 @@ def verify_installed_distribution(venv, package, url_reference=None):
         direct_url_entry = direct_url_file.relative_to(record_file.parent.parent)
         assert direct_url_file.exists()
         assert str(direct_url_entry) in {
-            row.split(",")[0] for row in record.read_text(encoding="utf-8").splitlines()
+            row.split(",")[0] for row in record_file.read_text(encoding="utf-8").splitlines()
         }
         assert json.loads(direct_url_file.read_text(encoding="utf-8")) == url_reference
     else:

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -355,7 +355,7 @@ def verify_installed_distribution(venv, package, url_reference=None):
     assert metadata["Version"] == package.version.text
 
     direct_url_file = distribution._path.joinpath("direct_url.json")
-    
+
     record_file = distribution._path.joinpath("RECORD")
     with open(record_file, "r") as f:
         record_file_contents = f.read().splitlines()

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -357,13 +357,13 @@ def verify_installed_distribution(venv, package, url_reference=None):
     direct_url_file = distribution._path.joinpath("direct_url.json")
 
     record_file = distribution._path.joinpath("RECORD")
-    with open(record_file, "r") as f:
-        record_file_contents = f.read().splitlines()
     direct_url_entry = direct_url_file.relative_to(record_file.parent.parent)
+    with open(record_file, "r") as f:
+        records_first_column = [row.split(",")[0] for row in f]
 
     if url_reference is not None:
         assert direct_url_file.exists()
-        assert [r for r in record_file_contents if r.startswith(str(direct_url_entry))]
+        assert str(direct_url_entry) in records_first_column
         assert json.loads(direct_url_file.read_text(encoding="utf-8")) == url_reference
     else:
         assert not direct_url_file.exists()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3964

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

___

Seems the dist-info/RECORD was introduced by PEP-376 back in 2009:
http://packaging.python.org/specifications/recording-installed-packages.html

> "If the RECORD file is missing, tools that rely on .dist-info must not atempt to uninstall or upgrade the package. (This does not apply to tools that rely on other sources of information, such as system package managers in Linux distros.)"

Also, [this](https://discuss.python.org/t/pep-610-recording-the-origin-of-distributions-installed-from-direct-url-references/1535/73) answered my question on whether direct_url.json should go into RECORD or not (it should).