### PR TITLE
exit with callable exit code in generated script

### DIFF
--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -27,10 +27,11 @@ if TYPE_CHECKING:
 
 SCRIPT_TEMPLATE = """\
 #!{python}
+import sys
 from {module} import {callable_holder}
 
 if __name__ == '__main__':
-    {callable_}()
+    sys.exit({callable_}())
 """
 
 WINDOWS_CMD_TEMPLATE = """\

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -148,10 +148,11 @@ My Package
 
     baz_script = """\
 #!{python}
+import sys
 from bar import baz
 
 if __name__ == '__main__':
-    baz.boom.bim()
+    sys.exit(baz.boom.bim())
 """.format(
         python=tmp_venv.python
     )
@@ -160,10 +161,11 @@ if __name__ == '__main__':
 
     foo_script = """\
 #!{python}
+import sys
 from foo import bar
 
 if __name__ == '__main__':
-    bar()
+    sys.exit(bar())
 """.format(
         python=tmp_venv.python
     )
@@ -172,10 +174,11 @@ if __name__ == '__main__':
 
     fox_script = """\
 #!{python}
+import sys
 from fuz.foo import bar
 
 if __name__ == '__main__':
-    bar.baz()
+    sys.exit(bar.baz())
 """.format(
         python=tmp_venv.python
     )


### PR DESCRIPTION
the behaviour is consistent with pip

# Pull Request Check List

Resolves: #4453

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
