### PR TITLE
Fix test_env.py::test_env_shell_commands_with_stdinput_in_their_arg_work_as_expected

### DIFF
--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -92,9 +92,11 @@ def test_env_shell_commands_with_stdinput_in_their_arg_work_as_expected(
     venv_path = Path(tmp_dir) / "Virtual Env"
     manager.build_venv(str(venv_path))
     venv = VirtualEnv(venv_path)
-    assert venv.run("python", "-", input_=GET_BASE_PREFIX, shell=True).strip() == str(
-        venv.get_base_prefix()
+    run_output_path = Path(
+        venv.run("python", "-", input_=GET_BASE_PREFIX, shell=True).strip()
     )
+    venv_base_prefix_path = Path(str(venv.get_base_prefix()))
+    assert run_output_path.resolve() == venv_base_prefix_path.resolve()
 
 
 @pytest.fixture


### PR DESCRIPTION
The test contains path comparison which does not take into account potential symlinks.
When testing under MacOS and brew-installed python, venv version points to a path with symlink while python outputs the resolved path.

# Pull Request Check List

- [n/a (fixes the test)] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
