### PR TITLE
fix(get-poetry): use exit code 1 with non-existing version

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -352,7 +352,9 @@ class Installer:
         version, current_version = self.get_version()
 
         if version is None:
-            return 0
+            if current_version is not None:
+                return 0
+            return 1
 
         self.customize_install()
         self.display_pre_message()


### PR DESCRIPTION
Follow-up to https://github.com/python-poetry/poetry/pull/3927, which
was reverted in https://github.com/python-poetry/poetry/pull/3943,
now handling the "Latest version already installed." case
(https://github.com/python-poetry/poetry/issues/3942).

Ref: https://github.com/python-poetry/poetry/issues/4027

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.