### PR TITLE
Improve deprecation warnings/errors/docs for new installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ python install-poetry.py --git https://github.com/python-poetry/poetry.git@maste
 
 Updating poetry to the latest stable version is as simple as calling the `self update` command.
 
+**Warning**: Poetry versions installed using the now deprecated `get-poetry.py` installer will not be able to use this
+command to update to 1.2 releases or later. Migrate to using the `install-poetry.py` installer or `pipx`.
+
 ```bash
 poetry self update
 ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -133,6 +133,11 @@ pip install --user poetry
 
 Updating Poetry to the latest stable version is as simple as calling the `self update` command.
 
+!!!warning
+
+    Poetry versions installed using the now deprecated `get-poetry.py` installer will not be able to use this
+    command to update to 1.2 releases or later. Migrate to using the `install-poetry.py` installer or `pipx`.
+
 ```bash
 poetry self update
 ```

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -449,6 +449,33 @@ class Installer:
 
                 break
 
+        def _is_supported(x):
+            mx = self.VERSION_REGEX.match(x)
+            vx = tuple(int(p) for p in mx.groups()[:3]) + (mx.group(5),)
+            return vx < (1, 2, 0)
+
+        if not _is_supported(version):
+            print(
+                colorize(
+                    "error",
+                    f"Version {version} does not support this installation method. Please specify a version prior to "
+                    f"1.2.0a1 explicitly using the '--version' option.\n"
+                    "Please see "
+                    "https://python-poetry.org/blog/announcing-poetry-1-2-0a1.html#deprecation-of-the-get-poetry-py-script "
+                    "for more information.",
+                )
+            )
+            return None, None
+
+        print(
+            colorize(
+                "warning",
+                "This installer is deprecated. "
+                "Poetry versions installed using this script will not be able to use 'self update' command to upgrade to "
+                "1.2.0a1 or later.",
+            )
+        )
+
         current_version = None
         if os.path.exists(POETRY_LIB):
             with open(
@@ -824,7 +851,7 @@ class Installer:
             HWND_BROADCAST,
             WM_SETTINGCHANGE,
             0,
-            u"Environment",
+            "Environment",
             SMTO_ABORTIFHUNG,
             5000,
             ctypes.byref(result),

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -413,6 +413,24 @@ class Installer:
         self.display_pre_message()
         self.ensure_directories()
 
+        def _is_self_upgrade_supported(x):
+            mx = self.VERSION_REGEX.match(x)
+            vx = tuple(int(p) for p in mx.groups()[:3]) + (mx.group(5),)
+            return vx >= (1, 2, 0)
+
+        if not _is_self_upgrade_supported(version):
+            self._write(
+                colorize(
+                    "warning",
+                    f"You are installing {version}. When using the current installer, this version does not support "
+                    f"updating using the 'self update' command. Please use 1.2.0a1 or later.",
+                )
+            )
+            if not self._accept_all:
+                continue_install = input("Do you want to continue? ([y]/n) ") or "y"
+                if continue_install.lower() in {"n", "no"}:
+                    return 0
+
         try:
             self.install(version)
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
- Explicitly block usage of `get-poetry.py` with `poetry (>=1.2.0a1)`.
- Add warning with excplicit user input when installing `poetry (<1.2.0a1)` using `install-poetry.py` installer.
- Add installer warning as it relates to the use of `self upgrade` command in the documentation.

Resolves: #4040
Relate-to: #4087