### PR TITLE
fix: Broken cache on Windows

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -18,6 +18,7 @@ from cleo.io.null_io import NullIO
 
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.package import Package
+from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.packages.utils.link import Link
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.utils._compat import decode
@@ -678,10 +679,10 @@ class Executor:
         return archive
 
     @staticmethod
-    def _validate_archive_hash(archive: Path, package: Package) -> str:
+    def _validate_archive_hash(archive: Union[Path, Link], package: Package) -> str:
         file_dep = FileDependency(
             package.name,
-            Path(archive.path) if isinstance(archive, Link) else archive,
+            url_to_path(archive.url) if isinstance(archive, Link) else archive,
         )
         archive_hash = "sha256:" + file_dep.hash()
         known_hashes = {f["hash"] for f in package.files}

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -680,7 +680,9 @@ class Executor:
 
     @staticmethod
     def _validate_archive_hash(archive: Union[Path, Link], package: Package) -> str:
-        archive_path = url_to_path(archive.url) if isinstance(archive, Link) else archive
+        archive_path = (
+            url_to_path(archive.url) if isinstance(archive, Link) else archive
+        )
         file_dep = FileDependency(
             package.name,
             archive_path,

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -120,7 +120,7 @@ class Executor:
         return self
 
     def pip_install(
-        self, req: Union[Path, str], upgrade: bool = False, editable: bool = False
+        self, req: Union[Path, Link], upgrade: bool = False, editable: bool = False
     ) -> int:
         func = pip_install
         if editable:
@@ -505,7 +505,7 @@ class Executor:
             )
         )
         self._write(operation, message)
-        return self.pip_install(str(archive), upgrade=operation.job_type == "update")
+        return self.pip_install(archive, upgrade=operation.job_type == "update")
 
     def _update(self, operation: Union[Install, Update]) -> int:
         return self._install(operation)

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -680,16 +680,17 @@ class Executor:
 
     @staticmethod
     def _validate_archive_hash(archive: Union[Path, Link], package: Package) -> str:
+        path = url_to_path(archive.url) if isinstance(archive, Link) else archive
         file_dep = FileDependency(
             package.name,
-            url_to_path(archive.url) if isinstance(archive, Link) else archive,
+            path,
         )
         archive_hash = "sha256:" + file_dep.hash()
         known_hashes = {f["hash"] for f in package.files}
 
         if archive_hash not in known_hashes:
             raise RuntimeError(
-                f"Hash for {package} from archive {archive.name} not found in known hashes (was: {archive_hash})"
+                f"Hash for {package} from archive {path.name} not found in known hashes (was: {archive_hash})"
             )
 
         return archive_hash

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -18,8 +18,8 @@ from cleo.io.null_io import NullIO
 
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.package import Package
-from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.packages.utils.link import Link
+from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.utils._compat import decode
 from poetry.utils.env import EnvCommandError

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -680,17 +680,17 @@ class Executor:
 
     @staticmethod
     def _validate_archive_hash(archive: Union[Path, Link], package: Package) -> str:
-        path = url_to_path(archive.url) if isinstance(archive, Link) else archive
+        archive_path = url_to_path(archive.url) if isinstance(archive, Link) else archive
         file_dep = FileDependency(
             package.name,
-            path,
+            archive_path,
         )
         archive_hash = "sha256:" + file_dep.hash()
         known_hashes = {f["hash"] for f in package.files}
 
         if archive_hash not in known_hashes:
             raise RuntimeError(
-                f"Hash for {package} from archive {path.name} not found in known hashes (was: {archive_hash})"
+                f"Hash for {package} from archive {archive_path.name} not found in known hashes (was: {archive_hash})"
             )
 
         return archive_hash

--- a/poetry/utils/pip.py
+++ b/poetry/utils/pip.py
@@ -4,12 +4,12 @@ import sys
 from pathlib import Path
 from typing import Union
 
+from poetry.core.packages.utils.link import Link
+from poetry.core.packages.utils.utils import url_to_path
 from poetry.exceptions import PoetryException
 from poetry.utils.env import Env
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import ephemeral_environment
-from poetry.core.packages.utils.link import Link
-from poetry.core.packages.utils.utils import url_to_path
 
 
 def pip_install(

--- a/poetry/utils/pip.py
+++ b/poetry/utils/pip.py
@@ -62,7 +62,9 @@ def pip_install(
         raise PoetryException(f"Failed to install {path.as_posix()}") from e
 
 
-def pip_editable_install(directory: Path, environment: Env) -> Union[int, str]:
+def pip_editable_install(
+    directory: Union[Path, Link], environment: Env
+) -> Union[int, str]:
     return pip_install(
         path=directory, environment=environment, editable=True, deps=False, upgrade=True
     )

--- a/poetry/utils/pip.py
+++ b/poetry/utils/pip.py
@@ -8,16 +8,18 @@ from poetry.exceptions import PoetryException
 from poetry.utils.env import Env
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import ephemeral_environment
+from poetry.core.packages.utils.link import Link
+from poetry.core.packages.utils.utils import url_to_path
 
 
 def pip_install(
-    path: Union[Path, str],
+    path: Union[Path, Link],
     environment: Env,
     editable: bool = False,
     deps: bool = False,
     upgrade: bool = False,
 ) -> Union[int, str]:
-    path = Path(path) if isinstance(path, str) else path
+    path = url_to_path(path.url) if isinstance(path, Link) else path
     is_wheel = path.suffix == ".whl"
 
     # We disable version check here as we are already pinning to version available in either the

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -462,3 +462,60 @@ def test_executor_should_write_pep610_url_references_for_git(
             "url": package.source_url,
         },
     )
+
+
+def test_executor_should_hash_links(config, io, pool, mocker, fixture_dir, tmp_dir):
+    # Produce a file:/// URI that is a valid link
+    link = Link(
+        fixture_dir("distributions")
+        .joinpath("demo-0.1.0-py2.py3-none-any.whl")
+        .as_uri()
+    )
+    mocker.patch.object(
+        Chef,
+        "get_cached_archive_for_link",
+        side_effect=lambda _: link,
+    )
+
+    env = MockEnv(path=Path(tmp_dir))
+    executor = Executor(env, pool, config, io)
+
+    package = Package("demo", "0.1.0")
+    package.files = [
+        {
+            "file": "demo-0.1.0-py2.py3-none-any.whl",
+            "hash": "md5:15507846fd4299596661d0197bfb4f90",
+        }
+    ]
+
+    archive = executor._download_link(
+        Install(package), Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl")
+    )
+
+    assert archive == link
+
+
+def test_executor_should_hash_paths(config, io, pool, mocker, fixture_dir, tmp_dir):
+    link = fixture_dir("distributions").joinpath("demo-0.1.0-py2.py3-none-any.whl")
+    mocker.patch.object(
+        Chef,
+        "get_cached_archive_for_link",
+        side_effect=lambda _: link,
+    )
+
+    env = MockEnv(path=Path(tmp_dir))
+    executor = Executor(env, pool, config, io)
+
+    package = Package("demo", "0.1.0")
+    package.files = [
+        {
+            "file": "demo-0.1.0-py2.py3-none-any.whl",
+            "hash": "md5:15507846fd4299596661d0197bfb4f90",
+        }
+    ]
+
+    archive = executor._download_link(
+        Install(package), Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl")
+    )
+
+    assert archive == link

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -11,6 +11,7 @@ from cleo.io.buffered_io import BufferedIO
 
 from poetry.config.config import Config
 from poetry.core.packages.package import Package
+from poetry.core.packages.utils.link import Link
 from poetry.core.utils._compat import PY36
 from poetry.installation.executor import Executor
 from poetry.installation.operations import Install
@@ -471,51 +472,33 @@ def test_executor_should_hash_links(config, io, pool, mocker, fixture_dir, tmp_d
         .joinpath("demo-0.1.0-py2.py3-none-any.whl")
         .as_uri()
     )
-    mocker.patch.object(
-        Chef,
-        "get_cached_archive_for_link",
+    mocker.patch(
+        "poetry.installation.chef.Chef.get_cached_archive_for_link",
         side_effect=lambda _: link,
     )
 
     env = MockEnv(path=Path(tmp_dir))
     executor = Executor(env, pool, config, io)
 
-    package = Package("demo", "0.1.0")
-    package.files = [
-        {
-            "file": "demo-0.1.0-py2.py3-none-any.whl",
-            "hash": "md5:15507846fd4299596661d0197bfb4f90",
-        }
-    ]
-
     archive = executor._download_link(
-        Install(package), Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl")
+        Install(Package("demo", "0.1.0")),
+        Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl"),
     )
-
     assert archive == link
 
 
 def test_executor_should_hash_paths(config, io, pool, mocker, fixture_dir, tmp_dir):
     link = fixture_dir("distributions").joinpath("demo-0.1.0-py2.py3-none-any.whl")
-    mocker.patch.object(
-        Chef,
-        "get_cached_archive_for_link",
+    mocker.patch(
+        "poetry.installation.chef.Chef.get_cached_archive_for_link",
         side_effect=lambda _: link,
     )
 
     env = MockEnv(path=Path(tmp_dir))
     executor = Executor(env, pool, config, io)
 
-    package = Package("demo", "0.1.0")
-    package.files = [
-        {
-            "file": "demo-0.1.0-py2.py3-none-any.whl",
-            "hash": "md5:15507846fd4299596661d0197bfb4f90",
-        }
-    ]
-
     archive = executor._download_link(
-        Install(package), Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl")
+        Install(Package("demo", "0.1.0")),
+        Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl"),
     )
-
     assert archive == link

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -476,7 +476,7 @@ def test_executor_should_use_cached_link_and_hash(
     )
     mocker.patch(
         "poetry.installation.chef.Chef.get_cached_archive_for_link",
-        side_effect=lambda _: link_cached,
+        return_value=link_cached,
     )
 
     package = Package("demo", "0.1.0")

--- a/tests/utils/test_pip.py
+++ b/tests/utils/test_pip.py
@@ -3,10 +3,21 @@ import subprocess
 import pytest
 
 from poetry.utils.pip import pip_install
+from poetry.core.packages.utils.link import Link
+from poetry.core.packages.utils.utils import path_to_url
 
 
 def test_pip_install_successful(tmp_dir, tmp_venv, fixture_dir):
     file_path = fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl")
+    result = pip_install(file_path, tmp_venv)
+
+    assert "Successfully installed demo-0.1.0" in result
+
+
+def test_pip_install_link(tmp_dir, tmp_venv, fixture_dir):
+    file_path = Link(
+        path_to_url(fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl"))
+    )
     result = pip_install(file_path, tmp_venv)
 
     assert "Successfully installed demo-0.1.0" in result

--- a/tests/utils/test_pip.py
+++ b/tests/utils/test_pip.py
@@ -2,9 +2,9 @@ import subprocess
 
 import pytest
 
-from poetry.utils.pip import pip_install
 from poetry.core.packages.utils.link import Link
 from poetry.core.packages.utils.utils import path_to_url
+from poetry.utils.pip import pip_install
 
 
 def test_pip_install_successful(tmp_dir, tmp_venv, fixture_dir):


### PR DESCRIPTION
(Backport to 1.1: #4549)

The previous implementation would fail to install packages on Windows because it creates a `Path` starting with a slash. Such a `Path` is invalid on Windows. Instead, use the utility function url_to_path.

Additionally (not a bug in 1.1, migrated from separate PR at #4532), Links and Paths were passed in to pip_install as a string. This makes it hard for pip_install to parse out the extension of the file to install. By accepting only Links or Paths, pip_install can parse out the extension using the Link. This also resolves a bug when Executor._download_link returns a Link, which can't be parsed by Path(str(link)) on Windows.

This was overlooked when running on Linux because file:/path/to/cache is somehow a valid pip install path in Python on Linux, but not a valid path on Windows. With this PR, pip install is always called with a proper Path (/path/to/cache) and never a Path-parsed Link (file:/path/to/cache)

# Pull Request Check List

Resolves: #4479 #4535

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code. (N/A)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
