### PR TITLE
installer: replace with install.python-poetry.org

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,8 +19,7 @@ test_task:
   env_script:
     - echo "PATH=/.local/bin:${PATH}" >> $CIRRUS_ENV
   poetry_script:
-    - curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-      | $PYTHON - -y
+    - curl -sL https://install.python-poetry.org | $PYTHON - -y
     - poetry config virtualenvs.in-project true
   test_script:
     - poetry install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,7 @@ jobs:
       - name: Bootstrap poetry
         shell: bash
         run: |
-          curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-            | python - -y ${{ matrix.bootstrap-args }}
+          curl -sL https://install.python-poetry.org | python - -y ${{ matrix.bootstrap-args }}
 
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ from the rest of your system.
 
 ### osx / linux / bashonwindows install instructions
 ```bash
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+curl -sSL https://install.python-poetry.org | python -
 ```
 ### windows powershell install instructions
 ```powershell
-(Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python -
+(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -
 ```
 
 **Warning**: The previous `get-poetry.py` installer is now deprecated, if you are currently using it

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -28,11 +28,11 @@ from the rest of your system.
 
 ### osx / linux / bashonwindows install instructions
 ```bash
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+curl -sSL https://install.python-poetry.org | python -
 ```
 ### windows powershell install instructions
 ```powershell
-(Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python -
+(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -
 ```
 
 {{% warning %}}

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -890,4 +890,11 @@ def main():
 
 
 if __name__ == "__main__":
+    sys.stdout.write(
+        colorize(
+            "warning",
+            "The canonical source for Poetry's installation script is now https://install.python-poetry.org. "
+            "Please update your usage to reflect this.\n",
+        )
+    )
     sys.exit(main())


### PR DESCRIPTION
Update references to installer on master with new canonical source at https://install.python-poetry.org.

Note: See https://github.com/python-poetry/install.python-poetry.org for source.