### PR TITLE
github: configure dependency detection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # keep dependency updates manual for now
+    open-pull-requests-limit: 0
+    reviewers:
+      - "python-poetry/triage"


### PR DESCRIPTION
This change adds dependabot configuration with updates disabled to
allow for restriction of manifest file selection used by the
dependency graph.

Ref: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
