### PR TITLE
Run pyupgrade with py36-plus flag

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -34,7 +34,6 @@ from contextlib import contextmanager
 from functools import cmp_to_key
 from gzip import GzipFile
 from io import UnsupportedOperation
-from io import open
 
 
 try:
@@ -434,7 +433,7 @@ class Installer:
         )
 
         if self._version and self._version not in releases:
-            print(colorize("error", "Version {} does not exist.".format(self._version)))
+            print(colorize("error", f"Version {self._version} does not exist."))
 
             return None, None
 
@@ -572,25 +571,25 @@ class Installer:
         if platform == "linux2":
             platform = "linux"
 
-        url = self._base_url + "{}/".format(version)
-        name = "poetry-{}-{}.tar.gz".format(version, platform)
-        checksum = "poetry-{}-{}.sha256sum".format(version, platform)
+        url = self._base_url + f"{version}/"
+        name = f"poetry-{version}-{platform}.tar.gz"
+        checksum = f"poetry-{version}-{platform}.sha256sum"
 
         try:
-            r = urlopen(url + "{}".format(checksum))
+            r = urlopen(url + f"{checksum}")
         except HTTPError as e:
             if e.code == 404:
-                raise RuntimeError("Could not find {} file".format(checksum))
+                raise RuntimeError(f"Could not find {checksum} file")
 
             raise
 
         checksum = r.read().decode()
 
         try:
-            r = urlopen(url + "{}".format(name))
+            r = urlopen(url + f"{name}")
         except HTTPError as e:
             if e.code == 404:
-                raise RuntimeError("Could not find {} file".format(name))
+                raise RuntimeError(f"Could not find {name} file")
 
             raise
 
@@ -692,7 +691,7 @@ class Installer:
             if WINDOWS:
                 python_executable = "python"
 
-            f.write(u("#!/usr/bin/env {}\n".format(python_executable)))
+            f.write(u(f"#!/usr/bin/env {python_executable}\n"))
             f.write(u(BIN))
 
         if not WINDOWS:
@@ -723,14 +722,14 @@ class Installer:
         # Updating any profile we can on UNIX systems
         export_string = self.get_export_string()
 
-        addition = "\n{}\n".format(export_string)
+        addition = f"\n{export_string}\n"
 
         profiles = self.get_unix_profiles()
         for profile in profiles:
             if not os.path.exists(profile):
                 continue
 
-            with open(profile, "r") as f:
+            with open(profile) as f:
                 content = f.read()
 
             if addition not in content:
@@ -758,8 +757,8 @@ class Installer:
                 ["fish", "-c", "echo $fish_user_paths"]
             ).decode("utf-8")
             if POETRY_BIN not in fish_user_paths:
-                cmd = "set -U fish_user_paths {} $fish_user_paths".format(POETRY_BIN)
-                set_fish_user_path = ["fish", "-c", "{}".format(cmd)]
+                cmd = f"set -U fish_user_paths {POETRY_BIN} $fish_user_paths"
+                set_fish_user_path = ["fish", "-c", f"{cmd}"]
                 subprocess.check_output(set_fish_user_path)
         else:
             print(
@@ -774,7 +773,7 @@ class Installer:
     def add_to_windows_path(self):
         try:
             old_path = self.get_windows_path_var()
-        except WindowsError:
+        except OSError:
             old_path = None
 
         if old_path is None:
@@ -824,7 +823,7 @@ class Installer:
             HWND_BROADCAST,
             WM_SETTINGCHANGE,
             0,
-            u"Environment",
+            "Environment",
             SMTO_ABORTIFHUNG,
             5000,
             ctypes.byref(result),
@@ -847,7 +846,7 @@ class Installer:
             cmd = "set -U fish_user_paths (string match -v {} $fish_user_paths)".format(
                 POETRY_BIN
             )
-            set_fish_user_path = ["fish", "-c", "{}".format(cmd)]
+            set_fish_user_path = ["fish", "-c", f"{cmd}"]
             subprocess.check_output(set_fish_user_path)
 
     def remove_from_windows_path(self):
@@ -866,14 +865,14 @@ class Installer:
         # Updating any profile we can on UNIX systems
         export_string = self.get_export_string()
 
-        addition = "{}\n".format(export_string)
+        addition = f"{export_string}\n"
 
         profiles = self.get_unix_profiles()
         for profile in profiles:
             if not os.path.exists(profile):
                 continue
 
-            with open(profile, "r") as f:
+            with open(profile) as f:
                 content = f.readlines()
 
             if addition not in content:
@@ -894,7 +893,7 @@ class Installer:
 
     def get_export_string(self):
         path = POETRY_BIN.replace(os.getenv("HOME", ""), "$HOME")
-        export_string = 'export PATH="{}:$PATH"'.format(path)
+        export_string = f'export PATH="{path}:$PATH"'
 
         return export_string
 

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -282,27 +282,27 @@ class Cursor:
         self._output = sys.stdout
 
     def move_up(self, lines: int = 1) -> "Cursor":
-        self._output.write("\x1b[{}A".format(lines))
+        self._output.write(f"\x1b[{lines}A")
 
         return self
 
     def move_down(self, lines: int = 1) -> "Cursor":
-        self._output.write("\x1b[{}B".format(lines))
+        self._output.write(f"\x1b[{lines}B")
 
         return self
 
     def move_right(self, columns: int = 1) -> "Cursor":
-        self._output.write("\x1b[{}C".format(columns))
+        self._output.write(f"\x1b[{columns}C")
 
         return self
 
     def move_left(self, columns: int = 1) -> "Cursor":
-        self._output.write("\x1b[{}D".format(columns))
+        self._output.write(f"\x1b[{columns}D")
 
         return self
 
     def move_to_column(self, column: int) -> "Cursor":
-        self._output.write("\x1b[{}G".format(column))
+        self._output.write(f"\x1b[{column}G")
 
         return self
 
@@ -684,9 +684,7 @@ class Installer:
         )
 
         if self._version and self._version not in releases:
-            self._write(
-                colorize("error", "Version {} does not exist.".format(self._version))
-            )
+            self._write(colorize("error", f"Version {self._version} does not exist."))
 
             return None, None
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -390,7 +390,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "poetry-core"
-version = "1.1.0a2"
+version = "1.1.0a3"
 description = "Poetry PEP 517 Build Backend"
 category = "main"
 optional = false
@@ -398,14 +398,14 @@ python-versions = "^3.6"
 develop = false
 
 [package.dependencies]
-dataclasses = {version = "^0.8", markers = "python_version >= \"3.6\" and python_version < \"3.7\""}
-importlib-metadata = {version = "^1.7.0", markers = "python_version >= \"3.5\" and python_version < \"3.8\""}
+dataclasses = {version = ">=0.8", markers = "python_version >= \"3.6\" and python_version < \"3.7\""}
+importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
 
 [package.source]
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "master"
-resolved_reference = "d3e60732ce9bd4f30dee3e594405fe6a80163b7e"
+resolved_reference = "44167a577b6cccafb1baef2e42a2991e11d8ea1e"
 
 [[package]]
 name = "pre-commit"
@@ -714,7 +714,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "cccd84fe6459fdb43ff8bb775ee093c7ee351f112a054ffc6ca5ecf59deba1d5"
+content-hash = "3a887f78f3fdbd77373b59353785f141c77a1ce3e7fa5263a57908f7a2ab6841"
 
 [metadata.files]
 appdirs = [
@@ -1031,18 +1031,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},

--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Dict
 from typing import List
 
@@ -222,7 +221,7 @@ class AddCommand(InstallerCommand, InitCommand):
             "The following packages are already present in the pyproject.toml and will be skipped:\n"
         )
         for name in existing_packages:
-            self.line("  • <c1>{name}</c1>".format(name=name))
+            self.line(f"  • <c1>{name}</c1>")
         self.line(
             "\nIf you want to update it to the latest compatible version, you can use `poetry update package`.\n"
             "If you prefer to upgrade it to the latest available version, you can use `poetry add package@latest`.\n"

--- a/poetry/console/commands/cache/clear.py
+++ b/poetry/console/commands/cache/clear.py
@@ -29,7 +29,7 @@ class CacheClearCommand(Command):
         try:
             cache_dir.relative_to(REPOSITORY_CACHE_DIR)
         except ValueError:
-            raise ValueError("{} is not a valid repository cache".format(root))
+            raise ValueError(f"{root} is not a valid repository cache")
 
         cache = CacheManager(
             {
@@ -55,9 +55,7 @@ class CacheClearCommand(Command):
             for path, dirs, files in os.walk(str(cache_dir)):
                 entries_count += len(files)
 
-            delete = self.confirm(
-                "<question>Delete {} entries?</>".format(entries_count)
-            )
+            delete = self.confirm(f"<question>Delete {entries_count} entries?</>")
             if not delete:
                 return 0
 
@@ -71,14 +69,14 @@ class CacheClearCommand(Command):
             package = parts[1]
             version = parts[2]
 
-            if not cache.has("{}:{}".format(package, version)):
-                self.line("No cache entries for {}:{}".format(package, version))
+            if not cache.has(f"{package}:{version}"):
+                self.line(f"No cache entries for {package}:{version}")
                 return 0
 
-            delete = self.confirm("Delete cache entry {}:{}".format(package, version))
+            delete = self.confirm(f"Delete cache entry {package}:{version}")
             if not delete:
                 return 0
 
-            cache.forget("{}:{}".format(package, version))
+            cache.forget(f"{package}:{version}")
         else:
             raise ValueError("Invalid cache key")

--- a/poetry/console/commands/cache/list.py
+++ b/poetry/console/commands/cache/list.py
@@ -17,7 +17,7 @@ class CacheListCommand(Command):
             caches = list(sorted(REPOSITORY_CACHE_DIR.iterdir()))
             if caches:
                 for cache in caches:
-                    self.line("<info>{}</>".format(cache.name))
+                    self.line(f"<info>{cache.name}</>")
                 return 0
 
         self.line("<warning>No caches found</>")

--- a/poetry/console/commands/check.py
+++ b/poetry/console/commands/check.py
@@ -22,9 +22,9 @@ class CheckCommand(Command):
             return 0
 
         for error in check_result["errors"]:
-            self.line("<error>Error: {}</error>".format(error))
+            self.line(f"<error>Error: {error}</error>")
 
         for error in check_result["warnings"]:
-            self.line("<warning>Warning: {}</warning>".format(error))
+            self.line(f"<warning>Warning: {error}</warning>")
 
         return 1

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -150,7 +150,7 @@ To remove a repository (repo is a short alias for repositories):
             else:
                 values = self.unique_config_values
                 if setting_key not in values:
-                    raise ValueError("There is no {} setting.".format(setting_key))
+                    raise ValueError(f"There is no {setting_key} setting.")
 
                 value = config.get(setting_key)
 
@@ -286,7 +286,7 @@ To remove a repository (repo is a short alias for repositories):
 
         value = values[0]
         if not validator(value):
-            raise RuntimeError('"{}" is an invalid value for {}'.format(value, key))
+            raise RuntimeError(f'"{value}" is an invalid value for {key}')
 
         source.add_property(key, normalizer(value))
 
@@ -301,7 +301,7 @@ To remove a repository (repo is a short alias for repositories):
             raw_val = raw.get(key)
 
             if isinstance(value, dict):
-                k += "{}.".format(key)
+                k += f"{key}."
                 self._list_configuration(value, raw_val, k=k)
                 k = orig_k
 

--- a/poetry/console/commands/debug/info.py
+++ b/poetry/console/commands/debug/info.py
@@ -16,7 +16,7 @@ class DebugInfoCommand(Command):
         self.line(
             "\n".join(
                 [
-                    "<info>Version</info>: <comment>{}</>".format(self.poetry.VERSION),
+                    f"<info>Version</info>: <comment>{self.poetry.VERSION}</>",
                     "<info>Python</info>:  <comment>{}</>".format(
                         poetry_python_version
                     ),

--- a/poetry/console/commands/debug/resolve.py
+++ b/poetry/console/commands/debug/resolve.py
@@ -131,8 +131,8 @@ class DebugResolveCommand(InitCommand):
 
             pkg = op.package
             row = [
-                "<c1>{}</c1>".format(pkg.complete_name),
-                "<b>{}</b>".format(pkg.version),
+                f"<c1>{pkg.complete_name}</c1>",
+                f"<b>{pkg.version}</b>",
                 "",
             ]
 

--- a/poetry/console/commands/env/info.py
+++ b/poetry/console/commands/env/info.py
@@ -37,7 +37,7 @@ class EnvInfoCommand(Command):
         self.line("")
         self.line("<b>Virtualenv</b>")
         listing = [
-            "<info>Python</info>:         <comment>{}</>".format(env_python_version),
+            f"<info>Python</info>:         <comment>{env_python_version}</>",
             "<info>Implementation</info>: <comment>{}</>".format(
                 env.python_implementation
             ),
@@ -59,9 +59,9 @@ class EnvInfoCommand(Command):
         self.line(
             "\n".join(
                 [
-                    "<info>Platform</info>: <comment>{}</>".format(env.platform),
-                    "<info>OS</info>:       <comment>{}</>".format(env.os),
-                    "<info>Python</info>:   <comment>{}</>".format(env.base),
+                    f"<info>Platform</info>: <comment>{env.platform}</>",
+                    f"<info>OS</info>:       <comment>{env.os}</>",
+                    f"<info>Python</info>:   <comment>{env.base}</>",
                 ]
             )
         )

--- a/poetry/console/commands/env/list.py
+++ b/poetry/console/commands/env/list.py
@@ -22,7 +22,7 @@ class EnvListCommand(Command):
                 name = str(venv.path)
 
             if venv == current_env:
-                self.line("<info>{} (Activated)</info>".format(name))
+                self.line(f"<info>{name} (Activated)</info>")
 
                 continue
 

--- a/poetry/console/commands/env/remove.py
+++ b/poetry/console/commands/env/remove.py
@@ -18,4 +18,4 @@ class EnvRemoveCommand(Command):
         manager = EnvManager(self.poetry)
         venv = manager.remove(self.argument("python"))
 
-        self.line("Deleted virtualenv: <comment>{}</comment>".format(venv.path))
+        self.line(f"Deleted virtualenv: <comment>{venv.path}</comment>")

--- a/poetry/console/commands/env/use.py
+++ b/poetry/console/commands/env/use.py
@@ -22,4 +22,4 @@ class EnvUseCommand(Command):
 
         env = manager.activate(self.argument("python"), self._io)
 
-        self.line("Using virtualenv: <comment>{}</>".format(env.path))
+        self.line(f"Using virtualenv: <comment>{env.path}</>")

--- a/poetry/console/commands/env_command.py
+++ b/poetry/console/commands/env_command.py
@@ -11,7 +11,7 @@ class EnvCommand(Command):
     def __init__(self) -> None:
         self._env = None
 
-        super(EnvCommand, self).__init__()
+        super().__init__()
 
     @property
     def env(self) -> "Env":

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -35,7 +35,7 @@ class ExportCommand(Command):
         fmt = self.option("format")
 
         if fmt not in Exporter.ACCEPTED_FORMATS:
-            raise ValueError("Invalid export format: {}".format(fmt))
+            raise ValueError(f"Invalid export format: {fmt}")
 
         output = self.option("output")
 

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -57,7 +57,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 """
 
     def __init__(self) -> None:
-        super(InitCommand, self).__init__()
+        super().__init__()
 
         self._pool = None
 
@@ -97,19 +97,19 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             name = Path.cwd().name.lower()
 
             question = self.create_question(
-                "Package name [<comment>{}</comment>]: ".format(name), default=name
+                f"Package name [<comment>{name}</comment>]: ", default=name
             )
             name = self.ask(question)
 
         version = "0.1.0"
         question = self.create_question(
-            "Version [<comment>{}</comment>]: ".format(version), default=version
+            f"Version [<comment>{version}</comment>]: ", default=version
         )
         version = self.ask(question)
 
         description = self.option("description") or ""
         question = self.create_question(
-            "Description [<comment>{}</comment>]: ".format(description),
+            f"Description [<comment>{description}</comment>]: ",
             default=description,
         )
         description = self.ask(question)
@@ -119,10 +119,10 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             author = vcs_config["user.name"]
             author_email = vcs_config.get("user.email")
             if author_email:
-                author += " <{}>".format(author_email)
+                author += f" <{author_email}>"
 
         question = self.create_question(
-            "Author [<comment>{}</comment>, n to skip]: ".format(author), default=author
+            f"Author [<comment>{author}</comment>, n to skip]: ", default=author
         )
         question.set_validator(lambda v: self._validate_author(v, author))
         author = self.ask(question)
@@ -135,7 +135,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         license = self.option("license") or ""
 
         question = self.create_question(
-            "License [<comment>{}</comment>]: ".format(license), default=license
+            f"License [<comment>{license}</comment>]: ", default=license
         )
         question.set_validator(self._validate_license)
         license = self.ask(question)
@@ -246,7 +246,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     or "path" in constraint
                     or "version" in constraint
                 ):
-                    self.line("Adding <info>{}</info>".format(package))
+                    self.line(f"Adding <info>{package}</info>")
                     requires.append(constraint)
                     package = self.ask("\nAdd a package:")
                     continue
@@ -337,9 +337,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 requirement["version"] = version
                 requirement["name"] = name
 
-                self.line(
-                    "Using version <b>{}</b> for <c1>{}</c1>".format(version, name)
-                )
+                self.line(f"Using version <b>{version}</b> for <c1>{name}</c1>")
             else:
                 # check that the specified version/constraint exists
                 # before we proceed
@@ -372,9 +370,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         if not package:
             # TODO: find similar
-            raise ValueError(
-                "Could not find a matching version of package {}".format(name)
-            )
+            raise ValueError(f"Could not find a matching version of package {name}")
 
         return package.pretty_name, selector.find_recommended_require_version(package)
 

--- a/poetry/console/commands/installer_command.py
+++ b/poetry/console/commands/installer_command.py
@@ -12,10 +12,10 @@ class InstallerCommand(EnvCommand):
     def __init__(self) -> None:
         self._installer: Optional["Installer"] = None
 
-        super(InstallerCommand, self).__init__()
+        super().__init__()
 
     def reset_poetry(self) -> None:
-        super(InstallerCommand, self).reset_poetry()
+        super().reset_poetry()
 
         self._installer.set_package(self.poetry.package)
         self._installer.set_locker(self.poetry.locker)

--- a/poetry/console/commands/new.py
+++ b/poetry/console/commands/new.py
@@ -60,7 +60,7 @@ class NewCommand(Command):
             author = config["user.name"]
             author_email = config.get("user.email")
             if author_email:
-                author += " <{}>".format(author_email)
+                author += f" <{author_email}>"
 
         current_env = SystemEnv(Path(sys.executable))
         default_python = "^{}".format(

--- a/poetry/console/commands/plugin/add.py
+++ b/poetry/console/commands/plugin/add.py
@@ -193,7 +193,7 @@ You can specify a package in the following forms:
             "<c2>pyproject.toml</c2> file and will be skipped:\n"
         )
         for name in existing_packages:
-            self.line("  • <c1>{name}</c1>".format(name=name))
+            self.line(f"  • <c1>{name}</c1>")
 
         self.line(
             "\nIf you want to update it to the latest compatible version, "

--- a/poetry/console/commands/remove.py
+++ b/poetry/console/commands/remove.py
@@ -49,7 +49,7 @@ list of installed packages
                     break
 
             if not found:
-                raise ValueError("Package {} not found".format(name))
+                raise ValueError(f"Package {name} not found")
 
         for key in requirements:
             del poetry_content[section][key]

--- a/poetry/console/commands/search.py
+++ b/poetry/console/commands/search.py
@@ -17,11 +17,11 @@ class SearchCommand(Command):
 
         for result in results:
             self.line("")
-            name = "<info>{}</>".format(result.name)
+            name = f"<info>{result.name}</>"
 
-            name += " (<comment>{}</>)".format(result.version)
+            name += f" (<comment>{result.version}</>)"
 
             self.line(name)
 
             if result.description:
-                self.line(" {}".format(result.description))
+                self.line(f" {result.description}")

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import hashlib
 import os
 import re
@@ -132,7 +130,7 @@ class SelfUpdateCommand(Command):
 
     def update(self, release: "Package") -> None:
         version = release.version
-        self.line("Updating to <info>{}</info>".format(version))
+        self.line(f"Updating to <info>{version}</info>")
 
         if self.lib_backup.exists():
             shutil.rmtree(str(self.lib_backup))
@@ -171,27 +169,27 @@ class SelfUpdateCommand(Command):
 
         release_name = self._get_release_name(version)
 
-        checksum = "{}.sha256sum".format(release_name)
+        checksum = f"{release_name}.sha256sum"
 
         base_url = self.BASE_URL
 
         try:
-            r = urlopen(base_url + "/{}/{}".format(version, checksum))
+            r = urlopen(base_url + f"/{version}/{checksum}")
         except HTTPError as e:
             if e.code == 404:
-                raise RuntimeError("Could not find {} file".format(checksum))
+                raise RuntimeError(f"Could not find {checksum} file")
 
             raise
 
         checksum = r.read().decode().strip()
 
         # We get the payload from the remote host
-        name = "{}.tar.gz".format(release_name)
+        name = f"{release_name}.tar.gz"
         try:
-            r = urlopen(base_url + "/{}/{}".format(version, name))
+            r = urlopen(base_url + f"/{version}/{name}")
         except HTTPError as e:
             if e.code == 404:
-                raise RuntimeError("Could not find {} file".format(name))
+                raise RuntimeError(f"Could not find {name} file")
 
             raise
 
@@ -201,7 +199,7 @@ class SelfUpdateCommand(Command):
         block_size = 8192
 
         bar = self.progress_bar(max=size)
-        bar.set_format(" - Downloading <info>{}</> <comment>%percent%%</>".format(name))
+        bar.set_format(f" - Downloading <info>{name}</> <comment>%percent%%</>")
         bar.start()
 
         sha = hashlib.sha256()
@@ -258,7 +256,7 @@ class SelfUpdateCommand(Command):
         if platform == "linux2":
             platform = "linux"
 
-        return "poetry-{}-{}".format(version, platform)
+        return f"poetry-{version}-{platform}"
 
     def make_bin(self) -> None:
         from poetry.utils._compat import WINDOWS
@@ -280,7 +278,7 @@ class SelfUpdateCommand(Command):
 
         bin_content = BIN
         if not WINDOWS:
-            bin_content = "#!/usr/bin/env {}\n".format(python_executable) + bin_content
+            bin_content = f"#!/usr/bin/env {python_executable}\n" + bin_content
 
         self.bin.joinpath("poetry").write_text(bin_content, encoding="utf-8")
 

--- a/poetry/console/commands/shell.py
+++ b/poetry/console/commands/shell.py
@@ -31,7 +31,7 @@ If one doesn't exist yet, it will be created.
 
             return
 
-        self.line("Spawning shell within <info>{}</>".format(self.env.path))
+        self.line(f"Spawning shell within <info>{self.env.path}</>")
 
         # Setting this to avoid spawning unnecessary nested shells
         environ["POETRY_ACTIVE"] = "1"

--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -95,7 +95,7 @@ lists all packages available."""
         with solver.use_environment(self.env):
             ops = solver.solve()
 
-        required_locked_packages = set([op.package for op in ops if not op.skipped])
+        required_locked_packages = {op.package for op in ops if not op.skipped}
 
         if self.option("no-dev"):
             required_locked_packages = [
@@ -110,7 +110,7 @@ lists all packages available."""
                     break
 
             if not pkg:
-                raise ValueError("Package {} not found".format(package))
+                raise ValueError(f"Package {package} not found")
 
             if self.option("tree"):
                 self.display_package_tree(self.io, pkg, locked_repo)
@@ -118,9 +118,9 @@ lists all packages available."""
                 return 0
 
             rows = [
-                ["<info>name</>", " : <c1>{}</>".format(pkg.pretty_name)],
-                ["<info>version</>", " : <b>{}</b>".format(pkg.pretty_version)],
-                ["<info>description</>", " : {}".format(pkg.description)],
+                ["<info>name</>", f" : <c1>{pkg.pretty_name}</>"],
+                ["<info>version</>", f" : <b>{pkg.pretty_version}</b>"],
+                ["<info>description</>", f" : {pkg.description}"],
             ]
 
             table.add_rows(rows)
@@ -272,12 +272,12 @@ lists all packages available."""
     def display_package_tree(
         self, io: "IO", package: "Package", installed_repo: "Repository"
     ) -> None:
-        io.write("<c1>{}</c1>".format(package.pretty_name))
+        io.write(f"<c1>{package.pretty_name}</c1>")
         description = ""
         if package.description:
             description = " " + package.description
 
-        io.write_line(" <b>{}</b>{}".format(package.pretty_version, description))
+        io.write_line(f" <b>{package.pretty_version}</b>{description}")
 
         dependencies = package.requires
         dependencies = sorted(dependencies, key=lambda x: x.name)
@@ -404,7 +404,7 @@ lists all packages available."""
         name = package.name
         selector = VersionSelector(self.poetry.pool)
 
-        return selector.find_best_candidate(name, ">={}".format(package.pretty_version))
+        return selector.find_best_candidate(name, f">={package.pretty_version}")
 
     def get_update_status(self, latest: "Package", package: "Package") -> str:
         from poetry.core.semver.helpers import parse_constraint

--- a/poetry/console/commands/source/show.py
+++ b/poetry/console/commands/source/show.py
@@ -41,8 +41,8 @@ class SourceShowCommand(Command):
 
             table = self.table(style="compact")
             rows = [
-                ["<info>name</>", " : <c1>{}</>".format(source.name)],
-                ["<info>url</>", " : {}".format(source.url)],
+                ["<info>name</>", f" : <c1>{source.name}</>"],
+                ["<info>url</>", f" : {source.url}"],
                 [
                     "<info>default</>",
                     " : {}".format(bool_string.get(source.default, False)),

--- a/poetry/console/commands/version.py
+++ b/poetry/console/commands/version.py
@@ -55,7 +55,7 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
             )
 
             if self.option("short"):
-                self.line("{}".format(version))
+                self.line(f"{version}")
             else:
                 self.line(
                     "Bumping version from <b>{}</> to <fg=green>{}</>".format(
@@ -70,7 +70,7 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
             self.poetry.file.write(content)
         else:
             if self.option("short"):
-                self.line("{}".format(self.poetry.package.pretty_version))
+                self.line(f"{self.poetry.package.pretty_version}")
             else:
                 self.line(
                     "<comment>{}</> <info>{}</>".format(

--- a/poetry/console/logging/formatters/formatter.py
+++ b/poetry/console/logging/formatters/formatter.py
@@ -1,6 +1,6 @@
 import logging
 
 
-class Formatter(object):
+class Formatter:
     def format(self, record: logging.LogRecord) -> str:
         raise NotImplementedError()

--- a/poetry/console/logging/io_formatter.py
+++ b/poetry/console/logging/io_formatter.py
@@ -30,4 +30,4 @@ class IOFormatter(logging.Formatter):
 
             return msg
 
-        return super(IOFormatter, self).format(record)
+        return super().format(record)

--- a/poetry/console/logging/io_handler.py
+++ b/poetry/console/logging/io_handler.py
@@ -13,7 +13,7 @@ class IOHandler(logging.Handler):
     def __init__(self, io: "IO") -> None:
         self._io = io
 
-        super(IOHandler, self).__init__()
+        super().__init__()
 
     def emit(self, record: "LogRecord") -> None:
         try:

--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Dict
@@ -41,7 +38,7 @@ class Factory(BaseFactory):
         if io is None:
             io = NullIO()
 
-        base_poetry = super(Factory, self).create_poetry(cwd)
+        base_poetry = super().create_poetry(cwd)
 
         locker = Locker(
             base_poetry.file.parent / "poetry.lock", base_poetry.local_config
@@ -54,9 +51,7 @@ class Factory(BaseFactory):
         local_config_file = TOMLFile(base_poetry.file.parent / "poetry.toml")
         if local_config_file.exists():
             if io.is_debug():
-                io.write_line(
-                    "Loading configuration file {}".format(local_config_file.path)
-                )
+                io.write_line(f"Loading configuration file {local_config_file.path}")
 
             config.merge(local_config_file.read())
 

--- a/poetry/installation/operations/install.py
+++ b/poetry/installation/operations/install.py
@@ -12,7 +12,7 @@ class Install(Operation):
     def __init__(
         self, package: "Package", reason: Optional[str] = None, priority: int = 0
     ) -> None:
-        super(Install, self).__init__(reason, priority=priority)
+        super().__init__(reason, priority=priority)
 
         self._package = package
 

--- a/poetry/installation/operations/operation.py
+++ b/poetry/installation/operations/operation.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.package import Package
 
 
-class Operation(object):
+class Operation:
     def __init__(self, reason: Optional[str] = None, priority: int = 0) -> None:
         self._reason = reason
 

--- a/poetry/installation/operations/uninstall.py
+++ b/poetry/installation/operations/uninstall.py
@@ -15,7 +15,7 @@ class Uninstall(Operation):
         reason: Optional[str] = None,
         priority: int = float("inf"),
     ) -> None:
-        super(Uninstall, self).__init__(reason, priority=priority)
+        super().__init__(reason, priority=priority)
 
         self._package = package
 

--- a/poetry/installation/operations/update.py
+++ b/poetry/installation/operations/update.py
@@ -19,7 +19,7 @@ class Update(Operation):
         self._initial_package = initial
         self._target_package = target
 
-        super(Update, self).__init__(reason, priority=priority)
+        super().__init__(reason, priority=priority)
 
     @property
     def initial_package(self) -> "Package":

--- a/poetry/layouts/layout.py
+++ b/poetry/layouts/layout.py
@@ -131,7 +131,7 @@ class Layout:
         else:
             poetry_content.remove("license")
 
-        poetry_content["readme"] = "README.{}".format(self._readme_format)
+        poetry_content["readme"] = f"README.{self._readme_format}"
         packages = self.get_package_include()
         if packages:
             poetry_content["packages"].append(packages)
@@ -177,7 +177,7 @@ class Layout:
         package_init.touch()
 
     def _create_readme(self, path: "Path") -> "Path":
-        readme_file = path.joinpath("README.{}".format(self._readme_format))
+        readme_file = path.joinpath(f"README.{self._readme_format}")
         readme_file.touch()
         return readme_file
 

--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import hashlib
 import os
 import shutil
@@ -40,7 +38,7 @@ WINDOWS_CMD_TEMPLATE = """\
 
 class EditableBuilder(Builder):
     def __init__(self, poetry: "Poetry", env: "Env", io: "IO") -> None:
-        super(EditableBuilder, self).__init__(poetry)
+        super().__init__(poetry)
 
         self._env = env
         self._io = io
@@ -76,7 +74,7 @@ class EditableBuilder(Builder):
         self._add_dist_info(added_files)
 
     def _run_build_script(self, build_script: Path) -> None:
-        self._debug("  - Executing build script: <b>{}</b>".format(build_script))
+        self._debug(f"  - Executing build script: <b>{build_script}</b>")
         self._env.run("python", str(self._path.joinpath(build_script)), call=True)
 
     def _setup_build(self) -> None:

--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -30,7 +30,7 @@ class Poetry(BasePoetry):
     ):
         from .repositories.pool import Pool  # noqa
 
-        super(Poetry, self).__init__(file, local_config, package)
+        super().__init__(file, local_config, package)
 
         self._locker = locker
         self._config = config

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -243,10 +243,7 @@ class SitePackages:
                 str, self._candidates if not writable_only else self.writable_candidates
             )
         )
-        for distribution in metadata.PathDistribution.discover(
-            name=name, path=path
-        ):  # type: metadata.PathDistribution
-            yield distribution
+        yield from metadata.PathDistribution.discover(name=name, path=path)
 
     def find_distribution(
         self, name: str, writable_only: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,19 +38,19 @@ class Config(BaseConfig):
         self.merge(self._config_source.config)
         self.merge(self._auth_config_source.config)
 
-        return super(Config, self).get(setting_name, default=default)
+        return super().get(setting_name, default=default)
 
     def raw(self) -> Dict[str, Any]:
         self.merge(self._config_source.config)
         self.merge(self._auth_config_source.config)
 
-        return super(Config, self).raw()
+        return super().raw()
 
     def all(self) -> Dict[str, Any]:
         self.merge(self._config_source.config)
         self.merge(self._auth_config_source.config)
 
-        return super(Config, self).all()
+        return super().all()
 
 
 @pytest.fixture
@@ -243,7 +243,7 @@ def project_factory(tmp_dir, config, repo, installed, default_python):
         poetry_lock_content=None,
         install_deps=True,
     ):
-        project_dir = workspace / "poetry-fixture-{}".format(name)
+        project_dir = workspace / f"poetry-fixture-{name}"
         dependencies = dependencies or {}
         dev_dependencies = dev_dependencies or {}
 

--- a/tests/console/commands/env/conftest.py
+++ b/tests/console/commands/env/conftest.py
@@ -33,7 +33,7 @@ def venvs_in_cache_dirs(
 ):
     directories = []
     for version in python_versions:
-        directory = venv_cache.joinpath("{}-py{}".format(venv_name, version))
+        directory = venv_cache.joinpath(f"{venv_name}-py{version}")
         directory.mkdir(parents=True, exist_ok=True)
         directories.append(directory.name)
     return directories

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -14,7 +14,7 @@ def check_output_wrapper(version=Version.parse("3.7.1")):
         if "sys.version_info[:3]" in cmd:
             return version.text
         elif "sys.version_info[:2]" in cmd:
-            return "{}.{}".format(version.major, version.minor)
+            return f"{version.major}.{version.minor}"
         else:
             return str(Path("/prefix"))
 

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -20,11 +20,9 @@ def test_remove_by_python_version(
     tester.execute("3.6")
 
     assert check_output.called
-    assert not (venv_cache / "{}-py3.6".format(venv_name)).exists()
+    assert not (venv_cache / f"{venv_name}-py3.6").exists()
 
-    expected = "Deleted virtualenv: {}\n".format(
-        (venv_cache / "{}-py3.6".format(venv_name))
-    )
+    expected = "Deleted virtualenv: {}\n".format(venv_cache / f"{venv_name}-py3.6")
     assert expected == tester.io.fetch_output()
 
 
@@ -36,6 +34,6 @@ def test_remove_by_name(tester, venvs_in_cache_dirs, venv_name, venv_cache):
 
         assert not (venv_cache / name).exists()
 
-        expected += "Deleted virtualenv: {}\n".format((venv_cache / name))
+        expected += "Deleted virtualenv: {}\n".format(venv_cache / name)
 
     assert expected == tester.io.fetch_output()

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -50,7 +50,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
 
     tester.execute("3.7")
 
-    venv_py37 = venv_cache / "{}-py3.7".format(venv_name)
+    venv_py37 = venv_cache / f"{venv_name}-py3.7"
     mock_build_env.assert_called_with(
         venv_py37,
         executable="python3.7",
@@ -82,7 +82,7 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
 
     python_minor = ".".join(str(v) for v in current_python[:2])
     python_patch = ".".join(str(v) for v in current_python[:3])
-    venv_dir = venv_cache / "{}-py{}".format(venv_name, python_minor)
+    venv_dir = venv_cache / f"{venv_name}-py{python_minor}"
     venv_dir.mkdir(parents=True, exist_ok=True)
 
     envs_file = TOMLFile(venv_cache / "envs.toml")
@@ -107,7 +107,7 @@ def test_get_prefers_explicitly_activated_non_existing_virtualenvs_over_env_var(
     os.environ["VIRTUAL_ENV"] = "/environment/prefix"
 
     python_minor = ".".join(str(v) for v in current_python[:2])
-    venv_dir = venv_cache / "{}-py{}".format(venv_name, python_minor)
+    venv_dir = venv_cache / f"{venv_name}-py{python_minor}"
 
     mocker.patch(
         "poetry.utils.env.EnvManager._env",

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -32,18 +32,18 @@ def test_self_update_should_install_all_necessary_elements(
     )
     mocker.patch.object(command, "_check_recommended_installation", return_value=None)
     mocker.patch.object(
-        command, "_get_release_name", return_value="poetry-{}-darwin".format(version)
+        command, "_get_release_name", return_value=f"poetry-{version}-darwin"
     )
     mocker.patch("subprocess.check_output", return_value=b"Python 3.8.2")
 
     http.register_uri(
         "GET",
-        command.BASE_URL + "/{}/poetry-{}-darwin.sha256sum".format(version, version),
+        command.BASE_URL + f"/{version}/poetry-{version}-darwin.sha256sum",
         body=FIXTURES.joinpath("poetry-1.0.5-darwin.sha256sum").read_bytes(),
     )
     http.register_uri(
         "GET",
-        command.BASE_URL + "/{}/poetry-{}-darwin.tar.gz".format(version, version),
+        command.BASE_URL + f"/{version}/poetry-{version}-darwin.tar.gz",
         body=FIXTURES.joinpath("poetry-1.0.5-darwin.tar.gz").read_bytes(),
     )
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -348,7 +348,7 @@ def test_add_directory_with_poetry(app, repo, tester, mocker):
     repo.add_package(get_package("pendulum", "1.4.4"))
 
     path = "../git/github.com/demo/pyproject-demo"
-    tester.execute("{}".format(path))
+    tester.execute(f"{path}")
 
     expected = """\
 
@@ -376,7 +376,7 @@ def test_add_file_constraint_wheel(app, repo, tester, mocker, poetry):
     repo.add_package(get_package("pendulum", "1.4.4"))
 
     path = "../distributions/demo-0.1.0-py2.py3-none-any.whl"
-    tester.execute("{}".format(path))
+    tester.execute(f"{path}")
 
     expected = """\
 
@@ -411,7 +411,7 @@ def test_add_file_constraint_sdist(app, repo, tester, mocker):
     repo.add_package(get_package("pendulum", "1.4.4"))
 
     path = "../distributions/demo-0.1.0.tar.gz"
-    tester.execute("{}".format(path))
+    tester.execute(f"{path}")
 
     expected = """\
 
@@ -586,7 +586,7 @@ def test_add_constraint_with_platform(app, repo, tester, env):
     repo.add_package(get_package("cachy", "0.1.0"))
     repo.add_package(cachy2)
 
-    tester.execute("cachy=0.2.0 --platform {} -vvv".format(platform))
+    tester.execute(f"cachy=0.2.0 --platform {platform} -vvv")
 
     expected = """\
 
@@ -1105,7 +1105,7 @@ def test_add_directory_constraint_old_installer(
     repo.add_package(get_package("cleo", "0.6.5"))
 
     path = "../git/github.com/demo/demo"
-    old_tester.execute("{}".format(path))
+    old_tester.execute(f"{path}")
 
     expected = """\
 
@@ -1141,7 +1141,7 @@ def test_add_directory_with_poetry_old_installer(
     repo.add_package(get_package("pendulum", "1.4.4"))
 
     path = "../git/github.com/demo/pyproject-demo"
-    old_tester.execute("{}".format(path))
+    old_tester.execute(f"{path}")
 
     expected = """\
 
@@ -1172,7 +1172,7 @@ def test_add_file_constraint_wheel_old_installer(
     repo.add_package(get_package("pendulum", "1.4.4"))
 
     path = "../distributions/demo-0.1.0-py2.py3-none-any.whl"
-    old_tester.execute("{}".format(path))
+    old_tester.execute(f"{path}")
 
     expected = """\
 
@@ -1210,7 +1210,7 @@ def test_add_file_constraint_sdist_old_installer(
     repo.add_package(get_package("pendulum", "1.4.4"))
 
     path = "../distributions/demo-0.1.0.tar.gz"
-    old_tester.execute("{}".format(path))
+    old_tester.execute(f"{path}")
 
     expected = """\
 
@@ -1396,7 +1396,7 @@ def test_add_constraint_with_platform_old_installer(
     repo.add_package(get_package("cachy", "0.1.0"))
     repo.add_package(cachy2)
 
-    old_tester.execute("cachy=0.2.0 --platform {} -vvv".format(platform))
+    old_tester.execute(f"cachy=0.2.0 --platform {platform} -vvv")
 
     expected = """\
 

--- a/tests/console/commands/test_cache.py
+++ b/tests/console/commands/test_cache.py
@@ -16,12 +16,12 @@ def repository_cache_dir(monkeypatch, tmpdir):
 
 @pytest.fixture
 def repository_one():
-    return "01_{}".format(uuid.uuid4())
+    return f"01_{uuid.uuid4()}"
 
 
 @pytest.fixture
 def repository_two():
-    return "02_{}".format(uuid.uuid4())
+    return f"02_{uuid.uuid4()}"
 
 
 @pytest.fixture

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from tests.helpers import get_package

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -646,9 +646,7 @@ line-length = 88
 """
     pyproject_file.write_text(decode(existing_section))
     tester.execute(inputs=init_basic_inputs)
-    assert (
-        "{}\n{}".format(existing_section, init_basic_toml) in pyproject_file.read_text()
-    )
+    assert f"{existing_section}\n{init_basic_toml}" in pyproject_file.read_text()
 
 
 def test_init_non_interactive_existing_pyproject_add_dependency(
@@ -686,7 +684,7 @@ foo = "^1.19.2"
 
 [tool.poetry.dev-dependencies]
 """
-    assert "{}\n{}".format(existing_section, expected) in pyproject_file.read_text()
+    assert f"{existing_section}\n{expected}" in pyproject_file.read_text()
 
 
 def test_init_existing_pyproject_with_build_system_fails(
@@ -704,4 +702,4 @@ build-backend = "setuptools.build_meta"
         tester.io.fetch_output().strip()
         == "A pyproject.toml file with a defined build-system already exists."
     )
-    assert "{}".format(existing_section) in pyproject_file.read_text()
+    assert f"{existing_section}" in pyproject_file.read_text()

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -148,7 +148,7 @@ def test_command_new_with_readme(fmt, tester, tmp_dir):
     fmt = "md"
     package = "package"
     path = Path(tmp_dir) / package
-    options = ["--readme {}".format(fmt) if fmt else "md", path.as_posix()]
+    options = [f"--readme {fmt}" if fmt else "md", path.as_posix()]
     tester.execute(" ".join(options))
 
     poetry = verify_project_directory(path, package, package, None)

--- a/tests/fixtures/directory/project_with_transitive_directory_dependencies/setup.py
+++ b/tests/fixtures/directory/project_with_transitive_directory_dependencies/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from distutils.core import setup
 
 packages = ["project_with_extras"]

--- a/tests/fixtures/git/github.com/demo/demo/setup.py
+++ b/tests/fixtures/git/github.com/demo/demo/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/git/github.com/demo/no-dependencies/setup.py
+++ b/tests/fixtures/git/github.com/demo/no-dependencies/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/git/github.com/demo/no-version/setup.py
+++ b/tests/fixtures/git/github.com/demo/no-version/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ast
 import os
 

--- a/tests/fixtures/git/github.com/demo/non-canonical-name/setup.py
+++ b/tests/fixtures/git/github.com/demo/non-canonical-name/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/project_with_setup/setup.py
+++ b/tests/fixtures/project_with_setup/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from setuptools import setup
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -96,7 +96,7 @@ def mock_download(url, dest, **__):
 
 class TestExecutor(Executor):
     def __init__(self, *args, **kwargs):
-        super(TestExecutor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._installs = []
         self._updates = []
@@ -115,10 +115,10 @@ class TestExecutor(Executor):
         return self._uninstalls
 
     def _do_execute_operation(self, operation):
-        super(TestExecutor, self)._do_execute_operation(operation)
+        super()._do_execute_operation(operation)
 
         if not operation.skipped:
-            getattr(self, "_{}s".format(operation.job_type)).append(operation.package)
+            getattr(self, f"_{operation.job_type}s").append(operation.package)
 
     def _execute_install(self, operation):
         return 0
@@ -132,7 +132,7 @@ class TestExecutor(Executor):
 
 class TestApplication(Application):
     def __init__(self, poetry):
-        super(TestApplication, self).__init__()
+        super().__init__()
         self._poetry = poetry
 
     def reset_poetry(self):
@@ -176,7 +176,7 @@ class TestLocker(Locker):
 
     def _write_lock_data(self, data):
         if self._write:
-            super(TestLocker, self)._write_lock_data(data)
+            super()._write_lock_data(data)
             self._locked = True
             return
 
@@ -185,9 +185,9 @@ class TestLocker(Locker):
 
 class TestRepository(Repository):
     def find_packages(self, dependency):
-        packages = super(TestRepository, self).find_packages(dependency)
+        packages = super().find_packages(dependency)
         if len(packages) == 0:
-            raise PackageNotFound("Package [{}] not found.".format(dependency.name))
+            raise PackageNotFound(f"Package [{dependency.name}] not found.")
 
         return packages
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import json
 import re
 import shutil

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import json
 import sys
 
@@ -42,7 +40,7 @@ class Installer(BaseInstaller):
 
 class Executor(BaseExecutor):
     def __init__(self, *args, **kwargs):
-        super(Executor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._installs = []
         self._updates = []
@@ -61,10 +59,10 @@ class Executor(BaseExecutor):
         return self._uninstalls
 
     def _do_execute_operation(self, operation):
-        super(Executor, self)._do_execute_operation(operation)
+        super()._do_execute_operation(operation)
 
         if not operation.skipped:
-            getattr(self, "_{}s".format(operation.job_type)).append(operation.package)
+            getattr(self, f"_{operation.job_type}s").append(operation.package)
 
     def _execute_install(self, operation):
         return 0
@@ -178,7 +176,7 @@ def installer(package, pool, locker, env, installed, config):
 
 
 def fixture(name):
-    file = TOMLFile(Path(__file__).parent / "fixtures" / "{}.test".format(name))
+    file = TOMLFile(Path(__file__).parent / "fixtures" / f"{name}.test")
 
     return json.loads(json.dumps(file.read()))
 
@@ -417,9 +415,9 @@ def test_run_install_remove_untracked(installer, locker, repo, package, installe
     assert 0 == installer.executor.installations_count
     assert 0 == installer.executor.updates_count
     assert 4 == installer.executor.removals_count
-    assert {"b", "c", "pip", "setuptools"} == set(
+    assert {"b", "c", "pip", "setuptools"} == {
         r.name for r in installer.executor.removals
-    )
+    }
 
 
 def test_run_whitelist_add(installer, locker, repo, package):

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import sys
 
 from pathlib import Path
@@ -123,7 +121,7 @@ def installer(package, pool, locker, env, installed, config):
 
 
 def fixture(name):
-    file = TOMLFile(Path(__file__).parent / "fixtures" / "{}.test".format(name))
+    file = TOMLFile(Path(__file__).parent / "fixtures" / f"{name}.test")
 
     return file.read()
 
@@ -346,7 +344,7 @@ def test_run_install_remove_untracked(installer, locker, repo, package, installe
     assert len(updates) == 0
 
     removals = installer.installer.removals
-    assert set(r.name for r in removals) == {"b", "c", "pip", "setuptools"}
+    assert {r.name for r in removals} == {"b", "c", "pip", "setuptools"}
 
 
 def test_run_whitelist_add(installer, locker, repo, package):

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -69,7 +69,7 @@ def test_requirement_source_type_url():
     )
 
     result = installer.requirement(foo, formatted=True)
-    expected = "{}#egg={}".format(foo.source_url, foo.name)
+    expected = f"{foo.source_url}#egg={foo.name}"
 
     assert expected == result
 

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os
 import shutil
 

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -346,7 +346,7 @@ A = []
 
 
 def test_reading_lock_file_should_raise_an_error_on_invalid_data(locker):
-    content = u"""[[package]]
+    content = """[[package]]
 name = "A"
 version = "1.0.0"
 description = ""

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -24,9 +24,7 @@ class MockRepository(LegacyRepository):
     FIXTURES = Path(__file__).parent / "fixtures" / "legacy"
 
     def __init__(self):
-        super(MockRepository, self).__init__(
-            "legacy", url="http://legacy.foo.bar", disable_cache=True
-        )
+        super().__init__("legacy", url="http://legacy.foo.bar", disable_cache=True)
 
     def _get(self, endpoint):
         parts = endpoint.split("/")
@@ -323,9 +321,7 @@ def test_get_package_retrieves_packages_with_no_hashes():
 class MockHttpRepository(LegacyRepository):
     def __init__(self, endpoint_responses, http):
         base_url = "http://legacy.foo.bar"
-        super(MockHttpRepository, self).__init__(
-            "legacy", url=base_url, disable_cache=True
-        )
+        super().__init__("legacy", url=base_url, disable_cache=True)
 
         for endpoint, response in endpoint_responses.items():
             url = base_url + endpoint

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -21,9 +21,7 @@ class MockRepository(PyPiRepository):
     DIST_FIXTURES = Path(__file__).parent / "fixtures" / "pypi.org" / "dists"
 
     def __init__(self, fallback=False):
-        super(MockRepository, self).__init__(
-            url="http://foo.bar", disable_cache=True, fallback=fallback
-        )
+        super().__init__(url="http://foo.bar", disable_cache=True, fallback=fallback)
 
     def _get(self, url):
         parts = url.split("/")[1:]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from pathlib import Path
 
 import pytest

--- a/tests/utils/fixtures/setups/ansible/setup.py
+++ b/tests/utils/fixtures/setups/ansible/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import os
 import os.path
@@ -63,9 +61,9 @@ def _maintain_symlinks(symlink_type, base_path):
     try:
         # Try the cache first because going from git checkout to sdist is the
         # only time we know that we're going to cache correctly
-        with open(SYMLINK_CACHE, "r") as f:
+        with open(SYMLINK_CACHE) as f:
             symlink_data = json.load(f)
-    except (IOError, OSError) as e:
+    except OSError as e:
         # IOError on py2, OSError on py3.  Both have errno
         if e.errno == 2:
             # SYMLINKS_CACHE doesn't exist.  Fallback to trying to create the
@@ -139,7 +137,7 @@ class SDistCommand(SDist):
 
 def read_file(file_name):
     """Read file and return its contents."""
-    with open(file_name, "r") as f:
+    with open(file_name) as f:
         return f.read()
 
 

--- a/tests/utils/fixtures/setups/flask/setup.py
+++ b/tests/utils/fixtures/setups/flask/setup.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import io
 import re
 from collections import OrderedDict
 
 from setuptools import setup
 
-with io.open("README.rst", "rt", encoding="utf8") as f:
+with open("README.rst", "rt", encoding="utf8") as f:
     readme = f.read()
 
-with io.open("flask/__init__.py", "rt", encoding="utf8") as f:
+with open("flask/__init__.py", "rt", encoding="utf8") as f:
     version = re.search(r"__version__ = \'(.*?)\'", f.read()).group(1)
 
 setup(

--- a/tests/utils/fixtures/setups/pendulum/setup.py
+++ b/tests/utils/fixtures/setups/pendulum/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from distutils.core import setup
 
 from build import *

--- a/tests/utils/fixtures/setups/pyyaml/setup.py
+++ b/tests/utils/fixtures/setups/pyyaml/setup.py
@@ -18,7 +18,7 @@ AUTHOR_EMAIL = "xi@resolvent.net"
 LICENSE = "MIT"
 PLATFORMS = "Any"
 URL = "http://pyyaml.org/wiki/PyYAML"
-DOWNLOAD_URL = "http://pyyaml.org/download/pyyaml/%s-%s.tar.gz" % (NAME, VERSION)
+DOWNLOAD_URL = f"http://pyyaml.org/download/pyyaml/{NAME}-{VERSION}.tar.gz"
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -185,7 +185,7 @@ class build_ext(_build_ext):
                 filenames.append(filename)
                 base = os.path.splitext(filename)[0]
                 for ext in ["c", "h", "pyx", "pxd"]:
-                    filename = "%s.%s" % (base, ext)
+                    filename = f"{base}.{ext}"
                     if filename not in filenames and os.path.isfile(filename):
                         filenames.append(filename)
         return filenames

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -38,7 +38,7 @@ print("nullpackage loaded"),
 
 class MockVirtualEnv(VirtualEnv):
     def __init__(self, path, base=None, sys_path=None):
-        super(MockVirtualEnv, self).__init__(path, base=base)
+        super().__init__(path, base=base)
 
         self._sys_path = sys_path
 
@@ -47,7 +47,7 @@ class MockVirtualEnv(VirtualEnv):
         if self._sys_path is not None:
             return self._sys_path
 
-        return super(MockVirtualEnv, self).sys_path
+        return super().sys_path
 
 
 @pytest.fixture()
@@ -80,7 +80,7 @@ def test_env_commands_with_spaces_in_their_arg_work_as_expected(tmp_dir, manager
     manager.build_venv(str(venv_path))
     venv = VirtualEnv(venv_path)
     assert venv.run("python", venv.pip, "--version", shell=True).startswith(
-        "pip {} from ".format(venv.pip_version)
+        f"pip {venv.pip_version} from "
     )
 
 
@@ -129,7 +129,7 @@ def check_output_wrapper(version=Version.parse("3.7.1")):
         if "sys.version_info[:3]" in cmd:
             return version.text
         elif "sys.version_info[:2]" in cmd:
-            return "{}.{}".format(version.major, version.minor)
+            return f"{version.major}.{version.minor}"
         else:
             return str(Path("/prefix"))
 
@@ -158,7 +158,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     venv_name = EnvManager.generate_env_name("simple-project", str(poetry.file.parent))
 
     m.assert_called_with(
-        Path(tmp_dir) / "{}-py3.7".format(venv_name),
+        Path(tmp_dir) / f"{venv_name}-py3.7",
         executable="python3.7",
         flags={"always-copy": False, "system-site-packages": False},
     )
@@ -169,7 +169,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     assert envs[venv_name]["minor"] == "3.7"
     assert envs[venv_name]["patch"] == "3.7.1"
 
-    assert env.path == Path(tmp_dir) / "{}-py3.7".format(venv_name)
+    assert env.path == Path(tmp_dir) / f"{venv_name}-py3.7"
     assert env.base == Path("/prefix")
 
 
@@ -181,7 +181,7 @@ def test_activate_activates_existing_virtualenv_no_envs_file(
 
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
-    os.mkdir(os.path.join(tmp_dir, "{}-py3.7".format(venv_name)))
+    os.mkdir(os.path.join(tmp_dir, f"{venv_name}-py3.7"))
 
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
@@ -205,7 +205,7 @@ def test_activate_activates_existing_virtualenv_no_envs_file(
     assert envs[venv_name]["minor"] == "3.7"
     assert envs[venv_name]["patch"] == "3.7.1"
 
-    assert env.path == Path(tmp_dir) / "{}-py3.7".format(venv_name)
+    assert env.path == Path(tmp_dir) / f"{venv_name}-py3.7"
     assert env.base == Path("/prefix")
 
 
@@ -222,7 +222,7 @@ def test_activate_activates_same_virtualenv_with_envs_file(
     doc[venv_name] = {"minor": "3.7", "patch": "3.7.1"}
     envs_file.write(doc)
 
-    os.mkdir(os.path.join(tmp_dir, "{}-py3.7".format(venv_name)))
+    os.mkdir(os.path.join(tmp_dir, f"{venv_name}-py3.7"))
 
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
@@ -245,7 +245,7 @@ def test_activate_activates_same_virtualenv_with_envs_file(
     assert envs[venv_name]["minor"] == "3.7"
     assert envs[venv_name]["patch"] == "3.7.1"
 
-    assert env.path == Path(tmp_dir) / "{}-py3.7".format(venv_name)
+    assert env.path == Path(tmp_dir) / f"{venv_name}-py3.7"
     assert env.base == Path("/prefix")
 
 
@@ -261,7 +261,7 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     doc[venv_name] = {"minor": "3.7", "patch": "3.7.1"}
     envs_file.write(doc)
 
-    os.mkdir(os.path.join(tmp_dir, "{}-py3.7".format(venv_name)))
+    os.mkdir(os.path.join(tmp_dir, f"{venv_name}-py3.7"))
 
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
@@ -278,7 +278,7 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     env = manager.activate("python3.6", NullIO())
 
     m.assert_called_with(
-        Path(tmp_dir) / "{}-py3.6".format(venv_name),
+        Path(tmp_dir) / f"{venv_name}-py3.6",
         executable="python3.6",
         flags={"always-copy": False, "system-site-packages": False},
     )
@@ -288,7 +288,7 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     assert envs[venv_name]["minor"] == "3.6"
     assert envs[venv_name]["patch"] == "3.6.6"
 
-    assert env.path == Path(tmp_dir) / "{}-py3.6".format(venv_name)
+    assert env.path == Path(tmp_dir) / f"{venv_name}-py3.6"
     assert env.base == Path("/prefix")
 
 
@@ -304,7 +304,7 @@ def test_activate_activates_recreates_for_different_patch(
     doc[venv_name] = {"minor": "3.7", "patch": "3.7.0"}
     envs_file.write(doc)
 
-    os.mkdir(os.path.join(tmp_dir, "{}-py3.7".format(venv_name)))
+    os.mkdir(os.path.join(tmp_dir, f"{venv_name}-py3.7"))
 
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
@@ -332,20 +332,20 @@ def test_activate_activates_recreates_for_different_patch(
     env = manager.activate("python3.7", NullIO())
 
     build_venv_m.assert_called_with(
-        Path(tmp_dir) / "{}-py3.7".format(venv_name),
+        Path(tmp_dir) / f"{venv_name}-py3.7",
         executable="python3.7",
         flags={"always-copy": False, "system-site-packages": False},
     )
-    remove_venv_m.assert_called_with(Path(tmp_dir) / "{}-py3.7".format(venv_name))
+    remove_venv_m.assert_called_with(Path(tmp_dir) / f"{venv_name}-py3.7")
 
     assert envs_file.exists()
     envs = envs_file.read()
     assert envs[venv_name]["minor"] == "3.7"
     assert envs[venv_name]["patch"] == "3.7.1"
 
-    assert env.path == Path(tmp_dir) / "{}-py3.7".format(venv_name)
+    assert env.path == Path(tmp_dir) / f"{venv_name}-py3.7"
     assert env.base == Path("/prefix")
-    assert (Path(tmp_dir) / "{}-py3.7".format(venv_name)).exists()
+    assert (Path(tmp_dir) / f"{venv_name}-py3.7").exists()
 
 
 def test_activate_does_not_recreate_when_switching_minor(
@@ -360,8 +360,8 @@ def test_activate_does_not_recreate_when_switching_minor(
     doc[venv_name] = {"minor": "3.7", "patch": "3.7.0"}
     envs_file.write(doc)
 
-    os.mkdir(os.path.join(tmp_dir, "{}-py3.7".format(venv_name)))
-    os.mkdir(os.path.join(tmp_dir, "{}-py3.6".format(venv_name)))
+    os.mkdir(os.path.join(tmp_dir, f"{venv_name}-py3.7"))
+    os.mkdir(os.path.join(tmp_dir, f"{venv_name}-py3.6"))
 
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
@@ -390,9 +390,9 @@ def test_activate_does_not_recreate_when_switching_minor(
     assert envs[venv_name]["minor"] == "3.6"
     assert envs[venv_name]["patch"] == "3.6.6"
 
-    assert env.path == Path(tmp_dir) / "{}-py3.6".format(venv_name)
+    assert env.path == Path(tmp_dir) / f"{venv_name}-py3.6"
     assert env.base == Path("/prefix")
-    assert (Path(tmp_dir) / "{}-py3.6".format(venv_name)).exists()
+    assert (Path(tmp_dir) / f"{venv_name}-py3.6").exists()
 
 
 def test_deactivate_non_activated_but_existing(
@@ -431,18 +431,15 @@ def test_deactivate_activated(tmp_dir, manager, poetry, config, mocker):
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     version = Version.parse(".".join(str(c) for c in sys.version_info[:3]))
     other_version = Version.parse("3.4") if version.major == 2 else version.next_minor()
+    (Path(tmp_dir) / f"{venv_name}-py{version.major}.{version.minor}").mkdir()
     (
-        Path(tmp_dir) / "{}-py{}.{}".format(venv_name, version.major, version.minor)
-    ).mkdir()
-    (
-        Path(tmp_dir)
-        / "{}-py{}.{}".format(venv_name, other_version.major, other_version.minor)
+        Path(tmp_dir) / f"{venv_name}-py{other_version.major}.{other_version.minor}"
     ).mkdir()
 
     envs_file = TOMLFile(Path(tmp_dir) / "envs.toml")
     doc = tomlkit.document()
     doc[venv_name] = {
-        "minor": "{}.{}".format(other_version.major, other_version.minor),
+        "minor": f"{other_version.major}.{other_version.minor}",
         "patch": other_version.text,
     }
     envs_file.write(doc)
@@ -474,7 +471,7 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
-    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
 
     envs_file = TOMLFile(Path(tmp_dir) / "envs.toml")
     doc = tomlkit.document()
@@ -492,7 +489,7 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
 
     env = manager.get()
 
-    assert env.path == Path(tmp_dir) / "{}-py3.7".format(venv_name)
+    assert env.path == Path(tmp_dir) / f"{venv_name}-py3.7"
     assert env.base == Path("/prefix")
 
 
@@ -500,22 +497,22 @@ def test_list(tmp_dir, manager, poetry, config):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
-    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
-    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.6").mkdir()
 
     venvs = manager.list()
 
     assert 2 == len(venvs)
-    assert (Path(tmp_dir) / "{}-py3.6".format(venv_name)) == venvs[0].path
-    assert (Path(tmp_dir) / "{}-py3.7".format(venv_name)) == venvs[1].path
+    assert (Path(tmp_dir) / f"{venv_name}-py3.6") == venvs[0].path
+    assert (Path(tmp_dir) / f"{venv_name}-py3.7") == venvs[1].path
 
 
 def test_remove_by_python_version(tmp_dir, manager, poetry, config, mocker):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
-    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
-    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.6").mkdir()
 
     mocker.patch(
         "subprocess.check_output",
@@ -524,34 +521,34 @@ def test_remove_by_python_version(tmp_dir, manager, poetry, config, mocker):
 
     venv = manager.remove("3.6")
 
-    assert (Path(tmp_dir) / "{}-py3.6".format(venv_name)) == venv.path
-    assert not (Path(tmp_dir) / "{}-py3.6".format(venv_name)).exists()
+    assert (Path(tmp_dir) / f"{venv_name}-py3.6") == venv.path
+    assert not (Path(tmp_dir) / f"{venv_name}-py3.6").exists()
 
 
 def test_remove_by_name(tmp_dir, manager, poetry, config, mocker):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
-    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
-    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.6").mkdir()
 
     mocker.patch(
         "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
 
-    venv = manager.remove("{}-py3.6".format(venv_name))
+    venv = manager.remove(f"{venv_name}-py3.6")
 
-    assert (Path(tmp_dir) / "{}-py3.6".format(venv_name)) == venv.path
-    assert not (Path(tmp_dir) / "{}-py3.6".format(venv_name)).exists()
+    assert (Path(tmp_dir) / f"{venv_name}-py3.6") == venv.path
+    assert not (Path(tmp_dir) / f"{venv_name}-py3.6").exists()
 
 
 def test_remove_also_deactivates(tmp_dir, manager, poetry, config, mocker):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
-    (Path(tmp_dir) / "{}-py3.7".format(venv_name)).mkdir()
-    (Path(tmp_dir) / "{}-py3.6".format(venv_name)).mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
+    (Path(tmp_dir) / f"{venv_name}-py3.6").mkdir()
 
     mocker.patch(
         "subprocess.check_output",
@@ -565,8 +562,8 @@ def test_remove_also_deactivates(tmp_dir, manager, poetry, config, mocker):
 
     venv = manager.remove("python3.6")
 
-    assert (Path(tmp_dir) / "{}-py3.6".format(venv_name)) == venv.path
-    assert not (Path(tmp_dir) / "{}-py3.6".format(venv_name)).exists()
+    assert (Path(tmp_dir) / f"{venv_name}-py3.6") == venv.path
+    assert not (Path(tmp_dir) / f"{venv_name}-py3.6").exists()
 
     envs = envs_file.read()
     assert venv_name not in envs
@@ -578,7 +575,7 @@ def test_remove_keeps_dir_if_not_deleteable(tmp_dir, manager, poetry, config, mo
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
     venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
-    venv_path = Path(tmp_dir) / "{}-py3.6".format(venv_name)
+    venv_path = Path(tmp_dir) / f"{venv_name}-py3.6"
     venv_path.mkdir()
 
     folder1_path = venv_path / "folder1"
@@ -605,7 +602,7 @@ def test_remove_keeps_dir_if_not_deleteable(tmp_dir, manager, poetry, config, mo
 
     m = mocker.patch("shutil.rmtree", side_effect=err_on_rm_venv_only)
 
-    venv = manager.remove("{}-py3.6".format(venv_name))
+    venv = manager.remove(f"{venv_name}-py3.6")
 
     m.assert_any_call(str(venv_path))
 
@@ -712,7 +709,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
     manager.create_venv(NullIO())
 
     m.assert_called_with(
-        config_virtualenvs_path / "{}-py3.7".format(venv_name),
+        config_virtualenvs_path / f"{venv_name}-py3.7",
         executable="python3",
         flags={"always-copy": False, "system-site-packages": False},
     )
@@ -736,7 +733,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     manager.create_venv(NullIO())
 
     m.assert_called_with(
-        config_virtualenvs_path / "{}-py3.9".format(venv_name),
+        config_virtualenvs_path / f"{venv_name}-py3.9",
         executable="python3.9",
         flags={"always-copy": False, "system-site-packages": False},
     )
@@ -819,8 +816,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
 
     assert not check_output.called
     m.assert_called_with(
-        config_virtualenvs_path
-        / "{}-py{}.{}".format(venv_name, version.major, version.minor),
+        config_virtualenvs_path / f"{venv_name}-py{version.major}.{version.minor}",
         executable=None,
         flags={"always-copy": False, "system-site-packages": False},
     )


### PR DESCRIPTION
I noticed that #3861 ran a pyupgrade sweep on the codebase to remove some old code but still had some remaining fluff like ```from __future__ import unicode_literals``` which shouldn't be needed >3.0.

I ran the same tool with the `--py36-plus` flag, which should make some more edits. Let me know if any further changes are needed!

Relates-to: #3860

# Pull Request Check List

Resolves: N/A

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ N/A ] Added **tests** for changed code.
- [ N/A ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
