### PR TITLE
Run tests involving file fixtures in a temporary directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,11 @@ def with_chained_keyring(mocker):
     keyring.set_keyring(ChainerBackend())
 
 
+# The fixtures directory. We copy files from here to a test-specific execution
+# directory, as some tests mutate the files within.
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
 @pytest.fixture
 def config_cache_dir(tmp_dir):
     path = Path(tmp_dir) / ".cache" / "pypoetry"
@@ -219,8 +224,12 @@ def http():
 
 
 @pytest.fixture
-def fixture_base():
-    return Path(__file__).parent / "fixtures"
+def fixture_base(tmp_path):
+    # Copy all the fixture data to a temporary per-test fixture folder.
+    # This is necessary because our tests mutate data inside.
+    test_base = tmp_path / "fixtures"
+    shutil.copytree(FIXTURE_DIR, test_base)
+    return test_base
 
 
 @pytest.fixture

--- a/tests/console/commands/test_cache.py
+++ b/tests/console/commands/test_cache.py
@@ -4,12 +4,10 @@ import pytest
 
 
 @pytest.fixture
-def repository_cache_dir(monkeypatch, tmpdir):
-    from pathlib import Path
-
+def repository_cache_dir(monkeypatch, tmp_path):
     import poetry.locations
 
-    path = Path(str(tmpdir))
+    path = tmp_path / "cache"
     monkeypatch.setattr(poetry.locations, "REPOSITORY_CACHE_DIR", path)
     return path
 
@@ -26,8 +24,8 @@ def repository_two():
 
 @pytest.fixture
 def mock_caches(repository_cache_dir, repository_one, repository_two):
-    (repository_cache_dir / repository_one).mkdir()
-    (repository_cache_dir / repository_two).mkdir()
+    (repository_cache_dir / repository_one).mkdir(parents=True)
+    (repository_cache_dir / repository_two).mkdir(parents=True)
 
 
 @pytest.fixture

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -74,10 +74,8 @@ def project_directory():
 
 
 @pytest.fixture
-def poetry(repo, project_directory, config):
-    p = Factory().create_poetry(
-        Path(__file__).parent.parent / "fixtures" / project_directory
-    )
+def poetry(repo, fixture_dir, project_directory, config):
+    p = Factory().create_poetry(fixture_dir(project_directory))
     p.set_locker(TestLocker(p.locker.lock.path, p.locker._local_config))
 
     with p.file.path.open(encoding="utf-8") as f:

--- a/tests/installation/fixtures/with-directory-dependency-poetry.test
+++ b/tests/installation/fixtures/with-directory-dependency-poetry.test
@@ -24,7 +24,7 @@ extras_b = ["cachy (>=0.2.0)"]
 
 [package.source]
 type = "directory"
-url = "tests/fixtures/project_with_extras"
+url = "project_with_extras"
 
 [metadata]
 content-hash = "123456789"

--- a/tests/installation/fixtures/with-directory-dependency-setuptools.test
+++ b/tests/installation/fixtures/with-directory-dependency-setuptools.test
@@ -25,7 +25,7 @@ python-versions = "*"
 
 [package.source]
 type = "directory"
-url = "tests/fixtures/project_with_setup"
+url = "project_with_setup"
 
 [package.dependencies]
 cachy = {version = ">=0.2.0", extras = ["msgpack"]}

--- a/tests/installation/fixtures/with-file-dependency.test
+++ b/tests/installation/fixtures/with-file-dependency.test
@@ -8,7 +8,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.source]
 type = "file"
-url = "tests/fixtures/distributions/demo-0.1.0-py2.py3-none-any.whl"
+url = "distributions/demo-0.1.0-py2.py3-none-any.whl"
 
 [package.dependencies]
 pendulum = ">=1.4.4"

--- a/tests/installation/fixtures/with-wheel-dependency-no-requires-dist.test
+++ b/tests/installation/fixtures/with-wheel-dependency-no-requires-dist.test
@@ -8,7 +8,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.source]
 type = "file"
-url = "tests/fixtures/wheel_with_no_requires_dist/demo-0.1.0-py2.py3-none-any.whl"
+url = "wheel_with_no_requires_dist/demo-0.1.0-py2.py3-none-any.whl"
 
 [metadata]
 python-versions = "*"

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -88,8 +88,9 @@ class CustomInstalledRepository(InstalledRepository):
 
 
 class Locker(BaseLocker):
-    def __init__(self):
-        self._lock = TOMLFile(Path.cwd().joinpath("poetry.lock"))
+    def __init__(self, lock=None):
+        lock = lock or Path.cwd().joinpath("poetry.lock")
+        self._lock = TOMLFile(lock)
         self._written_data = None
         self._locked = False
         self._content_hash = self._get_content_hash()
@@ -129,10 +130,15 @@ class Locker(BaseLocker):
         self._lock_data = data
 
 
+@pytest.fixture
+def cwd(fixture_base):
+    return fixture_base
+
+
 @pytest.fixture()
-def package():
+def package(cwd):
     p = ProjectPackage("root", "1.0")
-    p.root_dir = Path.cwd()
+    p.root_dir = cwd
 
     return p
 
@@ -156,8 +162,11 @@ def installed():
 
 
 @pytest.fixture()
-def locker():
-    return Locker()
+def locker(cwd):
+    # the lockfile only matters insofar as the paths of file dependencies are stored
+    # relative to its path
+    lockfile = cwd / "poetry.lock"
+    return Locker(lock=lockfile)
 
 
 @pytest.fixture()
@@ -1203,7 +1212,7 @@ def test_run_installs_with_local_poetry_file_transitive(
 def test_run_installs_with_local_setuptools_directory(
     installer, locker, repo, package, tmpdir, fixture_dir
 ):
-    file_path = fixture_dir("project_with_setup/")
+    file_path = fixture_dir("project_with_setup")
     package.add_dependency(
         Factory.create_dependency("project-with-setup", {"path": str(file_path)})
     )

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -44,8 +44,9 @@ class CustomInstalledRepository(InstalledRepository):
 
 
 class Locker(BaseLocker):
-    def __init__(self):
-        self._lock = TOMLFile(Path.cwd().joinpath("poetry.lock"))
+    def __init__(self, lock=None):
+        lock = lock or Path.cwd().joinpath("poetry.lock")
+        self._lock = TOMLFile(lock)
         self._written_data = None
         self._locked = False
         self._content_hash = self._get_content_hash()
@@ -85,10 +86,15 @@ class Locker(BaseLocker):
         self._lock_data = data
 
 
+@pytest.fixture
+def cwd(fixture_base):
+    return fixture_base
+
+
 @pytest.fixture()
-def package():
+def package(cwd):
     p = ProjectPackage("root", "1.0")
-    p.root_dir = Path.cwd()
+    p.root_dir = cwd
 
     return p
 
@@ -112,8 +118,11 @@ def installed():
 
 
 @pytest.fixture()
-def locker():
-    return Locker()
+def locker(cwd):
+    # the lockfile only matters insofar as the paths of file dependencies are stored
+    # relative to its path
+    lockfile = cwd / "poetry.lock"
+    return Locker(lock=lockfile)
 
 
 @pytest.fixture()

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -51,10 +51,8 @@ class MockVirtualEnv(VirtualEnv):
 
 
 @pytest.fixture()
-def poetry(config):
-    poetry = Factory().create_poetry(
-        Path(__file__).parent.parent / "fixtures" / "simple_project"
-    )
+def poetry(config, fixture_dir):
+    poetry = Factory().create_poetry(fixture_dir("simple_project"))
     poetry.set_config(config)
 
     return poetry


### PR DESCRIPTION
This change allows the test suite to be run in parallel and installer tests to be run from any directory. The runtime goes from ~60 seconds single-threaded to ~17 seconds with [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) on my machine with maximum parallelism.

A major barrier towards running tests in parallel is that some of them modify files in project fixtures. As a simple fix, copy the whole project fixture directory tree to a temporary folder and run tests there. Some of the fixtures for installer tests contain paths to the project fixtures. To make those work, now that the paths are temporary, make installer tests use the project fixture directory as their working directory.

This is far from a comprehensive cleanup, as the test and fixture dependencies are still difficult to understand. I have some ideas on how they could be made more explicit and consistent (and possibly more performant), but I wanted to put this change up for review before diving in too deep.

On a separate note, fixtures and helpers for the new and old installer tests are mostly the same and can be factored out and shared. This PR just makes the same change in both of those modules to limit the scope and make review easier, but I do have those changes ready, and can add them here if needed.

# Pull Request Check List

Relates-to: #3155

