### PR TITLE
fix: typos in multiple locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -971,7 +971,7 @@ commands in project subdirectories.
 - Improved dependency resolution to avoid unnecessary operations.
 - Improved dependency resolution speed.
 - Improved CLI reactivity by deferring imports.
-- License classifer is not automatically added to classifers.
+- License classifier is not automatically added to classifiers.
 
 ### Fixed
 
@@ -1016,7 +1016,7 @@ commands in project subdirectories.
 
 ### Changed
 
-- Changed how wilcard constraints are handled.
+- Changed how wildcard constraints are handled.
 
 ### Fixed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -186,7 +186,7 @@ poetry install --extras "mysql pgsql"
 poetry install -E mysql -E pgsql
 ```
 
-By default `poetry` will install your project's package everytime you run `install`:
+By default `poetry` will install your project's package every time you run `install`:
 
 ```bash
 $ poetry install

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -80,7 +80,7 @@ Keyring support is enabled using the [keyring library](https://pypi.org/project/
 Poetry will fallback to Pip style use of keyring so that backends like
 Microsoft's [artifacts-keyring](https://pypi.org/project/artifacts-keyring/) get a change to retrieve
 valid credentials. It will need to be properly installed into Poetry's virtualenv,
-preferrably by installing a plugin.
+preferably by installing a plugin.
 
 If you are letting Poetry manage your virtual environments you will want a virtualenv
 seeder installed in Poetry's virtualenv that installs the desired keyring backend

--- a/poetry/json/schemas/poetry-schema.json
+++ b/poetry/json/schemas/poetry-schema.json
@@ -59,7 +59,7 @@
         },
         "classifiers": {
             "type": "array",
-            "description": "A list of trove classifers."
+            "description": "A list of trove classifiers."
         },
         "packages": {
             "type": "array",

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -341,7 +341,7 @@ class PyPiRepository(RemoteRepository):
         # Checking wheels first as they are more likely to hold
         # the necessary information
         if "bdist_wheel" in urls:
-            # Check fo a universal wheel
+            # Check for a universal wheel
             wheels = urls["bdist_wheel"]
 
             universal_wheel = None

--- a/poetry/utils/extras.py
+++ b/poetry/utils/extras.py
@@ -44,7 +44,7 @@ def get_extra_package_names(
 
     def _extra_packages(package_names: Iterable[str]) -> Iterator[str]:
         """Recursively find dependencies for packages names"""
-        # for each extra pacakge name
+        # for each extra package name
         for package_name in package_names:
             # Find the actual Package object. A missing key indicates an implicit
             # dependency (like setuptools), which should be ignored

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -65,7 +65,7 @@ def test_requirement_source_type_url():
         "foo",
         "0.0.0",
         source_type="url",
-        source_url="https://somehwere.com/releases/foo-1.0.0.tar.gz",
+        source_url="https://somewhere.com/releases/foo-1.0.0.tar.gz",
     )
 
     result = installer.requirement(foo, formatted=True)

--- a/tests/utils/fixtures/setups/pyyaml/setup.py
+++ b/tests/utils/fixtures/setups/pyyaml/setup.py
@@ -12,7 +12,7 @@ supports standard YAML tags and provides Python-specific tags that
 allow to represent an arbitrary Python object.
 
 PyYAML is applicable for a broad range of tasks from complex
-configuration files to object serialization and persistance."""
+configuration files to object serialization and persistence."""
 AUTHOR = "Kirill Simonov"
 AUTHOR_EMAIL = "xi@resolvent.net"
 LICENSE = "MIT"


### PR DESCRIPTION
This commit fixes typographical errors in the CHANGELOG, docs folder,
poetry package, and the tests. I located the typos via the codespell utility,
which you can find at https://github.com/codespell-project/codespell

This was done using an updated codespell dictionary on Sept. 7 at 4:30 PM ET, rather than the one currently packaged with the utility. 

# Pull Request Check List

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.