### PR TITLE
Fix locked information for path, url and VCS dependencies

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -513,7 +513,25 @@ class Locker:
                 dependencies[dependency.pretty_name] = []
 
             constraint = inline_table()
-            constraint["version"] = str(dependency.pretty_constraint)
+
+            if dependency.is_directory() or dependency.is_file():
+                constraint["path"] = dependency.path.as_posix()
+
+                if dependency.is_directory() and dependency.develop:
+                    constraint["develop"] = True
+            elif dependency.is_url():
+                constraint["url"] = dependency.url
+            elif dependency.is_vcs():
+                constraint[dependency.vcs] = dependency.source
+
+                if dependency.branch:
+                    constraint["branch"] = dependency.branch
+                elif dependency.tag:
+                    constraint["tag"] = dependency.tag
+                elif dependency.rev:
+                    constraint["rev"] = dependency.rev
+            else:
+                constraint["version"] = str(dependency.pretty_constraint)
 
             if dependency.extras:
                 constraint["extras"] = sorted(dependency.extras)
@@ -529,7 +547,10 @@ class Locker:
         # All the constraints should have the same type,
         # but we want to simplify them if it's possible
         for dependency, constraints in tuple(dependencies.items()):
-            if all(len(constraint) == 1 for constraint in constraints):
+            if all(
+                len(constraint) == 1 and "version" in constraint
+                for constraint in constraints
+            ):
                 dependencies[dependency] = [
                     constraint["version"] for constraint in constraints
                 ]

--- a/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry-transitive.test
@@ -65,8 +65,8 @@ python-versions = "*"
 version = "1.2.3"
 
 [package.dependencies]
-project-with-extras = "1.2.3"
-project-with-transitive-file-dependencies = "1.2.3"
+project-with-extras = { "path" = "../../project_with_extras" }
+project-with-transitive-file-dependencies = { "path" = "../project_with_transitive_file_dependencies" }
 
 [package.source]
 type = "directory"
@@ -82,8 +82,8 @@ python-versions = "*"
 version = "1.2.3"
 
 [package.dependencies]
-demo = "0.1.0"
-inner-directory-project = "1.2.4"
+demo = { "path" = "../../distributions/demo-0.1.0-py2.py3-none-any.whl" }
+inner-directory-project = { "path" = "inner-directory-project" }
 
 [package.source]
 type = "directory"

--- a/tests/installation/fixtures/with-file-dependency-transitive.test
+++ b/tests/installation/fixtures/with-file-dependency-transitive.test
@@ -48,8 +48,8 @@ python-versions = "*"
 version = "1.2.3"
 
 [package.dependencies]
-demo = "0.1.0"
-inner-directory-project = "1.2.4"
+demo = { "path" = "../../distributions/demo-0.1.0-py2.py3-none-any.whl" }
+inner-directory-project = { "path" = "inner-directory-project" }
 
 [package.source]
 type = "directory"

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -1,6 +1,8 @@
 import logging
 import tempfile
 
+from pathlib import Path
+
 import pytest
 import tomlkit
 
@@ -531,3 +533,68 @@ content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77
     _ = locker.lock_data
 
     assert 0 == len(caplog.records)
+
+
+def test_locker_dumps_dependency_information_correctly(locker, root):
+    root_dir = Path(__file__).parent.parent.joinpath("fixtures")
+    package_a = get_package("A", "1.0.0")
+    package_a.add_dependency(
+        Factory.create_dependency(
+            "B", {"path": "project_with_extras", "develop": True}, root_dir=root_dir
+        )
+    )
+    package_a.add_dependency(
+        Factory.create_dependency(
+            "C",
+            {"path": "directory/project_with_transitive_directory_dependencies"},
+            root_dir=root_dir,
+        )
+    )
+    package_a.add_dependency(
+        Factory.create_dependency(
+            "D", {"path": "distributions/demo-0.1.0.tar.gz"}, root_dir=root_dir
+        )
+    )
+    package_a.add_dependency(
+        Factory.create_dependency(
+            "E", {"url": "https://python-poetry.org/poetry-1.2.0.tar.gz"}
+        )
+    )
+    package_a.add_dependency(
+        Factory.create_dependency(
+            "F", {"git": "https://github.com/python-poetry/poetry.git", "branch": "foo"}
+        )
+    )
+
+    packages = [package_a]
+
+    locker.set_lock_data(root, packages)
+
+    with locker.lock.open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """[[package]]
+name = "A"
+version = "1.0.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+B = {path = "project_with_extras", develop = true}
+C = {path = "directory/project_with_transitive_directory_dependencies"}
+D = {path = "distributions/demo-0.1.0.tar.gz"}
+E = {url = "https://python-poetry.org/poetry-1.2.0.tar.gz"}
+F = {git = "https://github.com/python-poetry/poetry.git", branch = "foo"}
+
+[metadata]
+lock-version = "1.1"
+python-versions = "*"
+content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
+
+[metadata.files]
+A = []
+"""
+
+    assert expected == content


### PR DESCRIPTION
After #3875 (#3947 for the `1.1` branch), people were starting to see issues where packages would not be installed or would be removed.

This was a bit tricky to track down but the cause was that the locked data for dependencies were not correct which caused packages to be discarded in the resolution process.

This issue has existed for quite some time but was not discovered until now because the fact that all packages were whitelisted meant that they were not retrieved from the lock file.

Note that users will need to update their lock file for the fix to take effect. It's also important to note that `lock --no-update` will **not** work and a full relock will be needed.

## Pull Request Check List

Resolves: #4051
Resolves: #3956
Resolves: #4111

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
