### PR TITLE
Fixed python_version for Python >= 3.10

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -109,7 +109,7 @@ env = {
     "platform_version": platform.version(),
     "python_full_version": platform.python_version(),
     "platform_python_implementation": platform.python_implementation(),
-    "python_version": platform.python_version()[:3],
+    "python_version": ".".join(platform.python_version_tuple()[:2]),
     "sys_platform": sys.platform,
     "version_info": tuple(sys.version_info),
     # Extra information


### PR DESCRIPTION
This seems to be a rather trivial fix. I am not sure where to put tests exactly (if needed at all, pointers welcome)