### PR TITLE
Python poetry#4016

### DIFF
--- a/poetry/cache/cache_control.py
+++ b/poetry/cache/cache_control.py
@@ -1,0 +1,32 @@
+from cachecontrol.adapter import CacheControlAdapter
+from cachecontrol.cache import DictCache
+from urllib3.util.retry import Retry
+
+
+def CacheControl(
+    sess,
+    cache=None,
+    cache_etags=True,
+    serializer=None,
+    heuristic=None,
+    controller_class=None,
+    adapter_class=None,
+    cacheable_methods=None,
+    max_retries=Retry(total=5, backoff_factor=1)
+):
+
+    cache = DictCache() if cache is None else cache
+    adapter_class = adapter_class or CacheControlAdapter
+    adapter = adapter_class(
+        cache,
+        cache_etags=cache_etags,
+        serializer=serializer,
+        heuristic=heuristic,
+        controller_class=controller_class,
+        cacheable_methods=cacheable_methods,
+        max_retries=max_retries
+    )
+    sess.mount("http://", adapter)
+    sess.mount("https://", adapter)
+
+    return sess

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -10,7 +10,6 @@ from typing import Union
 import requests
 import requests.auth
 
-from cachecontrol import CacheControl
 from cachecontrol.caches.file_cache import FileCache
 from cachy import CacheManager
 
@@ -25,6 +24,7 @@ from poetry.utils._compat import Path
 from poetry.utils.helpers import canonicalize_name
 from poetry.utils.patterns import wheel_file_re
 
+from ..cache.cache_control import CacheControl
 from ..config.config import Config
 from ..inspection.info import PackageInfo
 from ..installation.authenticator import Authenticator


### PR DESCRIPTION
Resolves: #4016

I'm experiencing the same issue on poetry 1.1.8 but I have created this patch to solve this issue. The problem is that by default, the requests library doesn't retry when a connection fails, and CacheControlAdapter also doesn't pass any retry parameters.

In our case this issue only arises on Windows behind an enterprise proxy, not on Linux, but as most developers work on Windows machines, we needed to fix this issue. We didn't experience this issue with poetry 1.0.10 though.
