### PR TITLE
Add missing type hints - Part 1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -736,7 +736,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "5678588fe09f29d580655584780de7596ec69558a2abd94f5639c2f950c84f57"
+content-hash = "0da3c8505456818f8ed4b117853d059f8e288a7cff5dc40d118998c92d1a43f1"
 
 [metadata.files]
 atomicwrites = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,11 +37,11 @@ testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3
 
 [[package]]
 name = "cachecontrol"
-version = "0.12.6"
+version = "0.12.10"
 description = "httplib2 caching for requests"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 lockfile = {version = ">=0.9", optional = true, markers = "extra == \"filecache\""}
@@ -672,6 +672,14 @@ docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-a
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
+name = "typing-extensions"
+version = "4.0.0"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "urllib3"
 version = "1.26.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -728,7 +736,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "15dc46f1a8bf5a3eb2a3c48f9a8527f89fac67487e8188e67c0a603c376fd0fd"
+content-hash = "5678588fe09f29d580655584780de7596ec69558a2abd94f5639c2f950c84f57"
 
 [metadata.files]
 atomicwrites = [
@@ -744,8 +752,8 @@ attrs = [
     {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
 ]
 cachecontrol = [
-    {file = "CacheControl-0.12.6-py2.py3-none-any.whl", hash = "sha256:10d056fa27f8563a271b345207402a6dcce8efab7e5b377e270329c62471b10d"},
-    {file = "CacheControl-0.12.6.tar.gz", hash = "sha256:be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8"},
+    {file = "CacheControl-0.12.10-py2.py3-none-any.whl", hash = "sha256:b0d43d8f71948ef5ebdee5fe236b86c6ffc7799370453dccb0e894c20dfa487c"},
+    {file = "CacheControl-0.12.10.tar.gz", hash = "sha256:d8aca75b82eec92d84b5d6eb8c8f66ea16f09d2adb09dbca27fe2d5fc8d3732d"},
 ]
 cachy = [
     {file = "cachy-0.3.0-py2.py3-none-any.whl", hash = "sha256:338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7"},
@@ -1107,6 +1115,10 @@ tomlkit = [
 tox = [
     {file = "tox-3.24.4-py2.py3-none-any.whl", hash = "sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10"},
     {file = "tox-3.24.4.tar.gz", hash = "sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.0.0-py3-none-any.whl", hash = "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"},
+    {file = "typing_extensions-4.0.0.tar.gz", hash = "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ pytest-sugar = "^0.9"
 httpretty = "^1.0"
 zipp = { version = "^3.4", python = "<3.8"}
 deepdiff = "^5.0"
+typing-extensions = "^4.0.0"
 
 [tool.poetry.scripts]
 poetry = "poetry.console.application:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ pytest-sugar = "^0.9"
 httpretty = "^1.0"
 zipp = { version = "^3.4", python = "<3.8"}
 deepdiff = "^5.0"
-typing-extensions = "^4.0.0"
+typing-extensions = {version = "^4.0.0", python = "<3.8"}
 
 [tool.poetry.scripts]
 poetry = "poetry.console.application:main"

--- a/src/poetry/plugins/application_plugin.py
+++ b/src/poetry/plugins/application_plugin.py
@@ -1,4 +1,10 @@
+from typing import TYPE_CHECKING
+
 from poetry.plugins.base_plugin import BasePlugin
+
+
+if TYPE_CHECKING:
+    from poetry.console.application import Application
 
 
 class ApplicationPlugin(BasePlugin):
@@ -8,5 +14,5 @@ class ApplicationPlugin(BasePlugin):
 
     type = "application.plugin"
 
-    def activate(self, application):
+    def activate(self, application: "Application") -> None:
         raise NotImplementedError()

--- a/src/poetry/plugins/plugin.py
+++ b/src/poetry/plugins/plugin.py
@@ -1,4 +1,12 @@
+from typing import TYPE_CHECKING
+
 from poetry.plugins.base_plugin import BasePlugin
+
+
+if TYPE_CHECKING:
+    from cleo.io.io import IO
+
+    from poetry.poetry import Poetry
 
 
 class Plugin(BasePlugin):
@@ -10,5 +18,5 @@ class Plugin(BasePlugin):
 
     type = "plugin"
 
-    def activate(self, poetry, io):
+    def activate(self, poetry: "Poetry", io: "IO") -> None:
         raise NotImplementedError()

--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -1,5 +1,6 @@
 import logging
 
+from typing import Any
 from typing import List
 
 import entrypoints
@@ -41,7 +42,7 @@ class PluginManager:
 
         self._plugins.append(plugin)
 
-    def activate(self, *args, **kwargs):
+    def activate(self, *args: Any, **kwargs: Any) -> None:
         for plugin in self._plugins:
             plugin.activate(*args, **kwargs)
 

--- a/src/poetry/utils/_compat.py
+++ b/src/poetry/utils/_compat.py
@@ -1,5 +1,8 @@
 import sys
 
+from typing import List
+from typing import Optional
+
 
 try:
     from importlib import metadata
@@ -10,7 +13,7 @@ except ImportError:
 WINDOWS = sys.platform == "win32"
 
 
-def decode(string, encodings=None):
+def decode(string: str, encodings: Optional[List[str]] = None) -> str:
     if not isinstance(string, bytes):
         return string
 
@@ -25,7 +28,7 @@ def decode(string, encodings=None):
     return string.decode(encodings[0], errors="ignore")
 
 
-def encode(string, encodings=None):
+def encode(string: str, encodings: Optional[List[str]] = None) -> bytes:
     if isinstance(string, bytes):
         return string
 
@@ -40,11 +43,11 @@ def encode(string, encodings=None):
     return string.encode(encodings[0], errors="ignore")
 
 
-def to_str(string):
+def to_str(string: str) -> str:
     return decode(string)
 
 
-def list_to_shell_command(cmd):
+def list_to_shell_command(cmd: List[str]) -> str:
     return " ".join(
         f'"{token}"' if " " in token and token[0] not in {"'", '"'} else token
         for token in cmd

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1168,7 +1168,7 @@ class Env:
 
             self._pip_executable = pip_executable
 
-    def get_embedded_wheel(self, distribution):
+    def get_embedded_wheel(self, distribution: str) -> Path:
         return get_embed_wheel(
             distribution, f"{self.version_info[0]}.{self.version_info[1]}"
         ).path
@@ -1785,7 +1785,7 @@ class NullEnv(SystemEnv):
 
 @contextmanager
 def ephemeral_environment(
-    executable=None,
+    executable: Optional[Union[str, Path]] = None,
     flags: Dict[str, bool] = None,
     with_pip: bool = False,
     with_wheel: Optional[bool] = None,

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -2,3 +2,8 @@ try:
     import zipp
 except ImportError:
     import zipfile as zipp  # noqa: F401, TC002
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # noqa: F401, TC002

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,12 +1,23 @@
 import os
 import re
 
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import Iterator
+from typing import Optional
+from typing import Tuple
+
 import pytest
 
 from poetry.config.config import Config
 
 
-def get_boolean_options(config=None):
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def get_boolean_options(config: Optional[Dict[str, Any]] = None) -> str:
     if config is None:
         config = Config.default_config
 
@@ -21,19 +32,21 @@ def get_boolean_options(config=None):
 @pytest.mark.parametrize(
     ("name", "value"), [("installer.parallel", True), ("virtualenvs.create", True)]
 )
-def test_config_get_default_value(config, name, value):
+def test_config_get_default_value(config: Config, name: str, value: bool):
     assert config.get(name) is value
 
 
-def test_config_get_processes_depended_on_values(config, config_cache_dir):
+def test_config_get_processes_depended_on_values(
+    config: Config, config_cache_dir: "Path"
+):
     assert str(config_cache_dir / "virtualenvs") == config.get("virtualenvs.path")
 
 
-def generate_environment_variable_tests():
+def generate_environment_variable_tests() -> Iterator[Tuple[str, str, str, bool]]:
     for env_value, value in [("true", True), ("false", False)]:
         for name in get_boolean_options():
             env_var = "POETRY_{}".format(re.sub("[.-]+", "_", name).upper())
-            yield (name, env_var, env_value, value)
+            yield name, env_var, env_value, value
 
 
 @pytest.mark.parametrize(
@@ -41,7 +54,12 @@ def generate_environment_variable_tests():
     list(generate_environment_variable_tests()),
 )
 def test_config_get_from_environment_variable(
-    config, environ, name, env_var, env_value, value
+    config: Config,
+    environ: Iterator[None],
+    name: str,
+    env_var: str,
+    env_value: str,
+    value: bool,
 ):
     os.environ[env_var] = env_value
     assert config.get(name) is value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,7 +271,7 @@ def tmp_venv(tmp_dir):
 
 
 @pytest.fixture
-def installed():
+def installed() -> Repository:
     return Repository()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,7 +268,7 @@ def mocked_open_files(mocker):
 
 
 @pytest.fixture
-def tmp_venv(tmp_dir) -> VirtualEnv:
+def tmp_venv(tmp_dir: str) -> Iterator[VirtualEnv]:
     venv_path = Path(tmp_dir) / "venv"
 
     EnvManager.build_venv(str(venv_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import Iterator
 from typing import Optional
@@ -122,7 +123,7 @@ def with_chained_keyring(mocker):
 
 
 @pytest.fixture
-def config_cache_dir(tmp_dir) -> Path:
+def config_cache_dir(tmp_dir: str) -> Path:
     path = Path(tmp_dir) / ".cache" / "pypoetry"
     path.mkdir(parents=True)
     return path
@@ -142,7 +143,7 @@ def config_source(config_cache_dir):
 
 
 @pytest.fixture
-def auth_config_source():
+def auth_config_source() -> DictConfigSource:
     source = DictConfigSource()
 
     return source
@@ -231,13 +232,13 @@ def http() -> Iterator["ModuleType"]:
 
 
 @pytest.fixture
-def fixture_base():
+def fixture_base() -> Path:
     return Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
-def fixture_dir(fixture_base):
-    def _fixture_dir(name):
+def fixture_dir(fixture_base: Path) -> Callable[[str], Path]:
+    def _fixture_dir(name: str):
         return fixture_base / name
 
     return _fixture_dir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Iterator
@@ -35,6 +36,10 @@ from tests.helpers import get_package
 from tests.helpers import mock_clone
 from tests.helpers import mock_download
 from tests.types import CommandTesterFactory
+
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 class Config(BaseConfig):
@@ -211,7 +216,7 @@ def git_mock(mocker):
 
 
 @pytest.fixture
-def http():
+def http() -> Iterator["ModuleType"]:
     httpretty.reset()
     httpretty.enable(allow_net_connect=False)
 
@@ -259,7 +264,7 @@ def mocked_open_files(mocker):
 
 
 @pytest.fixture
-def tmp_venv(tmp_dir):
+def tmp_venv(tmp_dir) -> VirtualEnv:
     venv_path = Path(tmp_dir) / "venv"
 
     EnvManager.build_venv(str(venv_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from typing import Dict
 from typing import Iterator
 from typing import Optional
 from typing import Tuple
+from typing import Type
 
 import httpretty
 import pytest
@@ -40,8 +41,6 @@ from tests.helpers import mock_download
 
 
 if TYPE_CHECKING:
-    from types import ModuleType
-
     from poetry.poetry import Poetry
     from tests.types import CommandTesterFactory
     from tests.types import ProjectFactory
@@ -221,7 +220,7 @@ def git_mock(mocker):
 
 
 @pytest.fixture
-def http() -> Iterator["ModuleType"]:
+def http() -> Iterator[Type[httpretty.httpretty]]:
     httpretty.reset()
     httpretty.enable(allow_net_connect=False)
 
@@ -301,7 +300,7 @@ def default_python(current_python: Tuple[int, int, int]) -> str:
 
 
 @pytest.fixture
-def repo(http: "ModuleType") -> TestRepository:
+def repo(http: Type[httpretty.httpretty]) -> TestRepository:
     http.register_uri(
         http.GET,
         re.compile("^https?://foo.bar/(.+?)$"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,7 +419,7 @@ def command_tester_factory(app, env) -> "CommandTesterFactory":
 
 
 @pytest.fixture
-def do_lock(command_tester_factory, poetry):
+def do_lock(command_tester_factory: "CommandTesterFactory", poetry: "Poetry") -> None:
     command_tester_factory("lock").execute()
     assert poetry.locker.lock.exists()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 from typing import Dict
+from typing import Iterator
+from typing import Tuple
 
 import httpretty
 import pytest
@@ -32,6 +34,7 @@ from tests.helpers import TestRepository
 from tests.helpers import get_package
 from tests.helpers import mock_clone
 from tests.helpers import mock_download
+from tests.types import CommandTesterFactory
 
 
 class Config(BaseConfig):
@@ -110,7 +113,7 @@ def with_chained_keyring(mocker):
 
 
 @pytest.fixture
-def config_cache_dir(tmp_dir):
+def config_cache_dir(tmp_dir) -> Path:
     path = Path(tmp_dir) / ".cache" / "pypoetry"
     path.mkdir(parents=True)
     return path
@@ -137,7 +140,7 @@ def auth_config_source():
 
 
 @pytest.fixture
-def config(config_source, auth_config_source, mocker):
+def config(config_source, auth_config_source, mocker) -> Config:
     import keyring
 
     from keyring.backends.fail import Keyring
@@ -189,7 +192,7 @@ def pep517_metadata_mock(mocker):
 
 
 @pytest.fixture
-def environ():
+def environ() -> Iterator[None]:
     original_environ = dict(os.environ)
 
     yield
@@ -273,12 +276,12 @@ def installed():
 
 
 @pytest.fixture(scope="session")
-def current_env():
+def current_env() -> SystemEnv:
     return SystemEnv(Path(sys.executable))
 
 
 @pytest.fixture(scope="session")
-def current_python(current_env):
+def current_python(current_env: SystemEnv) -> Tuple[int, int, int]:
     return current_env.version_info[:3]
 
 
@@ -288,7 +291,7 @@ def default_python(current_python):
 
 
 @pytest.fixture
-def repo(http):
+def repo(http) -> TestRepository:
     http.register_uri(
         http.GET,
         re.compile("^https?://foo.bar/(.+?)$"),
@@ -359,7 +362,7 @@ def project_factory(tmp_dir, config, repo, installed, default_python):
 
 
 @pytest.fixture
-def command_tester_factory(app, env):
+def command_tester_factory(app, env) -> CommandTesterFactory:
     def _tester(command, poetry=None, installer=None, executor=None, environment=None):
         command = app.find(command)
         tester = CommandTester(command)

--- a/tests/console/commands/debug/test_resolve.py
+++ b/tests/console/commands/debug/test_resolve.py
@@ -1,16 +1,25 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from poetry.factory import Factory
 from tests.helpers import get_package
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from tests.helpers import TestRepository
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture()
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("debug resolve")
 
 
 @pytest.fixture(autouse=True)
-def __add_packages(repo):
+def __add_packages(repo: "TestRepository") -> None:
     cachy020 = get_package("cachy", "0.2.0")
     cachy020.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
 
@@ -22,7 +31,7 @@ def __add_packages(repo):
     repo.add_package(get_package("cleo", "0.6.5"))
 
 
-def test_debug_resolve_gives_resolution_results(tester):
+def test_debug_resolve_gives_resolution_results(tester: "CommandTester"):
     tester.execute("cachy")
 
     expected = """\
@@ -37,7 +46,7 @@ cachy          0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_debug_resolve_tree_option_gives_the_dependency_tree(tester):
+def test_debug_resolve_tree_option_gives_the_dependency_tree(tester: "CommandTester"):
     tester.execute("cachy --tree")
 
     expected = """\
@@ -52,7 +61,7 @@ cachy 0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_debug_resolve_git_dependency(tester):
+def test_debug_resolve_git_dependency(tester: "CommandTester"):
     tester.execute("git+https://github.com/demo/demo.git")
 
     expected = """\

--- a/tests/console/commands/env/conftest.py
+++ b/tests/console/commands/env/conftest.py
@@ -1,36 +1,47 @@
 import os
 
 from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Iterator
+from typing import List
 
 import pytest
 
 from poetry.utils.env import EnvManager
 
 
+if TYPE_CHECKING:
+    from tests.helpers import PoetryTestApplication
+
+
 @pytest.fixture
-def venv_name(app):
+def venv_name(app: "PoetryTestApplication") -> str:
     return EnvManager.generate_env_name("simple-project", str(app.poetry.file.parent))
 
 
 @pytest.fixture
-def venv_cache(tmp_dir):
+def venv_cache(tmp_dir: str) -> Path:
     return Path(tmp_dir)
 
 
 @pytest.fixture(scope="module")
-def python_versions():
+def python_versions() -> List[str]:
     return ["3.6", "3.7"]
 
 
 @pytest.fixture
-def venvs_in_cache_config(app, venv_cache):
+def venvs_in_cache_config(app: "PoetryTestApplication", venv_cache: Path) -> None:
     app.poetry.config.merge({"virtualenvs": {"path": str(venv_cache)}})
 
 
 @pytest.fixture
 def venvs_in_cache_dirs(
-    app, venvs_in_cache_config, venv_name, venv_cache, python_versions
-):
+    app: "PoetryTestApplication",
+    venvs_in_cache_config: None,
+    venv_name: str,
+    venv_cache: Path,
+    python_versions: List[str],
+) -> List[str]:
     directories = []
     for version in python_versions:
         directory = venv_cache.joinpath(f"{venv_name}-py{version}")
@@ -40,7 +51,7 @@ def venvs_in_cache_dirs(
 
 
 @pytest.fixture
-def venvs_in_project_dir(app):
+def venvs_in_project_dir(app: "PoetryTestApplication") -> Iterator[Path]:
     os.environ.pop("VIRTUAL_ENV", None)
     venv_dir = app.poetry.file.parent.joinpath(".venv")
     venv_dir.mkdir(exist_ok=True)

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -1,9 +1,14 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
+from typing import Callable
 from typing import Union
 
 from poetry.core.semver.version import Version
 
+
+if TYPE_CHECKING:
+    from poetry.core.version.pep440.version import PEP440Version
 
 VERSION_3_7_1 = Version.parse("3.7.1")
 
@@ -12,8 +17,10 @@ def build_venv(path: Union[Path, str], **_: Any) -> None:
     Path(path).mkdir(parents=True, exist_ok=True)
 
 
-def check_output_wrapper(version=VERSION_3_7_1):
-    def check_output(cmd, *_, **__):
+def check_output_wrapper(
+    version: "PEP440Version" = VERSION_3_7_1,
+) -> Callable[[str, Any, Any], str]:
+    def check_output(cmd: str, *_: Any, **__: Any) -> str:
         if "sys.version_info[:3]" in cmd:
             return version.text
         elif "sys.version_info[:2]" in cmd:

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -1,14 +1,22 @@
 import sys
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from poetry.utils.env import MockEnv
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture(autouse=True)
-def setup(mocker):
+def setup(mocker: "MockerFixture") -> None:
     mocker.patch(
         "poetry.utils.env.EnvManager.get",
         return_value=MockEnv(
@@ -18,11 +26,11 @@ def setup(mocker):
 
 
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("env info")
 
 
-def test_env_info_displays_complete_info(tester):
+def test_env_info_displays_complete_info(tester: "CommandTester"):
     tester.execute()
 
     expected = """
@@ -50,7 +58,7 @@ Executable: {base_executable}
     assert expected == tester.io.fetch_output()
 
 
-def test_env_info_displays_path_only(tester):
+def test_env_info_displays_path_only(tester: "CommandTester"):
     tester.execute("--path")
     expected = str(Path("/prefix"))
     assert expected + "\n" == tester.io.fetch_output()

--- a/tests/console/commands/env/test_list.py
+++ b/tests/console/commands/env/test_list.py
@@ -1,11 +1,24 @@
+from typing import TYPE_CHECKING
+from typing import List
+
 import pytest
 import tomlkit
 
 from poetry.core.toml.file import TOMLFile
 
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from poetry.utils.env import MockEnv
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def venv_activate_37(venv_cache, venv_name):
+def venv_activate_37(venv_cache: "Path", venv_name: str) -> None:
     envs_file = TOMLFile(venv_cache / "envs.toml")
     doc = tomlkit.document()
     doc[venv_name] = {"minor": "3.7", "patch": "3.7.0"}
@@ -13,18 +26,28 @@ def venv_activate_37(venv_cache, venv_name):
 
 
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("env list")
 
 
-def test_none_activated(tester, venvs_in_cache_dirs, mocker, env):
+def test_none_activated(
+    tester: "CommandTester",
+    venvs_in_cache_dirs: List[str],
+    mocker: "MockerFixture",
+    env: "MockEnv",
+):
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=env)
     tester.execute()
     expected = "\n".join(venvs_in_cache_dirs).strip()
     assert expected == tester.io.fetch_output().strip()
 
 
-def test_activated(tester, venvs_in_cache_dirs, venv_cache, venv_activate_37):
+def test_activated(
+    tester: "CommandTester",
+    venvs_in_cache_dirs: List[str],
+    venv_cache: "Path",
+    venv_activate_37: None,
+):
     tester.execute()
     expected = (
         "\n".join(venvs_in_cache_dirs).strip().replace("py3.7", "py3.7 (Activated)")
@@ -32,7 +55,7 @@ def test_activated(tester, venvs_in_cache_dirs, venv_cache, venv_activate_37):
     assert expected == tester.io.fetch_output().strip()
 
 
-def test_in_project_venv(tester, venvs_in_project_dir):
+def test_in_project_venv(tester: "CommandTester", venvs_in_project_dir: List[str]):
     tester.execute()
     expected = ".venv (Activated)\n"
     assert expected == tester.io.fetch_output()

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -1,16 +1,32 @@
+from typing import TYPE_CHECKING
+from typing import List
+
 import pytest
 
 from poetry.core.semver.version import Version
 from tests.console.commands.env.helpers import check_output_wrapper
 
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("env remove")
 
 
 def test_remove_by_python_version(
-    mocker, tester, venvs_in_cache_dirs, venv_name, venv_cache
+    mocker: "MockerFixture",
+    tester: "CommandTester",
+    venvs_in_cache_dirs: List[str],
+    venv_name: str,
+    venv_cache: "Path",
 ):
     check_output = mocker.patch(
         "subprocess.check_output",
@@ -26,7 +42,12 @@ def test_remove_by_python_version(
     assert expected == tester.io.fetch_output()
 
 
-def test_remove_by_name(tester, venvs_in_cache_dirs, venv_name, venv_cache):
+def test_remove_by_name(
+    tester: "CommandTester",
+    venvs_in_cache_dirs: List[str],
+    venv_name: str,
+    venv_cache: "Path",
+):
     expected = ""
 
     for name in venvs_in_cache_dirs:
@@ -39,7 +60,12 @@ def test_remove_by_name(tester, venvs_in_cache_dirs, venv_name, venv_cache):
     assert expected == tester.io.fetch_output()
 
 
-def test_remove_all(tester, venvs_in_cache_dirs, venv_name, venv_cache):
+def test_remove_all(
+    tester: "CommandTester",
+    venvs_in_cache_dirs: List[str],
+    venv_name: str,
+    venv_cache: "Path",
+):
     expected = {""}
     tester.execute("--all")
     for name in venvs_in_cache_dirs:
@@ -48,7 +74,12 @@ def test_remove_all(tester, venvs_in_cache_dirs, venv_name, venv_cache):
     assert expected == set(tester.io.fetch_output().split("\n"))
 
 
-def test_remove_all_and_version(tester, venvs_in_cache_dirs, venv_name, venv_cache):
+def test_remove_all_and_version(
+    tester: "CommandTester",
+    venvs_in_cache_dirs: List[str],
+    venv_name: str,
+    venv_cache: "Path",
+):
     expected = {""}
     tester.execute(f"--all {venvs_in_cache_dirs[0]}")
     for name in venvs_in_cache_dirs:
@@ -57,7 +88,12 @@ def test_remove_all_and_version(tester, venvs_in_cache_dirs, venv_name, venv_cac
     assert expected == set(tester.io.fetch_output().split("\n"))
 
 
-def test_remove_multiple(tester, venvs_in_cache_dirs, venv_name, venv_cache):
+def test_remove_multiple(
+    tester: "CommandTester",
+    venvs_in_cache_dirs: List[str],
+    venv_name: str,
+    venv_cache: "Path",
+):
     expected = {""}
     removed_envs = venvs_in_cache_dirs[0:2]
     remaining_envs = venvs_in_cache_dirs[2:]

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -1,6 +1,8 @@
 import os
 
 from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Tuple
 
 import pytest
 import tomlkit
@@ -12,15 +14,24 @@ from tests.console.commands.env.helpers import build_venv
 from tests.console.commands.env.helpers import check_output_wrapper
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture(autouse=True)
-def setup(mocker):
+def setup(mocker: "MockerFixture") -> None:
     mocker.stopall()
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
 
 @pytest.fixture(autouse=True)
-def mock_subprocess_calls(setup, current_python, mocker):
+def mock_subprocess_calls(
+    setup: None, current_python: Tuple[int, int, int], mocker: "MockerFixture"
+) -> None:
     mocker.patch(
         "subprocess.check_output",
         side_effect=check_output_wrapper(Version.from_parts(*current_python)),
@@ -32,12 +43,16 @@ def mock_subprocess_calls(setup, current_python, mocker):
 
 
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("env use")
 
 
 def test_activate_activates_non_existing_virtualenv_no_envs_file(
-    mocker, tester, venv_cache, venv_name, venvs_in_cache_config
+    mocker: "MockerFixture",
+    tester: "CommandTester",
+    venv_cache: Path,
+    venv_name: str,
+    venvs_in_cache_config: None,
 ):
     mocker.patch(
         "subprocess.check_output",
@@ -79,7 +94,11 @@ Using virtualenv: {}
 
 
 def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
-    tester, current_python, venv_cache, venv_name, venvs_in_cache_config
+    tester: "CommandTester",
+    current_python: Tuple[int, int, int],
+    venv_cache: Path,
+    venv_name: str,
+    venvs_in_cache_config: None,
 ):
     os.environ["VIRTUAL_ENV"] = "/environment/prefix"
 
@@ -105,7 +124,12 @@ Using virtualenv: {}
 
 
 def test_get_prefers_explicitly_activated_non_existing_virtualenvs_over_env_var(
-    mocker, tester, current_python, venv_cache, venv_name, venvs_in_cache_config
+    mocker: "MockerFixture",
+    tester: "CommandTester",
+    current_python: Tuple[int, int, int],
+    venv_cache: Path,
+    venv_name: str,
+    venvs_in_cache_config: None,
 ):
     os.environ["VIRTUAL_ENV"] = "/environment/prefix"
 

--- a/tests/console/commands/plugin/conftest.py
+++ b/tests/console/commands/plugin/conftest.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from poetry.__version__ import __version__
@@ -8,8 +10,21 @@ from poetry.repositories.pool import Pool
 from poetry.utils.env import EnvManager
 
 
+if TYPE_CHECKING:
+    from cleo.io.io import IO
+    from pytest_mock import MockerFixture
+
+    from poetry.config.config import Config
+    from poetry.config.source import Source
+    from poetry.poetry import Poetry
+    from poetry.repositories import Repository
+    from poetry.utils.env import MockEnv
+    from tests.helpers import TestRepository
+    from tests.types import SourcesFactory
+
+
 @pytest.fixture()
-def installed():
+def installed() -> InstalledRepository:
     repository = InstalledRepository()
 
     repository.add_package(Package("poetry", __version__))
@@ -17,8 +32,10 @@ def installed():
     return repository
 
 
-def configure_sources_factory(repo):
-    def _configure_sources(poetry, sources, config, io):
+def configure_sources_factory(repo: "TestRepository") -> "SourcesFactory":
+    def _configure_sources(
+        poetry: "Poetry", sources: "Source", config: "Config", io: "IO"
+    ) -> None:
         pool = Pool()
         pool.add_repository(repo)
         poetry.set_pool(pool)
@@ -27,7 +44,12 @@ def configure_sources_factory(repo):
 
 
 @pytest.fixture(autouse=True)
-def setup_mocks(mocker, env, repo, installed):
+def setup_mocks(
+    mocker: "MockerFixture",
+    env: "MockEnv",
+    repo: "TestRepository",
+    installed: "Repository",
+) -> None:
     mocker.patch.object(EnvManager, "get_system_env", return_value=env)
     mocker.patch.object(InstalledRepository, "load", return_value=installed)
     mocker.patch.object(

--- a/tests/console/commands/plugin/test_add.py
+++ b/tests/console/commands/plugin/test_add.py
@@ -1,18 +1,40 @@
+from typing import TYPE_CHECKING
+from typing import Dict
+from typing import Union
+
 import pytest
 
 from poetry.core.packages.package import Package
 from poetry.factory import Factory
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from poetry.console.commands.update import UpdateCommand
+    from poetry.repositories import Repository
+    from poetry.utils.env import MockEnv
+    from tests.helpers import PoetryTestApplication
+    from tests.helpers import TestRepository
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture()
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("plugin add")
 
 
-def assert_plugin_add_result(tester, app, env, expected, constraint):
+def assert_plugin_add_result(
+    tester: "CommandTester",
+    app: "PoetryTestApplication",
+    env: "MockEnv",
+    expected: str,
+    constraint: Union[str, Dict[str, str]],
+) -> None:
     assert tester.io.fetch_output() == expected
 
-    update_command = app.find("update")
+    update_command: UpdateCommand = app.find("update")
     assert update_command.poetry.file.parent == env.path
     assert update_command.poetry.locker.lock.parent == env.path
     assert update_command.poetry.locker.lock.exists()
@@ -22,7 +44,13 @@ def assert_plugin_add_result(tester, app, env, expected, constraint):
     assert content["dependencies"]["poetry-plugin"] == constraint
 
 
-def test_add_no_constraint(app, repo, tester, env, installed):
+def test_add_no_constraint(
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    tester: "CommandTester",
+    env: "MockEnv",
+    installed: "Repository",
+):
     repo.add_package(Package("poetry-plugin", "0.1.0"))
 
     tester.execute("poetry-plugin")
@@ -41,7 +69,13 @@ Package operations: 1 install, 0 updates, 0 removals
     assert_plugin_add_result(tester, app, env, expected, "^0.1.0")
 
 
-def test_add_with_constraint(app, repo, tester, env, installed):
+def test_add_with_constraint(
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    tester: "CommandTester",
+    env: "MockEnv",
+    installed: "Repository",
+):
     repo.add_package(Package("poetry-plugin", "0.1.0"))
     repo.add_package(Package("poetry-plugin", "0.2.0"))
 
@@ -61,7 +95,13 @@ Package operations: 1 install, 0 updates, 0 removals
     assert_plugin_add_result(tester, app, env, expected, "^0.2.0")
 
 
-def test_add_with_git_constraint(app, repo, tester, env, installed):
+def test_add_with_git_constraint(
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    tester: "CommandTester",
+    env: "MockEnv",
+    installed: "Repository",
+):
     repo.add_package(Package("pendulum", "2.0.5"))
 
     tester.execute("git+https://github.com/demo/poetry-plugin.git")
@@ -83,7 +123,13 @@ Package operations: 2 installs, 0 updates, 0 removals
     )
 
 
-def test_add_with_git_constraint_with_extras(app, repo, tester, env, installed):
+def test_add_with_git_constraint_with_extras(
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    tester: "CommandTester",
+    env: "MockEnv",
+    installed: "Repository",
+):
     repo.add_package(Package("pendulum", "2.0.5"))
     repo.add_package(Package("tomlkit", "0.7.0"))
 
@@ -115,7 +161,11 @@ Package operations: 3 installs, 0 updates, 0 removals
 
 
 def test_add_existing_plugin_warns_about_no_operation(
-    app, repo, tester, env, installed
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    tester: "CommandTester",
+    env: "MockEnv",
+    installed: "Repository",
 ):
     env.path.joinpath("pyproject.toml").write_text(
         """\
@@ -152,13 +202,18 @@ If you prefer to upgrade it to the latest available version, you can use `poetry
 
     assert tester.io.fetch_output() == expected
 
-    update_command = app.find("update")
+    update_command: "UpdateCommand" = app.find("update")
     # The update command should not have been called
     assert update_command.poetry.file.parent != env.path
 
 
 def test_add_existing_plugin_updates_if_requested(
-    app, repo, tester, env, installed, mocker
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    tester: "CommandTester",
+    env: "MockEnv",
+    installed: "Repository",
+    mocker: "MockerFixture",
 ):
     env.path.joinpath("pyproject.toml").write_text(
         """\
@@ -200,7 +255,11 @@ Package operations: 0 installs, 1 update, 0 removals
 
 
 def test_adding_a_plugin_can_update_poetry_dependencies_if_needed(
-    app, repo, tester, env, installed
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    tester: "CommandTester",
+    env: "MockEnv",
+    installed: "Repository",
 ):
     poetry_package = Package("poetry", "1.2.0")
     poetry_package.add_dependency(Factory.create_dependency("tomlkit", "^0.7.0"))

--- a/tests/console/commands/plugin/test_add.py
+++ b/tests/console/commands/plugin/test_add.py
@@ -34,7 +34,7 @@ def assert_plugin_add_result(
 ) -> None:
     assert tester.io.fetch_output() == expected
 
-    update_command: UpdateCommand = app.find("update")
+    update_command: "UpdateCommand" = app.find("update")
     assert update_command.poetry.file.parent == env.path
     assert update_command.poetry.locker.lock.parent == env.path
     assert update_command.poetry.locker.lock.exists()

--- a/tests/console/commands/plugin/test_show.py
+++ b/tests/console/commands/plugin/test_show.py
@@ -1,3 +1,6 @@
+from typing import TYPE_CHECKING
+from typing import Type
+
 import pytest
 
 from entrypoints import EntryPoint as _EntryPoint
@@ -8,8 +11,18 @@ from poetry.plugins.application_plugin import ApplicationPlugin
 from poetry.plugins.plugin import Plugin
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from poetry.plugins.base_plugin import BasePlugin
+    from poetry.repositories import Repository
+    from tests.helpers import PoetryTestApplication
+    from tests.types import CommandTesterFactory
+
+
 class EntryPoint(_EntryPoint):
-    def load(self):
+    def load(self) -> Type["BasePlugin"]:
         if "ApplicationPlugin" in self.object_name:
             return ApplicationPlugin
 
@@ -17,11 +30,16 @@ class EntryPoint(_EntryPoint):
 
 
 @pytest.fixture()
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("plugin show")
 
 
-def test_show_displays_installed_plugins(app, tester, installed, mocker):
+def test_show_displays_installed_plugins(
+    app: "PoetryTestApplication",
+    tester: "CommandTester",
+    installed: "Repository",
+    mocker: "MockerFixture",
+):
     mocker.patch(
         "entrypoints.get_group_all",
         side_effect=[
@@ -55,7 +73,10 @@ def test_show_displays_installed_plugins(app, tester, installed, mocker):
 
 
 def test_show_displays_installed_plugins_with_multiple_plugins(
-    app, tester, installed, mocker
+    app: "PoetryTestApplication",
+    tester: "CommandTester",
+    installed: "Repository",
+    mocker: "MockerFixture",
 ):
     mocker.patch(
         "entrypoints.get_group_all",
@@ -100,7 +121,10 @@ def test_show_displays_installed_plugins_with_multiple_plugins(
 
 
 def test_show_displays_installed_plugins_with_dependencies(
-    app, tester, installed, mocker
+    app: "PoetryTestApplication",
+    tester: "CommandTester",
+    installed: "Repository",
+    mocker: "MockerFixture",
 ):
     mocker.patch(
         "entrypoints.get_group_all",

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,16 +14,29 @@ from poetry.repositories.repository import Repository
 from poetry.utils.env import EnvManager
 
 
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from poetry.utils.env import VirtualEnv
+    from tests.types import CommandTesterFactory
+
 FIXTURES = Path(__file__).parent.joinpath("fixtures")
 
 
 @pytest.fixture()
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("self update")
 
 
 def test_self_update_can_update_from_recommended_installation(
-    tester, http, mocker, environ, tmp_venv
+    tester: "CommandTester",
+    http: "ModuleType",
+    mocker: "MockerFixture",
+    environ: None,
+    tmp_venv: "VirtualEnv",
 ):
     mocker.patch.object(EnvManager, "get_system_env", return_value=tmp_venv)
 
@@ -76,7 +90,11 @@ Poetry ({}) is installed now. Great!
 
 
 def test_self_update_does_not_update_non_recommended_installation(
-    tester, http, mocker, environ, tmp_venv
+    tester: "CommandTester",
+    http: "ModuleType",
+    mocker: "MockerFixture",
+    environ: None,
+    tmp_venv: "VirtualEnv",
 ):
     mocker.patch.object(EnvManager, "get_system_env", return_value=tmp_venv)
 

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Type
 
 import pytest
 
@@ -15,7 +16,7 @@ from poetry.utils.env import EnvManager
 
 
 if TYPE_CHECKING:
-    from types import ModuleType
+    import httpretty
 
     from cleo.testers.command_tester import CommandTester
     from pytest_mock import MockerFixture
@@ -33,7 +34,7 @@ def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
 
 def test_self_update_can_update_from_recommended_installation(
     tester: "CommandTester",
-    http: "ModuleType",
+    http: Type["httpretty.httpretty"],
     mocker: "MockerFixture",
     environ: None,
     tmp_venv: "VirtualEnv",
@@ -91,7 +92,7 @@ Poetry ({}) is installed now. Great!
 
 def test_self_update_does_not_update_non_recommended_installation(
     tester: "CommandTester",
-    http: "ModuleType",
+    http: Type["httpretty.httpretty"],
     mocker: "MockerFixture",
     environ: None,
     tmp_venv: "VirtualEnv",

--- a/tests/console/commands/source/conftest.py
+++ b/tests/console/commands/source/conftest.py
@@ -1,25 +1,33 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from poetry.config.source import Source
 
 
+if TYPE_CHECKING:
+    from poetry.poetry import Poetry
+    from tests.types import CommandTesterFactory
+    from tests.types import ProjectFactory
+
+
 @pytest.fixture
-def source_one():
+def source_one() -> Source:
     return Source(name="one", url="https://one.com")
 
 
 @pytest.fixture
-def source_two():
+def source_two() -> Source:
     return Source(name="two", url="https://two.com")
 
 
 @pytest.fixture
-def source_default():
+def source_default() -> Source:
     return Source(name="default", url="https://default.com", default=True)
 
 
 @pytest.fixture
-def source_secondary():
+def source_secondary() -> Source:
     return Source(name="secondary", url="https://secondary.com", secondary=True)
 
 
@@ -27,7 +35,7 @@ _existing_source = Source(name="existing", url="https://existing.com")
 
 
 @pytest.fixture
-def source_existing():
+def source_existing() -> Source:
     return _existing_source
 
 
@@ -50,14 +58,17 @@ url = "{_existing_source.url}"
 
 
 @pytest.fixture
-def poetry_with_source(project_factory):
+def poetry_with_source(project_factory: "ProjectFactory") -> "Poetry":
     return project_factory(pyproject_content=PYPROJECT_WITH_SOURCES)
 
 
 @pytest.fixture
 def add_multiple_sources(
-    command_tester_factory, poetry_with_source, source_one, source_two
-):
+    command_tester_factory: "CommandTesterFactory",
+    poetry_with_source: "Poetry",
+    source_one: Source,
+    source_two: Source,
+) -> None:
     add = command_tester_factory("source add", poetry=poetry_with_source)
     for source in [source_one, source_two]:
         add.execute(f"{source.name} {source.url}")

--- a/tests/console/commands/source/test_add.py
+++ b/tests/console/commands/source/test_add.py
@@ -1,13 +1,30 @@
+from typing import TYPE_CHECKING
+
 import dataclasses
 import pytest
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from poetry.config.source import Source
+    from poetry.poetry import Poetry
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def tester(command_tester_factory, poetry_with_source):
+def tester(
+    command_tester_factory: "CommandTesterFactory", poetry_with_source: "Poetry"
+) -> "CommandTester":
     return command_tester_factory("source add", poetry=poetry_with_source)
 
 
-def assert_source_added(tester, poetry, source_existing, source_added):
+def assert_source_added(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    source_existing: "Source",
+    source_added: "Source",
+) -> None:
     assert (
         tester.io.fetch_output().strip()
         == f"Adding source with name {source_added.name}."
@@ -18,26 +35,37 @@ def assert_source_added(tester, poetry, source_existing, source_added):
     assert tester.status_code == 0
 
 
-def test_source_add_simple(tester, source_existing, source_one, poetry_with_source):
+def test_source_add_simple(
+    tester: "CommandTester",
+    source_existing: "Source",
+    source_one: "Source",
+    poetry_with_source: "Poetry",
+):
     tester.execute(f"{source_one.name} {source_one.url}")
     assert_source_added(tester, poetry_with_source, source_existing, source_one)
 
 
 def test_source_add_default(
-    tester, source_existing, source_default, poetry_with_source
+    tester: "CommandTester",
+    source_existing: "Source",
+    source_default: "Source",
+    poetry_with_source: "Poetry",
 ):
     tester.execute(f"--default {source_default.name} {source_default.url}")
     assert_source_added(tester, poetry_with_source, source_existing, source_default)
 
 
 def test_source_add_secondary(
-    tester, source_existing, source_secondary, poetry_with_source
+    tester: "CommandTester",
+    source_existing: "Source",
+    source_secondary: "Source",
+    poetry_with_source: "Poetry",
 ):
     tester.execute(f"--secondary {source_secondary.name} {source_secondary.url}")
     assert_source_added(tester, poetry_with_source, source_existing, source_secondary)
 
 
-def test_source_add_error_default_and_secondary(tester):
+def test_source_add_error_default_and_secondary(tester: "CommandTester"):
     tester.execute("--default --secondary error https://error.com")
     assert (
         tester.io.fetch_error().strip()
@@ -46,7 +74,7 @@ def test_source_add_error_default_and_secondary(tester):
     assert tester.status_code == 1
 
 
-def test_source_add_error_pypi(tester):
+def test_source_add_error_pypi(tester: "CommandTester"):
     tester.execute("pypi https://test.pypi.org/simple/")
     assert (
         tester.io.fetch_error().strip()
@@ -55,7 +83,9 @@ def test_source_add_error_pypi(tester):
     assert tester.status_code == 1
 
 
-def test_source_add_existing(tester, source_existing, poetry_with_source):
+def test_source_add_existing(
+    tester: "CommandTester", source_existing: "Source", poetry_with_source: "Poetry"
+):
     tester.execute(f"--default {source_existing.name} {source_existing.url}")
     assert (
         tester.io.fetch_output().strip()

--- a/tests/console/commands/source/test_remove.py
+++ b/tests/console/commands/source/test_remove.py
@@ -1,13 +1,31 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from poetry.config.source import Source
+    from poetry.poetry import Poetry
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def tester(command_tester_factory, poetry_with_source, add_multiple_sources):
+def tester(
+    command_tester_factory: "CommandTesterFactory",
+    poetry_with_source: "Poetry",
+    add_multiple_sources: None,
+) -> "CommandTester":
     return command_tester_factory("source remove", poetry=poetry_with_source)
 
 
 def test_source_remove_simple(
-    tester, poetry_with_source, source_existing, source_one, source_two
+    tester: "CommandTester",
+    poetry_with_source: "Poetry",
+    source_existing: "Source",
+    source_one: "Source",
+    source_two: "Source",
 ):
     tester.execute(f"{source_existing.name}")
     assert (
@@ -22,7 +40,7 @@ def test_source_remove_simple(
     assert tester.status_code == 0
 
 
-def test_source_remove_error(tester):
+def test_source_remove_error(tester: "CommandTester"):
     tester.execute("error")
     assert tester.io.fetch_error().strip() == "Source with name error was not found."
     assert tester.status_code == 1

--- a/tests/console/commands/source/test_show.py
+++ b/tests/console/commands/source/test_show.py
@@ -1,12 +1,26 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from poetry.config.source import Source
+    from poetry.poetry import Poetry
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def tester(command_tester_factory, poetry_with_source, add_multiple_sources):
+def tester(
+    command_tester_factory: "CommandTesterFactory",
+    poetry_with_source: "Poetry",
+    add_multiple_sources: None,
+) -> "CommandTester":
     return command_tester_factory("source show", poetry=poetry_with_source)
 
 
-def test_source_show_simple(tester):
+def test_source_show_simple(tester: "CommandTester"):
     tester.execute("")
 
     expected = """\
@@ -32,7 +46,7 @@ secondary  : no
     assert tester.status_code == 0
 
 
-def test_source_show_one(tester, source_one):
+def test_source_show_one(tester: "CommandTester", source_one: "Source"):
     tester.execute(f"{source_one.name}")
 
     expected = """\
@@ -48,7 +62,9 @@ secondary  : no
     assert tester.status_code == 0
 
 
-def test_source_show_two(tester, source_one, source_two):
+def test_source_show_two(
+    tester: "CommandTester", source_one: "Source", source_two: "Source"
+):
     tester.execute(f"{source_one.name} {source_two.name}")
 
     expected = """\
@@ -69,7 +85,7 @@ secondary  : no
     assert tester.status_code == 0
 
 
-def test_source_show_error(tester):
+def test_source_show_error(tester: "CommandTester"):
     tester.execute("error")
     assert tester.io.fetch_error().strip() == "No source found with name(s): error"
     assert tester.status_code == 1

--- a/tests/console/commands/test_about.py
+++ b/tests/console/commands/test_about.py
@@ -1,12 +1,20 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture()
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> CommandTester:
     return command_tester_factory("about")
 
 
-def test_about(tester):
+def test_about(tester: "CommandTester"):
     tester.execute()
     expected = """\
 Poetry - Package Management for Python

--- a/tests/console/commands/test_about.py
+++ b/tests/console/commands/test_about.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture()
-def tester(command_tester_factory: "CommandTesterFactory") -> CommandTester:
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("about")
 
 

--- a/tests/console/commands/test_cache.py
+++ b/tests/console/commands/test_cache.py
@@ -1,10 +1,21 @@
 import uuid
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+    from cleo.testers.command_tester import CommandTester
+
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def repository_cache_dir(monkeypatch, tmpdir):
+def repository_cache_dir(monkeypatch: "MonkeyPatch", tmpdir: "Path") -> "Path":
     from pathlib import Path
 
     import poetry.locations
@@ -15,27 +26,31 @@ def repository_cache_dir(monkeypatch, tmpdir):
 
 
 @pytest.fixture
-def repository_one():
+def repository_one() -> str:
     return f"01_{uuid.uuid4()}"
 
 
 @pytest.fixture
-def repository_two():
+def repository_two() -> str:
     return f"02_{uuid.uuid4()}"
 
 
 @pytest.fixture
-def mock_caches(repository_cache_dir, repository_one, repository_two):
+def mock_caches(
+    repository_cache_dir: "Path", repository_one: str, repository_two: str
+) -> None:
     (repository_cache_dir / repository_one).mkdir()
     (repository_cache_dir / repository_two).mkdir()
 
 
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("cache list")
 
 
-def test_cache_list(tester, mock_caches, repository_one, repository_two):
+def test_cache_list(
+    tester: "CommandTester", mock_caches: None, repository_one: str, repository_two: str
+):
     tester.execute()
 
     expected = """\
@@ -48,7 +63,7 @@ def test_cache_list(tester, mock_caches, repository_one, repository_two):
     assert expected == tester.io.fetch_output()
 
 
-def test_cache_list_empty(tester, repository_cache_dir):
+def test_cache_list_empty(tester: "CommandTester", repository_cache_dir: "Path"):
     tester.execute()
 
     expected = """\

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -1,14 +1,22 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture()
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("check")
 
 
-def test_check_valid(tester):
+def test_check_valid(tester: "CommandTester"):
     tester.execute()
 
     expected = """\
@@ -18,7 +26,7 @@ All set!
     assert expected == tester.io.fetch_output()
 
 
-def test_check_invalid(mocker, tester):
+def test_check_invalid(mocker: "MockerFixture", tester: "CommandTester"):
     mocker.patch(
         "poetry.factory.Factory.locate",
         return_value=Path(__file__).parent.parent.parent

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from unittest.mock import ANY
 from unittest.mock import Mock
 
@@ -5,6 +6,16 @@ import pytest
 
 from poetry.console.commands.export import Exporter
 from tests.helpers import get_package
+
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+    from cleo.testers.command_tester import CommandTester
+
+    from poetry.poetry import Poetry
+    from tests.helpers import TestRepository
+    from tests.types import CommandTesterFactory
+    from tests.types import ProjectFactory
 
 
 PYPROJECT_CONTENT = """\
@@ -42,22 +53,24 @@ feature_bar = ["bar"]
 
 
 @pytest.fixture(autouse=True)
-def setup(repo):
+def setup(repo: "TestRepository") -> None:
     repo.add_package(get_package("foo", "1.0.0"))
     repo.add_package(get_package("bar", "1.1.0"))
 
 
 @pytest.fixture
-def poetry(project_factory):
+def poetry(project_factory: "ProjectFactory") -> "Poetry":
     return project_factory(name="export", pyproject_content=PYPROJECT_CONTENT)
 
 
 @pytest.fixture
-def tester(command_tester_factory, poetry):
+def tester(
+    command_tester_factory: "CommandTesterFactory", poetry: "Poetry"
+) -> "CommandTester":
     return command_tester_factory("export", poetry=poetry)
 
 
-def _export_requirements(tester, poetry):
+def _export_requirements(tester: "CommandTester", poetry: "Poetry") -> None:
     tester.execute("--format requirements.txt --output requirements.txt")
 
     requirements = poetry.file.parent / "requirements.txt"
@@ -75,23 +88,27 @@ foo==1.0.0
     assert expected == content
 
 
-def test_export_exports_requirements_txt_file_locks_if_no_lock_file(tester, poetry):
+def test_export_exports_requirements_txt_file_locks_if_no_lock_file(
+    tester: "CommandTester", poetry: "Poetry"
+):
     assert not poetry.locker.lock.exists()
     _export_requirements(tester, poetry)
     assert "The lock file does not exist. Locking." in tester.io.fetch_error()
 
 
-def test_export_exports_requirements_txt_uses_lock_file(tester, poetry, do_lock):
+def test_export_exports_requirements_txt_uses_lock_file(
+    tester: "CommandTester", poetry: "Poetry", do_lock: None
+):
     _export_requirements(tester, poetry)
     assert "The lock file does not exist. Locking." not in tester.io.fetch_error()
 
 
-def test_export_fails_on_invalid_format(tester, do_lock):
+def test_export_fails_on_invalid_format(tester: "CommandTester", do_lock: None):
     with pytest.raises(ValueError):
         tester.execute("--format invalid")
 
 
-def test_export_prints_to_stdout_by_default(tester, do_lock):
+def test_export_prints_to_stdout_by_default(tester: "CommandTester", do_lock: None):
     tester.execute("--format requirements.txt")
     expected = """\
 foo==1.0.0
@@ -99,7 +116,9 @@ foo==1.0.0
     assert expected == tester.io.fetch_output()
 
 
-def test_export_uses_requirements_txt_format_by_default(tester, do_lock):
+def test_export_uses_requirements_txt_format_by_default(
+    tester: "CommandTester", do_lock: None
+):
     tester.execute()
     expected = """\
 foo==1.0.0
@@ -107,7 +126,7 @@ foo==1.0.0
     assert expected == tester.io.fetch_output()
 
 
-def test_export_includes_extras_by_flag(tester, do_lock):
+def test_export_includes_extras_by_flag(tester: "CommandTester", do_lock: None):
     tester.execute("--format requirements.txt --extras feature_bar")
     expected = """\
 bar==1.1.0
@@ -116,7 +135,9 @@ foo==1.0.0
     assert expected == tester.io.fetch_output()
 
 
-def test_export_with_urls(monkeypatch, tester, poetry):
+def test_export_with_urls(
+    monkeypatch: "MonkeyPatch", tester: "CommandTester", poetry: "Poetry"
+):
     """
     We are just validating that the option gets passed. The option itself is tested in
     the Exporter test.

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -1,12 +1,23 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("install")
 
 
-def test_group_options_are_passed_to_the_installer(tester, mocker):
+def test_group_options_are_passed_to_the_installer(
+    tester: "CommandTester", mocker: "MockerFixture"
+):
     """
     Group options are passed properly to the installer.
     """
@@ -19,7 +30,9 @@ def test_group_options_are_passed_to_the_installer(tester, mocker):
     assert tester.command.installer._only_groups == ["bam"]
 
 
-def test_sync_option_is_passed_to_the_installer(tester, mocker):
+def test_sync_option_is_passed_to_the_installer(
+    tester: "CommandTester", mocker: "MockerFixture"
+):
     """
     The --sync option is passed properly to the installer.
     """

--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -1,9 +1,22 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Callable
 
 import pytest
 
 from poetry.packages import Locker
 from tests.helpers import get_package
+
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from cleo.testers.command_tester import CommandTester
+
+    from poetry.poetry import Poetry
+    from tests.helpers import TestRepository
+    from tests.types import CommandTesterFactory
+    from tests.types import ProjectFactory
 
 
 @pytest.fixture
@@ -12,11 +25,15 @@ def source_dir(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("lock")
 
 
-def _project_factory(fixture_name, project_factory, fixture_dir):
+def _project_factory(
+    fixture_name: str,
+    project_factory: "ProjectFactory",
+    fixture_dir: Callable[[str], Path],
+) -> "Poetry":
     source = fixture_dir(fixture_name)
     pyproject_content = (source / "pyproject.toml").read_text(encoding="utf-8")
     poetry_lock_content = (source / "poetry.lock").read_text(encoding="utf-8")
@@ -28,22 +45,30 @@ def _project_factory(fixture_name, project_factory, fixture_dir):
 
 
 @pytest.fixture
-def poetry_with_outdated_lockfile(project_factory, fixture_dir):
+def poetry_with_outdated_lockfile(
+    project_factory: "ProjectFactory", fixture_dir: Callable[[str], Path]
+) -> "Poetry":
     return _project_factory("outdated_lock", project_factory, fixture_dir)
 
 
 @pytest.fixture
-def poetry_with_up_to_date_lockfile(project_factory, fixture_dir):
+def poetry_with_up_to_date_lockfile(
+    project_factory: "ProjectFactory", fixture_dir: Callable[[str], Path]
+) -> "Poetry":
     return _project_factory("up_to_date_lock", project_factory, fixture_dir)
 
 
 @pytest.fixture
-def poetry_with_old_lockfile(project_factory, fixture_dir):
+def poetry_with_old_lockfile(
+    project_factory: "ProjectFactory", fixture_dir: Callable[[str], Path]
+) -> "Poetry":
     return _project_factory("old_lock", project_factory, fixture_dir)
 
 
 def test_lock_check_outdated(
-    command_tester_factory, poetry_with_outdated_lockfile, http
+    command_tester_factory: "CommandTesterFactory",
+    poetry_with_outdated_lockfile: "Poetry",
+    http: "ModuleType",
 ):
     http.disable()
 
@@ -61,7 +86,9 @@ def test_lock_check_outdated(
 
 
 def test_lock_check_up_to_date(
-    command_tester_factory, poetry_with_up_to_date_lockfile, http
+    command_tester_factory: "CommandTesterFactory",
+    poetry_with_up_to_date_lockfile: "Poetry",
+    http: "ModuleType",
 ):
     http.disable()
 
@@ -78,7 +105,11 @@ def test_lock_check_up_to_date(
     assert status_code == 0
 
 
-def test_lock_no_update(command_tester_factory, poetry_with_old_lockfile, repo):
+def test_lock_no_update(
+    command_tester_factory: "CommandTesterFactory",
+    poetry_with_old_lockfile: "Poetry",
+    repo: "TestRepository",
+):
     repo.add_package(get_package("sampleproject", "1.3.1"))
     repo.add_package(get_package("sampleproject", "2.0.0"))
 

--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Callable
+from typing import Type
 
 import pytest
 
@@ -9,7 +10,7 @@ from tests.helpers import get_package
 
 
 if TYPE_CHECKING:
-    from types import ModuleType
+    import httpretty
 
     from cleo.testers.command_tester import CommandTester
 
@@ -68,7 +69,7 @@ def poetry_with_old_lockfile(
 def test_lock_check_outdated(
     command_tester_factory: "CommandTesterFactory",
     poetry_with_outdated_lockfile: "Poetry",
-    http: "ModuleType",
+    http: Type["httpretty.httpretty"],
 ):
     http.disable()
 
@@ -88,7 +89,7 @@ def test_lock_check_outdated(
 def test_lock_check_up_to_date(
     command_tester_factory: "CommandTesterFactory",
     poetry_with_up_to_date_lockfile: "Poetry",
-    http: "ModuleType",
+    http: Type["httpretty.httpretty"],
 ):
     http.disable()
 

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import List
 from typing import Optional
 
 import pytest
@@ -8,11 +9,14 @@ from poetry.factory import Factory
 
 
 if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
     from poetry.poetry import Poetry
+    from tests.types import CommandTesterFactory
 
 
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("new")
 
 
@@ -139,7 +143,13 @@ def verify_project_directory(
     ],
 )
 def test_command_new(
-    options, directory, package_name, package_path, include_from, tester, tmp_dir
+    options: List[str],
+    directory: str,
+    package_name: str,
+    package_path: str,
+    include_from: Optional[str],
+    tester: "CommandTester",
+    tmp_dir: str,
 ):
     path = Path(tmp_dir) / directory
     options.append(path.as_posix())
@@ -148,7 +158,9 @@ def test_command_new(
 
 
 @pytest.mark.parametrize("fmt", [(None,), ("md",), ("rst",)])
-def test_command_new_with_readme(fmt, tester, tmp_dir):
+def test_command_new_with_readme(
+    fmt: Optional[str], tester: "CommandTester", tmp_dir: str
+):
     fmt = "md"
     package = "package"
     path = Path(tmp_dir) / package

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Type
 
 import pytest
 import requests
@@ -9,7 +10,7 @@ from poetry.publishing.uploader import UploadError
 
 
 if TYPE_CHECKING:
-    from types import ModuleType
+    import httpretty
 
     from cleo.testers.application_tester import ApplicationTester
     from pytest_mock import MockerFixture
@@ -18,7 +19,9 @@ if TYPE_CHECKING:
 
 
 def test_publish_returns_non_zero_code_for_upload_errors(
-    app: "PoetryTestApplication", app_tester: "ApplicationTester", http: "ModuleType"
+    app: "PoetryTestApplication",
+    app_tester: "ApplicationTester",
+    http: Type["httpretty.httpretty"],
 ):
     http.register_uri(
         http.POST, "https://upload.pypi.org/legacy/", status=400, body="Bad Request"
@@ -43,7 +46,9 @@ Publishing simple-project (1.2.3) to PyPI
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
 def test_publish_returns_non_zero_code_for_connection_errors(
-    app: "PoetryTestApplication", app_tester: "ApplicationTester", http: "ModuleType"
+    app: "PoetryTestApplication",
+    app_tester: "ApplicationTester",
+    http: Type["httpretty.httpretty"],
 ):
     def request_callback(*_: Any, **__: Any) -> None:
         raise requests.ConnectionError()
@@ -82,7 +87,9 @@ def test_publish_with_client_cert(
     ] == publisher_publish.call_args
 
 
-def test_publish_dry_run(app_tester: "ApplicationTester", http: "ModuleType"):
+def test_publish_dry_run(
+    app_tester: "ApplicationTester", http: Type["httpretty.httpretty"]
+):
     http.register_uri(
         http.POST, "https://upload.pypi.org/legacy/", status=403, body="Forbidden"
     )

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 import requests
@@ -6,7 +8,18 @@ import requests
 from poetry.publishing.uploader import UploadError
 
 
-def test_publish_returns_non_zero_code_for_upload_errors(app, app_tester, http):
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from cleo.testers.application_tester import ApplicationTester
+    from pytest_mock import MockerFixture
+
+    from tests.helpers import PoetryTestApplication
+
+
+def test_publish_returns_non_zero_code_for_upload_errors(
+    app: "PoetryTestApplication", app_tester: "ApplicationTester", http: "ModuleType"
+):
     http.register_uri(
         http.POST, "https://upload.pypi.org/legacy/", status=400, body="Bad Request"
     )
@@ -29,8 +42,10 @@ Publishing simple-project (1.2.3) to PyPI
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
-def test_publish_returns_non_zero_code_for_connection_errors(app, app_tester, http):
-    def request_callback(*_, **__):
+def test_publish_returns_non_zero_code_for_connection_errors(
+    app: "PoetryTestApplication", app_tester: "ApplicationTester", http: "ModuleType"
+):
+    def request_callback(*_: Any, **__: Any) -> None:
         raise requests.ConnectionError()
 
     http.register_uri(
@@ -46,7 +61,7 @@ def test_publish_returns_non_zero_code_for_connection_errors(app, app_tester, ht
     assert expected in app_tester.io.fetch_error()
 
 
-def test_publish_with_cert(app_tester, mocker):
+def test_publish_with_cert(app_tester: "ApplicationTester", mocker: "MockerFixture"):
     publisher_publish = mocker.patch("poetry.publishing.Publisher.publish")
 
     app_tester.execute("publish --cert path/to/ca.pem")
@@ -56,7 +71,9 @@ def test_publish_with_cert(app_tester, mocker):
     ] == publisher_publish.call_args
 
 
-def test_publish_with_client_cert(app_tester, mocker):
+def test_publish_with_client_cert(
+    app_tester: "ApplicationTester", mocker: "MockerFixture"
+):
     publisher_publish = mocker.patch("poetry.publishing.Publisher.publish")
 
     app_tester.execute("publish --client-cert path/to/client.pem")
@@ -65,7 +82,7 @@ def test_publish_with_client_cert(app_tester, mocker):
     ] == publisher_publish.call_args
 
 
-def test_publish_dry_run(app_tester, http):
+def test_publish_dry_run(app_tester: "ApplicationTester", http: "ModuleType"):
     http.register_uri(
         http.POST, "https://upload.pypi.org/legacy/", status=403, body="Forbidden"
     )

--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 import tomlkit
 
@@ -5,13 +7,27 @@ from poetry.core.packages.package import Package
 from poetry.factory import Factory
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from poetry.repositories import Repository
+    from tests.helpers import PoetryTestApplication
+    from tests.helpers import TestRepository
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture()
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("remove")
 
 
 def test_remove_without_specific_group_removes_from_all_groups(
-    tester, app, repo, command_tester_factory, installed
+    tester: "CommandTester",
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    command_tester_factory: "CommandTesterFactory",
+    installed: "Repository",
 ):
     """
     Removing without specifying a group removes packages from all groups.
@@ -62,7 +78,11 @@ baz = "^1.0.0"
 
 
 def test_remove_without_specific_group_removes_from_specific_groups(
-    tester, app, repo, command_tester_factory, installed
+    tester: "CommandTester",
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    command_tester_factory: "CommandTesterFactory",
+    installed: "Repository",
 ):
     """
     Removing with a specific group given removes packages only from this group.
@@ -113,7 +133,11 @@ baz = "^1.0.0"
 
 
 def test_remove_does_not_live_empty_groups(
-    tester, app, repo, command_tester_factory, installed
+    tester: "CommandTester",
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    command_tester_factory: "CommandTesterFactory",
+    installed: "Repository",
 ):
     """
     Empty groups are automatically discarded after package removal.
@@ -157,7 +181,11 @@ baz = "^1.0.0"
 
 
 def test_remove_command_should_not_write_changes_upon_installer_errors(
-    tester, app, repo, command_tester_factory, mocker
+    tester: "CommandTester",
+    app: "PoetryTestApplication",
+    repo: "TestRepository",
+    command_tester_factory: "CommandTesterFactory",
+    mocker: "MockerFixture",
 ):
     repo.add_package(Package("foo", "2.0.0"))
 

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -1,22 +1,35 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 
+if TYPE_CHECKING:
+    from cleo.testers.application_tester import ApplicationTester
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from poetry.utils.env import MockEnv
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("run")
 
 
 @pytest.fixture(autouse=True)
-def patches(mocker, env):
+def patches(mocker: "MockerFixture", env: "MockEnv") -> None:
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=env)
 
 
-def test_run_passes_all_args(app_tester, env):
+def test_run_passes_all_args(app_tester: "ApplicationTester", env: "MockEnv"):
     app_tester.execute("run python -V")
     assert [["python", "-V"]] == env.executed
 
 
-def test_run_keeps_options_passed_before_command(app_tester, env):
+def test_run_keeps_options_passed_before_command(
+    app_tester: "ApplicationTester", env: "MockEnv"
+):
     app_tester.execute("-V --no-ansi run python", decorated=True)
 
     assert not app_tester.io.is_decorated()

--- a/tests/console/commands/test_search.py
+++ b/tests/console/commands/test_search.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Type
 
 import pytest
 
 
 if TYPE_CHECKING:
-    from types import ModuleType
+    import httpretty
 
     from cleo.testers.command_tester import CommandTester
 
@@ -18,7 +19,7 @@ FIXTURES_DIRECTORY = (
 
 
 @pytest.fixture(autouse=True)
-def mock_search_http_response(http: "ModuleType") -> None:
+def mock_search_http_response(http: Type["httpretty.httpretty"]) -> None:
     with FIXTURES_DIRECTORY.joinpath("search.html").open(encoding="utf-8") as f:
         http.register_uri("GET", "https://pypi.org/search", f.read())
 
@@ -28,7 +29,7 @@ def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("search")
 
 
-def test_search(tester: "CommandTester", http: "ModuleType"):
+def test_search(tester: "CommandTester", http: Type["httpretty.httpretty"]):
     tester.execute("sqlalchemy")
 
     expected = """

--- a/tests/console/commands/test_search.py
+++ b/tests/console/commands/test_search.py
@@ -1,7 +1,15 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from cleo.testers.command_tester import CommandTester
+
+    from tests.types import CommandTesterFactory
 
 TESTS_DIRECTORY = Path(__file__).parent.parent.parent
 FIXTURES_DIRECTORY = (
@@ -10,20 +18,17 @@ FIXTURES_DIRECTORY = (
 
 
 @pytest.fixture(autouse=True)
-def mock_search_http_response(http):
+def mock_search_http_response(http: "ModuleType") -> None:
     with FIXTURES_DIRECTORY.joinpath("search.html").open(encoding="utf-8") as f:
         http.register_uri("GET", "https://pypi.org/search", f.read())
 
 
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("search")
 
 
-def test_search(
-    tester,
-    http,
-):
+def test_search(tester: "CommandTester", http: "ModuleType"):
     tester.execute("sqlalchemy")
 
     expected = """

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from poetry.core.packages.dependency_group import DependencyGroup
@@ -5,12 +7,23 @@ from poetry.factory import Factory
 from tests.helpers import get_package
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from poetry.poetry import Poetry
+    from poetry.repositories import Repository
+    from tests.helpers import TestRepository
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("show")
 
 
-def test_show_basic_with_installed_packages(tester, poetry, installed):
+def test_show_basic_with_installed_packages(
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
     poetry.package.add_dependency(
@@ -85,7 +98,9 @@ pytest   3.7.3 Pytest package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_basic_with_installed_packages_single(tester, poetry, installed):
+def test_show_basic_with_installed_packages_single(
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
 
     cachy_010 = get_package("cachy", "0.1.0")
@@ -126,7 +141,7 @@ def test_show_basic_with_installed_packages_single(tester, poetry, installed):
 
 
 def test_show_basic_with_not_installed_packages_non_decorated(
-    tester, poetry, installed
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
 ):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
@@ -181,7 +196,9 @@ pendulum (!) 2.0.0 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_basic_with_not_installed_packages_decorated(tester, poetry, installed):
+def test_show_basic_with_not_installed_packages_decorated(
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
 
@@ -235,7 +252,12 @@ def test_show_basic_with_not_installed_packages_decorated(tester, poetry, instal
     assert expected == tester.io.fetch_output()
 
 
-def test_show_latest_non_decorated(tester, poetry, installed, repo):
+def test_show_latest_non_decorated(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
 
@@ -300,7 +322,12 @@ pendulum 2.0.0 2.0.1 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_latest_decorated(tester, poetry, installed, repo):
+def test_show_latest_decorated(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
 
@@ -365,7 +392,12 @@ def test_show_latest_decorated(tester, poetry, installed, repo):
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated(tester, poetry, installed, repo):
+def test_show_outdated(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
 
@@ -426,7 +458,12 @@ cachy 0.1.0 0.2.0 Cachy package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated_with_only_up_to_date_packages(tester, poetry, installed, repo):
+def test_show_outdated_with_only_up_to_date_packages(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     cachy_020 = get_package("cachy", "0.2.0")
     cachy_020.description = "Cachy package"
 
@@ -463,7 +500,12 @@ def test_show_outdated_with_only_up_to_date_packages(tester, poetry, installed, 
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated_has_prerelease_but_not_allowed(tester, poetry, installed, repo):
+def test_show_outdated_has_prerelease_but_not_allowed(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
 
@@ -529,7 +571,12 @@ cachy 0.1.0 0.2.0 Cachy package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated_has_prerelease_and_allowed(tester, poetry, installed, repo):
+def test_show_outdated_has_prerelease_and_allowed(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     poetry.package.add_dependency(
         Factory.create_dependency(
             "cachy", {"version": "^0.1.0", "allow-prereleases": True}
@@ -599,7 +646,12 @@ cachy 0.1.0.dev1 0.3.0.dev123 Cachy package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_outdated_formatting(tester, poetry, installed, repo):
+def test_show_outdated_formatting(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
 
@@ -665,7 +717,12 @@ pendulum 2.0.0 2.0.1 Pendulum package
 
 
 @pytest.mark.parametrize("project_directory", ["project_with_local_dependencies"])
-def test_show_outdated_local_dependencies(tester, poetry, installed, repo):
+def test_show_outdated_local_dependencies(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     cachy_010 = get_package("cachy", "0.1.0")
     cachy_010.description = "Cachy package"
     cachy_020 = get_package("cachy", "0.2.0")
@@ -775,7 +832,12 @@ project-with-setup 0.1.1 ../project_with_setup 0.1.2 ../project_with_setup
 
 
 @pytest.mark.parametrize("project_directory", ["project_with_git_dev_dependency"])
-def test_show_outdated_git_dev_dependency(tester, poetry, installed, repo):
+def test_show_outdated_git_dev_dependency(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     cachy_010 = get_package("cachy", "0.1.0")
     cachy_010.description = "Cachy package"
     cachy_020 = get_package("cachy", "0.2.0")
@@ -870,7 +932,12 @@ demo  0.1.1 9cf87a2 0.1.2 9cf87a2 Demo package
 
 
 @pytest.mark.parametrize("project_directory", ["project_with_git_dev_dependency"])
-def test_show_outdated_no_dev_git_dev_dependency(tester, poetry, installed, repo):
+def test_show_outdated_no_dev_git_dev_dependency(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     cachy_010 = get_package("cachy", "0.1.0")
     cachy_010.description = "Cachy package"
     cachy_020 = get_package("cachy", "0.2.0")
@@ -962,7 +1029,12 @@ cachy 0.1.0 0.2.0 Cachy package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_hides_incompatible_package(tester, poetry, installed, repo):
+def test_show_hides_incompatible_package(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     poetry.package.add_dependency(
         Factory.create_dependency("cachy", {"version": "^0.1.0", "python": "< 2.0"})
     )
@@ -1018,7 +1090,12 @@ pendulum 2.0.0 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_all_shows_incompatible_package(tester, poetry, installed, repo):
+def test_show_all_shows_incompatible_package(
+    tester: "CommandTester",
+    poetry: "Poetry",
+    installed: "Repository",
+    repo: "TestRepository",
+):
     cachy_010 = get_package("cachy", "0.1.0")
     cachy_010.description = "Cachy package"
 
@@ -1071,7 +1148,9 @@ pendulum  2.0.0 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_non_dev_with_basic_installed_packages(tester, poetry, installed):
+def test_show_non_dev_with_basic_installed_packages(
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
     poetry.package.add_dependency(
@@ -1145,7 +1224,9 @@ pendulum 2.0.0 Pendulum package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_with_group_only(tester, poetry, installed):
+def test_show_with_group_only(
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
     poetry.package.add_dependency(
@@ -1218,7 +1299,9 @@ pytest 3.7.3 Pytest package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_with_optional_group(tester, poetry, installed):
+def test_show_with_optional_group(
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
     group = DependencyGroup("dev", optional=True)
@@ -1302,7 +1385,7 @@ pytest   3.7.3 Pytest package
     assert expected == tester.io.fetch_output()
 
 
-def test_show_tree(tester, poetry, installed):
+def test_show_tree(tester: "CommandTester", poetry: "Poetry", installed: "Repository"):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.2.0"))
 
     cachy2 = get_package("cachy", "0.2.0")
@@ -1354,7 +1437,9 @@ cachy 0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_show_tree_no_dev(tester, poetry, installed):
+def test_show_tree_no_dev(
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.2.0"))
     poetry.package.add_dependency(
         Factory.create_dependency("pytest", "^6.1.0", groups=["dev"])
@@ -1421,7 +1506,9 @@ cachy 0.2.0
     assert expected == tester.io.fetch_output()
 
 
-def test_show_required_by_deps(tester, poetry, installed):
+def test_show_required_by_deps(
+    tester: "CommandTester", poetry: "Poetry", installed: "Repository"
+):
     poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.2.0"))
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "2.0.0"))
 

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -1,15 +1,23 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from poetry.console.commands.version import VersionCommand
 
 
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from tests.types import CommandTesterFactory
+
+
 @pytest.fixture()
-def command():
+def command() -> VersionCommand:
     return VersionCommand()
 
 
 @pytest.fixture
-def tester(command_tester_factory):
+def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
     return command_tester_factory("version")
 
 
@@ -39,25 +47,27 @@ def tester(command_tester_factory):
         ("0.0.0", "1.2.3", "1.2.3"),
     ],
 )
-def test_increment_version(version, rule, expected, command):
+def test_increment_version(
+    version: str, rule: str, expected: str, command: VersionCommand
+):
     assert expected == command.increment_version(version, rule).text
 
 
-def test_version_show(tester):
+def test_version_show(tester: "CommandTester"):
     tester.execute()
     assert "simple-project 1.2.3\n" == tester.io.fetch_output()
 
 
-def test_short_version_show(tester):
+def test_short_version_show(tester: "CommandTester"):
     tester.execute("--short")
     assert "1.2.3\n" == tester.io.fetch_output()
 
 
-def test_version_update(tester):
+def test_version_update(tester: "CommandTester"):
     tester.execute("2.0.0")
     assert "Bumping version from 1.2.3 to 2.0.0\n" == tester.io.fetch_output()
 
 
-def test_short_version_update(tester):
+def test_short_version_update(tester: "CommandTester"):
     tester.execute("--short 2.0.0")
     assert "2.0.0\n" == tester.io.fetch_output()

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 
@@ -23,14 +24,14 @@ def installer():
 
 
 @pytest.fixture
-def env(tmp_dir):
+def env(tmp_dir) -> MockEnv:
     path = Path(tmp_dir) / ".venv"
     path.mkdir(parents=True)
     return MockEnv(path=path, is_venv=True)
 
 
 @pytest.fixture(autouse=True)
-def setup(mocker, installer, installed, config, env):
+def setup(mocker, installer, installed, config, env) -> Iterator[None]:
     # Set Installer's installer
     p = mocker.patch("poetry.installation.installer.Installer._get_installer")
     p.return_value = installer

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -113,7 +113,7 @@ def app(poetry) -> PoetryTestApplication:
 
 
 @pytest.fixture
-def app_tester(app):
+def app_tester(app: PoetryTestApplication) -> ApplicationTester:
     return ApplicationTester(app)
 
 

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Iterator
 
 import pytest
@@ -18,13 +19,19 @@ from tests.helpers import TestLocker
 from tests.helpers import mock_clone
 
 
+if TYPE_CHECKING:
+    from poetry.poetry import Poetry
+    from tests.conftest import Config
+    from tests.helpers import TestRepository
+
+
 @pytest.fixture()
-def installer():
+def installer() -> NoopInstaller:
     return NoopInstaller()
 
 
 @pytest.fixture
-def env(tmp_dir) -> MockEnv:
+def env(tmp_dir: str) -> MockEnv:
     path = Path(tmp_dir) / ".venv"
     path.mkdir(parents=True)
     return MockEnv(path=path, is_venv=True)
@@ -70,12 +77,14 @@ def setup(mocker, installer, installed, config, env) -> Iterator[None]:
 
 
 @pytest.fixture
-def project_directory():
+def project_directory() -> str:
     return "simple_project"
 
 
 @pytest.fixture
-def poetry(repo, project_directory, config):
+def poetry(
+    repo: "TestRepository", project_directory: str, config: "Config"
+) -> "Poetry":
     p = Factory().create_poetry(
         Path(__file__).parent.parent / "fixtures" / project_directory
     )

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -97,7 +97,7 @@ def poetry(repo, project_directory, config):
 
 
 @pytest.fixture
-def app(poetry):
+def app(poetry) -> PoetryTestApplication:
     app_ = PoetryTestApplication(poetry)
 
     return app_

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -20,7 +20,10 @@ from tests.helpers import mock_clone
 
 
 if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
     from poetry.poetry import Poetry
+    from poetry.repositories import Repository
     from tests.conftest import Config
     from tests.helpers import TestRepository
 
@@ -38,7 +41,13 @@ def env(tmp_dir: str) -> MockEnv:
 
 
 @pytest.fixture(autouse=True)
-def setup(mocker, installer, installed, config, env) -> Iterator[None]:
+def setup(
+    mocker: "MockerFixture",
+    installer: NoopInstaller,
+    installed: "Repository",
+    config: "Config",
+    env: MockEnv,
+) -> Iterator[None]:
     # Set Installer's installer
     p = mocker.patch("poetry.installation.installer.Installer._get_installer")
     p.return_value = installer
@@ -106,7 +115,7 @@ def poetry(
 
 
 @pytest.fixture
-def app(poetry) -> PoetryTestApplication:
+def app(poetry: "Poetry") -> PoetryTestApplication:
     app_ = PoetryTestApplication(poetry)
 
     return app_
@@ -118,10 +127,10 @@ def app_tester(app: PoetryTestApplication) -> ApplicationTester:
 
 
 @pytest.fixture
-def new_installer_disabled(config):
+def new_installer_disabled(config: "Config") -> None:
     config.merge({"experimental": {"new-installer": False}})
 
 
 @pytest.fixture()
-def executor(poetry, config, env):
+def executor(poetry: "Poetry", config: "Config", env: MockEnv) -> TestExecutor:
     return TestExecutor(env, poetry.pool, config, NullIO())

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -1,5 +1,7 @@
 import re
 
+from typing import TYPE_CHECKING
+
 from cleo.testers.application_tester import ApplicationTester
 from entrypoints import EntryPoint
 
@@ -8,23 +10,27 @@ from poetry.console.commands.command import Command
 from poetry.plugins.application_plugin import ApplicationPlugin
 
 
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
 class FooCommand(Command):
     name = "foo"
 
     description = "Foo Command"
 
-    def handle(self):
+    def handle(self) -> int:
         self.line("foo called")
 
         return 0
 
 
 class AddCommandPlugin(ApplicationPlugin):
-    def activate(self, application: Application):
+    def activate(self, application: Application) -> None:
         application.command_loader.register_factory("foo", lambda: FooCommand())
 
 
-def test_application_with_plugins(mocker):
+def test_application_with_plugins(mocker: "MockerFixture"):
     mocker.patch(
         "entrypoints.get_group_all",
         return_value=[
@@ -43,7 +49,7 @@ def test_application_with_plugins(mocker):
     assert 0 == tester.status_code
 
 
-def test_application_with_plugins_disabled(mocker):
+def test_application_with_plugins_disabled(mocker: "MockerFixture"):
     mocker.patch(
         "entrypoints.get_group_all",
         return_value=[
@@ -62,7 +68,7 @@ def test_application_with_plugins_disabled(mocker):
     assert 0 == tester.status_code
 
 
-def test_application_execute_plugin_command(mocker):
+def test_application_execute_plugin_command(mocker: "MockerFixture"):
     mocker.patch(
         "entrypoints.get_group_all",
         return_value=[
@@ -81,7 +87,9 @@ def test_application_execute_plugin_command(mocker):
     assert 0 == tester.status_code
 
 
-def test_application_execute_plugin_command_with_plugins_disabled(mocker):
+def test_application_execute_plugin_command_with_plugins_disabled(
+    mocker: "MockerFixture",
+):
     mocker.patch(
         "entrypoints.get_group_all",
         return_value=[

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+from typing import Dict
 from typing import Optional
 
 from tests.compat import Protocol
@@ -32,4 +33,17 @@ class SourcesFactory(Protocol):
     def __call__(
         self, poetry: "Poetry", sources: "Source", config: "Config", io: "IO"
     ) -> None:
+        ...
+
+
+class ProjectFactory(Protocol):
+    def __call__(
+        self,
+        name: Optional[str] = None,
+        dependencies: Optional[Dict[str, str]] = None,
+        dev_dependencies: Optional[Dict[str, str]] = None,
+        pyproject_content: Optional[str] = None,
+        poetry_lock_content: Optional[str] = None,
+        install_deps: bool = True,
+    ) -> "Poetry":
         ...

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING
+from typing import Optional
+
+from tests.compat import Protocol
+
+
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from poetry.installation import Installer
+    from poetry.installation.executor import Executor
+    from poetry.poetry import Poetry
+    from poetry.utils.env import Env
+
+
+class CommandTesterFactory(Protocol):
+    def __call__(
+        self,
+        command: str,
+        poetry: Optional["Poetry"] = None,
+        installer: Optional["Installer"] = None,
+        executor: Optional["Executor"] = None,
+        environment: Optional["Env"] = None,
+    ) -> "CommandTester":
+        ...

--- a/tests/types.py
+++ b/tests/types.py
@@ -5,8 +5,11 @@ from tests.compat import Protocol
 
 
 if TYPE_CHECKING:
+    from cleo.io.io import IO
     from cleo.testers.command_tester import CommandTester
 
+    from poetry.config.config import Config
+    from poetry.config.source import Source
     from poetry.installation import Installer
     from poetry.installation.executor import Executor
     from poetry.poetry import Poetry
@@ -22,4 +25,11 @@ class CommandTesterFactory(Protocol):
         executor: Optional["Executor"] = None,
         environment: Optional["Env"] = None,
     ) -> "CommandTester":
+        ...
+
+
+class SourcesFactory(Protocol):
+    def __call__(
+        self, poetry: "Poetry", sources: "Source", config: "Config", io: "IO"
+    ) -> None:
         ...


### PR DESCRIPTION
This is the first part of incremental PR with the goal to force type hints in application code and tests.

This PR adds missing typehints to:

* application code
* tests.config
* test.console

The `conftest.py` in the tests root folder will be updated whenever needed.