### PR TITLE
Poetry Install with `pip` unavailable shouldn't throw Exception (Fixes #4521)

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -520,7 +520,7 @@ class Installer:
                 [sys.executable, "-m", "pip", "install", "virtualenv", "-t", tmp_dir],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                check=True
+                check=True,
             )
 
             sys.path.insert(0, tmp_dir)

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -516,10 +516,11 @@ class Installer:
         env_path = self._data_dir.joinpath("venv")
 
         with temporary_directory() as tmp_dir:
-            subprocess.call(
+            subprocess.run(
                 [sys.executable, "-m", "pip", "install", "virtualenv", "-t", tmp_dir],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                check=True
             )
 
             sys.path.insert(0, tmp_dir)


### PR DESCRIPTION
Fixes #4521

When installing Poetry through `install-poetry.py`, if `pip` is not
available, Exception should not be raised, rather installation should
be aborted with user-friendly error msg.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
