### PR TITLE
fix (install-poetry): revert use of capture_output

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -584,7 +584,8 @@ class Installer:
 
         subprocess.run(
             [str(python), "-m", "pip", "install", specification],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             check=True,
         )
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4441

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
