### PR TITLE
Use targeted repositories that are only scanned explicitly

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -148,6 +148,30 @@ a custom certificate authority or client certificates, similarly refer to the ex
 `certificates` section. Poetry will use these values to authenticate to your private repository when downloading or
 looking for packages.
 
+#### Using targeted repositories
+
+Some repositories are slow and can negatively affect the speed of dependency resolution. You can add
+slow repositories using `targeted` mode, which forces poetry to only communicate with the repository
+for packages that explicitly use the repository as their source.
+
+```toml
+[[tool.poetry.source]]
+name = "slow"
+url = "https://foo.bar/simple/"
+targeted = true
+
+[tool.poetry.dependencies]
+python = "^3"
+your_package = { version = "^1", source="slow" }
+```
+
+This way, poetry will not scan your repository for any packages except those that you specify.
+
+{{% note %}}
+
+This is strict, in that dependencies of your targeted package will also *not* use your targeted repository unless also explicitly configured to do so.
+
+{{% /note %}}
 
 ### Disabling the PyPI repository
 

--- a/poetry/config/source.py
+++ b/poetry/config/source.py
@@ -10,6 +10,7 @@ class Source:
     url: str
     default: bool = dataclasses.field(default=False)
     secondary: bool = dataclasses.field(default=False)
+    targeted: bool = dataclasses.field(default=False)
 
     def to_dict(self) -> Dict[str, Union[str, bool]]:
         return dataclasses.asdict(self)

--- a/poetry/console/commands/source/add.py
+++ b/poetry/console/commands/source/add.py
@@ -36,6 +36,7 @@ class SourceAddCommand(Command):
             "you add other sources.",
         ),
         option("secondary", "s", "Set this source as secondary."),
+        option("targeted", "s", "Set this source as explicitly targeted."),
     ]
 
     @staticmethod
@@ -51,6 +52,7 @@ class SourceAddCommand(Command):
         url = self.argument("url")
         is_default = self.option("default")
         is_secondary = self.option("secondary")
+        is_targeted = self.option("targeted")
 
         if is_default and is_secondary:
             self.line_error(
@@ -58,8 +60,18 @@ class SourceAddCommand(Command):
             )
             return 1
 
+        if is_secondary and is_targeted:
+            self.line_error(
+                "Cannot configure a source as both <c1>secondary</c1> and <c1>targeted</c1>."
+            )
+            return 1
+
         new_source = Source(
-            name=name, url=url, default=is_default, secondary=is_secondary
+            name=name,
+            url=url,
+            default=is_default,
+            secondary=is_secondary,
+            targeted=is_targeted,
         )
         existing_sources = self.poetry.get_sources()
 

--- a/poetry/console/commands/source/show.py
+++ b/poetry/console/commands/source/show.py
@@ -51,6 +51,10 @@ class SourceShowCommand(Command):
                     "<info>secondary</>",
                     " : {}".format(bool_string.get(source.secondary, False)),
                 ],
+                [
+                    "<info>targeted</>",
+                    " : {}".format(bool_string.get(source.targeted, False)),
+                ],
             ]
             table.add_rows(rows)
             table.render()

--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -140,6 +140,7 @@ class Factory(BaseFactory):
             repository = cls.create_legacy_repository(source, config)
             is_default = source.get("default", False)
             is_secondary = source.get("secondary", False)
+            is_targeted = source.get("targeted", False)
             if io.is_debug():
                 message = "Adding repository {} ({})".format(
                     repository.name, repository.url
@@ -148,10 +149,17 @@ class Factory(BaseFactory):
                     message += " and setting it as the default one"
                 elif is_secondary:
                     message += " and setting it as secondary"
+                elif is_targeted:
+                    message += " and using it only when requested"
 
                 io.write_line(message)
 
-            poetry.pool.add_repository(repository, is_default, secondary=is_secondary)
+            poetry.pool.add_repository(
+                repository,
+                is_default,
+                secondary=is_secondary,
+                targeted=is_targeted,
+            )
 
         # Put PyPI last to prefer private repositories
         # unless we have no default source AND no primary sources

--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -523,6 +523,10 @@
                 "secondary": {
                     "type": "boolean",
                     "description": "Declare this repository as secondary, i.e. it will only be looked up last for packages."
+                },
+                "targeted": {
+                    "type": "boolean",
+                    "description": "Use this repository only when requested, i.e. it will only use for packages that request it as a source."
                 }
             }
         }

--- a/tests/console/commands/source/test_show.py
+++ b/tests/console/commands/source/test_show.py
@@ -14,16 +14,19 @@ name       : existing
 url        : https://existing.com
 default    : no
 secondary  : no
+targeted   : no
 
 name       : one
 url        : https://one.com
 default    : no
 secondary  : no
+targeted   : no
 
 name       : two
 url        : https://two.com
 default    : no
 secondary  : no
+targeted   : no
 """.splitlines()
     assert (
         list(map(lambda l: l.strip(), tester.io.fetch_output().strip().splitlines()))
@@ -40,6 +43,7 @@ name       : one
 url        : https://one.com
 default    : no
 secondary  : no
+targeted   : no
 """.splitlines()
     assert (
         list(map(lambda l: l.strip(), tester.io.fetch_output().strip().splitlines()))
@@ -56,11 +60,13 @@ name       : one
 url        : https://one.com
 default    : no
 secondary  : no
+targeted   : no
 
 name       : two
 url        : https://two.com
 default    : no
 secondary  : no
+targeted   : no
 """.splitlines()
     assert (
         list(map(lambda l: l.strip(), tester.io.fetch_output().strip().splitlines()))


### PR DESCRIPTION
This PR adds functionality for "targeted" repositories, which are not scanned during solving unless a package explicitly marks it as a source.

Example: 

```toml
[[tool.poetry.source]]
name = "slow"
url = "https://foo.bar/simple/"
targeted = true

[tool.poetry.dependencies]
python = "^3"
your_package = { version = "^1", source="slow" }
```

# Pull Request Check List

Resolves: #4035 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
