### PR TITLE
Fix documentation typos (you -> your)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-
 **Warning**: The previous `get-poetry.py` installer is now deprecated, if you are currently using it
 you should migrate to the new, supported, `install-poetry.py` installer.
 
-The installer installs the `poetry` tool to Poetry's `bin` directory. This location depends on you system:
+The installer installs the `poetry` tool to Poetry's `bin` directory. This location depends on your system:
 
 - `$HOME/.local/bin` for Unix
 - `%APPDATA%\Python\Scripts` on Windows
 
-If this directory is not on you `PATH`, you will need to add it manually
+If this directory is not on your `PATH`, you will need to add it manually
 if you want to invoke Poetry with simply `poetry`.
 
 Alternatively, you can use the full path to `poetry` to use it.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -34,12 +34,12 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-
     The previous `get-poetry.py` installer is now deprecated, if you are currently using it
     you should migrate to the new, supported, `install-poetry.py` installer.
 
-The installer installs the `poetry` tool to Poetry's `bin` directory. This location depends on you system:
+The installer installs the `poetry` tool to Poetry's `bin` directory. This location depends on your system:
 
 - `$HOME/.local/bin` for Unix
 - `%APPDATA%\Python\Scripts` on Windows
 
-If this directory is not on you `PATH`, you will need to add it manually
+If this directory is not on your `PATH`, you will need to add it manually
 if you want to invoke Poetry with simply `poetry`.
 
 Alternatively, you can use the full path to `poetry` to use it.

--- a/docs/docs/pyproject.md
+++ b/docs/docs/pyproject.md
@@ -305,7 +305,7 @@ any custom url in the `urls` section.
 "Bug Tracker" = "https://github.com/python-poetry/poetry/issues"
 ```
 
-If you publish you package on PyPI, they will appear in the `Project Links` section.
+If you publish your package on PyPI, they will appear in the `Project Links` section.
 
 ## Poetry and PEP-517
 

--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -49,7 +49,7 @@ If you do not specify the password you will be prompted to write it.
     poetry config pypi-token.pypi my-token
     ```
 
-    If you still want to use you username and password, you can do so with the following
+    If you still want to use your username and password, you can do so with the following
     call to `config`.
 
     ```bash


### PR DESCRIPTION
Some docs used "you" where they should use "your" for possessiveness.
No code is changed, merely documentation.

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

