### PR TITLE
Fix installing under MinGW on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The [complete documentation](https://python-poetry.org/docs/) is available on th
 Poetry provides a custom installer that will install `poetry` isolated
 from the rest of your system.
 
-### osx / linux / bashonwindows install instructions
+### osx / linux / bashonwindows / Windows+MingW install instructions
 ```bash
 curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
 ```

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -544,12 +544,12 @@ class Installer:
         self._bin_dir.mkdir(parents=True, exist_ok=True)
 
         script = "poetry"
-        target_script = "venv/bin/"
+        script_dir = "bin"
         if WINDOWS:
             script = "poetry.exe"
             if not MINGW:
-                target_script = "venv/Scripts/"
-        target_script += script
+                script_dir = "Scripts"
+        target_script = f"venv/{script_dir}/{script}"
 
         if self._bin_dir.joinpath(script).exists():
             self._bin_dir.joinpath(script).unlink()


### PR DESCRIPTION
`python[.exe]`, when installed on Windows via (msys2) MingW, can be found under a path structure similar to that you might find on *nix systems.

The `install-poetry.py` script was failing to take this into consideration, causing installation issues in the above case.

A similar fault in poetry itself was resolved in #3713.

----

### Pull Request Check List

Related: #2867, #3713

- [ ] Added **tests** for changed code.
    - *There don't appear to be any tests for `install-poetry.py` (except the CI run).*
- [x] Updated **documentation** for changed code.
