### PR TITLE
Handle NotImplementedError when creating symlink on install; fixes #4626

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy-3.7-v7.3.7"]
         experimental: [false]
         bootstrap-args: [""]
         include:

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -558,9 +558,10 @@ class Installer:
             self._bin_dir.joinpath(script).symlink_to(
                 self._data_dir.joinpath(target_script)
             )
-        except OSError:
-            # This can happen if the user
-            # does not have the correct permission on Windows
+        except (NotImplementedError, OSError):
+            # This can happen if the user does not have the correct permission
+            # or if they are using PyPy which does not implement symlink on
+            # Windows.
             shutil.copy(
                 self._data_dir.joinpath(target_script), self._bin_dir.joinpath(script)
             )

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -322,8 +322,11 @@ class PyPiRepository(RemoteRepository):
         return data.asdict()
 
     def _get(self, endpoint: str) -> Union[dict, None]:
+        headers = {
+            "Accept": "application/json",
+        }
         try:
-            json_response = self.session.get(self._base_url + endpoint)
+            json_response = self.session.get(self._base_url + endpoint, headers=headers)
         except requests.exceptions.TooManyRedirects:
             # Cache control redirect loop.
             # We try to remove the cache and try again


### PR DESCRIPTION
Handle `NotImplementedError` when creating symlink on install. I was able to recreate the issue locally with PyPy version 3.7.10 and Poetry version 1.1.11 and I verified my fix after making changes: `python install-poetry.py` completed successfully with this change in place. If accepted, please tag the merge with the label **hacktoberfest-accepted**.

Resolves: #4626 

- [ ] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

I am happy to add a test over this change if requested, but I don't see where tests covering the `install-poetry.py` script live in the repository.