### PR TITLE
Fix for "poetry lock --no-update" so that dependencies with extras are not updated unnecessarily

### DIFF
--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -378,8 +378,9 @@ class VersionSolver:
                             if version.version != locked.version:
                                 version = None
                             break
-            with suppress(IndexError):
-                version = version or packages[0]
+            if version is None:
+                with suppress(IndexError):
+                    version = packages[0]
 
             if version is None:
                 # If there are no versions that satisfy the constraint,

--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -366,21 +366,21 @@ class VersionSolver:
                 )
                 return dependency.complete_name
 
-            version = None
+            package = None
             if dependency.name not in self._use_latest:
                 # prefer locked version of compatible (not exact same) dependency;
                 # required in order to not unnecessarily update dependencies with
                 # extras, e.g. "coverage" vs. "coverage[toml]"
                 locked = self._locked.get(dependency.name, None)
             if locked is not None:
-                version = next(
+                package = next(
                     (p for p in packages if p.version == locked.version), None
                 )
-            if version is None:
+            if package is None:
                 with suppress(IndexError):
-                    version = packages[0]
+                    package = packages[0]
 
-            if version is None:
+            if package is None:
                 # If there are no versions that satisfy the constraint,
                 # add an incompatibility that indicates that.
                 self._add_incompatibility(
@@ -389,12 +389,12 @@ class VersionSolver:
 
                 return dependency.complete_name
         else:
-            version = locked
+            package = locked
 
-        version = self._provider.complete_package(version)
+        package = self._provider.complete_package(package)
 
         conflict = False
-        for incompatibility in self._provider.incompatibilities_for(version):
+        for incompatibility in self._provider.incompatibilities_for(package):
             self._add_incompatibility(incompatibility)
 
             # If an incompatibility is already satisfied, then selecting version
@@ -409,9 +409,9 @@ class VersionSolver:
             )
 
         if not conflict:
-            self._solution.decide(version)
+            self._solution.decide(package)
             self._log(
-                f"selecting {version.complete_name} ({version.full_pretty_version})"
+                f"selecting {package.complete_name} ({package.full_pretty_version})"
             )
 
         return dependency.complete_name

--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -372,12 +372,10 @@ class VersionSolver:
                 # required in order to not unnecessarily update dependencies with
                 # extras, e.g. "coverage" vs. "coverage[toml]"
                 locked = self._locked.get(dependency.name, None)
-                if locked is not None:
-                    for version in packages:
-                        if version.version <= locked.version:
-                            if version.version != locked.version:
-                                version = None
-                            break
+            if locked is not None:
+                version = next(
+                    (p for p in packages if p.version == locked.version), None
+                )
             if version is None:
                 with suppress(IndexError):
                     version = packages[0]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4612
Resolves: #3128
Resolves: #5185

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
When calling `poetry lock` with `--no-update` dependencies with extras should not be updated unnecessarily.
