### PR TITLE
installer: use venv and improve error handling

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -49,6 +49,13 @@ jobs:
         shell: bash
         run: python install-poetry.py -y
 
+      - name: Upload Failure Log
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: poetry-installer-error.log
+          path: poetry-installer-error-*.log
+
       - name: Verify Installation
         shell: bash
         run: |

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -3,8 +3,7 @@ This script will install Poetry and its dependencies.
 
 It does, in order:
 
-  - Downloads the virtualenv package to a temporary directory and add it to sys.path.
-  - Creates a virtual environment in the correct OS data dir which will be
+  - Creates a virtual environment using venv (or virtualenv zipapp) in the correct OS data dir which will be
       - `%APPDATA%\\pypoetry` on Windows
       -  ~/Library/Application Support/pypoetry on MacOS
       - `${XDG_DATA_HOME}/pypoetry` (or `~/.local/share/pypoetry` if it's not set) on UNIX systems
@@ -220,21 +219,6 @@ if WINDOWS:
         _get_win_folder = _get_win_folder_from_registry
 
 
-@contextmanager
-def temporary_directory(*args, **kwargs):
-    try:
-        from tempfile import TemporaryDirectory
-    except ImportError:
-        name = tempfile.mkdtemp(*args, **kwargs)
-
-        yield name
-
-        shutil.rmtree(name)
-    else:
-        with TemporaryDirectory(*args, **kwargs) as name:
-            yield name
-
-
 PRE_MESSAGE = """# Welcome to {poetry}!
 
 This will download and install the latest version of {poetry},
@@ -283,6 +267,76 @@ class PoetryInstallationError(RuntimeError):
         super(PoetryInstallationError, self).__init__()
         self.return_code = return_code
         self.log = log
+
+
+class VirtualEnvironment:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        # str is required for compatibility with subprocess run on CPython <= 3.7 on Windows
+        self._python = str(
+            self._path.joinpath("Scripts/python.exe" if WINDOWS else "bin/python")
+        )
+
+    @property
+    def path(self):
+        return self._path
+
+    @classmethod
+    def make(cls, target: Path) -> "VirtualEnvironment":
+        try:
+            import venv
+
+            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
+            builder.ensure_directories(target)
+            builder.create(target)
+        except ImportError:
+            # fallback to using virtualenv package if venv is not available, eg: ubuntu
+            python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+            virtualenv_bootstrap_url = (
+                f"https://bootstrap.pypa.io/virtualenv/{python_version}/virtualenv.pyz"
+            )
+
+            with tempfile.TemporaryDirectory(prefix="poetry-installer") as temp_dir:
+                virtualenv_pyz = Path(temp_dir) / "virtualenv.pyz"
+                request = Request(
+                    virtualenv_bootstrap_url, headers={"User-Agent": "Python Poetry"}
+                )
+                virtualenv_pyz.write_bytes(urlopen(request).read())
+                cls.run(
+                    sys.executable, virtualenv_pyz, "--clear", "--always-copy", target
+                )
+
+        # We add a special file so that Poetry can detect
+        # its own virtual environment
+        target.joinpath("poetry_env").touch()
+
+        env = cls(target)
+
+        # we do this here to ensure that outdated system default pip does not trigger older bugs
+        env.pip("install", "--disable-pip-version-check", "--upgrade", "pip")
+
+        return env
+
+    @staticmethod
+    def run(*args, **kwargs) -> subprocess.CompletedProcess:
+        completed_process = subprocess.run(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            **kwargs,
+        )
+        if completed_process.returncode != 0:
+            raise PoetryInstallationError(
+                return_code=completed_process.returncode,
+                log=completed_process.stdout.decode(),
+            )
+        return completed_process
+
+    def python(self, *args, **kwargs) -> subprocess.CompletedProcess:
+        return self.run(self._python, *args, **kwargs)
+
+    def pip(self, *args, **kwargs) -> subprocess.CompletedProcess:
+        return self.python("-m", "pip", "--isolated", *args, **kwargs)
 
 
 class Cursor:
@@ -466,9 +520,9 @@ class Installer:
             )
         )
 
-        env_path = self.make_env(version)
-        self.install_poetry(version, env_path)
-        self.make_bin(version)
+        env = self.make_env(version)
+        self.install_poetry(version, env)
+        self.make_bin(version, env)
 
         self._overwrite(
             "Installing {} ({}): {}".format(
@@ -510,7 +564,7 @@ class Installer:
 
         return 0
 
-    def make_env(self, version: str) -> Path:
+    def make_env(self, version: str) -> VirtualEnvironment:
         self._overwrite(
             "Installing {} ({}): {}".format(
                 colorize("info", "Poetry"),
@@ -520,28 +574,9 @@ class Installer:
         )
 
         env_path = self._data_dir.joinpath("venv")
+        return VirtualEnvironment.make(env_path)
 
-        with temporary_directory() as tmp_dir:
-            subprocess.run(
-                [sys.executable, "-m", "pip", "install", "virtualenv", "-t", tmp_dir],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                check=True,
-            )
-
-            sys.path.insert(0, tmp_dir)
-
-            import virtualenv
-
-            virtualenv.cli_run([str(env_path), "--clear"])
-
-        # We add a special file so that Poetry can detect
-        # its own virtual environment
-        env_path.joinpath("poetry_env").touch()
-
-        return env_path
-
-    def make_bin(self, version: str) -> None:
+    def make_bin(self, version: str, env: VirtualEnvironment) -> None:
         self._overwrite(
             "Installing {} ({}): {}".format(
                 colorize("info", "Poetry"),
@@ -553,26 +588,23 @@ class Installer:
         self._bin_dir.mkdir(parents=True, exist_ok=True)
 
         script = "poetry"
-        target_script = "venv/bin/poetry"
+        script_bin = "bin"
         if WINDOWS:
             script = "poetry.exe"
-            target_script = "venv/Scripts/poetry.exe"
+            script_bin = "Scripts"
+        target_script = env.path.joinpath(script_bin, script)
 
         if self._bin_dir.joinpath(script).exists():
             self._bin_dir.joinpath(script).unlink()
 
         try:
-            self._bin_dir.joinpath(script).symlink_to(
-                self._data_dir.joinpath(target_script)
-            )
+            self._bin_dir.joinpath(script).symlink_to(target_script)
         except OSError:
             # This can happen if the user
             # does not have the correct permission on Windows
-            shutil.copy(
-                self._data_dir.joinpath(target_script), self._bin_dir.joinpath(script)
-            )
+            shutil.copy(target_script, self._bin_dir.joinpath(script))
 
-    def install_poetry(self, version: str, env_path: Path) -> None:
+    def install_poetry(self, version: str, env: VirtualEnvironment) -> None:
         self._overwrite(
             "Installing {} ({}): {}".format(
                 colorize("info", "Poetry"),
@@ -581,11 +613,6 @@ class Installer:
             )
         )
 
-        if WINDOWS:
-            python = env_path.joinpath("Scripts/python.exe")
-        else:
-            python = env_path.joinpath("bin/python")
-
         if self._git:
             specification = "git+" + version
         elif self._path:
@@ -593,12 +620,7 @@ class Installer:
         else:
             specification = f"poetry=={version}"
 
-        subprocess.run(
-            [str(python), "-m", "pip", "install", specification],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=True,
-        )
+        env.pip("install", specification)
 
     def display_pre_message(self) -> None:
         kwargs = {


### PR DESCRIPTION
This change drops the dependency on `virtualenv` for the installer,
replacing environment creation with the built-in `venv` module available
in Python >= 3.2.

In addition, this change also improves error handling for subprocess
commands.

The following behavioural changes are also introduced.

- An error log is written to a secure temporary file with stdout and
  tracebacks on error.
- If an existing virtual environment exists prior to installation, this
  is saved, and used for recovery if installation fails.
  
Resolves: #4093
Resolves: #4089