### PR TITLE
Fix the detection of the system environment with custom installer

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -528,6 +528,10 @@ class Installer:
 
             virtualenv.cli_run([str(env_path), "--clear"])
 
+        # We add a special file so that Poetry can detect
+        # its own virtual environment
+        env_path.joinpath("poetry_env").touch()
+
         return env_path
 
     def make_bin(self, version: str) -> None:

--- a/poetry/console/commands/env/info.py
+++ b/poetry/console/commands/env/info.py
@@ -33,6 +33,8 @@ class EnvInfoCommand(Command):
         self._display_complete_info(env)
 
     def _display_complete_info(self, env: "Env") -> None:
+        from poetry.utils.env import GenericEnv
+
         env_python_version = ".".join(str(s) for s in env.version_info[:3])
         self.line("")
         self.line("<b>Virtualenv</b>")
@@ -43,6 +45,9 @@ class EnvInfoCommand(Command):
             ),
             "<info>Path</info>:           <comment>{}</>".format(
                 env.path if env.is_venv() else "NA"
+            ),
+            "<info>Executable</info>:     <comment>{}</>".format(
+                env.python if env.is_venv() else "NA"
             ),
         ]
         if env.is_venv():
@@ -55,13 +60,18 @@ class EnvInfoCommand(Command):
 
         self.line("")
 
+        system_env = GenericEnv(env.base)
         self.line("<b>System</b>")
         self.line(
             "\n".join(
                 [
-                    "<info>Platform</info>: <comment>{}</>".format(env.platform),
-                    "<info>OS</info>:       <comment>{}</>".format(env.os),
-                    "<info>Python</info>:   <comment>{}</>".format(env.base),
+                    "<info>Platform</info>:   <comment>{}</>".format(env.platform),
+                    "<info>OS</info>:         <comment>{}</>".format(env.os),
+                    "<info>Python</info>:     <comment>{}</>".format(
+                        ".".join(str(v) for v in system_env.version_info[:3])
+                    ),
+                    "<info>Path</info>:       <comment>{}</>".format(system_env.path),
+                    "<info>Executable</info>: <comment>{}</>".format(system_env.python),
                 ]
             )
         )

--- a/poetry/console/commands/env/info.py
+++ b/poetry/console/commands/env/info.py
@@ -33,8 +33,6 @@ class EnvInfoCommand(Command):
         self._display_complete_info(env)
 
     def _display_complete_info(self, env: "Env") -> None:
-        from poetry.utils.env import GenericEnv
-
         env_python_version = ".".join(str(s) for s in env.version_info[:3])
         self.line("")
         self.line("<b>Virtualenv</b>")
@@ -60,7 +58,7 @@ class EnvInfoCommand(Command):
 
         self.line("")
 
-        system_env = GenericEnv(env.base)
+        system_env = env.parent_env
         self.line("<b>System</b>")
         self.line(
             "\n".join(

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1011,8 +1011,13 @@ class EnvManager:
         """
         prefix, base_prefix = Path(sys.prefix), Path(cls.get_base_prefix())
         if not naive:
+            if prefix.joinpath("poetry_env").exists():
+                return GenericEnv(base_prefix)
+
+            from poetry.locations import data_dir
+
             try:
-                Path(__file__).relative_to(prefix)
+                prefix.relative_to(data_dir())
             except ValueError:
                 pass
             else:

--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1042,20 +1042,21 @@ class EnvManager:
         (e.g. plugin installation or self update).
         """
         prefix, base_prefix = Path(sys.prefix), Path(cls.get_base_prefix())
+        env = SystemEnv(prefix)
         if not naive:
             if prefix.joinpath("poetry_env").exists():
-                return GenericEnv(base_prefix)
-
-            from poetry.locations import data_dir
-
-            try:
-                prefix.relative_to(data_dir())
-            except ValueError:
-                pass
+                env = GenericEnv(base_prefix, child_env=env)
             else:
-                return GenericEnv(base_prefix)
+                from poetry.locations import data_dir
 
-        return SystemEnv(prefix)
+                try:
+                    prefix.relative_to(data_dir())
+                except ValueError:
+                    pass
+                else:
+                    env = GenericEnv(base_prefix, child_env=env)
+
+        return env
 
     @classmethod
     def get_base_prefix(cls) -> Path:
@@ -1093,29 +1094,10 @@ class Env:
         self._path = path
         self._bin_dir = self._path / bin_dir
 
-        try:
-            python_executables = sorted(
-                [
-                    p.name
-                    for p in self._bin_dir.glob("python*")
-                    if re.match(r"python(?:\d+(?:\.\d+)?)?(?:\.exe)?$", p.name)
-                ]
-            )
-            self._executable = python_executables[0].rstrip(".exe")
-        except IndexError:
-            self._executable = "python" + (".exe" if self._is_windows else "")
+        self._executable = "python"
+        self._pip_executable = "pip"
 
-        try:
-            pip_executables = sorted(
-                [
-                    p.name
-                    for p in self._bin_dir.glob("pip*")
-                    if re.match(r"pip(?:\d+(?:\.\d+)?)?(?:\.exe)?$", p.name)
-                ]
-            )
-            self._pip_executable = pip_executables[0].rstrip(".exe")
-        except IndexError:
-            self._pip_executable = "pip" + (".exe" if self._is_windows else "")
+        self.find_executables()
 
         self._base = base or path
 
@@ -1159,6 +1141,39 @@ class Env:
             self._marker_env = self.get_marker_env()
 
         return self._marker_env
+
+    @property
+    def parent_env(self) -> "GenericEnv":
+        return GenericEnv(self.base, child_env=self)
+
+    def find_executables(self) -> None:
+        python_executables = sorted(
+            [
+                p.name
+                for p in self._bin_dir.glob("python*")
+                if re.match(r"python(?:\d+(?:\.\d+)?)?(?:\.exe)?$", p.name)
+            ]
+        )
+        if python_executables:
+            executable = python_executables[0]
+            if executable.endswith(".exe"):
+                executable = executable[:-4]
+
+            self._executable = executable
+
+        pip_executables = sorted(
+            [
+                p.name
+                for p in self._bin_dir.glob("pip*")
+                if re.match(r"pip(?:\d+(?:\.\d+)?)?(?:\.exe)?$", p.name)
+            ]
+        )
+        if pip_executables:
+            pip_executable = pip_executables[0]
+            if pip_executable.endswith(".exe"):
+                pip_executable = pip_executable[:-4]
+
+            self._pip_executable = pip_executable
 
     def get_embedded_wheel(self, distribution):
         return get_embed_wheel(
@@ -1390,7 +1405,11 @@ class Env:
         """
         Return path to the given executable.
         """
-        bin_path = (self._bin_dir / bin).with_suffix(".exe" if self._is_windows else "")
+        if self._is_windows and not bin.endswith(".exe"):
+            bin_path = self._bin_dir / (bin + ".exe")
+        else:
+            bin_path = self._bin_dir / bin
+
         if not bin_path.exists():
             # On Windows, some executables can be in the base path
             # This is especially true when installing Python with
@@ -1401,7 +1420,11 @@ class Env:
             # that creates a fake virtual environment pointing to
             # a base Python install.
             if self._is_windows:
-                bin_path = (self._path / bin).with_suffix(".exe")
+                if not bin.endswith(".exe"):
+                    bin_path = self._bin_dir / (bin + ".exe")
+                else:
+                    bin_path = self._path / bin
+
                 if bin_path.exists():
                     return str(bin_path)
 
@@ -1649,6 +1672,70 @@ class VirtualEnv(Env):
 
 
 class GenericEnv(VirtualEnv):
+    def __init__(
+        self, path: Path, base: Optional[Path] = None, child_env: Optional["Env"] = None
+    ) -> None:
+        self._child_env = child_env
+
+        super().__init__(path, base=base)
+
+    def find_executables(self) -> None:
+        patterns = [("python*", "pip*")]
+
+        if self._child_env:
+            minor_version = "{}.{}".format(
+                self._child_env.version_info[0], self._child_env.version_info[1]
+            )
+            major_version = "{}".format(self._child_env.version_info[0])
+            patterns = [
+                ("python{}".format(minor_version), "pip{}".format(minor_version)),
+                ("python{}".format(major_version), "pip{}".format(major_version)),
+            ]
+
+        python_executable = None
+        pip_executable = None
+
+        for python_pattern, pip_pattern in patterns:
+            if python_executable and pip_executable:
+                break
+
+            if not python_executable:
+                python_executables = sorted(
+                    [
+                        p.name
+                        for p in self._bin_dir.glob(python_pattern)
+                        if re.match(r"python(?:\d+(?:\.\d+)?)?(?:\.exe)?$", p.name)
+                    ]
+                )
+
+                if python_executables:
+                    executable = python_executables[0]
+                    if executable.endswith(".exe"):
+                        executable = executable[:-4]
+
+                    python_executable = executable
+
+            if not pip_executable:
+                pip_executables = sorted(
+                    [
+                        p.name
+                        for p in self._bin_dir.glob(pip_pattern)
+                        if re.match(r"pip(?:\d+(?:\.\d+)?)?(?:\.exe)?$", p.name)
+                    ]
+                )
+                if pip_executables:
+                    pip_executable = pip_executables[0]
+                    if pip_executable.endswith(".exe"):
+                        pip_executable = pip_executable[:-4]
+
+                    pip_executable = pip_executable
+
+            if python_executable:
+                self._executable = python_executable
+
+            if pip_executable:
+                self._pip_executable = pip_executable
+
     def get_paths(self) -> Dict[str, str]:
         output = self.run_python_script(GET_PATHS_FOR_GENERIC_ENVS)
 

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -1,7 +1,10 @@
+import sys
+
 from pathlib import Path
 
 import pytest
 
+from poetry.utils._compat import WINDOWS
 from poetry.utils.env import MockEnv
 
 
@@ -28,14 +31,21 @@ Virtualenv
 Python:         3.7.0
 Implementation: CPython
 Path:           {prefix}
+Executable:     {executable}
 Valid:          True
 
 System
-Platform: darwin
-OS:       posix
-Python:   {base_prefix}
+Platform:   darwin
+OS:         posix
+Python:     {base_version}
+Path:       {base_prefix}
+Executable: {base_executable}
 """.format(
-        prefix=str(Path("/prefix")), base_prefix=str(Path("/base/prefix"))
+        prefix=str(Path("/prefix")),
+        base_prefix=str(Path("/base/prefix")),
+        base_version=".".join(str(v) for v in sys.version_info[:3]),
+        executable=sys.executable,
+        base_executable="python" + (".exe" if WINDOWS else ""),
     )
 
     assert expected == tester.io.fetch_output()

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-from poetry.utils._compat import WINDOWS
 from poetry.utils.env import MockEnv
 
 
@@ -45,7 +44,7 @@ Executable: {base_executable}
         base_prefix=str(Path("/base/prefix")),
         base_version=".".join(str(v) for v in sys.version_info[:3]),
         executable=sys.executable,
-        base_executable="python" + (".exe" if WINDOWS else ""),
+        base_executable="python",
     )
 
     assert expected == tester.io.fetch_output()

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -19,6 +19,7 @@ from poetry.utils._compat import WINDOWS
 from poetry.utils.env import GET_BASE_PREFIX
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import EnvManager
+from poetry.utils.env import GenericEnv
 from poetry.utils.env import NoCompatiblePythonVersionFound
 from poetry.utils.env import SystemEnv
 from poetry.utils.env import VirtualEnv
@@ -998,6 +999,87 @@ def test_env_finds_the_correct_executables(tmp_dir, manager):
         expected_pip_executable = major_pip_executable
 
     venv = VirtualEnv(venv_path)
+
+    assert Path(venv.python).name == expected_executable
+    assert Path(venv.pip).name == expected_pip_executable
+
+
+def test_env_finds_the_correct_executables_for_generic_env(tmp_dir, manager):
+    venv_path = Path(tmp_dir) / "Virtual Env"
+    child_venv_path = Path(tmp_dir) / "Child Virtual Env"
+    manager.build_venv(str(venv_path), with_pip=True)
+    parent_venv = VirtualEnv(venv_path)
+    manager.build_venv(
+        str(child_venv_path), executable=parent_venv.python, with_pip=True
+    )
+    venv = GenericEnv(parent_venv.path, child_env=VirtualEnv(child_venv_path))
+
+    expected_executable = "python{}.{}{}".format(
+        sys.version_info[0], sys.version_info[1], ".exe" if WINDOWS else ""
+    )
+    expected_pip_executable = "pip{}.{}{}".format(
+        sys.version_info[0], sys.version_info[1], ".exe" if WINDOWS else ""
+    )
+
+    assert Path(venv.python).name == expected_executable
+    assert Path(venv.pip).name == expected_pip_executable
+
+
+def test_env_finds_fallback_executables_for_generic_env(tmp_dir, manager):
+    venv_path = Path(tmp_dir) / "Virtual Env"
+    child_venv_path = Path(tmp_dir) / "Child Virtual Env"
+    manager.build_venv(str(venv_path), with_pip=True)
+    parent_venv = VirtualEnv(venv_path)
+    manager.build_venv(
+        str(child_venv_path), executable=parent_venv.python, with_pip=True
+    )
+    venv = GenericEnv(parent_venv.path, child_env=VirtualEnv(child_venv_path))
+
+    default_executable = "python" + (".exe" if WINDOWS else "")
+    major_executable = "python{}{}".format(
+        sys.version_info[0], ".exe" if WINDOWS else ""
+    )
+    minor_executable = "python{}.{}{}".format(
+        sys.version_info[0], sys.version_info[1], ".exe" if WINDOWS else ""
+    )
+    expected_executable = minor_executable
+    if (
+        venv._bin_dir.joinpath(expected_executable).exists()
+        and venv._bin_dir.joinpath(major_executable).exists()
+    ):
+        venv._bin_dir.joinpath(expected_executable).unlink()
+        expected_executable = major_executable
+
+    if (
+        venv._bin_dir.joinpath(expected_executable).exists()
+        and venv._bin_dir.joinpath(default_executable).exists()
+    ):
+        venv._bin_dir.joinpath(expected_executable).unlink()
+        expected_executable = default_executable
+
+    default_pip_executable = "pip" + (".exe" if WINDOWS else "")
+    major_pip_executable = "pip{}{}".format(
+        sys.version_info[0], ".exe" if WINDOWS else ""
+    )
+    minor_pip_executable = "pip{}.{}{}".format(
+        sys.version_info[0], sys.version_info[1], ".exe" if WINDOWS else ""
+    )
+    expected_pip_executable = minor_pip_executable
+    if (
+        venv._bin_dir.joinpath(expected_pip_executable).exists()
+        and venv._bin_dir.joinpath(major_pip_executable).exists()
+    ):
+        venv._bin_dir.joinpath(expected_pip_executable).unlink()
+        expected_pip_executable = major_pip_executable
+
+    if (
+        venv._bin_dir.joinpath(expected_pip_executable).exists()
+        and venv._bin_dir.joinpath(default_pip_executable).exists()
+    ):
+        venv._bin_dir.joinpath(expected_pip_executable).unlink()
+        expected_pip_executable = default_pip_executable
+
+    venv = GenericEnv(parent_venv.path, child_env=VirtualEnv(child_venv_path))
 
     assert Path(venv.python).name == expected_executable
     assert Path(venv.pip).name == expected_pip_executable

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1001,7 +1001,7 @@ def test_env_finds_the_correct_executables(tmp_dir, manager):
     venv = VirtualEnv(venv_path)
 
     assert Path(venv.python).name == expected_executable
-    assert Path(venv.pip).name == expected_pip_executable
+    assert Path(venv.pip).name.startswith(expected_pip_executable.split(".")[0])
 
 
 def test_env_finds_the_correct_executables_for_generic_env(tmp_dir, manager):
@@ -1020,6 +1020,10 @@ def test_env_finds_the_correct_executables_for_generic_env(tmp_dir, manager):
     expected_pip_executable = "pip{}.{}{}".format(
         sys.version_info[0], sys.version_info[1], ".exe" if WINDOWS else ""
     )
+
+    if WINDOWS:
+        expected_executable = "python.exe"
+        expected_pip_executable = "pip.exe"
 
     assert Path(venv.python).name == expected_executable
     assert Path(venv.pip).name == expected_pip_executable
@@ -1077,6 +1081,12 @@ def test_env_finds_fallback_executables_for_generic_env(tmp_dir, manager):
         and venv._bin_dir.joinpath(default_pip_executable).exists()
     ):
         venv._bin_dir.joinpath(expected_pip_executable).unlink()
+        expected_pip_executable = default_pip_executable
+
+    if not venv._bin_dir.joinpath(expected_executable).exists():
+        expected_executable = default_executable
+
+    if not venv._bin_dir.joinpath(expected_pip_executable).exists():
         expected_pip_executable = default_pip_executable
 
     venv = GenericEnv(parent_venv.path, child_env=VirtualEnv(child_venv_path))


### PR DESCRIPTION
After several attempts at fixing this, I think this is the best approach: differentiate the custom Poetry virtual environment – by putting a special file – from standard ones so that there is no confusion about what Poetry needs to do when detecting the system environment.

Resolves #4427 
Resolves #4414 
Resolves #4369 
Resolves #4254

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
