### PR TITLE
[1.1] fix: Broken cache on Windows

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -612,15 +612,14 @@ class Executor(object):
             hashes = {f["hash"] for f in package.files}
             hash_types = {h.split(":")[0] for h in hashes}
             archive_hashes = set()
+            path = url_to_path(archive.url) if isinstance(archive, Link) else archive
             for hash_type in hash_types:
                 archive_hashes.add(
                     "{}:{}".format(
                         hash_type,
                         FileDependency(
                             package.name,
-                            url_to_path(archive.url)
-                            if isinstance(archive, Link)
-                            else archive,
+                            path,
                         ).hash(hash_type),
                     )
                 )
@@ -630,7 +629,7 @@ class Executor(object):
                     "Invalid hashes ({}) for {} using archive {}. Expected one of {}.".format(
                         ", ".join(sorted(archive_hashes)),
                         package,
-                        archive.name,
+                        path.name,
                         ", ".join(sorted(hashes)),
                     )
                 )

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -11,6 +11,7 @@ from subprocess import CalledProcessError
 
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.utils.link import Link
+from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.io.null_io import NullIO
 from poetry.utils._compat import PY2
@@ -617,7 +618,7 @@ class Executor(object):
                         hash_type,
                         FileDependency(
                             package.name,
-                            Path(archive.path)
+                            url_to_path(archive.url)
                             if isinstance(archive, Link)
                             else archive,
                         ).hash(hash_type),

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -616,11 +616,7 @@ class Executor(object):
             for hash_type in hash_types:
                 archive_hashes.add(
                     "{}:{}".format(
-                        hash_type,
-                        FileDependency(
-                            package.name,
-                            path,
-                        ).hash(hash_type),
+                        hash_type, FileDependency(package.name, path).hash(hash_type),
                     )
                 )
 

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -612,11 +612,11 @@ class Executor(object):
             hashes = {f["hash"] for f in package.files}
             hash_types = {h.split(":")[0] for h in hashes}
             archive_hashes = set()
-            path = url_to_path(archive.url) if isinstance(archive, Link) else archive
+            archive_path = url_to_path(archive.url) if isinstance(archive, Link) else archive
             for hash_type in hash_types:
                 archive_hashes.add(
                     "{}:{}".format(
-                        hash_type, FileDependency(package.name, path).hash(hash_type),
+                        hash_type, FileDependency(package.name, archive_path).hash(hash_type),
                     )
                 )
 
@@ -625,7 +625,7 @@ class Executor(object):
                     "Invalid hashes ({}) for {} using archive {}. Expected one of {}.".format(
                         ", ".join(sorted(archive_hashes)),
                         package,
-                        path.name,
+                        archive_path.name,
                         ", ".join(sorted(hashes)),
                     )
                 )

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -612,11 +612,14 @@ class Executor(object):
             hashes = {f["hash"] for f in package.files}
             hash_types = {h.split(":")[0] for h in hashes}
             archive_hashes = set()
-            archive_path = url_to_path(archive.url) if isinstance(archive, Link) else archive
+            archive_path = (
+                url_to_path(archive.url) if isinstance(archive, Link) else archive
+            )
             for hash_type in hash_types:
                 archive_hashes.add(
                     "{}:{}".format(
-                        hash_type, FileDependency(package.name, archive_path).hash(hash_type),
+                        hash_type,
+                        FileDependency(package.name, archive_path).hash(hash_type),
                     )
                 )
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -336,11 +336,7 @@ def test_executor_should_hash_links(config, io, pool, mocker, fixture_dir, tmp_d
         .joinpath("demo-0.1.0-py2.py3-none-any.whl")
         .as_uri()
     )
-    mocker.patch.object(
-        Chef,
-        "get_cached_archive_for_link",
-        side_effect=lambda _: link,
-    )
+    mocker.patch.object(Chef, "get_cached_archive_for_link", side_effect=lambda _: link)
 
     env = MockEnv(path=Path(tmp_dir))
     executor = Executor(env, pool, config, io)
@@ -362,11 +358,7 @@ def test_executor_should_hash_links(config, io, pool, mocker, fixture_dir, tmp_d
 
 def test_executor_should_hash_paths(config, io, pool, mocker, fixture_dir, tmp_dir):
     link = fixture_dir("distributions").joinpath("demo-0.1.0-py2.py3-none-any.whl")
-    mocker.patch.object(
-        Chef,
-        "get_cached_archive_for_link",
-        side_effect=lambda _: link,
-    )
+    mocker.patch.object(Chef, "get_cached_archive_for_link", side_effect=lambda _: link)
 
     env = MockEnv(path=Path(tmp_dir))
     executor = Executor(env, pool, config, io)

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -327,3 +327,60 @@ def test_executor_should_check_every_possible_hash_types_before_failing(
             Install(package),
             Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl"),
         )
+
+
+def test_executor_should_hash_links(config, io, pool, mocker, fixture_dir, tmp_dir):
+    # Produce a file:/// URI that is a valid link
+    link = Link(
+        fixture_dir("distributions")
+        .joinpath("demo-0.1.0-py2.py3-none-any.whl")
+        .as_uri()
+    )
+    mocker.patch.object(
+        Chef,
+        "get_cached_archive_for_link",
+        side_effect=lambda _: link,
+    )
+
+    env = MockEnv(path=Path(tmp_dir))
+    executor = Executor(env, pool, config, io)
+
+    package = Package("demo", "0.1.0")
+    package.files = [
+        {
+            "file": "demo-0.1.0-py2.py3-none-any.whl",
+            "hash": "md5:15507846fd4299596661d0197bfb4f90",
+        }
+    ]
+
+    archive = executor._download_link(
+        Install(package), Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl")
+    )
+
+    assert archive == link
+
+
+def test_executor_should_hash_paths(config, io, pool, mocker, fixture_dir, tmp_dir):
+    link = fixture_dir("distributions").joinpath("demo-0.1.0-py2.py3-none-any.whl")
+    mocker.patch.object(
+        Chef,
+        "get_cached_archive_for_link",
+        side_effect=lambda _: link,
+    )
+
+    env = MockEnv(path=Path(tmp_dir))
+    executor = Executor(env, pool, config, io)
+
+    package = Package("demo", "0.1.0")
+    package.files = [
+        {
+            "file": "demo-0.1.0-py2.py3-none-any.whl",
+            "hash": "md5:15507846fd4299596661d0197bfb4f90",
+        }
+    ]
+
+    archive = executor._download_link(
+        Install(package), Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl")
+    )
+
+    assert archive == link


### PR DESCRIPTION
(Backport to 1.1) (Original PR: #4531)

The previous implementation would fail to install packages on Windows
because it creates a `Path` starting with a slash. Such a `Path` is
invalid on Windows. Instead, use the utility function url_to_path.

# Pull Request Check List

Resolves: #4479 #4535

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code. (N/A)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->