### PR TITLE
Revert "Update packaging requirement to support 21.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,9 @@ html5lib = "^1.0"
 shellingham = "^1.1"
 tomlkit = ">=0.7.0,<1.0.0"
 pexpect = "^4.7.0"
-# Leave unclamped since packaging doesn't follow semantic versioning.
-packaging = ">=20.4"
+packaging = "^20.4"
 # exclude 20.4.5 - 20.4.6 due to https://github.com/pypa/pip/issues/9953
 virtualenv = "(>=20.4.3,<20.4.5 || >=20.4.7)"
-# Leave unclamped since keyring doesn't follow semantic versioning.
 keyring = ">=21.2.0"
 entrypoints = "^0.3"
 importlib-metadata = {version = "^1.6.0", python = "<3.8"}


### PR DESCRIPTION
Reverts python-poetry/poetry#4362

Versions < 21.0 are currently incompatible with Poetry master thanks to this change: https://github.com/pypa/packaging/commit/d650cfd74fb9e63175b73603793ccae1d984a8b5

Because the `tags.py` file is no longer totally standalone, the current approach of feeding the file to a Python interpreter's stdin is broken. This needs to be rolled back until we can come up with a new technique for gathering tags.

Additionally, Python 2.7 support is dropped from `tags.py` which will break management with `poetry env`. More work is needed to support newer packaging versions.