### PR TITLE
Backport security fix #3885 for package hashes to 1.1

### DIFF
--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -109,6 +109,11 @@ class Chooser:
 
             selected_links.append(link)
 
+        if links and not selected_links:
+            raise RuntimeError(
+                f"Retrieved digest for link {link.filename}({h}) not in poetry.lock metadata {hashes}"
+            )
+
         return selected_links
 
     def _sort_key(self, package, link):  # type: (Package, Link) -> Tuple

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -195,3 +195,36 @@ def test_chooser_chooses_distributions_that_match_the_package_hashes(
     link = chooser.choose_for(package)
 
     assert "isort-4.3.4.tar.gz" == link.filename
+
+
+@pytest.mark.parametrize("source_type", ["", "legacy"])
+def test_chooser_throws_an_error_if_package_hashes_do_not_match(
+    env,
+    mock_pypi,
+    mock_legacy,
+    source_type,
+    pool,
+):
+    chooser = Chooser(pool, env)
+
+    package = Package("isort", "4.3.4")
+    files = [
+        {
+            "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "filename": "isort-4.3.4.tar.gz",
+        }
+    ]
+    if source_type == "legacy":
+        package = Package(
+            package.name,
+            package.version.text,
+            source_type="legacy",
+            source_reference="foo",
+            source_url="https://foo.bar/simple/",
+        )
+
+    package.files = files
+
+    with pytest.raises(RuntimeError) as e:
+        chooser.choose_for(package)
+    assert files[0]["hash"] in str(e)


### PR DESCRIPTION
Backport the security fix of #3885 on Poetry 1.1.
This commit has already been merged in `master` but it didn't make it to the 1.1 minor.

This fix is one of the two changes to make Poetry check the hashes of the downloaded files after `poetry.lock`.

Unfortunately this PR isn't sufficient to correct the bug, as [this other PR](https://github.com/python-poetry/poetry-core/pull/159) needs to be backported to `poetry-core` 1.0.
Still, it is necessary.