### PR TITLE
Prefer authenticator from repository when available

### DIFF
--- a/poetry/installation/chooser.py
+++ b/poetry/installation/chooser.py
@@ -9,6 +9,7 @@ from packaging.tags import Tag
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.repositories.pool import Pool
+from poetry.repositories.repository import Repository
 from poetry.utils.env import Env
 from poetry.utils.patterns import wheel_file_re
 
@@ -79,7 +80,7 @@ class Chooser:
 
         return chosen
 
-    def _get_links(self, package: Package) -> List[Link]:
+    def get_repository(self, package: Package) -> Repository:
         if not package.source_type:
             if not self._pool.has_repository("pypi"):
                 repository = self._pool.repositories[0]
@@ -88,6 +89,10 @@ class Chooser:
         else:
             repository = self._pool.repository(package.source_reference)
 
+        return repository
+
+    def _get_links(self, package: Package) -> List[Link]:
+        repository = self.get_repository(package)
         links = repository.find_links_for_package(package)
 
         hashes = [f["hash"] for f in package.files]

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -688,7 +688,9 @@ class Executor:
         return archive
 
     def _download_archive(self, operation: Union[Install, Update], link: Link) -> Path:
-        response = self._authenticator.request(
+        repository = self._chooser.get_repository(operation.package)
+        authenticator = getattr(repository, "_authenticator", self._authenticator)
+        response = authenticator.request(
             "get", link.url, stream=True, io=self._sections.get(id(operation), self._io)
         )
         wheel_size = response.headers.get("content-length")

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -28,7 +28,6 @@ from poetry.core.semver.version_constraint import VersionConstraint
 from poetry.core.semver.version_range import VersionRange
 from poetry.locations import REPOSITORY_CACHE_DIR
 from poetry.utils.helpers import canonicalize_name
-from poetry.utils.helpers import download_file
 from poetry.utils.helpers import temporary_directory
 from poetry.utils.patterns import wheel_file_re
 
@@ -444,6 +443,3 @@ class LegacyRepository(PyPiRepository):
             )
 
         return Page(response.url, response.content, response.headers)
-
-    def _download(self, url, dest):  # type: (str, str) -> None
-        return download_file(url, dest, session=self.session)


### PR DESCRIPTION
Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>

Resolves: #1012 #2593 #3110 #4016 
Supersedes: #3349
Introduced: #2595

Feature toggle to side step this issue until resolved:
```
poetry config experimental.new-installer false
```


- [x] Added **tests** for changed code.

This will ensure that the configured certificates and auth are used when downloading files from a legacy repository.
There are quite a few issues relating to this being broken, so the list of resolves above may be incomplete.
