### PR TITLE
Allow for empty choice while selecting dependencies

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -306,19 +306,26 @@ You can specify a package in the following forms:
 
                     self.line(info_string)
 
+                    # Default to an empty value to signal no package was selected
+                    choices.append("")
+
                     package = self.choice(
                         "\nEnter package # to add, or the complete package name if it"
                         " is not listed",
                         choices,
                         attempts=3,
+                        default=len(choices) - 1,
                     )
 
+                    if not package:
+                        self.line("<warning>No package selected</warning>")
+
                     # package selected by user, set constraint name to package name
-                    if package is not False:
+                    if package:
                         constraint["name"] = package
 
                 # no constraint yet, determine the best version automatically
-                if package is not False and "version" not in constraint:
+                if package and "version" not in constraint:
                     question = self.create_question(
                         "Enter the version constraint to require "
                         "(or leave blank to use the latest version):"
@@ -340,7 +347,7 @@ You can specify a package in the following forms:
 
                     constraint["version"] = package_constraint
 
-                if package is not False:
+                if package:
                     result.append(constraint)
 
                 if self.io.is_interactive():

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -177,6 +177,50 @@ pytest = "^3.6.0"
     assert expected in tester.io.fetch_output()
 
 
+# Regression test for https://github.com/python-poetry/poetry/issues/2355
+def test_interactive_with_dependencies_and_no_selection(
+    tester: CommandTester, repo: TestRepository
+):
+    repo.add_package(get_package("django-pendulum", "0.1.6-pre4"))
+    repo.add_package(get_package("pendulum", "2.0.0"))
+    repo.add_package(get_package("pytest", "3.6.0"))
+
+    inputs = [
+        "my-package",  # Package name
+        "1.2.3",  # Version
+        "This is a description",  # Description
+        "n",  # Author
+        "MIT",  # License
+        "~2.7 || ^3.6",  # Python
+        "",  # Interactive packages
+        "pendulu",  # Search for package
+        "",  # Do not select an option
+        "",  # Stop searching for packages
+        "",  # Interactive dev packages
+        "pytest",  # Search for package
+        "",  # Do not select an option
+        "",
+        "",
+        "\n",  # Generate
+    ]
+    tester.execute(inputs="\n".join(inputs))
+    expected = """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+readme = "README.md"
+packages = [{include = "my_package"}]
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+"""
+
+    assert expected in tester.io.fetch_output()
+
+
 def test_empty_license(tester: CommandTester):
     inputs = [
         "my-package",  # Package name


### PR DESCRIPTION
Fixes #2355

This works around an issue with cleo's `Command.choice` implementation.
If the user does not make a selection then an AttributeError is raised.

# Pull Request Check List

Resolves: #2355

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code (not applicable, I think).

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
