### PR TITLE
Auto retrieve git branch name when no rev/branch is specified on git url (fix #3366)

### DIFF
--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -424,6 +424,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                         "git", url.url, rev=pair.get("rev")
                     )
                     pair["name"] = package.name
+                    if "rev" not in pair:
+                        pair["rev"] = package._source_reference
                     result.append(pair)
 
                     continue

--- a/poetry/puzzle/provider.py
+++ b/poetry/puzzle/provider.py
@@ -221,7 +221,7 @@ class Provider:
             if reference is not None:
                 git.checkout(reference, tmp_dir)
             else:
-                reference = "HEAD"
+                reference = git.get_current_branch(tmp_dir).strip()
 
             revision = git.rev_parse(reference, tmp_dir).strip()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,9 @@ def git_mock(mocker):
     p = mocker.patch("poetry.core.vcs.git.Git.rev_parse")
     p.return_value = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
 
+    p2 = mocker.patch("poetry.core.vcs.git.Git.get_current_branch", create=True)
+    p2.return_value = "main"
+
 
 @pytest.fixture
 def http():

--- a/tests/console/commands/plugin/test_add.py
+++ b/tests/console/commands/plugin/test_add.py
@@ -79,7 +79,11 @@ Package operations: 2 installs, 0 updates, 0 removals
 """
 
     assert_plugin_add_result(
-        tester, app, env, expected, {"git": "https://github.com/demo/poetry-plugin.git"}
+        tester,
+        app,
+        env,
+        expected,
+        {"git": "https://github.com/demo/poetry-plugin.git", "rev": "main"},
     )
 
 
@@ -110,6 +114,7 @@ Package operations: 3 installs, 0 updates, 0 removals
         {
             "git": "https://github.com/demo/poetry-plugin.git",
             "extras": ["foo"],
+            "rev": "main",
         },
     )
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -197,7 +197,8 @@ Package operations: 2 installs, 0 updates, 0 removals
 
     assert "demo" in content["dependencies"]
     assert content["dependencies"]["demo"] == {
-        "git": "https://github.com/demo/demo.git"
+        "git": "https://github.com/demo/demo.git",
+        "rev": "main",
     }
 
 
@@ -258,6 +259,7 @@ Package operations: 4 installs, 0 updates, 0 removals
     assert content["dependencies"]["demo"] == {
         "git": "https://github.com/demo/demo.git",
         "extras": ["foo", "bar"],
+        "rev": "main",
     }
 
 
@@ -1040,7 +1042,8 @@ Package operations: 2 installs, 0 updates, 0 removals
 
     assert "demo" in content["dependencies"]
     assert content["dependencies"]["demo"] == {
-        "git": "https://github.com/demo/demo.git"
+        "git": "https://github.com/demo/demo.git",
+        "rev": "main",
     }
 
 
@@ -1099,6 +1102,7 @@ Package operations: 4 installs, 0 updates, 0 removals
     assert content["dependencies"]["demo"] == {
         "git": "https://github.com/demo/demo.git",
         "extras": ["foo", "bar"],
+        "rev": "main",
     }
 
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -214,7 +214,7 @@ packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
-demo = {git = "https://github.com/demo/demo.git"}
+demo = {git = "https://github.com/demo/demo.git", rev = "main"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^3.6.0"
@@ -302,7 +302,7 @@ packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
-demo = {git = "https://github.com/demo/pyproject-demo.git"}
+demo = {git = "https://github.com/demo/pyproject-demo.git", rev = "main"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^3.6.0"

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -2062,7 +2062,8 @@ def test_installer_uses_prereleases_if_they_are_compatible(
     package.python_versions = "~2.7 || ^3.4"
     package.add_dependency(
         Factory.create_dependency(
-            "prerelease", {"git": "https://github.com/demo/prerelease.git"}
+            "prerelease",
+            {"git": "https://github.com/demo/prerelease.git", "rev": "main"},
         )
     )
 

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -1710,7 +1710,8 @@ def test_installer_uses_prereleases_if_they_are_compatible(
     package.python_versions = "~2.7 || ^3.4"
     package.add_dependency(
         Factory.create_dependency(
-            "prerelease", {"git": "https://github.com/demo/prerelease.git"}
+            "prerelease",
+            {"git": "https://github.com/demo/prerelease.git", "rev": "main"},
         )
     )
 

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -1227,7 +1227,10 @@ def test_solver_can_resolve_git_dependencies(solver, repo, package):
     repo.add_package(cleo)
 
     package.add_dependency(
-        Factory.create_dependency("demo", {"git": "https://github.com/demo/demo.git"})
+        Factory.create_dependency(
+            "demo",
+            {"git": "https://github.com/demo/demo.git", "rev": DEFAULT_SOURCE_REF},
+        )
     )
 
     transaction = solver.solve()
@@ -1598,7 +1601,10 @@ def test_solver_git_dependencies_update(solver, repo, package, installed):
     installed.add_package(demo_installed)
 
     package.add_dependency(
-        Factory.create_dependency("demo", {"git": "https://github.com/demo/demo.git"})
+        Factory.create_dependency(
+            "demo",
+            {"git": "https://github.com/demo/demo.git", "rev": DEFAULT_SOURCE_REF},
+        )
     )
 
     transaction = solver.solve()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3366

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

As a result, if you use poetry add `poetry add git+ssh://git@github.demo/demo.git`, the `pyproject.toml` will include

```
[tool.poetry.dependencies]
python = "^3.9"
test-poetry = {git = "git@github.com:demo/demo.git", rev = "its_default_branch_name"}
```

This pull request relies on python-poetry/poetry-core#192 which is merged to master branch of poetry-core yet. Currently, this PR is using mocker.patch for `poetry.core.vcs.git.Git.get_current_branch`. But it actually needs a new release of poetry-core including python-poetry/poetry-core#185 to take effect.
