### PR TITLE
Improve the `self update` command and environment detection

### DIFF
--- a/poetry/locations.py
+++ b/poetry/locations.py
@@ -1,9 +1,19 @@
+import os
+
 from .utils._compat import Path
 from .utils.appdirs import user_cache_dir
 from .utils.appdirs import user_config_dir
+from .utils.appdirs import user_data_dir
 
 
 CACHE_DIR = user_cache_dir("pypoetry")
 CONFIG_DIR = user_config_dir("pypoetry")
 
 REPOSITORY_CACHE_DIR = Path(CACHE_DIR) / "cache" / "repositories"
+
+
+def data_dir():  # type: () -> Path
+    if os.getenv("POETRY_HOME"):
+        return Path(os.getenv("POETRY_HOME")).expanduser()
+
+    return Path(user_data_dir("pypoetry", roaming=True))

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -586,3 +586,8 @@ class Locker(object):
                 data["develop"] = package.develop
 
         return data
+
+
+class NullLocker(Locker):
+    def set_lock_data(self, root, packages):  # type: (Package, List[Package]) -> None
+        pass


### PR DESCRIPTION
This PR ensures that the next bug fix release – which should be `1.1.7` – will be upgradable to the next feature release it it has been installed with the new installer.

It also ensures, similar to #4084, that the proper environment is selected instead of Poetry's own virtualenv.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
