### PR TITLE
[Docs / Basic Usage] Use PowerShell on Windows

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -131,15 +131,15 @@ in order for the subsequent commands to run from within the virtual environment.
 
 
 Alternatively, to avoid creating a new shell, you can manually activate the
-virtual environment by running `source {path_to_venv}/bin/activate` (`{path_to_venv}\Scripts\activate.bat` on Windows).
+virtual environment by running `source {path_to_venv}/bin/activate` (`{path_to_venv}\Scripts\activate.ps1` on Windows PowerShell).
 To get the path to your virtual environment run `poetry env info --path`.
 You can also combine these into a nice one-liner, `source $(poetry env info --path)/bin/activate`
 To deactivate this virtual environment simply use `deactivate`.
 
-|                   | POSIX Shell                                     | Windows                               | Exit/Deactivate |
+|                   | POSIX Shell                                     | Windows (PowerShell)                  | Exit/Deactivate |
 | ----------------- | ----------------------------------------------- | ------------------------------------- | --------------- |
 | New Shell         | `poetry shell`                                  | `poetry shell`                        | `exit`          |
-| Manual Activation | `source {path_to_venv}/bin/activate`            | `{path_to_venv}\Scripts\activate.bat` | `deactivate`    |
+| Manual Activation | `source {path_to_venv}/bin/activate`            | `{path_to_venv}\Scripts\activate.ps1` | `deactivate`    |
 | One-liner         | `source $(poetry env info --path)/bin/activate` |                                       | `deactivate`    |
 
 


### PR DESCRIPTION
Further to #3372 and #3373, on Windows, you'd typically use PowerShell rather than CMD. PowerShell scripts end in `.ps1` while CMD "batch scripts" end in `.bat`.

Also, any chance this could be pushed to the live docs anytime soon? The basic fix (#3373) was pushed to master 6 months ago, and the suggestions that you "source" the activate a virtual environment on Windows made me wonder, in charitable moments, if anyone had ever actually tried to do that, and in less charitable moments ... well ... not great things about poetry's general support of Windows.

# Pull Request Check List

Resolves: #3372

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ n/a ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
