### PR TITLE
Added --lock option for "poetry remove"

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -319,7 +319,7 @@ poetry remove pendulum
 
 * `--dev (-D)`: Removes a package from the development dependencies.
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
-
+* `--lock`: Do not perform install (only update the lockfile).
 
 ## show
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -319,7 +319,7 @@ poetry remove pendulum
 
 * `--dev (-D)`: Removes a package from the development dependencies.
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
-* `--lock`: Do not perform install (only update the lockfile).
+* `--lock`: Do not perform uninstall (only update the lockfile).
 
 ## show
 

--- a/poetry/console/commands/remove.py
+++ b/poetry/console/commands/remove.py
@@ -19,6 +19,7 @@ class RemoveCommand(InstallerCommand):
             "Output the operations but do not execute anything "
             "(implicitly enables --verbose).",
         ),
+        option("lock", None, "Do not perform operations (only update the lockfile)."),
     ]
 
     help = """The <info>remove</info> command removes a package from the current
@@ -73,6 +74,8 @@ list of installed packages
         self._installer.verbose(self._io.is_verbose())
         self._installer.update(True)
         self._installer.whitelist(requirements)
+        if self.option("lock"):
+            self._installer.lock()
 
         status = self._installer.run()
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3971

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
Poetry already supports "add --lock" and "update --lock" but for some reason the corresponding "remove --lock" feature was missing.