### PR TITLE
fix: Use importlib to invoke packaging.tags in Env

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -333,14 +333,14 @@ dev = ["pytest", "black", "mypy"]
 
 [[package]]
 name = "packaging"
-version = "20.9"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pexpect"
@@ -721,7 +721,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a6debe7eeee8b7d0715ed531cb2ec206284590eb4825749039c0e5006e8c8fcc"
+content-hash = "f74aedfd57d8aa47486cacfd4e2f5a24e952cfe1aee43c7b6a6d801eec5254ea"
 
 [metadata.files]
 atomicwrites = [
@@ -980,8 +980,8 @@ ordered-set = [
     {file = "ordered_set-4.1.0-py3-none-any.whl", hash = "sha256:046e1132c71fcf3330438a539928932caf51ddbc582496833e23de611de14562"},
 ]
 packaging = [
-    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
-    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,10 @@ crashtest = "^0.3.0"
 entrypoints = "^0.3"
 html5lib = "^1.0"
 importlib-metadata = { version = ">=1.6.0", python = "<3.8" }
+# packaging uses calver, so version is unclamped
 keyring = ">=21.2.0"
-packaging = "^20.4"
+# packaging uses calver, so version is unclamped
+packaging = ">=20.4"
 pexpect = "^4.7.0"
 pkginfo = "^1.5"
 requests = "^2.18"

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -119,6 +119,18 @@ def test_env_shell_commands_with_stdinput_in_their_arg_work_as_expected(
     assert run_output_path.resolve() == venv_base_prefix_path.resolve()
 
 
+def test_env_get_supported_tags_matches_inside_virtualenv(
+    tmp_dir: str, manager: EnvManager
+):
+    venv_path = Path(tmp_dir) / "Virtual Env"
+    manager.build_venv(str(venv_path))
+    venv = VirtualEnv(venv_path)
+
+    import packaging.tags
+
+    assert venv.get_supported_tags() == list(packaging.tags.sys_tags())
+
+
 @pytest.fixture
 def in_project_venv_dir(poetry: Poetry) -> Iterator[Path]:
     os.environ.pop("VIRTUAL_ENV", None)


### PR DESCRIPTION
This PR also re-implements #4362 and fixes #4264.

The `packaging` version change means that we will give up the ability for Poetry to manage Python 2.7 environments. Consensus is needed to determine if Python 2.7 is worth losing the ability to follow upstream.
Additionally, this version restriction is a burden on downstreams who want to ship Poetry without bundled dependencies.
