### PR TITLE
Remove all remaining imports of __future__.absolute_import

### DIFF
--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from pathlib import Path

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from pathlib import Path


### PR DESCRIPTION
This removes all remaining imports of `__future__.absolute_import` as
this is not needed anymore in Python >= 3.6

Relates-to: #3860

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
I assume here, that existing tests are not failing is enough, please let me know if you want me write some more explicit test. Also, I don't know which documentation to update in this case.