### PR TITLE
Updated Docs

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -207,7 +207,7 @@ For libraries it is not necessary to commit the lock file.
 
 ### Installing dependencies only
 
-The current project is installed in [editable](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs) mode by default.
+The current project is installed in [editable](https://pip.pypa.io/en/stable/cli/pip_install/#install-editable) mode by default.
 
 If you want to install the dependencies only, run the `install` command with the `--no-root` flag:
 


### PR DESCRIPTION
fixed broken link

The link leading to '--editable' option in pip documentation was broken. fixed it with the new link


