### PR TITLE
install poetry wrapper function in bashrc.d

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -22,6 +22,7 @@ import site
 import subprocess
 import sys
 import tempfile
+import textwrap
 
 from contextlib import closing
 from contextlib import contextmanager
@@ -449,6 +450,23 @@ class Installer:
         )
 
         self._data_dir.joinpath("VERSION").write_text(version)
+
+        bashrcd = Path.home() / ".bashrc.d"
+        if bashrcd.exists():
+            (bashrcd / "poetry").write_text(
+                textwrap.dedent(
+                    f"""\
+                    poetry ()
+                    {{
+                        if [ "$1" = "shell" ]; then
+                            . "$({self._data_dir}/bin/poetry env info -p)/bin/activate"
+                        else
+                            {self._data_dir}/bin/poetry "${{@}}"
+                        fi
+                    }}
+                    """
+                )
+            )
 
         return 0
 


### PR DESCRIPTION
# Pull Request Check List

~Resolves:~

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- ~Added **tests** for changed code.~
- ~Updated **documentation** for changed code.~

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

I noticed that `install-poetry.py` doesn't install poetry in `$PATH` anymore (as `get-poetry.py` did). I'm not sure why this has been changed and I hope it doesn't block this PR.

I don't like that `poetry shell` enters commands in my bash history (`pexpect.sendline`) and that it starts a new shell (lacking the latest shell history). This (sourced) wrapper function fixes that as well.

`~/.bashrc.d/` is available on Fedora 34, I'm not sure since what release this has been added and if it's available on other (Linux) distributions.

I haven't checked for compatibility with other shells (zsh/fish etc.), if you like this change I'm willing to do check/fix it.