### PR TITLE
add deprecation warning for `get-poetry.py` to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ from the rest of your system by vendorizing its dependencies. This is the
 recommended way of installing `poetry`.
 
 *Note:*
-    The `get-poetry.py` script described here, will be replaced in poetry version 1.2 by `install-poetry.py`.
+    The `get-poetry.py` script described here will be replaced in Poetry 1.2 by `install-poetry.py`.
     From poetry 1.1.7 onwards you can already use this script as described [here](https://python-poetry.org/docs/master/#installation).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Poetry provides a custom installer that will install `poetry` isolated
 from the rest of your system by vendorizing its dependencies. This is the
 recommended way of installing `poetry`.
 
+*Note:*
+    The `get-poetry.py` script described here, will be replaced in poetry version 1.2 by `install-poetry.py`.
+    From poetry 1.1.7 onwards you can already use this script as described [here](https://python-poetry.org/docs/master/#installation).
+
 ```bash
 curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ recommended way of installing `poetry`.
 
 *Note:*
     The `get-poetry.py` script described here will be replaced in Poetry 1.2 by `install-poetry.py`.
-    From poetry 1.1.7 onwards you can already use this script as described [here](https://python-poetry.org/docs/master/#installation).
+    From Poetry **1.1.7 onwards**, you can already use this script as described [here](https://python-poetry.org/docs/master/#installation).
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -34,7 +34,7 @@ recommended way of installing `poetry`.
 
 {{% note %}}
 The `get-poetry.py` script described here will be replaced in Poetry 1.2 by `install-poetry.py`.
-From Poetry **1.1.7 onwards**, you can already use this script as described [here]({{< relref "/master/#installation" >}}).
+From Poetry **1.1.7 onwards**, you can already use this script as described [here]({{< relref "docs/master/#installation" >}}).
 {{% /note %}}
 
 ### osx / linux / bashonwindows install instructions

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -33,7 +33,7 @@ from the rest of your system by vendorizing its dependencies. This is the
 recommended way of installing `poetry`.
 
 {{% note %}}
-The `get-poetry.py` script described here, will be replaced in poetry version 1.2 by `install-poetry.py`.
+The `get-poetry.py` script described here will be replaced in Poetry 1.2 by `install-poetry.py`.
 From poetry 1.1.7 onwards you can already use this script as described [here]({{< relref "/master/#installation" >}}).
 {{% /note %}}
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -32,6 +32,11 @@ Poetry provides a custom installer that will install `poetry` isolated
 from the rest of your system by vendorizing its dependencies. This is the
 recommended way of installing `poetry`.
 
+{{% note %}}
+The `get-poetry.py` script described here, will be replaced in poetry version 1.2 by `install-poetry.py`.
+From poetry 1.1.7 onwards you can already use this script as described [here]({{< relref "/master/#installation" >}}).
+{{% /note %}}
+
 ### osx / linux / bashonwindows install instructions
 ```bash
 curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -34,7 +34,7 @@ recommended way of installing `poetry`.
 
 {{% note %}}
 The `get-poetry.py` script described here will be replaced in Poetry 1.2 by `install-poetry.py`.
-From poetry 1.1.7 onwards you can already use this script as described [here]({{< relref "/master/#installation" >}}).
+From Poetry **1.1.7 onwards**, you can already use this script as described [here]({{< relref "/master/#installation" >}}).
 {{% /note %}}
 
 ### osx / linux / bashonwindows install instructions


### PR DESCRIPTION
# Pull Request Check List

This PR adds a deprecation warning for `get-poetry.py` to the docs and README in the 1.1 branch to avoid confusions between the recommended installation method on github and the docs.

Resolves: #4248