### PR TITLE
fix(install-poetry): use exit code 1 with non-existing version

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -408,6 +408,8 @@ class Installer:
             version, current_version = self.get_version()
 
         if version is None:
+            if current_version is None:
+                return 1
             return 0
 
         self.display_pre_message()


### PR DESCRIPTION
Ref: https://github.com/python-poetry/poetry/issues/4027

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.