### PR TITLE
fix: create path dependencies relative to package rather than lockfile (#4245)

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -180,11 +180,7 @@ class Locker:
                 root_dir = self._lock.path.parent
                 if package.source_type == "directory":
                     # root dir should be the source of the package relative to the lock path
-                    root_dir = Path(
-                        os.path.relpath(
-                            Path(package.source_url), self._lock.path.parent
-                        )
-                    ).resolve()
+                    root_dir = Path(package.source_url)
 
                 if isinstance(constraint, list):
                     for c in constraint:

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -176,20 +176,26 @@ class Locker:
                         package.marker = parse_marker(split_dep[1].strip())
 
             for dep_name, constraint in info.get("dependencies", {}).items():
+
+                root_dir = self._lock.path.parent
+                if package.source_type == "directory":
+                    # root dir should be the source of the package relative to the lock path
+                    root_dir = Path(
+                        os.path.relpath(
+                            Path(package.source_url), self._lock.path.parent
+                        )
+                    ).resolve()
+
                 if isinstance(constraint, list):
                     for c in constraint:
                         package.add_dependency(
-                            Factory.create_dependency(
-                                dep_name, c, root_dir=self._lock.path.parent
-                            )
+                            Factory.create_dependency(dep_name, c, root_dir=root_dir)
                         )
 
                     continue
 
                 package.add_dependency(
-                    Factory.create_dependency(
-                        dep_name, constraint, root_dir=self._lock.path.parent
-                    )
+                    Factory.create_dependency(dep_name, constraint, root_dir=root_dir)
                 )
 
             if "develop" in info:

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -637,6 +637,8 @@ lib-b = []
     create_dependency_patch.assert_called_once_with(
         "lib-b", {"develop": True, "path": "../libB"}, root_dir=mocker.ANY
     )
-    root_dir = create_dependency_patch.call_args.kwargs["root_dir"]
+    call_kwargs = create_dependency_patch.call_args[1]
+    root_dir = call_kwargs["root_dir"]
     assert root_dir.match("*/lib/libA")
-    assert root_dir.is_relative_to(locker.lock.path.parent.resolve())
+    # relative_to raises an exception if not relative - is_relative_to comes in py3.9
+    assert root_dir.relative_to(locker.lock.path.parent.resolve()) is not None

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -348,7 +348,7 @@ A = []
 
 
 def test_reading_lock_file_should_raise_an_error_on_invalid_data(locker):
-    content = u"""[[package]]
+    content = """[[package]]
 name = "A"
 version = "1.0.0"
 description = ""
@@ -598,3 +598,45 @@ A = []
 """
 
     assert expected == content
+
+
+def test_locked_repository_uses_root_dir_of_package(locker, mocker):
+    content = """\
+[[package]]
+name = "lib-a"
+version = "0.1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "^2.7.9"
+develop = true
+
+[package.dependencies]
+lib-b = {path = "../libB", develop = true}
+
+[package.source]
+type = "directory"
+url = "lib/libA"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "*"
+content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
+
+[metadata.files]
+lib-a = []
+lib-b = []
+"""
+
+    locker.lock.write(tomlkit.parse(content))
+    create_dependency_patch = mocker.patch(
+        "poetry.factory.Factory.create_dependency", autospec=True
+    )
+    locker.locked_repository()
+
+    create_dependency_patch.assert_called_once_with(
+        "lib-b", {"develop": True, "path": "../libB"}, root_dir=mocker.ANY
+    )
+    root_dir = create_dependency_patch.call_args.kwargs["root_dir"]
+    assert root_dir.match("*/lib/libA")
+    assert root_dir.is_relative_to(locker.lock.path.parent.resolve())


### PR DESCRIPTION
Resolves path dependencies relative to the package and lockfile rather than just the lockfile.

Resolves: #4245

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
