### PR TITLE
Improves hash mismatch exception language

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -678,9 +678,10 @@ class Executor:
                     Path(archive.path) if isinstance(archive, Link) else archive,
                 ).hash()
             )
-            if archive_hash not in {f["hash"] for f in package.files}:
+            known_hashes = {f["hash"] for f in package.files}
+            if archive_hash not in known_hashes:
                 raise RuntimeError(
-                    f"Invalid hash for {package} using archive {archive.name}"
+                    f"Hash for {package} from archive {archive.name} not found in known hashes ({archive_hash})"
                 )
 
             self._hashes[package.name] = archive_hash

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -678,7 +678,7 @@ class Executor:
         return archive
 
     @staticmethod
-    def get_and_validate_archive_hash(archive: Path, package: Package) -> str:
+    def _validate_archive_hash(archive: Path, package: Package) -> str:
         file_dep = FileDependency(
             package.name,
             Path(archive.path) if isinstance(archive, Link) else archive,

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -17,6 +17,7 @@ from typing import Union
 from cleo.io.null_io import NullIO
 
 from poetry.core.packages.file_dependency import FileDependency
+from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.utils._compat import decode
@@ -671,22 +672,27 @@ class Executor:
                 archive = self._chef.prepare(archive)
 
         if package.files:
-            archive_hash = (
-                "sha256:"
-                + FileDependency(
-                    package.name,
-                    Path(archive.path) if isinstance(archive, Link) else archive,
-                ).hash()
-            )
-            known_hashes = {f["hash"] for f in package.files}
-            if archive_hash not in known_hashes:
-                raise RuntimeError(
-                    f"Hash for {package} from archive {archive.name} not found in known hashes ({archive_hash})"
-                )
+            archive_hash = self.get_and_validate_archive_hash(archive, package)
 
             self._hashes[package.name] = archive_hash
 
         return archive
+
+    @staticmethod
+    def get_and_validate_archive_hash(archive: Path, package: Package) -> str:
+        file_dep = FileDependency(
+            package.name,
+            Path(archive.path) if isinstance(archive, Link) else archive,
+        )
+        archive_hash = "sha256:" + file_dep.hash()
+        known_hashes = {f["hash"] for f in package.files}
+
+        if archive_hash not in known_hashes:
+            raise RuntimeError(
+                f"Hash for {package} from archive {archive.name} not found in known hashes (was: {archive_hash})"
+            )
+
+        return archive_hash
 
     def _download_archive(self, operation: Union[Install, Update], link: Link) -> Path:
         response = self._authenticator.request(

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -671,7 +671,7 @@ class Executor:
                 archive = self._chef.prepare(archive)
 
         if package.files:
-            archive_hash = self.get_and_validate_archive_hash(archive, package)
+            archive_hash = self._validate_archive_hash(archive, package)
 
             self._hashes[package.name] = archive_hash
 

--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
     from cleo.io.io import IO  # noqa
 
     from poetry.config.config import Config
-    from poetry.core.packages.package import Package
     from poetry.repositories import Pool
     from poetry.utils.env import Env
 


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

I can't get tests to run locally off of master for some reason, so I didn't run them here. There don't seem to be any tests for the particular method from which I extracted this new method. I'm down for writing some tests for the new method if I could get `make test` working, or even `poetry install` for that matter. I might need to just blow away my poetry working directory and recreate it.

I think this area could be further improved by representing the hashes as a `dataclass` or something containing the hash type and the string digest. The types of hashes would be more robust then instead of hardcoding sha256 here and in `FileDependency.hash()`. It would also enable enumeration of hash types of known hashes so that `FileDependency.hash()` could return a list of hashes based on requested types. Doing this might alleviate the md5/sha256 problems arising from changes in poetry-core 1.0.6+ that affect Poetry 1.1.7+ users using Artifactory.
