### PR TITLE
Strip Local version label (PEP 440) from Packages build from PackageInfo

### DIFF
--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -141,7 +141,7 @@ class PackageInfo:
 
         package = Package(
             name=name,
-            version=self.version,
+            version=self.public_version,
             source_type=self._source_type,
             source_url=self._source_url,
             source_reference=self._source_reference,
@@ -588,3 +588,10 @@ class PackageInfo:
             return cls.from_bdist(path=path)
         except PackageInfoError:
             return cls.from_sdist(path=path)
+
+    @property
+    def public_version(self) -> str:
+        """
+        Removes +<local version label> from packages.
+        """
+        return self.version.split("+")[0]

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -229,18 +229,17 @@ def test_info_prefer_poetry_config_over_egg_info():
     demo_check_info(info)
 
 
-def test_info_public_version():
-    package_info = PackageInfo(version="1.2.3+localVersion")
-    assert package_info.public_version == "1.2.3"
-
-
-def test_info_public_version_no_mutation():
-    package_info = PackageInfo(version="1.2.3")
-    assert package_info.public_version == "1.2.3"
-
-
-def test_package_from_info_with_public_version():
-    package_info = PackageInfo(name="test-package", version="1.2.3+local_super_version")
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("1.2.3+local_super_version", "1.2.3"),
+        ("1.2.3+localVersion", "1.2.3"),
+        ("1.2.3", "1.2.3"),
+    ],
+)
+def test_info_public_version(version, expected):
+    package_info = PackageInfo(name="test-package", version=version)
+    assert package_info.public_version == expected
     package = package_info.to_package()  # type: Package
     assert type(package.version) == Version
-    assert package.version.text == "1.2.3"
+    assert package.version.text == expected

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -4,6 +4,8 @@ from typing import Set
 
 import pytest
 
+from poetry.core.packages.package import Package
+from poetry.core.semver.version import Version
 from poetry.inspection.info import PackageInfo
 from poetry.inspection.info import PackageInfoError
 from poetry.utils._compat import decode
@@ -225,3 +227,20 @@ def test_info_prefer_poetry_config_over_egg_info():
         FIXTURE_DIR_INSPECTIONS / "demo_with_obsolete_egg_info"
     )
     demo_check_info(info)
+
+
+def test_info_public_version():
+    package_info = PackageInfo(version="1.2.3+localVersion")
+    assert package_info.public_version == "1.2.3"
+
+
+def test_info_public_version_no_mutation():
+    package_info = PackageInfo(version="1.2.3")
+    assert package_info.public_version == "1.2.3"
+
+
+def test_package_from_info_with_public_version():
+    package_info = PackageInfo(name="test-package", version="1.2.3+local_super_version")
+    package = package_info.to_package()  # type: Package
+    assert type(package.version) == Version
+    assert package.version.text == "1.2.3"


### PR DESCRIPTION
Resolves: #2613 

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Rebased into master i.l.o. 1.1 branch to avoid Python 2.7 (https://github.com/python-poetry/poetry/pull/4219)
RE: Documentation... I can't see anywhere the documentation would need to be updated. If it does, point me at it and I'll work it over.

New tests:
```
 poetry run pytest tests/
Test session starts (platform: linux, Python 3.8.5, pytest 6.2.4, pytest-sugar 0.9.4)
rootdir: /mnt/d/Source/poetry
plugins: cov-2.12.0, mock-3.6.1, sugar-0.9.4
collecting ...
 tests/test_factory.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                         2% ▎
 tests/config/test_config.py ✓✓✓✓✓✓✓                                                                                                                                                                                                           3% ▍
 tests/console/test_application.py ✓✓✓✓                                                                                                                                                                                                        3% ▍
 tests/console/commands/test_about.py ✓                                                                                                                                                                                                        4% ▍
 tests/console/commands/test_add.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                              7% ▊
                                    ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                             11% █▎
                                    ✓✓✓                                                                                                                                                                                                       11% █▎
 tests/console/commands/test_cache.py ✓✓                                                                                                                                                                                                      12% █▎
 tests/console/commands/test_check.py ✓✓                                                                                                                                                                                                      12% █▎
 tests/console/commands/test_config.py ✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                             13% █▍
 tests/console/commands/test_export.py ✓✓✓✓✓✓                                                                                                                                                                                                 14% █▌
 tests/console/commands/test_init.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                      17% █▋
 tests/console/commands/test_lock.py ✓✓✓                                                                                                                                                                                                      17% █▊
 tests/console/commands/test_new.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                         19% █▉
 tests/console/commands/test_publish.py ✓✓✓✓✓                                                                                                                                                                                                 20% ██
 tests/console/commands/test_remove.py ✓                                                                                                                                                                                                      20% ██
 tests/console/commands/test_run.py ✓✓                                                                                                                                                                                                        20% ██
 tests/console/commands/test_search.py ✓                                                                                                                                                                                                      20% ██▏
 tests/console/commands/test_show.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                      23% ██▍
 tests/console/commands/test_version.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                             26% ██▋
 tests/console/commands/debug/test_resolve.py ✓✓✓                                                                                                                                                                                             27% ██▋
 tests/console/commands/env/test_info.py ✓✓                                                                                                                                                                                                   27% ██▋
 tests/console/commands/env/test_list.py ✓✓✓                                                                                                                                                                                                  27% ██▊
 tests/console/commands/env/test_remove.py ✓✓                                                                                                                                                                                                 27% ██▊
 tests/console/commands/env/test_use.py ✓✓✓                                                                                                                                                                                                   28% ██▊
 tests/console/commands/plugin/test_add.py ✓✓✓✓✓✓✓                                                                                                                                                                                            29% ██▉
 tests/console/commands/plugin/test_remove.py ✓✓                                                                                                                                                                                              29% ██▉
 tests/console/commands/plugin/test_show.py ✓✓✓                                                                                                                                                                                               29% ██▉
 tests/console/commands/self/test_update.py ✓✓                                                                                                                                                                                                30% ██▉
 tests/console/commands/source/test_add.py ✓✓✓✓✓✓                                                                                                                                                                                             30% ███▏
 tests/console/commands/source/test_remove.py ✓✓                                                                                                                                                                                              31% ███▏
 tests/console/commands/source/test_show.py ✓✓✓✓                                                                                                                                                                                              31% ███▎
 tests/inspection/test_info.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                          34% ███▌
 tests/installation/test_authenticator.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                   36% ███▋
 tests/installation/test_chef.py ✓✓✓                                                                                                                                                                                                          37% ███▋
 tests/installation/test_chooser.py ✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                              38% ███▊
 tests/installation/test_executor.py ✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                            40% ████
 tests/installation/test_installer.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓s✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                47% ████▊
 tests/installation/test_installer_old.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓s✓✓✓✓✓✓✓✓                                                                                                                                                  54% █████▍
 tests/installation/test_pip_installer.py ✓✓✓✓✓✓✓✓                                                                                                                                                                                            55% █████▌
 tests/masonry/builders/test_editable_builder.py ✓✓✓✓                                                                                                                                                                                         55% █████▌
 tests/mixology/solutions/providers/test_python_requirement_solution_provider.py ✓✓                                                                                                                                                           55% █████▋
 tests/mixology/solutions/solutions/test_python_requirement_solution.py ✓                                                                                                                                                                     56% █████▋
 tests/mixology/version_solver/test_backtracking.py ✓✓✓✓✓✓✓✓                                                                                                                                                                                  57% █████▋
 tests/mixology/version_solver/test_basic_graph.py ✓✓✓✓                                                                                                                                                                                       57% █████▊
 tests/mixology/version_solver/test_python_constraint.py ✓                                                                                                                                                                                    57% █████▊
 tests/mixology/version_solver/test_unsolvable.py ✓✓✓✓✓                                                                                                                                                                                       58% █████▊
 tests/mixology/version_solver/test_with_lock.py ✓✓✓✓✓                                                                                                                                                                                        59% █████▉
 tests/packages/test_locker.py ✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                  60% ██████
 tests/plugins/test_plugin_manager.py ✓✓✓                                                                                                                                                                                                     61% ██████▏
 tests/publishing/test_publisher.py ✓✓✓✓✓✓✓✓                                                                                                                                                                                                  62% ██████▎
 tests/publishing/test_uploader.py ✓✓✓✓                                                                                                                                                                                                       62% ██████▎
 tests/puzzle/test_provider.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                          65% ██████▌
 tests/puzzle/test_solver.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓s✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                 78% ███████▊
 tests/repositories/test_installed_repository.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                               79% ███████▉
 tests/repositories/test_legacy_repository.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                       83% ████████▍
 tests/repositories/test_pool.py ✓✓✓✓✓✓✓                                                                                                                                                                                                      84% ████████▍
 tests/repositories/test_pypi_repository.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                   86% ████████▋
 tests/utils/test_env.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                            91% █████████▏
 tests/utils/test_env_site.py ✓✓                                                                                                                                                                                                              91% █████████▎
 tests/utils/test_exporter.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                95% █████████▌
 tests/utils/test_extras.py ✓✓✓✓✓✓✓                                                                                                                                                                                                           96% █████████▋
 tests/utils/test_helpers.py ✓✓✓                                                                                                                                                                                                              97% █████████▋
 tests/utils/test_password_manager.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                         99% █████████▉
 tests/utils/test_pip.py ✓✓                                                                                                                                                                                                                   99% █████████▉
 tests/utils/test_setup_reader.py ✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                  100% ██████████
==============================
---- >8  ----  Warnings removed.  ---- 8< ----
==============================
Results (126.20s):
     763 passed
       3 skipped
```
