### PR TITLE
pypi, retry when receiving a 200 with empty body

### DIFF
--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -313,6 +313,9 @@ class PyPiRepository(RemoteRepository):
     def _get(self, endpoint):  # type: (str) -> Union[dict, None]
         try:
             json_response = self.session.get(self._base_url + endpoint)
+            if json_response.status_code == 200 and json_response.content == b"":
+                logger.warn("Got empty response from PyPI for %s. Retrying...", endpoint)
+                json_response = self.session.get(self._base_url + endpoint)
         except requests.exceptions.TooManyRedirects:
             # Cache control redirect loop.
             # We try to remove the cache and try again


### PR DESCRIPTION
For some reason, pypi is returning a 200 and an empty body from time to time. The next time you query the same endpoint it returns a proper JSON object. This is not fixing a bug in poetry, but working around the issue.

This was resulting in issue where anything operation modifying the lock file would randomly fail due to `JSONDecodeError`. This is unrelated to https://github.com/python-poetry/poetry/pull/4592

# Pull Request Check List

Resolves: Issue not created.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code. <=== N/A
- [ ] Updated **documentation** for changed code. <=== N/A

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
