### PR TITLE
[1.1] Fix archive hash generation

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -608,7 +608,13 @@ class Executor(object):
                 archive = self._chef.prepare(archive)
 
         if package.files:
-            archive_hash = "sha256:" + FileDependency(package.name, archive).hash()
+            archive_hash = (
+                "sha256:"
+                + FileDependency(
+                    package.name,
+                    Path(archive.path) if isinstance(archive, Link) else archive,
+                ).hash()
+            )
             if archive_hash not in {f["hash"] for f in package.files}:
                 raise RuntimeError(
                     "Invalid hash for {} using archive {}".format(package, archive.name)


### PR DESCRIPTION
Backport of ccf1322129e832e8293ac532656aed9a716d2f33 to the `1.1` branch.

This PR – coupled with #4420 and https://github.com/python-poetry/poetry-core/pull/193 – should fix the file hashes check.

## Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
