### PR TITLE
removed a pitfall where the built-in name dir was being shadowed and …

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -178,7 +178,7 @@ def _get_win_folder_from_registry(csidl_name):
         _winreg.HKEY_CURRENT_USER,
         r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",
     )
-    dir, type = _winreg.QueryValueEx(key, shell_folder_name)
+    dir, _ = _winreg.QueryValueEx(key, shell_folder_name)
 
     return dir
 

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -178,7 +178,8 @@ def _get_win_folder_from_registry(csidl_name):
         _winreg.HKEY_CURRENT_USER,
         r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",
     )
-    dir, _ = _winreg.QueryValueEx(key, shell_folder_name)
+    directory, _ = _winreg.QueryValueEx(key, shell_folder_name)
+    return directory
 
     return dir
 


### PR DESCRIPTION
**The problem**
There was a built-in name shadowing pitfall on install-poetry.py where the name dir, which is a Python built-in method, was being used as a variable.;

If for any reason the method gets called within that context, it would cause a had to detect bug because dir(arg) would not be a method being called, but a variable being called as a method.

On top of this, the name itself was not being used for any action

Solution
Removed the name using underscore notation