### PR TITLE
Forward compatibility for multiple readme files

### DIFF
--- a/src/poetry/json/schemas/poetry-schema.json
+++ b/src/poetry/json/schemas/poetry-schema.json
@@ -54,8 +54,19 @@
       "$ref": "#/definitions/maintainers"
     },
     "readme": {
-      "type": "string",
-      "description": "The path to the README file"
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The path to the README file."
+        },
+        {
+          "type": "array",
+          "description": "A list of paths to the readme files.",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "classifiers": {
       "type": "array",

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -25,6 +25,10 @@ def test_create_poetry():
     poetry = Factory().create_poetry(fixtures_dir / "sample_project")
 
     package = poetry.package
+    if hasattr(package, "readmes"):
+        single_readme = package.readmes[0]
+    else:
+        single_readme = package.readme
 
     assert package.name == "my-package"
     assert package.version.text == "1.2.3"
@@ -32,7 +36,7 @@ def test_create_poetry():
     assert package.authors == ["Sébastien Eustace <sebastien@eustace.io>"]
     assert package.license.id == "MIT"
     assert (
-        package.readme.relative_to(fixtures_dir).as_posix()
+        single_readme.relative_to(fixtures_dir).as_posix()
         == "sample_project/README.rst"
     )
     assert package.homepage == "https://python-poetry.org"


### PR DESCRIPTION
This makes poetry aware about the upcoming changes in python-poetry/poetry-core#248 in order to support declaration of multiple readme files in pyproject.toml

Relates: python-poetry/poetry#873