### PR TITLE
Introduce dependency sorting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,14 @@ If you encounter any problems with it, set to `true` to use the system git backe
 
 Defaults to `false`.
 
+### `dependencies.sort`
+
+**Type**: boolean
+
+Sort dependencies alphabetically when adding.
+
+Defaults to `false`.
+
 ### `installer.parallel`
 
 **Type**: boolean

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,7 +175,7 @@ Defaults to `false`.
 
 **Type**: boolean
 
-Sort dependencies alphabetically when adding.
+Sort dependencies in `pyproject.toml` alphabetically when adding.
 
 Defaults to `false`.
 

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -107,6 +107,7 @@ _default_config: Config | None = None
 class Config:
     default_config: dict[str, Any] = {
         "cache-dir": str(DEFAULT_CACHE_DIR),
+        "dependencies": {"sort": False},
         "virtualenvs": {
             "create": True,
             "in-project": None,
@@ -260,6 +261,7 @@ class Config:
     @staticmethod
     def _get_normalizer(name: str) -> Callable[[str], Any]:
         if name in {
+            "dependencies.sort",
             "virtualenvs.create",
             "virtualenvs.in-project",
             "virtualenvs.options.always-copy",

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -235,7 +235,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
             sorted_dependencies = OrderedDict(sorted(section.items()))
             if sorted_dependencies.get("python"):
                 sorted_dependencies.move_to_end("python", last=False)
-            if group == "default":
+            if group == MAIN_GROUP:
                 poetry_content["dependencies"] = sorted_dependencies
             else:
                 poetry_content["group"][group]["dependencies"] = sorted_dependencies

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 
+from collections import OrderedDict
 from typing import Any
 
 from cleo.helpers import argument
@@ -229,6 +230,15 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
                     root_dir=self.poetry.file.parent,
                 )
             )
+
+        if self.poetry.config.get("dependencies.sort") is True:
+            sorted_dependencies = OrderedDict(sorted(section.items()))
+            if sorted_dependencies.get("python"):
+                sorted_dependencies.move_to_end("python", last=False)
+            if group == "default":
+                poetry_content["dependencies"] = sorted_dependencies
+            else:
+                poetry_content["group"][group]["dependencies"] = sorted_dependencies
 
         # Refresh the locker
         self.poetry.set_locker(

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -59,6 +59,7 @@ To remove a repository (repo is a short alias for repositories):
                 lambda val: str(Path(val)),
                 str(DEFAULT_CACHE_DIR / "virtualenvs"),
             ),
+            "dependencies.sort": (boolean_validator, boolean_normalizer, False),
             "virtualenvs.create": (boolean_validator, boolean_normalizer, True),
             "virtualenvs.in-project": (boolean_validator, boolean_normalizer, False),
             "virtualenvs.options.always-copy": (

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -12,7 +12,6 @@ from typing import Union
 
 from cleo.helpers import option
 from packaging.utils import canonicalize_name
-from tomlkit import document
 from tomlkit import inline_table
 
 from poetry.console.commands.command import Command
@@ -56,13 +55,6 @@ class InitCommand(Command):
             flag=False,
             multiple=True,
         ),
-        option(
-            "sort-dependencies",
-            None,
-            "Sort dependencies in pyproject.toml alphabetically.",
-            flag=True,
-            value_required=False,
-        ),
         option("license", "l", "License of the package.", flag=False),
     ]
 
@@ -80,9 +72,9 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         from pathlib import Path
 
         from poetry.core.pyproject.toml import PyProjectTOML
-        from poetry.core.toml.file import TOMLFile
         from poetry.core.vcs.git import GitConfig
 
+        from poetry.config.config import Config
         from poetry.layouts import layout
         from poetry.utils.env import SystemEnv
 
@@ -103,6 +95,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 )
                 return 1
 
+        config = Config()
         vcs_config = GitConfig()
 
         if self.io.is_interactive():
@@ -218,19 +211,9 @@ You can specify a package in the following forms:
             if self.io.is_interactive():
                 self.line("")
 
-        sort_dependencies = self.option("sort-dependencies")
-        question = "Would you like to sort your dependencies alphabetically?"
-        if self.confirm(question, True):
-            sort_dependencies = True
-            if self.io.is_interactive():
-                self.line("")
-        if sort_dependencies is True:
+        if config.get("dependencies.sort") is True:
             requirements = OrderedDict(sorted(requirements.items()))
             dev_requirements = OrderedDict(sorted(dev_requirements.items()))
-            local_config_file = TOMLFile(Path.cwd() / "poetry.toml")
-            local_config_file_contents = document()
-            local_config_file_contents.update({"dependencies": {"sort": True}})
-            local_config_file.write(local_config_file_contents)
 
         layout_ = layout("standard")(
             name,

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -29,7 +29,12 @@ def get_options_based_on_normalizer(normalizer: Callable) -> str:
 
 
 @pytest.mark.parametrize(
-    ("name", "value"), [("installer.parallel", True), ("virtualenvs.create", True)]
+    ("name", "value"),
+    [
+        ("dependencies.sort", False),
+        ("installer.parallel", True),
+        ("virtualenvs.create", True),
+    ],
 )
 def test_config_get_default_value(config: Config, name: str, value: bool):
     assert config.get(name) is value

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.semver.version import Version
 
 from poetry.repositories.legacy_repository import LegacyRepository
@@ -820,7 +821,7 @@ Package operations: 1 install, 0 updates, 0 removals
     }
 
 
-@pytest.mark.parametrize("group", ("default", "dev", "test"))
+@pytest.mark.parametrize("group", (MAIN_GROUP, "dev", "test"))
 @pytest.mark.parametrize("sort_config_value", ("true", "false", None))
 def test_add_constraint_with_sort(
     group: str,
@@ -831,7 +832,7 @@ def test_add_constraint_with_sort(
 ):
     if sort_config_value:
         os.environ["POETRY_DEPENDENCIES_SORT"] = sort_config_value
-    group_option = f" --group {group}" if group != "default" else ""
+    group_option = f" --group {group}" if group != MAIN_GROUP else ""
 
     repo.add_package(get_package("pendulum", "1.4.4"))
     repo.add_package(get_package("cachy", "0.2.0"))
@@ -863,7 +864,7 @@ Package operations: 3 installs, 0 updates, 0 removals
         if sort_config_value == "true"
         else OrderedDict(pendulum="1.4.4", cachy="0.2.0", cleo="0.6.5")
     )
-    if group == "default":
+    if group == MAIN_GROUP:
         expected_content.update(python="~2.7 || ^3.4")
         expected_content.move_to_end("python", last=False)
         poetry_content = OrderedDict(

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -855,7 +855,7 @@ Package operations: 3 installs, 0 updates, 0 removals
 
     expected_set = set(expected_output.splitlines())
     output_set = set(tester.io.fetch_output().splitlines())
-    assert expected_set == output_set
+    assert output_set == expected_set
     assert tester.command.installer.executor.installations_count == 3
 
     expected_content = (
@@ -874,7 +874,7 @@ Package operations: 3 installs, 0 updates, 0 removals
             app.poetry.file.read()["tool"]["poetry"]["group"][group]["dependencies"]
         )
 
-    assert expected_content == poetry_content
+    assert poetry_content == expected_content
 
 
 def test_add_constraint_with_source(

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -51,6 +51,7 @@ def test_list_displays_default_value_if_not_set(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
+dependencies.sort = false
 experimental.new-installer = true
 experimental.system-git-client = false
 installer.max-workers = null
@@ -80,6 +81,7 @@ def test_list_displays_set_get_setting(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
+dependencies.sort = false
 experimental.new-installer = true
 experimental.system-git-client = false
 installer.max-workers = null
@@ -133,6 +135,7 @@ def test_list_displays_set_get_local_setting(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
+dependencies.sort = false
 experimental.new-installer = true
 experimental.system-git-client = false
 installer.max-workers = null

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -139,7 +139,7 @@ def test_noninteractive_with_sort(
     command = app.find("init")
     command._pool = poetry.pool
 
-    repo.add_package(get_package("django-pendulum", "0.1.6-pre4"))
+    repo.add_package(get_package("django-pendulum", "0.1.5"))
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest-requests", "0.2.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
@@ -164,7 +164,7 @@ def test_noninteractive_with_sort(
     )
     tester.execute(args=args, interactive=False)
     expected_output = (
-        "Using version ^0.1.6-preview.4 for django-pendulum\n"
+        "Using version ^0.1.5 for django-pendulum\n"
         "Using version ^2.0.0 for pendulum\n"
         "Using version ^2.0.0 for flask\n"
         "Using version ^0.2.0 for pytest-requests\n"
@@ -185,7 +185,7 @@ packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
-django-pendulum = "^0.1.6-preview.4"
+django-pendulum = "^0.1.5"
 flask = "^2.0.0"
 pendulum = "^2.0.0"
 
@@ -303,7 +303,7 @@ def test_interactive_with_dependencies_and_sort(
     mocker.patch.dict(os.environ, clear=True)
     os.environ["POETRY_DEPENDENCIES_SORT"] = "true"
 
-    repo.add_package(get_package("django-pendulum", "0.1.6-pre4"))
+    repo.add_package(get_package("django-pendulum", "0.1.5"))
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest-requests", "0.2.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
@@ -351,7 +351,7 @@ packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
-django-pendulum = "^0.1.6-preview.4"
+django-pendulum = "^0.1.5"
 flask = "^2.0.0"
 pendulum = "^2.0.0"
 


### PR DESCRIPTION
Resolves: #312
Resolves: #4383

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

## Description

Thank you for Poetry. It's a huge help to the Python community, and I enjoy working with it.

When installing a package with `poetry add`, the package is appended to the appropriate section of the _pyproject.toml_. Some developers have their dependencies sorted alphabetically, so they have to manually sort the new dependency into the appropriate place in _pyproject.toml_. It would be great to have the dependencies automatically sorted.

This PR will introduce the ability to sort dependencies alphabetically when adding. Dependency sorting can be configured with `poetry config dependencies.sort true` or `export POETRY_DEPENDENCIES_SORT=true`. If `true`, dependencies will be sorted alphabetically when adding. For the default dependency group, `python` will be at the top of the list.

## Related

https://github.com/python-poetry/poetry/issues/312#issuecomment-466782002
https://github.com/python-poetry/poetry/issues/312#issuecomment-724623426
python-poetry/poetry#2308
python-poetry/poetry#4260
