### PR TITLE
fix: Don't try to parse `Link`s as `Path`s

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -119,7 +119,7 @@ class Executor:
         return self
 
     def pip_install(
-        self, req: Union[Path, str], upgrade: bool = False, editable: bool = False
+        self, req: Union[Path, Link], upgrade: bool = False, editable: bool = False
     ) -> int:
         func = pip_install
         if editable:
@@ -504,7 +504,7 @@ class Executor:
             )
         )
         self._write(operation, message)
-        return self.pip_install(str(archive), upgrade=operation.job_type == "update")
+        return self.pip_install(archive, upgrade=operation.job_type == "update")
 
     def _update(self, operation: Union[Install, Update]) -> int:
         return self._install(operation)

--- a/poetry/utils/pip.py
+++ b/poetry/utils/pip.py
@@ -8,16 +8,18 @@ from poetry.exceptions import PoetryException
 from poetry.utils.env import Env
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import ephemeral_environment
+from poetry.core.packages.utils.link import Link
+from poetry.core.packages.utils.utils import url_to_path
 
 
 def pip_install(
-    path: Union[Path, str],
+    path: Union[Path, Link],
     environment: Env,
     editable: bool = False,
     deps: bool = False,
     upgrade: bool = False,
 ) -> Union[int, str]:
-    path = Path(path) if isinstance(path, str) else path
+    path = url_to_path(path.url) if isinstance(path, Link) else path
     is_wheel = path.suffix == ".whl"
 
     # We disable version check here as we are already pinning to version available in either the


### PR DESCRIPTION
Previously, `Link`s and `Path`s were passed in to `pip_install` as a
string. This makes it hard for pip_install to parse out the extension of
the file to install. By accepting only `Link`s or `Path`s, `pip_install`
can parse out the extension using the `Link`.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
