### PR TITLE
Fix Python 3.10 version being detected as 3.1

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -102,7 +102,7 @@ env = {
     "platform_version": platform.version(),
     "python_full_version": platform.python_version(),
     "platform_python_implementation": platform.python_implementation(),
-    "python_version": platform.python_version()[:3],
+    "python_version": "{0.major}.{0.minor}".format(sys.version_info),
     "sys_platform": sys.platform,
     "version_info": tuple(sys.version_info),
     # Extra information


### PR DESCRIPTION
Resolves: #4354 

- [ ] Added **tests** for changed code. Testing requires mocking `import sys`, which is difficult to say the least. We could use something like `forbiddenfruit` but it seems like overkill. What do you think?
- [ ] Updated **documentation** for changed code. N/A