### PR TITLE
Removed import of __future__.unicode_literals

### DIFF
--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import hashlib
 import os
 import shutil

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from tests.helpers import get_package

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import json
 import re
 import shutil

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import itertools
 import json
 import sys

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import itertools
 import sys
 

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os
 import shutil
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from pathlib import Path
 


### PR DESCRIPTION
This PR removes all remaining imports of `__future__.unicode_literals`. 
This is not needed anymore since we support Python versions >= 3.6

Relates-to: #3860

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code, the existing tests still pass
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Not sure which documentation I should update here. Please let me know if you have any idea on how to actually test it, i.e. by writing new tests.