### PR TITLE
Relates-to: #3155 run installer tests from any directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,3 +405,8 @@ def command_tester_factory(app, env):
 def do_lock(command_tester_factory, poetry):
     command_tester_factory("lock").execute()
     assert poetry.locker.lock.exists()
+
+
+@pytest.fixture
+def project_root():
+    return Path(__file__).parent.parent

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -88,8 +88,8 @@ class CustomInstalledRepository(InstalledRepository):
 
 
 class Locker(BaseLocker):
-    def __init__(self):
-        self._lock = TOMLFile(Path.cwd().joinpath("poetry.lock"))
+    def __init__(self, lock_path):
+        self._lock = TOMLFile(Path(lock_path).joinpath("poetry.lock"))
         self._written_data = None
         self._locked = False
         self._content_hash = self._get_content_hash()
@@ -156,8 +156,8 @@ def installed():
 
 
 @pytest.fixture()
-def locker():
-    return Locker()
+def locker(project_root):
+    return Locker(lock_path=project_root)
 
 
 @pytest.fixture()

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -44,8 +44,8 @@ class CustomInstalledRepository(InstalledRepository):
 
 
 class Locker(BaseLocker):
-    def __init__(self):
-        self._lock = TOMLFile(Path.cwd().joinpath("poetry.lock"))
+    def __init__(self, lock_path):
+        self._lock = TOMLFile(Path(lock_path).joinpath("poetry.lock"))
         self._written_data = None
         self._locked = False
         self._content_hash = self._get_content_hash()
@@ -112,8 +112,8 @@ def installed():
 
 
 @pytest.fixture()
-def locker():
-    return Locker()
+def locker(project_root):
+    return Locker(lock_path=project_root)
 
 
 @pytest.fixture()


### PR DESCRIPTION
_Welcome guys, my first contrib, thanks for great tool, I use it everyday and it's great to finally help._
Relates to: #3155
[Locker sets package.source_url relative to lock path](https://github.com/python-poetry/poetry/blob/34ca1657cbd2834d98e3bb99ed76fd2df2e6b3b2/poetry/packages/locker.py#L598-L603), this made it so that tests were failing if run outside root directory because [lock path was set to Path.cwd()](https://github.com/python-poetry/poetry/blob/34ca1657cbd2834d98e3bb99ed76fd2df2e6b3b2/tests/installation/test_installer.py#L92) and [fixtures were set](https://github.com/python-poetry/poetry/blob/7d7a86d60922c7a91d9e6b890898aa14557ba449/tests/installation/fixtures/with-file-dependency.test#L11) to be relative to project dir.

By using `project_root` fixture as lock path now tests can be run from any directory.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] ~~Added **tests** for changed code.~~ (not applicable)
- [x] ~~Updated **documentation** for changed code.~~ (not applicable)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Notes:
- I didn't have time to check all tests to see if `project_root` fixture could be reused somewhere. I did grep for `project_root` though and I didn't find any duplicate code.
- I was confused why `test_installer_old.py` exists but I changed it as well.
- [Here](https://github.com/python-poetry/poetry/blob/34ca1657cbd2834d98e3bb99ed76fd2df2e6b3b2/tests/installation/test_installer.py#L135), we also set `root_dir` for package but because [locker uses](https://github.com/python-poetry/poetry/blob/34ca1657cbd2834d98e3bb99ed76fd2df2e6b3b2/poetry/packages/locker.py#L601) `self._lock.path` changing that `p.root_dir` didn't help. I wonder if locker should have idea of what is root_dir of package of which dependencies are being installed, unless `self._lock.path` and `package.root_dir` are always the same. Are they ?
- With or without this PR project root lock was used in test_installer.py tests meaning that `locker._lock.read()` fixture would actually show [poetry's lock file ](https://github.com/python-poetry/poetry/blob/master/poetry.lock). Maybe that's not the best and it should be set to non-existing lock file since in tests we don't seem to read and writing is mocked out.