### PR TITLE
install-poetry: prompt before deleting `data_dir`

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -484,6 +484,18 @@ class Installer:
 
             return 1
 
+        if not self._accept_all:
+            self._write(
+                "{}: Uninstalling Poetry will {} {}.".format(
+                    colorize("warning", "WARNING"),
+                    colorize("warning", "DELETE"),
+                    self._data_dir,
+                )
+            )
+            continue_uninstall = input("Do you want to continue? ([y]/n) ") or "y"
+            if continue_uninstall.lower() not in {"y", "yes"}:
+                return 1
+
         version = None
         if self._data_dir.joinpath("VERSION").exists():
             version = self._data_dir.joinpath("VERSION").read_text().strip()


### PR DESCRIPTION
The _install-poetry.py_ script supports an `--uninstall` option. The uninstall performs `shutil.rmtree(str(self._data_dir))`.

https://github.com/python-poetry/poetry/blob/82459bd6f38785882a8eff0fbce2a8b0119b205c/install-poetry.py#L479-L500

If `$POETRY_HOME` is set, `self._data_dir` is set to `$POETRY_HOME`.

https://github.com/python-poetry/poetry/blob/82459bd6f38785882a8eff0fbce2a8b0119b205c/install-poetry.py#L395

https://github.com/python-poetry/poetry/blob/82459bd6f38785882a8eff0fbce2a8b0119b205c/install-poetry.py#L134-L136

Uninstallation will therefore delete the entire `$POETRY_HOME` directory.

This PR will update _install-poetry.py_ to prompt the user before performing this destructive operation.