### PR TITLE
Adds File existence check to Uploader

### DIFF
--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -212,8 +212,6 @@ class Uploader:
         skip_existing: bool = False,
     ) -> None:
         for file in self.files:
-            # TODO: Check existence
-
             self._upload_file(session, url, file, dry_run, skip_existing)
 
     def _upload_file(
@@ -225,6 +223,9 @@ class Uploader:
         skip_existing: bool = False,
     ) -> None:
         from cleo.ui.progress_bar import ProgressBar
+
+        if not file.is_file():
+            raise UploadError(f"Archive ({file}) does not exist")
 
         data = self.post_data(file)
         data.update(

--- a/tests/publishing/test_uploader.py
+++ b/tests/publishing/test_uploader.py
@@ -119,3 +119,14 @@ def test_uploader_skip_existing_bubbles_unskippable_errors(
 
     with pytest.raises(UploadError):
         uploader.upload("https://foo.com", skip_existing=True)
+
+
+def test_uploader_properly_handles_file_not_existing(
+    mocker: MockerFixture, http: type[httpretty.httpretty], uploader: Uploader
+):
+    mocker.patch("pathlib.Path.is_file", return_value=False)
+
+    with pytest.raises(UploadError) as e:
+        uploader.upload("https://foo.com")
+
+    assert f"Archive ({uploader.files[0]}) does not exist" == str(e.value)


### PR DESCRIPTION
This handles the TODO for checking the existence of the files being
uploaded by the Uploader class.
https://github.com/python-poetry/poetry/blob/c967a4a5abc6a0edd29c57eca307894f6e1c4f16/poetry/publishing/uploader.py#L229
In the case that a file does not exist, it raises a UploadError.

The raised error message is as follows:
```Wheel or Tar files associated with the Project Package do not exist```

# Pull Request Check List

Resolves: NA

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- Updated **documentation** for changed code. [NA]

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Questions:

- At the moment, the error message being shown is pretty generic. Should I be specific with the file that could not be found?
