### PR TITLE
Fix nested local dependencies (#3368)

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -187,10 +187,13 @@ class Locker:
 
                     continue
 
+                root_dir = self._lock.path.parent
+
+                if package.source_type == "directory":
+                    root_dir = Path(package.source_url)
+
                 package.add_dependency(
-                    Factory.create_dependency(
-                        dep_name, constraint, root_dir=self._lock.path.parent
-                    )
+                    Factory.create_dependency(dep_name, constraint, root_dir=root_dir)
                 )
 
             if "develop" in info:


### PR DESCRIPTION
This PR resolves the issue when the project has more than 2 levels of path dependencies.

```
/lib
    /pkg1
        pyproject.toml
    /pkg2
        pyproject.toml
/apps
    /app1
        pyproject.toml
```  

### Solution

Check when the source package is `directory` to use the property `source_url` as `root_dir` instead of using the `self._lock.path.parent` if the source package is not a directory type the installation process continues normally.

That makes [poetry-core](https://github.com/python-poetry/poetry-core/blob/master/poetry/core/packages/directory_dependency.py#L30) resolve correctly the full path property.

# Pull Request Check List

Resolves: #3368 

- [x] Added **tests** for changed code.
- [ ] <s>Updated **documentation** for changed code.</s>
