### PR TITLE
Set up mypy pre-commit hook for incremental adoption

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,16 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+      - id: mypy
+        pass_filenames: false
+        additional_dependencies:
+          - types-requests
+        args:
+          - poetry
+
   - repo: https://github.com/timothycrosley/isort
     rev: 5.7.0
     hooks:

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,42 @@ strict_optional = True
 warn_unused_ignores = True
 warn_redundant_casts = True
 warn_unused_configs = True
+
+[mypy-poetry.config.*]
+ignore_errors = True
+
+[mypy-poetry.console.*]
+ignore_errors = True
+
+[mypy-poetry.factory.*]
+ignore_errors = True
+
+[mypy-poetry.inspection.*]
+ignore_errors = True
+
+[mypy-poetry.installation.*]
+ignore_errors = True
+
+[mypy-poetry.locations.*]
+ignore_errors = True
+
+[mypy-poetry.mixology.*]
+ignore_errors = True
+
+[mypy-poetry.packages.*]
+ignore_errors = True
+
+[mypy-poetry.plugins.*]
+ignore_errors = True
+
+[mypy-poetry.publishing.*]
+ignore_errors = True
+
+[mypy-poetry.puzzle.*]
+ignore_errors = True
+
+[mypy-poetry.repositories.*]
+ignore_errors = True
+
+[mypy-poetry.utils.*]
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,7 +11,7 @@ warn_unused_configs = True
 # of Mypy. Modules should be removed from this whitelist as and when
 # their respective type errors have been addressed. No new modules
 # should be added to this whitelist.
-# see https://github.com/python-poetry/poetry-core/pull/199.
+# see https://github.com/python-poetry/poetry/pull/4510.
 
 [mypy-poetry.config.*]
 ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,12 @@ warn_unused_ignores = True
 warn_redundant_casts = True
 warn_unused_configs = True
 
+# The following whitelist is used to allow for incremental adoption
+# of Mypy. Modules should be removed from this whitelist as and when
+# their respective type errors have been addressed. No new modules
+# should be added to this whitelist.
+# see https://github.com/python-poetry/poetry-core/pull/199.
+
 [mypy-poetry.config.*]
 ignore_errors = True
 
@@ -45,3 +51,5 @@ ignore_errors = True
 
 [mypy-poetry.utils.*]
 ignore_errors = True
+
+# end of whitelist

--- a/poetry/__init__.py
+++ b/poetry/__init__.py
@@ -1,4 +1,5 @@
 from pkgutil import extend_path
+from typing import List
 
 
-__path__ = extend_path(__path__, __name__)
+__path__: List[str] = extend_path(__path__, __name__)

--- a/poetry/poetry.py
+++ b/poetry/poetry.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import List
+from typing import Optional
 
 from poetry.__version__ import __version__
 from poetry.config.source import Source
@@ -35,7 +36,7 @@ class Poetry(BasePoetry):
         self._locker = locker
         self._config = config
         self._pool = Pool()
-        self._plugin_manager = None
+        self._plugin_manager: Optional[PluginManager] = None
 
     @property
     def locker(self) -> "Locker":


### PR DESCRIPTION
At first glance this pull request might seem a little daft, as i've added a mypy pre-commit hook, and then configured mypy to ignore errors in everything.

There's a method in my madness

this project has many hundreds of type errors and eliminating them would be a significant challenge. A more practical approach is to white-list the current set of files, and then incrementally reduce the scope of that whitelist over time. Or to put it another way, tackle the type errors in one file at a time, and in all new modules.

The plan would be

1. merge this pull request with a blanket white list of files
2. accept pull requests which address type errors in specific files. where possible, files should be completely cleared of errors and removed from the whitelist in that pull request
3. accept future pull requests which make the white list smaller or more specific
4. one day, possibly, if we're very lucky, the whitelist can be removed entirely