### PR TITLE
replace f-string in get-poetry by `.format()` for python2 compatibility

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -458,11 +458,11 @@ class Installer:
             print(
                 colorize(
                     "error",
-                    f"Version {version} does not support this installation method. Please specify a version prior to "
-                    f"1.2.0a1 explicitly using the '--version' option.\n"
+                    "Version {version} does not support this installation method. Please specify a version prior to "
+                    "1.2.0a1 explicitly using the '--version' option.\n"
                     "Please see "
                     "https://python-poetry.org/blog/announcing-poetry-1-2-0a1.html#deprecation-of-the-get-poetry-py-script "
-                    "for more information.",
+                    "for more information.".format(version=version),
                 )
             )
             return None, None


### PR DESCRIPTION
# Pull Request Check List

https://github.com/python-poetry/poetry/commit/c28728fbe3e69c9995a4ea132dd767074f00e6f8 introduces f-strings in `get-poetry.py`. Because this script is intended to run in python2 as well, f-strings must be replaced by `.format()`

Resolves: https://github.com/python-poetry/poetry/issues/4131
