### PR TITLE
Update cli.md

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -260,6 +260,12 @@ poetry will choose a suitable one based on the available package versions.
 poetry add requests pendulum
 ```
 
+You can specify the package as a developer package using the `--dev` flag, like so:
+
+```bash
+poetry add pylint --dev
+```
+
 You also can specify a constraint when adding a package, like so:
 
 ```bash


### PR DESCRIPTION
Adds a small section to show users how to install developer depenencies.

This is just a suggested change to the documentation. I found it unnecessarily difficult to find out how to add a developer package to the project. Requesting against `master` branch since it's just docs.

Please feel free to amend as you see fit.