### PR TITLE
Ignore combinations of overrides whose intersection of markers is empty

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -663,8 +663,9 @@ class Provider:
                         dep_other.set_constraint(
                             dep_other.constraint.intersect(dep_any.constraint)
                         )
-            else:
-                # if there is no any marker dependency,
+            elif not inverted_marker.is_empty():
+                # if there is no any marker dependency
+                # and the inverted marker is not empty,
                 # a dependency with the inverted union of all markers is required
                 # in order to not miss other dependencies later, for instance:
                 #   - foo (1.0) ; python == 3.7
@@ -680,10 +681,11 @@ class Provider:
 
             overrides = []
             overrides_marker_intersection = AnyMarker()
-            for _dep in self._overrides.get(package, {}).values():
-                overrides_marker_intersection = overrides_marker_intersection.intersect(
-                    _dep.marker
-                )
+            for dep_overrides in self._overrides.values():
+                for _dep in dep_overrides.values():
+                    overrides_marker_intersection = (
+                        overrides_marker_intersection.intersect(_dep.marker)
+                    )
             for _dep in _deps:
                 if not overrides_marker_intersection.intersect(_dep.marker).is_empty():
                     current_overrides = self._overrides.copy()

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -16,8 +16,10 @@ from typing import Iterator
 
 from cleo.ui.progress_indicator import ProgressIndicator
 from poetry.core.packages.utils.utils import get_python_constraint_from_marker
+from poetry.core.semver.empty_constraint import EmptyConstraint
 from poetry.core.semver.version import Version
 from poetry.core.vcs.git import Git
+from poetry.core.version.markers import AnyMarker
 from poetry.core.version.markers import MarkerUnion
 
 from poetry.inspection.info import PackageInfo
@@ -70,7 +72,7 @@ class Provider:
         self._search_for: dict[Dependency, list[Package]] = {}
         self._is_debugging = self._io.is_debug() or self._io.is_very_verbose()
         self._in_progress = False
-        self._overrides: dict = {}
+        self._overrides: dict[DependencyPackage, dict[str, Dependency]] = {}
         self._deferred_cache: dict[Dependency, Package] = {}
         self._load_deferred = True
 
@@ -356,6 +358,28 @@ class Provider:
 
         return package
 
+    def _get_dependencies_with_overrides(
+        self, dependencies: list[Dependency], package: DependencyPackage
+    ) -> list[Dependency]:
+        overrides = self._overrides.get(package, {})
+        _dependencies = []
+        overridden = []
+        for dep in dependencies:
+            if dep.name in overrides:
+                if dep.name in overridden:
+                    continue
+
+                # empty constraint is used in overrides to mark that the package has
+                # already been handled and is not required for the attached markers
+                if not overrides[dep.name].constraint.is_empty():
+                    _dependencies.append(overrides[dep.name])
+                overridden.append(dep.name)
+
+                continue
+
+            _dependencies.append(dep)
+        return _dependencies
+
     def incompatibilities_for(
         self, package: DependencyPackage
     ) -> list[Incompatibility]:
@@ -409,21 +433,7 @@ class Provider:
             and self._python_constraint.allows_any(dep.python_constraint)
             and (not self._env or dep.marker.validate(self._env.marker_env))
         ]
-
-        overrides = self._overrides.get(package, {})
-        dependencies = []
-        overridden = []
-        for dep in _dependencies:
-            if dep.name in overrides:
-                if dep.name in overridden:
-                    continue
-
-                dependencies.append(overrides[dep.name])
-                overridden.append(dep.name)
-
-                continue
-
-            dependencies.append(dep)
+        dependencies = self._get_dependencies_with_overrides(_dependencies, package)
 
         return [
             Incompatibility(
@@ -505,20 +515,7 @@ class Provider:
 
             _dependencies.append(dep)
 
-        overrides = self._overrides.get(package, {})
-        dependencies = []
-        overridden = []
-        for dep in _dependencies:
-            if dep.name in overrides:
-                if dep.name in overridden:
-                    continue
-
-                dependencies.append(overrides[dep.name])
-                overridden.append(dep.name)
-
-                continue
-
-            dependencies.append(dep)
+        dependencies = self._get_dependencies_with_overrides(_dependencies, package)
 
         # Searching for duplicate dependencies
         #
@@ -654,28 +651,49 @@ class Provider:
             any_markers_dependencies = [d for d in _deps if d.marker.is_any()]
             other_markers_dependencies = [d for d in _deps if not d.marker.is_any()]
 
-            if any_markers_dependencies:
-                marker = other_markers_dependencies[0].marker
-                for other_dep in other_markers_dependencies[1:]:
-                    marker = marker.union(other_dep.marker)
+            marker = other_markers_dependencies[0].marker
+            for other_dep in other_markers_dependencies[1:]:
+                marker = marker.union(other_dep.marker)
+            inverted_marker = marker.invert()
 
-                inverted_marker = marker.invert()
+            if any_markers_dependencies:
                 for dep_any in any_markers_dependencies:
                     dep_any.marker = inverted_marker
                     for dep_other in other_markers_dependencies:
                         dep_other.set_constraint(
                             dep_other.constraint.intersect(dep_any.constraint)
                         )
+            else:
+                # if there is no any marker dependency,
+                # a dependency with the inverted union of all markers is required
+                # in order to not miss other dependencies later, for instance:
+                #   - foo (1.0) ; python == 3.7
+                #   - foo (2.0) ; python == 3.8
+                #   - bar (2.0) ; python == 3.8
+                #   - bar (3.0) ; python == 3.9
+                #
+                # the last dependency would be missed without this,
+                # because the intersection with both foo dependencies is empty
+                inverted_marker_dep = _deps[0].with_constraint(EmptyConstraint())
+                inverted_marker_dep.marker = inverted_marker
+                _deps.append(inverted_marker_dep)
 
             overrides = []
+            overrides_marker_intersection = AnyMarker()
+            for _dep in self._overrides.get(package, {}).values():
+                overrides_marker_intersection = overrides_marker_intersection.intersect(
+                    _dep.marker
+                )
             for _dep in _deps:
-                current_overrides = self._overrides.copy()
-                package_overrides = current_overrides.get(package, {}).copy()
-                package_overrides.update({_dep.name: _dep})
-                current_overrides.update({package: package_overrides})
-                overrides.append(current_overrides)
+                if not overrides_marker_intersection.intersect(_dep.marker).is_empty():
+                    current_overrides = self._overrides.copy()
+                    package_overrides = current_overrides.get(package, {}).copy()
+                    package_overrides.update({_dep.name: _dep})
+                    current_overrides.update({package: package_overrides})
+                    overrides.append(current_overrides)
 
-            raise OverrideNeeded(*overrides)
+            if overrides:
+                raise OverrideNeeded(*overrides)
 
         # Modifying dependencies as needed
         clean_dependencies = []


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3367
Resolves: #4670
Resolves: #4870
Resolves: #4947

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
Currently, poetry tries all combinations for multiple-constraints-dependencies, even if markers exclude each other, which means that the concerning combination is not relevant. As a consequence, dependency resolution may fail even if there is a solution as in #3367 or dependency resolution will take unnecessarily long as in #4670.

Instead of considering all combinations, only combinations whose intersection of markers is not empty should be considered in the overrides.

In the following example, it is clear that only two of the four combinations are relevant (one with both dependencies for 3.6 and one with both dependencies for 3.7). Mixed combinations are not sensible.

```
lib1= [
    {version = "1.0", python = "~3.6"},
    {version = "2.0", python = "~3.7"}
]
lib2 = [
    {version = "1.0", python = "~3.6"},
    {version = "2.0", python = "~3.7"},
]
```
However, there is one special case that has to be considered. Let's extend the previous example as follows:

```
lib1= [
    {version = "1.0", python = "~3.6"},
    {version = "2.0", python = "~3.7"}
]
lib2 = [
    {version = "1.0", python = "~3.6"},
    {version = "2.0", python = "~3.7"},
    {version = "3.0", python = "~3.8"}
]
```

Now, only considering the combinations whose intersection of markers is not empty is not enough because the constraint for lib2 for python 3.8 would be ignored. Thus, when determining the overrides, a dummy override with the inversion of the union of all markers of a dependency has to be added if there is no any marker dependency. In the example above, an empty constraint for lib1 with markers `not (python = "~3.6" or python = "~3.7")` (inversion of union of all markers of lib1) has to be added to the overrides. Thus, a solution for lib2 for python 3.8 can be found, not considering lib1 at all.

I am aware that this solution heavily relies on poetry's ability to recognize if the intersection of markers is empty and that poetry probably will fail in this task for more complex markers. However, I think that even in that case the drawback of this solution are only some additional (unnecessary but harmless) dependency resolutions (for the dummy overrides).

PR python-poetry/poetry-core#226 improves poetry's ability to recognize if the intersection of markers is empty.
