### PR TITLE
Add option to export only dev-dependencies

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -597,6 +597,7 @@ Only the `requirements.txt` format is currently supported.
 * `--output (-o)`: The name of the output file.  If omitted, print to standard
   output.
 * `--dev`: Include development dependencies.
+* `--only-dev`: Include only development dependencies.
 * `--extras (-E)`: Extra sets of dependencies to include.
 * `--without-hashes`: Exclude hashes from the exported file.
 * `--with-credentials`: Include credentials for extra indices.

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -21,6 +21,7 @@ class ExportCommand(Command):
         option("output", "o", "The name of the output file.", flag=False),
         option("without-hashes", None, "Exclude hashes from the exported file."),
         option("dev", None, "Include development dependencies."),
+        option("only-dev", None, "Include only development dependencies."),
         option(
             "extras",
             "E",
@@ -69,6 +70,7 @@ class ExportCommand(Command):
             output or self.io,
             with_hashes=not self.option("without-hashes"),
             dev=self.option("dev"),
+            only_dev=self.option("only-dev"),
             extras=self.option("extras"),
             with_credentials=self.option("with-credentials"),
         )

--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -88,7 +88,9 @@ class Locker:
         return False
 
     def locked_repository(
-        self, with_dev_reqs: bool = False
+        self,
+        with_dev_reqs: bool = False,
+        with_only_dev_reqs: bool = False
     ) -> poetry.repositories.Repository:
         """
         Searches and returns a repository of locked packages.
@@ -103,6 +105,10 @@ class Locker:
 
         if with_dev_reqs:
             locked_packages = lock_data["package"]
+        elif with_only_dev_reqs:
+            locked_packages = [
+                p for p in lock_data["package"] if p["category"] == "dev"
+            ]
         else:
             locked_packages = [
                 p for p in lock_data["package"] if p["category"] == "main"
@@ -348,9 +354,13 @@ class Locker:
         self,
         project_requires: List[Dependency],
         dev: bool = False,
+        only_dev: bool = False,
         extras: Optional[Union[bool, Sequence[str]]] = None,
     ) -> Iterator[DependencyPackage]:
-        repository = self.locked_repository(with_dev_reqs=dev)
+        repository = self.locked_repository(
+            with_dev_reqs=dev,
+            with_only_dev_reqs=only_dev
+        )
 
         # Build a set of all packages required by our selected extras
         extra_package_names = (

--- a/poetry/utils/exporter.py
+++ b/poetry/utils/exporter.py
@@ -32,6 +32,7 @@ class Exporter:
         output: Union[IO, str],
         with_hashes: bool = True,
         dev: bool = False,
+        only_dev: bool = False,
         extras: Optional[Union[bool, Sequence[str]]] = None,
         with_credentials: bool = False,
     ) -> None:
@@ -43,6 +44,7 @@ class Exporter:
             output,
             with_hashes=with_hashes,
             dev=dev,
+            only_dev=only_dev,
             extras=extras,
             with_credentials=with_credentials,
         )
@@ -53,6 +55,7 @@ class Exporter:
         output: Union[IO, str],
         with_hashes: bool = True,
         dev: bool = False,
+        only_dev: bool = False,
         extras: Optional[Union[bool, Sequence[str]]] = None,
         with_credentials: bool = False,
     ) -> None:
@@ -61,7 +64,7 @@ class Exporter:
         dependency_lines = set()
 
         for dependency_package in self._poetry.locker.get_project_dependency_packages(
-            project_requires=self._poetry.package.all_requires, dev=dev, extras=extras
+            project_requires=self._poetry.package.all_requires, dev=dev, only_dev=only_dev, extras=extras
         ):
             line = ""
 


### PR DESCRIPTION
This PR adds the support, for exporting only the dev-dependencies, to the poetry.

#### Pull Request Check List

Resolves: #1441

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
