### PR TITLE
Print shell commands in debug mode

### DIFF
--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -222,6 +222,7 @@ class Application(BaseApplication):
             "poetry.packages.locker",
             "poetry.packages.package",
             "poetry.utils.password_manager",
+            "poetry.utils.env",
         ]
 
         loggers += command.loggers

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import itertools
 import json
+import logging
 import os
 import platform
 import re
@@ -151,6 +152,8 @@ import sysconfig
 
 print(json.dumps(sysconfig.get_paths()))
 """
+
+logger = logging.getLogger(__name__)
 
 
 class SitePackages:
@@ -1258,6 +1261,9 @@ class Env:
             if kwargs.get("shell", False):
                 cmd = list_to_shell_command(cmd)
 
+            logger.debug(
+                "Env: Executing command: {}".format(list_to_shell_command(cmd))
+            )
             if input_:
                 output = subprocess.run(
                     cmd,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4052 

- ~~[ ] Added **tests** for changed code.~~
- ~~[ ] Updated **documentation** for changed code.~~

### Description

This PR adds a log statements that prints executed system commands in debug mode.

### Example
```
> poetry run python -m poetry add numpy -vvv
...
PyPI: No release information found for numpy-1.4.0, skipping
PyPI: 1 packages found for numpy >=1.20.2,<2.0.0
PyPI: Getting info for numpy (1.20.2) from PyPI
PyPI: No dependencies found, downloading archives
PyPI: Downloading sdist: numpy-1.20.2.zip
Env: Executing command: /var/folders/gf/1pvd7x357qx38kxfq202t4qw0000gn/T/tmp_a3dq219/.venv/bin/python -W ignore -
Env: Executing command: /var/folders/gf/1pvd7x357qx38kxfq202t4qw0000gn/T/tmp_a3dq219/.venv/bin/python /Users/hhartmann/Library/Caches/pypoetry/virtualenvs/poetry-rDsmJivz-py3.8/li
b/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip install --disable-pip-version-check --ignore-installed pep517===0.8.2 toml==0.10.1
```

### Discussion

* I have opted not to include input provided in the `input_` variable, since it is very large (essentially full python scripts). Eventually it might be worth adding a way to get this information as well.
* I have not seen tests for logs in this project (nor do I in general believe tests for log statements are a good idea.)  Hence I am skipping them here. 
* The details of the `-vvv` flag are currently undocumented. I am open to adding those if this is deemed to be a good idea.

### Comment

This is a first-time PR for me to this project. LMK, if this is a welcome feature and/or good approach. Happy to learn and adapt.