### PR TITLE
We can't install package include relative path dependency as VCS dependency

### DIFF
--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -16,7 +16,7 @@ from tomlkit import inline_table
 
 from .command import Command
 from .env_command import EnvCommand
-
+from poetry.utils.helpers import with_temp_directory_manager
 
 if TYPE_CHECKING:
     from poetry.repositories import Pool
@@ -414,7 +414,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     if extras:
                         pair["extras"] = extras
 
-                    with Provider.build_tmp_dir_for_vcs(url.url) as tmp_dir:
+                    with with_temp_directory_manager() as m:
+                        tmp_dir = m.build_tmp_dir_for_vcs(url.url)
                         package = Provider.get_package_from_vcs(
                             "git", url.url, tmp_dir, rev=pair.get("rev")
                         )

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -414,9 +414,10 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     if extras:
                         pair["extras"] = extras
 
-                    package = Provider.get_package_from_vcs(
-                        "git", url.url, rev=pair.get("rev")
-                    )
+                    with Provider.build_tmp_dir_for_vcs(url.url) as tmp_dir:
+                        package = Provider.get_package_from_vcs(
+                            "git", url.url, tmp_dir, rev=pair.get("rev")
+                        )
                     pair["name"] = package.name
                     result.append(pair)
 

--- a/poetry/console/commands/show.py
+++ b/poetry/console/commands/show.py
@@ -7,7 +7,7 @@ from cleo.helpers import argument
 from cleo.helpers import option
 
 from .env_command import EnvCommand
-
+from poetry.utils.helpers import with_temp_directory_manager
 
 if TYPE_CHECKING:
     from cleo.io.io import IO  # noqa
@@ -395,7 +395,9 @@ lists all packages available."""
                     provider = Provider(self.poetry.package, self.poetry.pool, NullIO())
 
                     if dep.is_vcs():
-                        return provider.search_for_vcs(dep)[0]
+                        with with_temp_directory_manager() as m:
+                            ret = provider.search_for_vcs(dep, m)[0]
+                        return ret
                     if dep.is_file():
                         return provider.search_for_file(dep)[0]
                     if dep.is_directory():

--- a/poetry/mixology/__init__.py
+++ b/poetry/mixology/__init__.py
@@ -3,7 +3,7 @@ from typing import Dict
 from typing import List
 
 from .version_solver import VersionSolver
-
+from poetry.utils.helpers import with_temp_directory_manager
 
 if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
@@ -19,6 +19,7 @@ def resolve_version(
     locked: Dict[str, "DependencyPackage"] = None,
     use_latest: List[str] = None,
 ) -> "SolverResult":
-    solver = VersionSolver(root, provider, locked=locked, use_latest=use_latest)
+    with with_temp_directory_manager() as m:
+        solver = VersionSolver(root, provider, m, locked=locked, use_latest=use_latest)
 
     return solver.solve()

--- a/poetry/utils/helpers.py
+++ b/poetry/utils/helpers.py
@@ -135,3 +135,28 @@ def is_dir_writable(path: Path, create: bool = False) -> bool:
         return False
     else:
         return True
+
+@contextmanager
+def with_temp_directory_manager():
+    m = TempDirManager()
+    try:        
+        yield(m)
+    except Exception:
+        raise
+    finally:
+        m.release()
+
+class TempDirManager():
+    def __init__(self) -> None:
+        self._tmp_dirs = []
+
+    def release(self):
+        for d in self._tmp_dirs:
+            safe_rmtree(str(d))
+
+    def build_tmp_dir_for_vcs(self, url):
+        tmp_dir = Path(
+            tempfile.mkdtemp(prefix="pypoetry-git-{}".format(url.split("/")[-1].rstrip(".git")))
+        )
+        self._tmp_dirs.append(tmp_dir)
+        return tmp_dir

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    execute_setup_py: execute setup py by venv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 
 from cleo.testers.command_tester import CommandTester
 
+from poetry.utils.helpers import with_temp_directory_manager
 from poetry.config.config import Config as BaseConfig
 from poetry.config.dict_config_source import DictConfigSource
 from poetry.factory import Factory
@@ -187,6 +188,10 @@ def tmp_dir():
 
     shutil.rmtree(dir_)
 
+@pytest.fixture
+def temp_dir_manager():
+    with with_temp_directory_manager() as m:
+        yield m
 
 @pytest.fixture
 def mocked_open_files(mocker):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,11 @@ def download_mock(mocker):
 
 
 @pytest.fixture(autouse=True)
-def pep517_metadata_mock(mocker):
+def pep517_metadata_mock(request, mocker):
+    marker = request.node.get_closest_marker("execute_setup_py")
+    if marker:
+        return
+
     @classmethod  # noqa
     def _pep517_metadata(cls, path):
         try:

--- a/tests/fixtures/git/github.com/demo/relative_dependency/setup.py
+++ b/tests/fixtures/git/github.com/demo/relative_dependency/setup.py
@@ -1,0 +1,10 @@
+import os
+from setuptools import setup
+
+setup(
+    name="relative_dependency",
+    version="0.1.0",
+    install_requires=[
+        'subdir_package @ file://localhost/%s/subdir_package/' % os.getcwd().replace('\\', '/'),
+    ]
+)

--- a/tests/fixtures/git/github.com/demo/relative_dependency/setup.py
+++ b/tests/fixtures/git/github.com/demo/relative_dependency/setup.py
@@ -1,10 +1,11 @@
 import os
 from setuptools import setup
 
+PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 setup(
     name="relative_dependency",
     version="0.1.0",
     install_requires=[
-        'subdir_package @ file://localhost/%s/subdir_package/' % os.getcwd().replace('\\', '/'),
+        f"subdir_package @ file://{PKG_DIR}/subdir_package"
     ]
 )

--- a/tests/fixtures/git/github.com/demo/relative_dependency/subdir_package/setup.py
+++ b/tests/fixtures/git/github.com/demo/relative_dependency/subdir_package/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="subdir_package",
+    version="0.1.0",
+    packages = find_packages(),
+)

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -47,18 +47,18 @@ def provider(root, pool):
 
 
 @pytest.mark.parametrize("value", [True, False])
-def test_search_for_vcs_retains_develop_flag(provider, value):
+def test_search_for_vcs_retains_develop_flag(provider, value, temp_dir_manager):
     dependency = VCSDependency(
         "demo", "git", "https://github.com/demo/demo.git", develop=value
     )
-    package = provider.search_for_vcs(dependency)[0]
+    package = provider.search_for_vcs(dependency, temp_dir_manager)[0]
     assert package.develop == value
 
 
-def test_search_for_vcs_setup_egg_info(provider):
+def test_search_for_vcs_setup_egg_info(provider, temp_dir_manager):
     dependency = VCSDependency("demo", "git", "https://github.com/demo/demo.git")
 
-    package = provider.search_for_vcs(dependency)[0]
+    package = provider.search_for_vcs(dependency, temp_dir_manager)[0]
 
     assert package.name == "demo"
     assert package.version.text == "0.1.2"
@@ -73,12 +73,12 @@ def test_search_for_vcs_setup_egg_info(provider):
     }
 
 
-def test_search_for_vcs_setup_egg_info_with_extras(provider):
+def test_search_for_vcs_setup_egg_info_with_extras(provider, temp_dir_manager):
     dependency = VCSDependency(
         "demo", "git", "https://github.com/demo/demo.git", extras=["foo"]
     )
 
-    package = provider.search_for_vcs(dependency)[0]
+    package = provider.search_for_vcs(dependency, temp_dir_manager)[0]
 
     assert package.name == "demo"
     assert package.version.text == "0.1.2"
@@ -93,12 +93,12 @@ def test_search_for_vcs_setup_egg_info_with_extras(provider):
     }
 
 
-def test_search_for_vcs_read_setup(provider, mocker):
+def test_search_for_vcs_read_setup(provider, mocker, temp_dir_manager):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = VCSDependency("demo", "git", "https://github.com/demo/demo.git")
 
-    package = provider.search_for_vcs(dependency)[0]
+    package = provider.search_for_vcs(dependency, temp_dir_manager)[0]
 
     assert package.name == "demo"
     assert package.version.text == "0.1.2"
@@ -113,14 +113,14 @@ def test_search_for_vcs_read_setup(provider, mocker):
     }
 
 
-def test_search_for_vcs_read_setup_with_extras(provider, mocker):
+def test_search_for_vcs_read_setup_with_extras(provider, mocker, temp_dir_manager):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=MockEnv())
 
     dependency = VCSDependency(
         "demo", "git", "https://github.com/demo/demo.git", extras=["foo"]
     )
 
-    package = provider.search_for_vcs(dependency)[0]
+    package = provider.search_for_vcs(dependency, temp_dir_manager)[0]
 
     assert package.name == "demo"
     assert package.version.text == "0.1.2"
@@ -131,7 +131,7 @@ def test_search_for_vcs_read_setup_with_extras(provider, mocker):
     assert optional == [get_dependency("tomlkit"), get_dependency("cleo")]
 
 
-def test_search_for_vcs_read_setup_raises_error_if_no_version(provider, mocker):
+def test_search_for_vcs_read_setup_raises_error_if_no_version(provider, mocker, temp_dir_manager):
     mocker.patch(
         "poetry.inspection.info.PackageInfo._pep517_metadata",
         return_value=PackageInfo(name="demo", version=None),
@@ -140,7 +140,7 @@ def test_search_for_vcs_read_setup_raises_error_if_no_version(provider, mocker):
     dependency = VCSDependency("demo", "git", "https://github.com/demo/no-version.git")
 
     with pytest.raises(RuntimeError):
-        provider.search_for_vcs(dependency)
+        provider.search_for_vcs(dependency, temp_dir_manager)
 
 
 @pytest.mark.parametrize("directory", ["demo", "non-canonical-name"])

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -2850,7 +2850,7 @@ def test_solver_git_dependencies_with_relative_path(solver, package):
     )
 
     ops = solver.solve()
-
+    
     expecteds = [
         {"job": "install", "package": {"name": "subdir-package", "version": "0.1.0"}},
         {"job": "install", "package": {"name": "relative-dependency", "version": "0.1.0"}},

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -2841,3 +2841,21 @@ def test_solver_should_not_raise_errors_for_irrelevant_transitive_python_constra
             {"job": "install", "package": virtualenv},
         ],
     )
+
+
+@pytest.mark.execute_setup_py
+def test_solver_git_dependencies_with_relative_path(solver, package):
+    package.add_dependency(
+        Factory.create_dependency("relative_dependency", {"git": "https://github.com/demo/relative_dependency.git"})
+    )
+
+    ops = solver.solve()
+
+    expecteds = [
+        {"job": "install", "package": {"name": "subdir-package", "version": "0.1.0"}},
+        {"job": "install", "package": {"name": "relative-dependency", "version": "0.1.0"}},
+    ]
+
+    op_list = [{"job": op.job_type, "package": {"name": op.package.name, "version": str(op.package.version)}} for op in ops]
+    assert expecteds == op_list
+


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.


# summary

- We can't install package include relative path dependency as VCS dependency
	- [The package](https://github.com/ota42y/poetry_package_with_subdir_package) depend other package which in sub folder
	- The package is valid
		- We can install package as local package or use `pip install`
		- This is differnt issue than [git subfolder](https://github.com/python-poetry/poetry/pull/1822)
- This problem caused by removing tmp directory
	- poetry clone repository to tmp dir and remove it immedietly
	- poetry create directory dependency for sub folders package
	- When install process, poetry can't find sub folder
- We can install with small change but this change break lock file
	- We save lock file directory dependency for tmp dir
	- We can't install package from lock file
- We should add new semantics for lock file and I want to disscuss.

# probllem

This package (`poetry_package_with_subdir_package`) is valid package and it have relative path dependency for sub directory (`poetry_subdir_package`).
https://github.com/ota42y/poetry_package_with_subdir_package

We can create a directory dependency for a locally cloned folder.
But we can't create a VCS dependency for this repository

Example is this.
```bash
mkdir /tmp/poetry-git-relative-bug && cd /tmp/poetry-git-relative-bug

# use vcs dependency
mkdir poetry_vcs_bug && cd poetry_vcs_bug

cat > pyproject.toml << EOF
[tool.poetry]
name = "poetry_vcs_bug"
version = "0.1.0"
description = ""
authors = ["ota42y <ota42y@gmail.com>"]

[tool.poetry.dependencies]
python = "^3.8"
poetry_package_with_subdir_package = {git = "git@github.com:ota42y/poetry_package_with_subdir_package.git"}
# poetry_package_with_subdir_package = {path = '../poetry_package_with_subdir_package'}

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
EOF

poetry install

# We got this error.
#  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pypoetry-git-poetry_package_with_subdir_packagead_tu1nh/poetry_subdir_package'


# clone local folder and create directory dependency
cd ../
git clone git@github.com:ota42y/poetry_package_with_subdir_package.git
mkdir poetry_local_dependency && cd poetry_local_dependency

cat > pyproject.toml << EOF
[tool.poetry]
name = "poetry_local_dependency"
version = "0.1.0"
description = ""
authors = ["ota42y <ota42y@gmail.com>"]

[tool.poetry.dependencies]
python = "^3.8"
# poetry_package_with_subdir_package = {git = "git@github.com:ota42y/poetry_package_with_subdir_package.git"}
poetry_package_with_subdir_package = {path = '../poetry_package_with_subdir_package'}

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
EOF

poetry install
# succeeded
```

I create [other package](https://github.com/ota42y/poetry_git_with_local_package) which have relative path dependency using `setup.py`  but I got same error.
This mean we can't use VCS package which include relative path even if the package use pip or poetry.


# Cause

## temporary directory problem


Provider#get_package_from_vcs clone git repository to temporary directory.
poetry immediately creates `Package` object and remove temporary directory.
https://github.com/python-poetry/poetry/blob/fcc2c839952a57e0268b623b319fa512982ca405/poetry/puzzle/provider.py#L227


The relative dependency of the package is then interpreted as a directory dependency on the folder in the temporary directory.

For example, in the previous example, the object would be like this:  

```python
pkg = Package(name='poetry_package_with_subdir_package", source_type='git')
pkg.requires = [
    DirectoryDependency(name='poetry_subdir_package' 
                        path='/tmp/pypoetry-git-poetry_package_with_subdir_packagead_tu1nh/poetry_subdir_package'
    )
]
```

poetry install original pakcage (VCS dependency package) from git repository so we can install this package correctory.
But the directory dependency package depende on temporary directory and which alerady removed so we can't install it.


## long life temporary diectory
We can solve this issue by this PR's changes.
This changes 

This change can be installed by extending the lifetime of the temporary directory.
But poetry write directory dependency which depend on temporary directory to lock file so we can't install package from lock file.

```toml
[[package]]
name = "poetry-subdir-package"
version = "0.1.0"
description = ""
category = "main"
optional = false
python-versions = "^3.8"
develop = false

[package.source]
type = "directory"
url = "../../../../tmp/pypoetry-git-poetry_package_with_subdir_packagead_tu1nh/poetry_subdir_package"
```


# how to solve
I think these package is valid package because we can install from local folder and we can install by pip so we should fix this problem.

I've come up with two solutions.

- convert relative dependency in VCS dependency to git subfolder dependency
- craete new dependency type like VCS relative dependency


## convert relative dependency in VCS dependency to git subfolder dependency

This problem cause by VCS dependency, and relative dependency in git repository is equal to git subfolder's dependency.
So we can convert git subfolder's dependency.

For example, if we have a `Package` that has a dependency on the `./poetry_subdir_package`.

```python
pkg = Package(name='demo", source_type='git',
	source_url="https://github.com/ota42y/poetry_git_with_local_package",
	source_reference="abc")
```

We can convert directory dependency (`./poetry_subdir_package`) to git subfolder dependency with same revision like this

```pyhon
pkg.requires = [
    VCSDependency(name='poetry_subdir_package' vcs='git',
		source="https://github.com/ota42y/poetry_git_with_local_package",
		rev="abc",
		subfolder="./poetry_subdir_package"
    )
]
```

We can convert in [creating package from VCS](https://github.com/python-poetry/poetry/blob/fcc2c839952a57e0268b623b319fa512982ca405/poetry/puzzle/provider.py#L174)

pros/cons
- :+1: small changes because we can use current lock file's semantics
- :-1: git subfolder [doesn't released](https://github.com/python-poetry/poetry/pull/1822)
- :-1: we should clone git repository for relative package so install process will be slow
- :-1:  we can't save this package is relative dependency package on lock file
	- we should update relative dependency package when original package updated
	- poetry may be able to block the update with specific option because poetry treat it as an unrelated package.


# craete new dependency type like VCS relative dependency

If we can create `Dependency` for relative dependency in VCS dependency, we can solve this problem by simple way.

For example, if we have a `Package` that has a dependency on the `./poetry_subdir_package`.

```python
pkg = Package(name='demo", source_type='git',
	source_url="https://github.com/ota42y/poetry_git_with_local_package",
	source_reference="abc")
```

We can create `Dependency` for relative dependency in VCS dependency and set pkg.requires.
When we install VCSDirectoryDependency, we should clone this repository to tmp dir and install like DirectoryDependency.

```python
pkg.requires = [
    VCSDirectoryDependency(
		name='poetry_subdir_package',
		parent_name='demo', path="./poetry_subdir_package"
		source_type='git',
		source_url="https://github.com/ota42y/poetry_git_with_local_package",
		source_reference="abc",
		clone_dir='tmp/pypoetry-git-poetry_package_with_subdir_packagead_tu1nh'
    )
]
```


poetry write `Package` with VCSDirectoryDependency to lock file, we should add new propeties to source section and we can create VCSDirectoryDependency from lock file.

```toml
[[package]]
name = "poetry-subdir-package"
version = "0.1.0"
description = ""
category = "main"
optional = false
python-versions = "^3.8"
develop = false

[package.source]
type = "vcs_directory"
path = "./poetry_subdir_package"
name = "demo"
url = "git@github.com:ota42y/poetry_package_with_subdir_package.git"
reference = "master"
resolved_reference = "c3af6b7af157c0321a58c5e5c41dc929897af98a"
```

pros/cons
- :+1: only one clone
- :+1: we can save this package is relative dependency package and has relation to original package to lock file
- :-1: very big changes
	- We need to build dependency comparisons and conflict solver. 
	- Keep backward compatibility
  
I want to solve this problem because we can't use valid package.
I think the latter is a simpler solution, but it may require a lot of change, and there may be a lot of things to solve because I don't know the full poetry spec.  
If there are any other good solutions, I'd love to discuss them.
