### PR TITLE
Fix Install Error Not Shown (#4474)

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -439,9 +439,8 @@ class Installer:
         try:
             self.install(version)
         except subprocess.CalledProcessError as e:
-            print(
-                colorize("error", f"\nAn error has occurred: {e}\n{e.stderr.decode()}")
-            )
+            error_info = (e.stderr or e.stdout or b"No output available.").decode()
+            print(colorize("error", f"\nAn error has occurred: {e}\n{error_info}"))
 
             return e.returncode
 


### PR DESCRIPTION
An AttributeError in the install script happens when an install operation failure doesn't result in stderr output. In these cases, it
appears the data is written to stdout instead. To fix this, the error output will use stdout when no stderr output exists. If neither of these exist a "No output available." message will be shown instead to prevent the AttributeError from obscuring what is actually going on in the flow of the install script.

# Pull Request Check List

Resolves: #4474

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
