### PR TITLE
Rename whitelist_externals in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,7 +65,7 @@ isolated_build = true
 envlist = py27, py36
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
     poetry install -v
     poetry run pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pytest = "^6.2"
 pytest-cov = "^2.8"
 pytest-mock = "^3.5"
 pre-commit = { version = "^2.6", python = "^3.6.1" }
-tox = "^3.0"
+tox = "^3.18"
 pytest-sugar = "^0.9"
 httpretty = "^1.0"
 zipp = { version = "^3.4", python = "<3.8"}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 3.3.0
+minversion = 3.18.0
 isolated_build = True
 envlist = py36, py37, py38, py39, doc
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ isolated_build = True
 envlist = py36, py37, py38, py39, doc
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
     poetry install -vv --no-root
     poetry run pytest {posargs} tests/


### PR DESCRIPTION
`whitelist_externals` is now deprecated in tox and has been renamed to `allowlist_externals`

https://tox.readthedocs.io/en/latest/config.html#conf-allowlist_externals
