### PR TITLE
Handles name == None case (re: issue #4311, #3628)

### DIFF
--- a/poetry/repositories/installed_repository.py
+++ b/poetry/repositories/installed_repository.py
@@ -231,8 +231,13 @@ class InstalledRepository(Repository):
                 metadata.distributions(path=[entry]),
                 key=lambda d: str(d._path),
             ):
-                name = canonicalize_name(distribution.metadata["name"])
-
+                try:
+                    name = canonicalize_name(distribution.metadata["name"])
+                except TypeError as e:
+                    # handling the case where a distribution is empty but is nevertheless picked up in the search
+                    # and its name is `None`
+                    continue
+                    
                 if name in seen:
                     continue
 


### PR DESCRIPTION
Addresses issue #4311 and others, related to `canonicalize_name` throwing TypeError because a str or bytes like object was expected.

# Pull Request Check List

Resolves: #4311, #3628

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
