### PR TITLE
Document a solution for using passwords that start with a dash

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -101,6 +101,15 @@ export POETRY_HTTP_BASIC_PYPI_PASSWORD=password
 See [Using environment variables]({{< relref "configuration#using-environment-variables" >}}) for more information
 on how to configure Poetry with environment variables.
 
+If your password starts with a dash (e.g. randomly generated tokens in a CI environment), it will be parsed as a command 
+line option instead of a password. You can prevent this by adding double dashes to prevent any following argument from being parsed
+as an option.
+
+```bash
+poetry config -- http-basic.pypi myUsername -myPasswordStartingWithDash
+```
+
+
 #### Custom certificate authority and mutual TLS authentication
 Poetry supports repositories that are secured by a custom certificate authority as well as those that require
 certificate-based client authentication.  The following will configure the "foo" repository to validate the repository's

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -101,7 +101,7 @@ export POETRY_HTTP_BASIC_PYPI_PASSWORD=password
 See [Using environment variables]({{< relref "configuration#using-environment-variables" >}}) for more information
 on how to configure Poetry with environment variables.
 
-If your password starts with a dash (e.g. randomly generated tokens in a CI environment), it will be parsed as a command 
+If your password starts with a dash (e.g. randomly generated tokens in a CI environment), it will be parsed as a command
 line option instead of a password. You can prevent this by adding double dashes to prevent any following argument from being parsed
 as an option.
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -101,9 +101,8 @@ export POETRY_HTTP_BASIC_PYPI_PASSWORD=password
 See [Using environment variables]({{< relref "configuration#using-environment-variables" >}}) for more information
 on how to configure Poetry with environment variables.
 
-If your password starts with a dash (e.g. randomly generated tokens in a CI environment), it will be parsed as a command
-line option instead of a password. You can prevent this by adding double dashes to prevent any following argument from being parsed
-as an option.
+If your password starts with a dash (e.g. randomly generated tokens in a CI environment), it will be parsed as a command line option instead of a password.
+You can prevent this by adding double dashes to prevent any following argument from being parsed as an option.
 
 ```bash
 poetry config -- http-basic.pypi myUsername -myPasswordStartingWithDash

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -101,7 +101,8 @@ export POETRY_HTTP_BASIC_PYPI_PASSWORD=password
 See [Using environment variables]({{< relref "configuration#using-environment-variables" >}}) for more information
 on how to configure Poetry with environment variables.
 
-If your password starts with a dash (e.g. randomly generated tokens in a CI environment), it will be parsed as a command line option instead of a password.
+If your password starts with a dash (e.g. randomly generated tokens in a CI environment), it will be parsed as a
+command line option instead of a password.
 You can prevent this by adding double dashes to prevent any following argument from being parsed as an option.
 
 ```bash

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -109,7 +109,6 @@ as an option.
 poetry config -- http-basic.pypi myUsername -myPasswordStartingWithDash
 ```
 
-
 #### Custom certificate authority and mutual TLS authentication
 Poetry supports repositories that are secured by a custom certificate authority as well as those that require
 certificate-based client authentication.  The following will configure the "foo" repository to validate the repository's


### PR DESCRIPTION
Document a solution for using passwords that start with a dash. This happened to a few people when using automatically generated tokens in a CI environment.

Resolves: #2889
