### PR TITLE
remove deprecated string format command for subset of poetry/console/…

### DIFF
--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -247,7 +247,7 @@ class AddCommand(InstallerCommand, InitCommand):
             "The following packages are already present in the pyproject.toml and will be skipped:\n"
         )
         for name in existing_packages:
-            self.line("  • <c1>{name}</c1>".format(name=name))
+            self.line(f" • <c1>{name}</c1>")
         self.line(
             "\nIf you want to update it to the latest compatible version, you can use `poetry update package`.\n"
             "If you prefer to upgrade it to the latest available version, you can use `poetry add package@latest`.\n"

--- a/poetry/console/commands/add.py
+++ b/poetry/console/commands/add.py
@@ -247,7 +247,7 @@ class AddCommand(InstallerCommand, InitCommand):
             "The following packages are already present in the pyproject.toml and will be skipped:\n"
         )
         for name in existing_packages:
-            self.line(f" • <c1>{name}</c1>")
+            self.line(f"  • <c1>{name}</c1>")
         self.line(
             "\nIf you want to update it to the latest compatible version, you can use `poetry update package`.\n"
             "If you prefer to upgrade it to the latest available version, you can use `poetry add package@latest`.\n"

--- a/poetry/console/commands/cache/clear.py
+++ b/poetry/console/commands/cache/clear.py
@@ -29,7 +29,7 @@ class CacheClearCommand(Command):
         try:
             cache_dir.relative_to(REPOSITORY_CACHE_DIR)
         except ValueError:
-            raise ValueError("{} is not a valid repository cache".format(root))
+            raise ValueError(f"{root} is not a valid repository cache")
 
         cache = CacheManager(
             {
@@ -43,11 +43,11 @@ class CacheClearCommand(Command):
             if not self.option("all"):
                 raise RuntimeError(
                     "Add the --all option if you want to clear all "
-                    "{} caches".format(parts[0])
+                    f"{parts[0]} caches"
                 )
 
             if not os.path.exists(str(cache_dir)):
-                self.line("No cache entries for {}".format(parts[0]))
+                self.line(f"No cache entries for {parts[0]}")
                 return 0
 
             # Calculate number of entries
@@ -56,7 +56,7 @@ class CacheClearCommand(Command):
                 entries_count += len(files)
 
             delete = self.confirm(
-                "<question>Delete {} entries?</>".format(entries_count)
+                f"<question>Delete {entries_count} entries?</>"
             )
             if not delete:
                 return 0
@@ -71,14 +71,14 @@ class CacheClearCommand(Command):
             package = parts[1]
             version = parts[2]
 
-            if not cache.has("{}:{}".format(package, version)):
-                self.line("No cache entries for {}:{}".format(package, version))
+            if not cache.has(f"{package}:{version}"):
+                self.line(f"No cache entries for {package}:{version}")
                 return 0
 
-            delete = self.confirm("Delete cache entry {}:{}".format(package, version))
+            delete = self.confirm(f"Delete cache entry {package}:{version}")
             if not delete:
                 return 0
 
-            cache.forget("{}:{}".format(package, version))
+            cache.forget(f"{package}:{version}")
         else:
             raise ValueError("Invalid cache key")

--- a/poetry/console/commands/cache/clear.py
+++ b/poetry/console/commands/cache/clear.py
@@ -55,9 +55,7 @@ class CacheClearCommand(Command):
             for path, dirs, files in os.walk(str(cache_dir)):
                 entries_count += len(files)
 
-            delete = self.confirm(
-                f"<question>Delete {entries_count} entries?</>"
-            )
+            delete = self.confirm(f"<question>Delete {entries_count} entries?</>")
             if not delete:
                 return 0
 

--- a/poetry/console/commands/cache/list.py
+++ b/poetry/console/commands/cache/list.py
@@ -17,7 +17,7 @@ class CacheListCommand(Command):
             caches = list(sorted(REPOSITORY_CACHE_DIR.iterdir()))
             if caches:
                 for cache in caches:
-                    self.line("<info>{}</>".format(cache.name))
+                    self.line(f"<info>{cache.name}</>")
                 return 0
 
         self.line("<warning>No caches found</>")

--- a/poetry/console/commands/check.py
+++ b/poetry/console/commands/check.py
@@ -22,9 +22,9 @@ class CheckCommand(Command):
             return 0
 
         for error in check_result["errors"]:
-            self.line("<error>Error: {}</error>".format(error))
+            self.line(f"<error>Error: {error}</error>")
 
         for error in check_result["warnings"]:
-            self.line("<warning>Warning: {}</warning>".format(error))
+            self.line(f"<warning>Warning: {error}</warning>")
 
         return 1

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -140,9 +140,7 @@ To remove a repository (repo is a short alias for repositories):
                 else:
                     repo = config.get(f"repositories.{m.group(1)}")
                     if repo is None:
-                        raise ValueError(
-                            f"There is no {m.group(1)} repository defined"
-                        )
+                        raise ValueError(f"There is no {m.group(1)} repository defined")
 
                     value = repo
 
@@ -184,22 +182,16 @@ To remove a repository (repo is a short alias for repositories):
             if self.option("unset"):
                 repo = config.get(f"repositories.{m.group(1)}")
                 if repo is None:
-                    raise ValueError(
-                        f"There is no {m.group(1)} repository defined"
-                    )
+                    raise ValueError(f"There is no {m.group(1)} repository defined")
 
-                config.config_source.remove_property(
-                    f"repositories.{m.group(1)}"
-                )
+                config.config_source.remove_property(f"repositories.{m.group(1)}")
 
                 return 0
 
             if len(values) == 1:
                 url = values[0]
 
-                config.config_source.add_property(
-                    f"repositories.{m.group(1)}.url", url
-                )
+                config.config_source.add_property(f"repositories.{m.group(1)}.url", url)
 
                 return 0
 
@@ -316,7 +308,9 @@ To remove a repository (repo is a short alias for repositories):
             if k.startswith("repositories."):
                 message = f"<c1>{k + key}</c1> = <c2>{json.dumps(raw_val)}</c2>"
             elif isinstance(raw_val, str) and raw_val != value:
-                message = f"<c1>{k + key}</c1> = <c2>{json.dumps(raw_val)}</c2>  # {value}"
+                message = (
+                    f"<c1>{k + key}</c1> = <c2>{json.dumps(raw_val)}</c2>  # {value}"
+                )
             else:
                 message = f"<c1>{k + key}</c1> = <c2>{ json.dumps(value)}</c2>"
 

--- a/poetry/console/commands/config.py
+++ b/poetry/console/commands/config.py
@@ -138,10 +138,10 @@ To remove a repository (repo is a short alias for repositories):
                     if config.get("repositories") is not None:
                         value = config.get("repositories")
                 else:
-                    repo = config.get("repositories.{}".format(m.group(1)))
+                    repo = config.get(f"repositories.{m.group(1)}")
                     if repo is None:
                         raise ValueError(
-                            "There is no {} repository defined".format(m.group(1))
+                            f"There is no {m.group(1)} repository defined"
                         )
 
                     value = repo
@@ -150,7 +150,7 @@ To remove a repository (repo is a short alias for repositories):
             else:
                 values = self.unique_config_values
                 if setting_key not in values:
-                    raise ValueError("There is no {} setting.".format(setting_key))
+                    raise ValueError(f"There is no {setting_key} setting.")
 
                 value = config.get(setting_key)
 
@@ -182,14 +182,14 @@ To remove a repository (repo is a short alias for repositories):
                 raise ValueError("You cannot remove the [repositories] section")
 
             if self.option("unset"):
-                repo = config.get("repositories.{}".format(m.group(1)))
+                repo = config.get(f"repositories.{m.group(1)}")
                 if repo is None:
                     raise ValueError(
-                        "There is no {} repository defined".format(m.group(1))
+                        f"There is no {m.group(1)} repository defined"
                     )
 
                 config.config_source.remove_property(
-                    "repositories.{}".format(m.group(1))
+                    f"repositories.{m.group(1)}"
                 )
 
                 return 0
@@ -198,7 +198,7 @@ To remove a repository (repo is a short alias for repositories):
                 url = values[0]
 
                 config.config_source.add_property(
-                    "repositories.{}.url".format(m.group(1)), url
+                    f"repositories.{m.group(1)}.url", url
                 )
 
                 return 0
@@ -230,7 +230,7 @@ To remove a repository (repo is a short alias for repositories):
                 elif len(values) != 2:
                     raise ValueError(
                         "Expected one or two arguments "
-                        "(username, password), got {}".format(len(values))
+                        f"(username, password), got {len(values)}"
                     )
                 else:
                     username = values[0]
@@ -240,7 +240,7 @@ To remove a repository (repo is a short alias for repositories):
             elif m.group(1) == "pypi-token":
                 if len(values) != 1:
                     raise ValueError(
-                        "Expected only one argument (token), got {}".format(len(values))
+                        f"Expected only one argument (token), got {len(values)}"
                     )
 
                 token = values[0]
@@ -256,21 +256,21 @@ To remove a repository (repo is a short alias for repositories):
         if m:
             if self.option("unset"):
                 config.auth_config_source.remove_property(
-                    "certificates.{}.{}".format(m.group(1), m.group(2))
+                    f"certificates.{m.group(1)}.{m.group(2)}"
                 )
 
                 return 0
 
             if len(values) == 1:
                 config.auth_config_source.add_property(
-                    "certificates.{}.{}".format(m.group(1), m.group(2)), values[0]
+                    f"certificates.{m.group(1)}.{m.group(2)}", values[0]
                 )
             else:
                 raise ValueError("You must pass exactly 1 value")
 
             return 0
-
-        raise ValueError("Setting {} does not exist".format(self.argument("key")))
+        selfArg = self.argument("key")
+        raise ValueError(f"Setting {selfArg} does not exist")
 
     def _handle_single_value(
         self,
@@ -286,7 +286,7 @@ To remove a repository (repo is a short alias for repositories):
 
         value = values[0]
         if not validator(value):
-            raise RuntimeError('"{}" is an invalid value for {}'.format(value, key))
+            raise RuntimeError(f'"{value}" is an invalid value for {key}')
 
         source.add_property(key, normalizer(value))
 
@@ -301,7 +301,7 @@ To remove a repository (repo is a short alias for repositories):
             raw_val = raw.get(key)
 
             if isinstance(value, dict):
-                k += "{}.".format(key)
+                k += f"{key}."
                 self._list_configuration(value, raw_val, k=k)
                 k = orig_k
 
@@ -310,19 +310,15 @@ To remove a repository (repo is a short alias for repositories):
                 value = [
                     json.dumps(val) if isinstance(val, list) else val for val in value
                 ]
-
-                value = "[{}]".format(", ".join(value))
+                valueList = ", ".join(value)
+                value = f"[{valueList}]"
 
             if k.startswith("repositories."):
-                message = "<c1>{}</c1> = <c2>{}</c2>".format(
-                    k + key, json.dumps(raw_val)
-                )
+                message = f"<c1>{k + key}</c1> = <c2>{json.dumps(raw_val)}</c2>"
             elif isinstance(raw_val, str) and raw_val != value:
-                message = "<c1>{}</c1> = <c2>{}</c2>  # {}".format(
-                    k + key, json.dumps(raw_val), value
-                )
+                message = f"<c1>{k + key}</c1> = <c2>{json.dumps(raw_val)}</c2>  # {value}"
             else:
-                message = "<c1>{}</c1> = <c2>{}</c2>".format(k + key, json.dumps(value))
+                message = f"<c1>{k + key}</c1> = <c2>{ json.dumps(value)}</c2>"
 
             self.line(message)
 
@@ -365,8 +361,8 @@ To remove a repository (repo is a short alias for repositories):
                         json.dumps(val) if isinstance(val, list) else val
                         for val in value
                     ]
-
-                    value = "[{}]".format(", ".join(value))
+                    valueList = ", ".join(value)
+                    value = f"[{valueList}]"
 
                 value = json.dumps(value)
 

--- a/poetry/console/commands/debug/info.py
+++ b/poetry/console/commands/debug/info.py
@@ -16,10 +16,8 @@ class DebugInfoCommand(Command):
         self.line(
             "\n".join(
                 [
-                    "<info>Version</info>: <comment>{}</>".format(self.poetry.VERSION),
-                    "<info>Python</info>:  <comment>{}</>".format(
-                        poetry_python_version
-                    ),
+                    f"<info>Version</info>: <comment>{self.poetry.VERSION}</>",
+                    f"<info>Python</info>:  <comment>{poetry_python_version}</>",
                 ]
             )
         )

--- a/poetry/console/commands/debug/resolve.py
+++ b/poetry/console/commands/debug/resolve.py
@@ -131,8 +131,8 @@ class DebugResolveCommand(InitCommand):
 
             pkg = op.package
             row = [
-                "<c1>{}</c1>".format(pkg.complete_name),
-                "<b>{}</b>".format(pkg.version),
+                f"<c1>{pkg.complete_name}</c1>",
+                f"<b>{pkg.version}</b>",
                 "",
             ]
 

--- a/poetry/console/commands/env/info.py
+++ b/poetry/console/commands/env/info.py
@@ -39,7 +39,9 @@ class EnvInfoCommand(Command):
         self.line("")
         self.line("<b>Virtualenv</b>")
         listing = [
-            f"<info>Python</info>:         <comment>{env_python_version}</>".format(env_python_version),
+            f"<info>Python</info>:         <comment>{env_python_version}</>".format(
+                env_python_version
+            ),
             f"<info>Implementation</info>: <comment>{env.python_implementation}</>".format(
                 env.python_implementation
             ),
@@ -47,11 +49,9 @@ class EnvInfoCommand(Command):
             f"<info>Executable</info>:     <comment>{env_python }</>",
         ]
         if env.is_venv():
-            tag="comment" if env.is_sane() else "error"
-            is_valid=env.is_sane()
-            listing.append(
-                f"<info>Valid</info>:          <{tag}>{is_valid}</{tag}>"
-            )
+            tag = "comment" if env.is_sane() else "error"
+            is_valid = env.is_sane()
+            listing.append(f"<info>Valid</info>:          <{tag}>{is_valid}</{tag}>")
         self.line("\n".join(listing))
 
         self.line("")

--- a/poetry/console/commands/env/info.py
+++ b/poetry/console/commands/env/info.py
@@ -34,42 +34,39 @@ class EnvInfoCommand(Command):
 
     def _display_complete_info(self, env: "Env") -> None:
         env_python_version = ".".join(str(s) for s in env.version_info[:3])
+        env_path = env.path if env.is_venv() else "NA"
+        env_python = env.python if env.is_venv() else "NA"
         self.line("")
         self.line("<b>Virtualenv</b>")
         listing = [
-            "<info>Python</info>:         <comment>{}</>".format(env_python_version),
-            "<info>Implementation</info>: <comment>{}</>".format(
+            f"<info>Python</info>:         <comment>{env_python_version}</>".format(env_python_version),
+            f"<info>Implementation</info>: <comment>{env.python_implementation}</>".format(
                 env.python_implementation
             ),
-            "<info>Path</info>:           <comment>{}</>".format(
-                env.path if env.is_venv() else "NA"
-            ),
-            "<info>Executable</info>:     <comment>{}</>".format(
-                env.python if env.is_venv() else "NA"
-            ),
+            f"<info>Path</info>:           <comment>{env_path }</>",
+            f"<info>Executable</info>:     <comment>{env_python }</>",
         ]
         if env.is_venv():
+            tag="comment" if env.is_sane() else "error"
+            is_valid=env.is_sane()
             listing.append(
-                "<info>Valid</info>:          <{tag}>{is_valid}</{tag}>".format(
-                    tag="comment" if env.is_sane() else "error", is_valid=env.is_sane()
-                )
+                f"<info>Valid</info>:          <{tag}>{is_valid}</{tag}>"
             )
         self.line("\n".join(listing))
 
         self.line("")
 
         system_env = env.parent_env
+        system_env_version_info = ".".join(str(v) for v in system_env.version_info[:3])
         self.line("<b>System</b>")
         self.line(
             "\n".join(
                 [
-                    "<info>Platform</info>:   <comment>{}</>".format(env.platform),
-                    "<info>OS</info>:         <comment>{}</>".format(env.os),
-                    "<info>Python</info>:     <comment>{}</>".format(
-                        ".".join(str(v) for v in system_env.version_info[:3])
-                    ),
-                    "<info>Path</info>:       <comment>{}</>".format(system_env.path),
-                    "<info>Executable</info>: <comment>{}</>".format(system_env.python),
+                    f"<info>Platform</info>:   <comment>{env.platform}</>",
+                    f"<info>OS</info>:         <comment>{env.os}</>",
+                    f"<info>Python</info>:     <comment>{system_env_version_info}</>",
+                    f"<info>Path</info>:       <comment>{system_env.path}</>",
+                    f"<info>Executable</info>: <comment>{system_env.python}</>",
                 ]
             )
         )

--- a/poetry/console/commands/env/list.py
+++ b/poetry/console/commands/env/list.py
@@ -22,7 +22,7 @@ class EnvListCommand(Command):
                 name = str(venv.path)
 
             if venv == current_env:
-                self.line("<info>{} (Activated)</info>".format(name))
+                self.line(f"<info>{name} (Activated)</info>")
 
                 continue
 

--- a/poetry/console/commands/env/remove.py
+++ b/poetry/console/commands/env/remove.py
@@ -18,4 +18,4 @@ class EnvRemoveCommand(Command):
         manager = EnvManager(self.poetry)
         venv = manager.remove(self.argument("python"))
 
-        self.line("Deleted virtualenv: <comment>{}</comment>".format(venv.path))
+        self.line(f"Deleted virtualenv: <comment>{venv.path}</comment>")

--- a/poetry/console/commands/env/use.py
+++ b/poetry/console/commands/env/use.py
@@ -22,4 +22,4 @@ class EnvUseCommand(Command):
 
         env = manager.activate(self.argument("python"), self._io)
 
-        self.line("Using virtualenv: <comment>{}</>".format(env.path))
+        self.line(f"Using virtualenv: <comment>{env.path}</>")

--- a/poetry/console/commands/export.py
+++ b/poetry/console/commands/export.py
@@ -35,7 +35,7 @@ class ExportCommand(Command):
         fmt = self.option("format")
 
         if fmt not in Exporter.ACCEPTED_FORMATS:
-            raise ValueError("Invalid export format: {}".format(fmt))
+            raise ValueError(f"Invalid export format: {fmt}")
 
         output = self.option("output")
 

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -98,19 +98,19 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             name = Path.cwd().name.lower()
 
             question = self.create_question(
-                "Package name [<comment>{}</comment>]: ".format(name), default=name
+                f"Package name [<comment>{name}</comment>]: ", default=name
             )
             name = self.ask(question)
 
         version = "0.1.0"
         question = self.create_question(
-            "Version [<comment>{}</comment>]: ".format(version), default=version
+            f"Version [<comment>{version}</comment>]: ", default=version
         )
         version = self.ask(question)
 
         description = self.option("description") or ""
         question = self.create_question(
-            "Description [<comment>{}</comment>]: ".format(description),
+            f"Description [<comment>{description}</comment>]: ",
             default=description,
         )
         description = self.ask(question)
@@ -120,10 +120,10 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             author = vcs_config["user.name"]
             author_email = vcs_config.get("user.email")
             if author_email:
-                author += " <{}>".format(author_email)
+                author += f" <{author_email}>"
 
         question = self.create_question(
-            "Author [<comment>{}</comment>, n to skip]: ".format(author), default=author
+            f"Author [<comment>{author}</comment>, n to skip]: ", default=author
         )
         question.set_validator(lambda v: self._validate_author(v, author))
         author = self.ask(question)
@@ -136,7 +136,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         license = self.option("license") or ""
 
         question = self.create_question(
-            "License [<comment>{}</comment>]: ".format(license), default=license
+            f"License [<comment>{license}</comment>]: ", default=license
         )
         question.set_validator(self._validate_license)
         license = self.ask(question)
@@ -144,13 +144,10 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         python = self.option("python")
         if not python:
             current_env = SystemEnv(Path(sys.executable))
-            default_python = "^{}".format(
-                ".".join(str(v) for v in current_env.version_info[:2])
-            )
+            curr_evn_version_info = ".".join(str(v) for v in current_env.version_info[:2])
+            default_python = f"^{curr_evn_version_info}"
             question = self.create_question(
-                "Compatible Python versions [<comment>{}</comment>]: ".format(
-                    default_python
-                ),
+                f"Compatible Python versions [<comment>{default_python}</comment>]: ",
                 default=default_python,
             )
             python = self.ask(question)
@@ -251,7 +248,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     or "path" in constraint
                     or "version" in constraint
                 ):
-                    self.line("Adding <info>{}</info>".format(package))
+                    self.line(f"Adding <info>{package}</info>")
                     requires.append(constraint)
                     package = self.ask("\nAdd a package:")
                     continue
@@ -280,9 +277,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                         choices.append(found_package.pretty_name)
 
                     self.line(
-                        "Found <info>{}</info> packages matching <c1>{}</c1>".format(
-                            len(matches), package
-                        )
+                        f"Found <info>{len(matches)}</info> packages matching <c1>{package}</c1>"
                     )
 
                     package = self.choice(
@@ -312,9 +307,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                         )
 
                         self.line(
-                            "Using version <b>{}</b> for <c1>{}</c1>".format(
-                                package_constraint, package
-                            )
+                            f"Using version <b>{package_constraint}</b> for <c1>{package}</c1>"
                         )
 
                     constraint["version"] = package_constraint
@@ -344,7 +337,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 requirement["name"] = name
 
                 self.line(
-                    "Using version <b>{}</b> for <c1>{}</c1>".format(version, name)
+                    f"Using version <b>{version}</b> for <c1>{name}</c1>"
                 )
             else:
                 # check that the specified version/constraint exists
@@ -379,7 +372,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if not package:
             # TODO: find similar
             raise ValueError(
-                "Could not find a matching version of package {}".format(name)
+                f"Could not find a matching version of package {name}"
             )
 
         return package.pretty_name, selector.find_recommended_require_version(package)

--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -144,7 +144,9 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         python = self.option("python")
         if not python:
             current_env = SystemEnv(Path(sys.executable))
-            curr_evn_version_info = ".".join(str(v) for v in current_env.version_info[:2])
+            curr_evn_version_info = ".".join(
+                str(v) for v in current_env.version_info[:2]
+            )
             default_python = f"^{curr_evn_version_info}"
             question = self.create_question(
                 f"Compatible Python versions [<comment>{default_python}</comment>]: ",
@@ -336,9 +338,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 requirement["version"] = version
                 requirement["name"] = name
 
-                self.line(
-                    f"Using version <b>{version}</b> for <c1>{name}</c1>"
-                )
+                self.line(f"Using version <b>{version}</b> for <c1>{name}</c1>")
             else:
                 # check that the specified version/constraint exists
                 # before we proceed
@@ -371,9 +371,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         if not package:
             # TODO: find similar
-            raise ValueError(
-                f"Could not find a matching version of package {name}"
-            )
+            raise ValueError(f"Could not find a matching version of package {name}")
 
         return package.pretty_name, selector.find_recommended_require_version(package)
 


### PR DESCRIPTION
…command files

This PR updates the deprecated format() fn for string interprolation and replaces it with the f".." notation for a subset of the poetry/console/command module


Relates-to: #3860
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.