### PR TITLE
Validate hash regardless of type

### DIFF
--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -63,7 +63,7 @@ class PackageInfo:
         platform=None,  # type: Optional[str]
         requires_dist=None,  # type: Optional[List[str]]
         requires_python=None,  # type: Optional[str]
-        files=None,  # type: Optional[List[str]]
+        files=None,  # type: Optional[List[Dict[str, str]]]
         cache_version=None,  # type: Optional[str]
     ):
         self.name = name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"
 
-poetry-core = "~1.0.6"
+poetry-core = { git = "https://github.com/python-poetry/poetry-core.git", branch = "1.0" }
 cleo = "^0.8.1"
 clikit = "^0.6.2"
 crashtest = { version = "^0.3.0", python = "^3.6" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry"
-version = "1.1.9"
+version = "1.1.10-alpha.0"
 description = "Python dependency management and packaging made easy."
 authors = [
     "Sébastien Eustace <sebastien@eustace.io>"
@@ -24,7 +24,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"
 
-poetry-core = "~1.0.5"
+poetry-core = "~1.0.6"
 cleo = "^0.8.1"
 clikit = "^0.6.2"
 crashtest = { version = "^0.3.0", python = "^3.6" }


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4523

Also see : #4529 which does the same thing.

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

**NB : this requires a higher version of `poetry-core`, which I presume will be `1.0.6`**

Lockfile has not been updated - because this has not been released yet. Have linked to git for time being.

---

- Check hash regardless of which type has been used