### PR TITLE
docs: remove completions for homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,20 +120,11 @@ See `poetry help completions` for full details, but the gist is as simple as usi
 # Bash
 poetry completions bash > /etc/bash_completion.d/poetry.bash-completion
 
-# Bash (Homebrew)
-poetry completions bash > $(brew --prefix)/etc/bash_completion.d/poetry.bash-completion
-
 # Fish
 poetry completions fish > ~/.config/fish/completions/poetry.fish
 
-# Fish (Homebrew)
-poetry completions fish > (brew --prefix)/share/fish/vendor_completions.d/poetry.fish
-
 # Zsh
 poetry completions zsh > ~/.zfunc/_poetry
-
-# Zsh (Homebrew)
-poetry completions zsh > $(brew --prefix)/share/zsh/site-functions/_poetry
 
 # Zsh (Oh-My-Zsh)
 mkdir $ZSH_CUSTOM/plugins/poetry

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -171,14 +171,8 @@ See `poetry help completions` for full details, but the gist is as simple as usi
 # Bash
 poetry completions bash > /etc/bash_completion.d/poetry.bash-completion
 
-# Bash (Homebrew)
-poetry completions bash > $(brew --prefix)/etc/bash_completion.d/poetry.bash-completion
-
 # Fish
 poetry completions fish > ~/.config/fish/completions/poetry.fish
-
-# Fish (Homebrew)
-poetry completions fish > (brew --prefix)/share/fish/vendor_completions.d/poetry.fish
 
 # Zsh
 poetry completions zsh > ~/.zfunc/_poetry


### PR DESCRIPTION
# Pull Request Check List

Since https://github.com/Homebrew/homebrew-core/commit/a788a0d054577d3fa1f2ae0a62e00dfb59da934a, `brew install poetry` installs shell completions automatically, so no need for any manual step.

Also, I noticed the `brew` installation is not documented anywhere. If interested, I can document that in a follow-up PR.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
