### PR TITLE
add flag `--use-env` to poetry commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,8 @@ then `--help` combined with any of those can give you more information.
 * `--no-ansi`: Disable ANSI output.
 * `--version (-V)`: Display this application version.
 * `--no-interaction (-n)`: Do not ask any interactive question.
+* `--no-plugins`       Disables plugins.
+* `--use-env=USE-ENV`  The python executable to use.
 
 
 ## new

--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -18,8 +18,8 @@ To achieve this, it will first check if it's currently running inside a virtual 
 If it is, it will use it directly without creating a new one. But if it's not, it will use
 one that it has already created or create a brand new one for you.
 
-By default, Poetry will try to use the currently activated Python version
-to create the virtual environment for the current project.
+By default, Poetry will use the Python used during installation to create the virtual environment
+for the current project.
 
 However, for various reasons, this Python version might not be compatible
 with the `python` requirement of the project. In this case, Poetry will try
@@ -36,7 +36,7 @@ would be:
 ```bash
 pyenv install 2.7.15
 pyenv local 2.7.15  # Activate Python 2.7 for the current project
-poetry install
+poetry install --use-env python2.7
 ```
 {{% /note %}}
 
@@ -69,6 +69,36 @@ special `system` Python version to retrieve the default behavior:
 ```bash
 poetry env use system
 ```
+
+# Multiple environments
+
+You can use `poetry env use` to create multiple environments for your project with different interpreters. `poetry env use`
+will store the information about the used currently used python version in `{cachedir}/virtualenvs/env.toml` by default.
+
+Sometimes it might be feasible to run a poetry command like `poetry shell` or `poetry run` on an environment without
+switching the default. For this purpose the global option `--use-env` exists.
+
+Let's assume we already have an evironment for python3.7 and want to add another one for python3.8 without setting it
+as the new default one:
+
+```bash
+poetry install --use-env python3.8
+```
+
+We can even open a new shell for this environment:
+
+```bash
+poetry shell --use-env python3.8
+```
+
+Or run a specific command:
+
+```bash
+poetry run --use-env python3.8 python --version
+```
+
+Just like `poetry env use` the `--use-env` parameter expects a full path to an executable, a python executable in `$PATH`
+or minor Python version.
 
 ## Displaying the environment information
 

--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -21,6 +21,7 @@ from cleo.io.io import IO
 from cleo.io.outputs.output import Output
 
 from poetry.__version__ import __version__
+from poetry.core.semver.version import Version
 
 from .command_loader import CommandLoader
 from .commands.command import Command
@@ -264,8 +265,17 @@ class Application(BaseApplication):
         io = event.io
         poetry = command.poetry
 
+        try:
+            python_version = Version.parse(event.io.input.option("use-env"))
+            python = f"python{python_version.major}"
+            if python_version.precision > 1:
+                python += f".{python_version.minor}"
+        except ValueError:
+            # Executable in PATH or full executable path
+            python = event.io.input.option("use-env")
+
         env_manager = EnvManager(poetry)
-        env = env_manager.create_venv(io, executable=event.io.input.option("use-env"))
+        env = env_manager.create_venv(io, executable=python)
 
         if env.is_venv() and io.is_verbose():
             io.write_line(f"Using virtualenv: <comment>{env.path}</>")

--- a/poetry/console/application.py
+++ b/poetry/console/application.py
@@ -265,7 +265,7 @@ class Application(BaseApplication):
         poetry = command.poetry
 
         env_manager = EnvManager(poetry)
-        env = env_manager.create_venv(io)
+        env = env_manager.create_venv(io, executable=event.io.input.option("use-env"))
 
         if env.is_venv() and io.is_verbose():
             io.write_line(f"Using virtualenv: <comment>{env.path}</>")
@@ -326,6 +326,11 @@ class Application(BaseApplication):
 
         definition.add_option(
             Option("--no-plugins", flag=True, description="Disables plugins.")
+        )
+        definition.add_option(
+            Option(
+                "--use-env", flag=False, description="The python executable to use."
+            ),
         )
 
         return definition


### PR DESCRIPTION
The PR adds a new global parameter `--use-env`. It adds the ability to tell poetry which python executable it should use in the same way `poetry env use` can do it.

The benefits of the parameter are:
 * running commands in several environments without switching the default python executable first
 * if in-project venvs are used, there is no need to add an entry to the `envs.toml`

I haven't add any tests until now. Recommendations are welcome :)

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
