### PR TITLE
Update uploader.py

### DIFF
--- a/poetry/publishing/uploader.py
+++ b/poetry/publishing/uploader.py
@@ -69,7 +69,7 @@ class Uploader:
         retry = util.Retry(
             connect=5,
             total=10,
-            method_whitelist=["GET"],
+            allowed_methods=["GET"],
             status_forcelist=[500, 501, 502, 503],
         )
 


### PR DESCRIPTION
This addresses the following `DeprecationWarning` that `pytest` was displaying:

```
DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
```