### PR TITLE
Fix printing install errors redirected to stdout

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -440,7 +440,7 @@ class Installer:
             self.install(version)
         except subprocess.CalledProcessError as e:
             print(
-                colorize("error", f"\nAn error has occurred: {e}\n{e.stderr.decode()}")
+                colorize("error", f"\nAn error has occurred: {e}\n{e.stdout.decode()}")
             )
 
             return e.returncode


### PR DESCRIPTION
After #4443 stderr was redirected to stdout, so stderr would be None and throw an error.

https://github.com/python-poetry/poetry/blob/a1a0a1d3f5e870dbf0afb6bedb5dbff1be8fca19/install-poetry.py#L588