### PR TITLE
fix: required extras packages are installed

### DIFF
--- a/poetry/puzzle/solver.py
+++ b/poetry/puzzle/solver.py
@@ -163,14 +163,18 @@ class Solver:
                         and not _package.is_same_package_as(package)
                         and _package.version == package.version
                     ):
+                        missing_deps = []
                         for dep in package.requires:
                             if dep.is_same_package_as(_package):
                                 continue
 
                             if dep not in _package.requires:
-                                _package.add_dependency(dep)
+                                missing_deps.append(dep)
+                        for dep in missing_deps:
+                            package.add_dependency(dep)
 
-                continue
+                if any(x.name == package.name for x in final_packages):
+                    continue
 
             final_packages.append(package)
             depths.append(results[package])


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4721

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


I do not understand depths properly so this likely needs fixing. In my local example I have depths of (2,4,3) and this just always chooses the first instance. 