### PR TITLE
Fix typo in #3713

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -1047,7 +1047,7 @@ class Env:
 
     def __init__(self, path: Path, base: Optional[Path] = None) -> None:
         self._is_windows = sys.platform == "win32"
-        self._is_mingw = sysconfig.get_platform() == "mingw"
+        self._is_mingw = sysconfig.get_platform().startswith("mingw")
 
         if not self._is_windows or self._is_mingw:
             bin_dir = "bin"


### PR DESCRIPTION
When running `python` within the various shells made available on Windows by [MSys2](https://www.msys2.org/), `sysconfig.get_platform()` returns:

* MSys2 : `msys-3.2.0-x86-64`
* MinGW x32 : `mingw_i686`
* MinGW x64 : `mingw_x86_64`
* MinGW UCRT64 : `mingw_x86_64_ucrt`
* MinGW Clang64 : `mingw_x86_64_clang`

In the case that `sysconfig.get_platform()` *does* return `mingw` (with no suffix), this change should still support that.

#### Pull Request Check List

Related: #3713

- [ ] ~Added **tests** for changed code.~
        - I think a test for this would require a suitable CI environment (Windows+MinGW) to be set up. However setting that up is a bit beyond the scope of this PR, related as it may be.
- [ ] ~Updated **documentation** for changed code.~
        - No documentation change needed.