### PR TITLE
more typechecking fixes

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,7 +13,7 @@ warn_unused_configs = True
 # should be added to this whitelist.
 # see https://github.com/python-poetry/poetry/pull/4510.
 
-[mypy-poetry.config.*]
+[mypy-poetry.config.file_config_source]
 ignore_errors = True
 
 [mypy-poetry.console.*]
@@ -34,16 +34,13 @@ ignore_errors = True
 [mypy-poetry.mixology.*]
 ignore_errors = True
 
-[mypy-poetry.packages.*]
-ignore_errors = True
-
-[mypy-poetry.publishing.*]
+[mypy-poetry.packages.locker]
 ignore_errors = True
 
 [mypy-poetry.puzzle.*]
 ignore_errors = True
 
-[mypy-poetry.repositories.*]
+[mypy-poetry.repositories.installed_repository]
 ignore_errors = True
 
 [mypy-poetry.utils.*]

--- a/poetry/config/config.py
+++ b/poetry/config/config.py
@@ -14,9 +14,6 @@ from .config_source import ConfigSource
 from .dict_config_source import DictConfigSource
 
 
-_NOT_SET = object()
-
-
 def boolean_validator(val: str) -> bool:
     return val in {"true", "false", "1", "0"}
 
@@ -27,7 +24,7 @@ def boolean_normalizer(val: str) -> bool:
 
 class Config:
 
-    default_config = {
+    default_config: Dict[str, Any] = {
         "cache-dir": str(CACHE_DIR),
         "virtualenvs": {
             "create": True,
@@ -45,12 +42,8 @@ class Config:
         self._config = deepcopy(self.default_config)
         self._use_environment = use_environment
         self._base_dir = base_dir
-        self._config_source = DictConfigSource()
-        self._auth_config_source = DictConfigSource()
-
-    @property
-    def name(self) -> str:
-        return str(self._file.path)
+        self._config_source: ConfigSource = DictConfigSource()
+        self._auth_config_source: ConfigSource = DictConfigSource()
 
     @property
     def config(self) -> Dict:
@@ -114,9 +107,9 @@ class Config:
             env = "POETRY_{}".format(
                 "_".join(k.upper().replace("-", "_") for k in keys)
             )
-            value = os.getenv(env, _NOT_SET)
-            if value is not _NOT_SET:
-                return self.process(self._get_normalizer(setting_name)(value))
+            env_value = os.getenv(env)
+            if env_value is not None:
+                return self.process(self._get_normalizer(setting_name)(env_value))
 
         value = self._config
         for key in keys:

--- a/poetry/config/dict_config_source.py
+++ b/poetry/config/dict_config_source.py
@@ -6,7 +6,7 @@ from .config_source import ConfigSource
 
 class DictConfigSource(ConfigSource):
     def __init__(self) -> None:
-        self._config = {}
+        self._config: Dict[str, Any] = {}
 
     @property
     def config(self) -> Dict[str, Any]:

--- a/poetry/inspection/info.py
+++ b/poetry/inspection/info.py
@@ -59,7 +59,7 @@ class PackageInfo:
         platform: Optional[str] = None,
         requires_dist: Optional[List[str]] = None,
         requires_python: Optional[str] = None,
-        files: Optional[List[str]] = None,
+        files: Optional[List[Dict[str, str]]] = None,
         cache_version: Optional[str] = None,
     ):
         self.name = name

--- a/poetry/packages/project_package.py
+++ b/poetry/packages/project_package.py
@@ -21,5 +21,3 @@ class ProjectPackage(_ProjectPackage):
         else:
             self._version = version
             self._pretty_version = pretty_version or version.text
-
-        return self

--- a/poetry/publishing/publisher.py
+++ b/poetry/publishing/publisher.py
@@ -44,7 +44,7 @@ class Publisher:
         password: Optional[str],
         cert: Optional[Path] = None,
         client_cert: Optional[Path] = None,
-        dry_run: Optional[bool] = False,
+        dry_run: bool = False,
     ) -> None:
         if not repository_name:
             url = "https://upload.pypi.org/legacy/"

--- a/poetry/repositories/base_repository.py
+++ b/poetry/repositories/base_repository.py
@@ -10,22 +10,22 @@ if TYPE_CHECKING:
 
 class BaseRepository:
     def __init__(self) -> None:
-        self._packages = []
+        self._packages: List[Package] = []
 
     @property
     def packages(self) -> List["Package"]:
         return self._packages
 
-    def has_package(self, package: "Package") -> None:
+    def has_package(self, package: "Package") -> bool:
         raise NotImplementedError()
 
     def package(
         self, name: str, version: str, extras: Optional[List[str]] = None
-    ) -> None:
+    ) -> "Package":
         raise NotImplementedError()
 
-    def find_packages(self, dependency: "Dependency") -> None:
+    def find_packages(self, dependency: "Dependency") -> List["Package"]:
         raise NotImplementedError()
 
-    def search(self, query: str) -> None:
+    def search(self, query: str) -> List["Package"]:
         raise NotImplementedError()

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -149,6 +149,8 @@ class Page:
         return self._clean_re.sub(lambda match: "%%%2x" % ord(match.group(0)), url)
 
 
+# TODO: revisit whether the LegacyRepository should inherit from PyPiRepository.
+# <https://github.com/python-poetry/poetry/pull/4755#discussion_r748865374>.
 class LegacyRepository(PyPiRepository):
     def __init__(
         self,

--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -5,6 +5,7 @@ import urllib.parse
 import warnings
 
 from collections import defaultdict
+from html import unescape
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -12,6 +13,7 @@ from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
+from urllib.parse import quote
 
 import requests
 import requests.auth
@@ -42,23 +44,6 @@ from .pypi_repository import PyPiRepository
 
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
-
-try:
-    from html import unescape
-except ImportError:
-    try:
-        from html.parser import HTMLParser
-    except ImportError:
-        from HTMLParser import HTMLParser
-
-    unescape = HTMLParser().unescape
-
-
-try:
-    from urllib.parse import quote
-except ImportError:
-    from urllib import quote
-
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -269,7 +254,7 @@ class LegacyRepository(PyPiRepository):
         if self._cache.store("matches").has(key):
             versions = self._cache.store("matches").get(key)
         else:
-            page = self._get("/{}/".format(dependency.name.replace(".", "-")))
+            page = self._get_page("/{}/".format(dependency.name.replace(".", "-")))
             if page is None:
                 return []
 
@@ -338,14 +323,14 @@ class LegacyRepository(PyPiRepository):
             return package
 
     def find_links_for_package(self, package: Package) -> List[Link]:
-        page = self._get("/{}/".format(package.name.replace(".", "-")))
+        page = self._get_page("/{}/".format(package.name.replace(".", "-")))
         if page is None:
             return []
 
         return list(page.links_for_version(package.version))
 
     def _get_release_info(self, name: str, version: str) -> dict:
-        page = self._get("/{}/".format(canonicalize_name(name).replace(".", "-")))
+        page = self._get_page("/{}/".format(canonicalize_name(name).replace(".", "-")))
         if page is None:
             raise PackageNotFound(f'No package named "{name}"')
 
@@ -419,7 +404,7 @@ class LegacyRepository(PyPiRepository):
 
         return data.asdict()
 
-    def _get(self, endpoint: str) -> Optional[Page]:
+    def _get_page(self, endpoint: str) -> Optional[Page]:
         url = self._url + endpoint
         try:
             response = self.session.get(url)

--- a/poetry/repositories/pool.py
+++ b/poetry/repositories/pool.py
@@ -65,6 +65,8 @@ class Pool(BaseRepository):
         """
         Adds a repository to the pool.
         """
+        # FIXME: surely it's a problem that the repository name can be None here?
+        # All nameless repositories will collide in self._lookup.
         repository_name = (
             repository.name.lower() if repository.name is not None else None
         )

--- a/poetry/repositories/pool.py
+++ b/poetry/repositories/pool.py
@@ -22,11 +22,11 @@ class Pool(BaseRepository):
         if repositories is None:
             repositories = []
 
-        self._lookup: Dict[str, int] = {}
+        self._lookup: Dict[Optional[str], int] = {}
         self._repositories: List[Repository] = []
         self._default = False
         self._has_primary_repositories = False
-        self._secondary_start_idx = None
+        self._secondary_start_idx: Optional[int] = None
 
         for repository in repositories:
             self.add_repository(repository)

--- a/poetry/repositories/repository.py
+++ b/poetry/repositories/repository.py
@@ -24,7 +24,7 @@ class Repository(BaseRepository):
             self.add_package(package)
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         return self._name
 
     def package(

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -28,7 +28,7 @@ class MockRepository(LegacyRepository):
             "legacy", url="http://legacy.foo.bar", disable_cache=True
         )
 
-    def _get(self, endpoint):
+    def _get_page(self, endpoint):
         parts = endpoint.split("/")
         name = parts[1]
 
@@ -49,7 +49,7 @@ class MockRepository(LegacyRepository):
 def test_page_relative_links_path_are_correct():
     repo = MockRepository()
 
-    page = repo._get("/relative")
+    page = repo._get_page("/relative")
 
     for link in page.links:
         assert link.netloc == "legacy.foo.bar"
@@ -59,7 +59,7 @@ def test_page_relative_links_path_are_correct():
 def test_page_absolute_links_path_are_correct():
     repo = MockRepository()
 
-    page = repo._get("/absolute")
+    page = repo._get_page("/absolute")
 
     for link in page.links:
         assert link.netloc == "files.pythonhosted.org"
@@ -68,7 +68,7 @@ def test_page_absolute_links_path_are_correct():
 
 def test_sdist_format_support():
     repo = MockRepository()
-    page = repo._get("/relative")
+    page = repo._get_page("/relative")
     bz2_links = list(filter(lambda link: link.ext == ".tar.bz2", page.links))
     assert len(bz2_links) == 1
     assert bz2_links[0].filename == "poetry-0.1.1.tar.bz2"
@@ -335,21 +335,21 @@ class MockHttpRepository(LegacyRepository):
 def test_get_200_returns_page(http):
     repo = MockHttpRepository({"/foo": 200}, http)
 
-    assert repo._get("/foo")
+    assert repo._get_page("/foo")
 
 
 @pytest.mark.parametrize("status_code", [401, 403, 404])
 def test_get_40x_and_returns_none(http, status_code):
     repo = MockHttpRepository({"/foo": status_code}, http)
 
-    assert repo._get("/foo") is None
+    assert repo._get_page("/foo") is None
 
 
 def test_get_5xx_raises(http):
     repo = MockHttpRepository({"/foo": 500}, http)
 
     with pytest.raises(RepositoryError):
-        repo._get("/foo")
+        repo._get_page("/foo")
 
 
 def test_get_redirected_response_url(http, monkeypatch):
@@ -363,4 +363,4 @@ def test_get_redirected_response_url(http, monkeypatch):
         return response
 
     monkeypatch.setattr(repo.session, "get", get_mock)
-    assert repo._get("/foo")._url == "http://legacy.redirect.bar/foo/"
+    assert repo._get_page("/foo")._url == "http://legacy.redirect.bar/foo/"


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Encouraged by seeing #4751 merged - and so fast, thank you! - I took on a few more of the relatively easy mypy warnings.

I have tried to prefer updating the annotations where possible, but this time I have found reasons to make some modest rearrangements to the code:

- [`Config.name`](https://github.com/python-poetry/poetry/blob/1ae27b04f2a29fa32b5814b542580ae3699fe8dc/poetry/config/config.py#L51-L53) seems to be just broken as there is no `_file` attribute.  I find no callers, so have removed it.

- refactored authentication in uploader.py so that mypy can see that the username and password are not `None`

- AIUI poetry is dropping support for python2, so I just went with python3 imports of `html.unescape` and `urllib.parse.quote`

- renamed `LegacyRepositoy._get()` as `LegacyRepository._get_page()`: so far as I can see it has little in common with its parent class's `PyPiRepository._get()`, and mypy complains about them not being the same

One place where I have just updated the annotation to match the code but which smells funny to me is in pool.py.  Is it really intended that the `repository_name` indexing `self._lookup` might be `None`?  I tried asserting that it was not, but lots of testcases failed...