### PR TITLE
Fix dropped markers in dependency walk

### DIFF
--- a/poetry/packages/locker.py
+++ b/poetry/packages/locker.py
@@ -248,16 +248,15 @@ class Locker:
                         locked_package.to_dependency().constraint
                     )
 
-                if key not in nested_dependencies:
-                    for require in locked_package.requires:
-                        if require.marker.is_empty():
-                            require.marker = requirement.marker
-                        else:
-                            require.marker = require.marker.intersect(
-                                requirement.marker
-                            )
+                for require in locked_package.requires:
+                    if require.marker.is_empty():
+                        require.marker = requirement.marker
+                    else:
+                        require.marker = require.marker.intersect(requirement.marker)
 
-                        require.marker = require.marker.intersect(locked_package.marker)
+                    require.marker = require.marker.intersect(locked_package.marker)
+
+                    if key not in nested_dependencies:
                         next_level_dependencies.append(require)
 
             if requirement.name in project_level_dependencies and level == 0:

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -943,6 +943,79 @@ foo==1.2.3
     assert expected == content
 
 
+def test_exporter_can_export_requirements_txt_with_nested_packages_and_multiple_markers(
+    tmp_dir, poetry
+):
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo",
+                    "version": "1.2.3",
+                    "category": "main",
+                    "optional": False,
+                    "python-versions": "*",
+                    "dependencies": {
+                        "bar": [
+                            {
+                                "version": ">=1.2.3,<7.8.10",
+                                "markers": 'platform_system != "Windows"',
+                            },
+                            {
+                                "version": ">=4.5.6,<7.8.10",
+                                "markers": 'platform_system == "Windows"',
+                            },
+                        ]
+                    },
+                },
+                {
+                    "name": "bar",
+                    "version": "7.8.9",
+                    "category": "main",
+                    "optional": True,
+                    "python-versions": "*",
+                    "dependencies": {
+                        "baz": {
+                            "version": "!=10.11.12",
+                            "markers": 'platform_system == "Windows"',
+                        }
+                    },
+                },
+                {
+                    "name": "baz",
+                    "version": "10.11.13",
+                    "category": "main",
+                    "optional": True,
+                    "python-versions": "*",
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo": [], "bar": [], "baz": []},
+            },
+        }
+    )
+    set_package_requires(poetry)
+
+    exporter = Exporter(poetry)
+
+    exporter.export(
+        "requirements.txt", Path(tmp_dir), "requirements.txt", with_hashes=False
+    )
+
+    with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = """\
+bar==7.8.9; platform_system != "Windows" or platform_system == "Windows"
+baz==10.11.13; platform_system == "Windows"
+foo==1.2.3
+"""
+
+    assert expected == content
+
+
 def test_exporter_can_export_requirements_txt_with_git_packages_and_markers(
     tmp_dir, poetry
 ):


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3511

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

I would very much like a fix for #3511, and tonight for the first time I tried to understand the proposed fix at #3512.  I must admit I found it all a bit confusing!  Here is a version that makes a _much_ more localised change - my hope is that this is more palatable for merging.

Again the aim is to make sure that when we encounter an already-encountered dependency, we do not drop the associated markers.  But I've done this just by moving where we make the `if key not in nested_dependencies` check.

It's definitely possible that I've missed some good reason why #3512 is more complicated than this; but I have borrowed the unit test case added at #3512 and that still passes (and fails without the fix).  And I've also tested the fix in a couple of real life projects where I have run into this bug, and it does the job for those too.

@johnmacnamararseg @abn