### PR TITLE
remove __future__ imports and 'coding: utf-8' declarations that are n…

### DIFF
--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Dict
@@ -10,17 +7,16 @@ from typing import Optional
 from cleo.io.io import IO
 from cleo.io.null_io import NullIO
 
+from poetry.config.config import Config
+from poetry.config.file_config_source import FileConfigSource
 from poetry.core.factory import Factory as BaseFactory
 from poetry.core.toml.file import TOMLFile
-
-from .config.config import Config
-from .config.file_config_source import FileConfigSource
-from .locations import CONFIG_DIR
-from .packages.locker import Locker
-from .packages.project_package import ProjectPackage
-from .plugins.plugin_manager import PluginManager
-from .poetry import Poetry
-from .repositories.pypi_repository import PyPiRepository
+from poetry.locations import CONFIG_DIR
+from poetry.packages.locker import Locker
+from poetry.packages.project_package import ProjectPackage
+from poetry.plugins.plugin_manager import PluginManager
+from poetry.poetry import Poetry
+from poetry.repositories.pypi_repository import PyPiRepository
 
 
 if TYPE_CHECKING:

--- a/poetry/masonry/builders/editable.py
+++ b/poetry/masonry/builders/editable.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import hashlib
 import os
 import shutil

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from tests.helpers import get_package

--- a/tests/fixtures/directory/project_with_transitive_directory_dependencies/setup.py
+++ b/tests/fixtures/directory/project_with_transitive_directory_dependencies/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from distutils.core import setup
 
 packages = ["project_with_extras"]

--- a/tests/fixtures/git/github.com/demo/demo/setup.py
+++ b/tests/fixtures/git/github.com/demo/demo/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/git/github.com/demo/no-dependencies/setup.py
+++ b/tests/fixtures/git/github.com/demo/no-dependencies/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/git/github.com/demo/no-version/setup.py
+++ b/tests/fixtures/git/github.com/demo/no-version/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ast
 import os
 

--- a/tests/fixtures/git/github.com/demo/non-canonical-name/setup.py
+++ b/tests/fixtures/git/github.com/demo/non-canonical-name/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/fixtures/project_with_setup/setup.py
+++ b/tests/fixtures/project_with_setup/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from setuptools import setup
 
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import json
 import re
 import shutil

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import itertools
 import json
 import sys

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import itertools
 import sys
 

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os
 import shutil
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from pathlib import Path
 
 import pytest

--- a/tests/utils/fixtures/setups/ansible/setup.py
+++ b/tests/utils/fixtures/setups/ansible/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import os
 import os.path

--- a/tests/utils/fixtures/setups/flask/setup.py
+++ b/tests/utils/fixtures/setups/flask/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import io
 import re
 from collections import OrderedDict

--- a/tests/utils/fixtures/setups/pendulum/setup.py
+++ b/tests/utils/fixtures/setups/pendulum/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from distutils.core import setup
 
 from build import *


### PR DESCRIPTION
…ot necessary in python 3

# Pull Request Check List

Relates-to: #3860 

Removes __future__ imports that are not needed in python 3, and `-*- coding: utf-8 -*-` tags that are also not needed in python 3 because unicode is already the default.

Not sure if either of the checkboxes below are relevant here, but I did ensure that `poetry run pytest` still runs clean with all tests passing.
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

