### PR TITLE
Remove the `doc` env from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.3.0
 isolated_build = True
-envlist = py36, py37, py38, py39, doc
+envlist = py36, py37, py38, py39
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
In https://github.com/python-poetry/poetry/commit/bce4ac5d2c7e35c98d196e89f2325fdc11c5f6e9, the `doc` env was removed from tox.ini, and the doc was restructured differently. Since the `doc` env is not used anymore, I removed it from `tox.ini` file.

Relates-to: #4142
