### PR TITLE
Fix for 3.6 with locale not set

### DIFF
--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -21,6 +21,7 @@ from cleo.io.io import IO
 from cleo.io.outputs.output import Output
 
 from poetry.__version__ import __version__
+from poetry.core.utils._compat import PY37
 
 from .command_loader import CommandLoader
 from .commands.command import Command
@@ -142,6 +143,20 @@ class Application(BaseApplication):
         error_output: Optional[Output] = None,
     ) -> IO:
         io = super().create_io(input, output, error_output)
+
+        # Remove when support for Python 3.6 is removed
+        # https://github.com/python-poetry/poetry/issues/3412
+        if (
+            not PY37
+            and hasattr(io.output, "_stream")
+            and hasattr(io.output._stream, "buffer")
+            and io.output._stream.encoding != "utf-8"
+        ):
+            import io as io_
+
+            io.output._stream = io_.TextIOWrapper(
+                io.output._stream.buffer, encoding="utf-8"
+            )
 
         # Set our own CLI styles
         formatter = io.output.formatter


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/3412

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

I manually tested this by first installing the version of `poetry` on `master`, then running:
```bash
LANG= /path/to/poetry install
```
This should fail. Then making the change I did here and rerunning the above works.

Not sure what tests or docs should be updated, if any.