### PR TITLE
docs: clarify the use of `exit` to leave shell env

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -520,6 +520,10 @@ If one doesn't exist yet, it will be created.
 poetry shell
 ```
 
+Note that this commmand starts a new shell and activates the virtual environment.
+
+As such, `exit` should be used to properly exit the shell and the virtual environment instead of `deactivate`.
+
 ## check
 
 The `check` command validates the structure of the `pyproject.toml` file


### PR DESCRIPTION
As mentioned in #2387, add more clarity on how to exit the shell created by `poetry shell`, mentioning the use of `exit` instead of `deactivate`.
