### PR TITLE
Fix version constraint operator in the docs FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,7 +41,7 @@ The only good alternative is to define an upper bound on your constraints,
 which you can increase in a new release after testing that your package is compatible
 with the new major version of your dependency.
 
-For example instead of using `>=3.4` you should use `~3.4` which allows all versions `<4.0`.
+For example instead of using `>=3.4` you should use `^3.4` which allows all versions `<4.0`.
 The `^` operator works very well with libraries following [semantic versioning](https://semver.org).
 
 ### Is tox supported?


### PR DESCRIPTION
The FAQ in the docs used the wrong version constraint operator for discouraging the use of `>=` by suggesting one that constrains the Python version to `>=3.4,<4`. The more concise operator `~3.4` was used, but it should be `^3.4`.