### PR TITLE
Update shebang in make-nix-release

### DIFF
--- a/make-nix-release.sh
+++ b/make-nix-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 


### PR DESCRIPTION
Some features used in the make-nix-release script are valid bash but not valid sh.

In sh
- OSTYPE is undefined ([SC3028](https://github.com/koalaman/shellcheck/wiki/SC3028))
- use = for equality comparison ([SC3014](https://github.com/koalaman/shellcheck/wiki/SC3014))
- array references are undefined ([SC3054](https://github.com/koalaman/shellcheck/wiki/SC3054))

Update the shebang to clarify the target language.