### PR TITLE
install package itself when combining `--default` with `--only`

### DIFF
--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -173,7 +173,9 @@ dependencies and not including the current project, run the command with the
         if return_code != 0:
             return return_code
 
-        if self.option("no-root") or self.option("only"):
+        if self.option("no-root") or (
+            self.option("only") and not self.option("default")
+        ):
             return 0
 
         try:


### PR DESCRIPTION
When combining the `--default` and `--only` flag on `poetry install` currently the project itself is not installed. This PR fixes this.