### PR TITLE
Use local `install-poetry.py` on CI for tests and test against Python 3.10.0-rc.2 on all platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,7 @@ jobs:
         shell: bash
         env:
           BOOTSTRAP_ARGS: ${{ startsWith(matrix.python-version, '3.10') && '--git https://github.com/python-poetry/poetry.git' || '' }}
-        run: |
-          curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-            | python - -y ${{ env.BOOTSTRAP_ARGS }}
+        run: python install-poetry.py -y ${{ env.BOOTSTRAP_ARGS }}
 
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,18 +19,10 @@ jobs:
   tests:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        experimental: [false]
-        bootstrap-args: [""]
-        include:
-          - os: Ubuntu
-            python-version: "3.10.0-alpha - 3.10.0"
-            experimental: true
-            bootstrap-args: "--git https://github.com/python-poetry/poetry.git"
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.2"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -47,9 +39,11 @@ jobs:
 
       - name: Bootstrap poetry
         shell: bash
+        env:
+          BOOTSTRAP_ARGS: ${{ startsWith(matrix.python-version, '3.10') && '--git https://github.com/python-poetry/poetry.git' || '' }}
         run: |
           curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-            | python - -y ${{ matrix.bootstrap-args }}
+            | python - -y ${{ env.BOOTSTRAP_ARGS }}
 
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}


### PR DESCRIPTION
# Pull Request Check List

- [x] ~Added **tests** for changed code.~ Not applicable
- [x] ~Updated **documentation** for changed code.~ Not applicable

## Context
When working on https://github.com/python-poetry/poetry/issues/4424 and its associated PR https://github.com/python-poetry/poetry/pull/4425, I unfortunately broke installer for Python 3.6, because `capture_output` is not available in Python 3.6.
First of all, sorry about that, I should have been more careful.

The fact that there's no tests for `install-poetry.py` script couldn't prevent the mistake from happening.

## Proposal
This pull request updates the CI workflow that runs tests so that we install poetry using the installer from the current branch, rather than the one on `master` branch.

While this would not replace full functional tests, this could be a quick win to ensure that poetry is still installable on all supported Python versions and OSes on pull requests that update `install-poetry.py`.
To showcase this, I've reintroduced the change that made the installer fail on Python 3.6 [here](https://github.com/mkniewallner/poetry/commit/c8578319d4c088d54bb8ada59d27e9aeed62a0f1), which correctly makes the workflow fail for Python 3.6 jobs [on the CI](https://github.com/mkniewallner/poetry/runs/3517983970?check_suite_focus=true).

Alternatively, if we have other reasons to install poetry from `master` branch, we could add a dedicated job that specifically tests the installation of poetry through `install-poetry.py`, and keep installing poetry from `master` branch when running unit tests.

This PR also updates the matrix so that we run the tests on Python 3.10.0-rc.2, and make sure that it makes the workflow fail if the tests don't pass, as the RC2 is IMO stable enough to be worth having green tests.
If this part should stay as is, I'd be happy to revert the commit, or make necessary changes.

Note that quotes have been added for versions because it avoid YAML to interpret them as floats (see https://github.com/actions/setup-python/pull/175 and https://github.com/actions/setup-python/issues/198).