### PR TITLE
Use flake8-eradicate

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,7 @@ ban-relative-imports = true
 inline-quotes = double
 enable-extensions = TC, TC2
 type-checking-exempt-modules = typing, typing-extensions
+eradicate-whitelist-extend = ^-.*;
 extend-ignore =
     # E501: Line too long (FIXME: long string constants)
     E501,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
           - flake8-broken-line==0.4.0
           - flake8-bugbear==21.9.2
           - flake8-comprehensions==3.7.0
+          - flake8-eradicate==1.2.0
           - flake8-no-pep420==1.2.0
           - flake8-quotes==3.3.1
           - flake8-tidy-imports==4.5.0


### PR DESCRIPTION
Relates-to: #4776

Very low hanging fruit, but perhaps too little benefit or maybe just an investment in the future.

There seems to be no commented out code in poetry (or `eradicate` can't find it).

`eradicate` only finds 5 false positives in [this comment](https://github.com/python-poetry/poetry/blob/5c328a3637b0efd93d6581539d2f3a3d062fc03d/src/poetry/puzzle/provider.py#L534-L551):

```
src/poetry/puzzle/provider.py:540:1: E800 Found commented out code
src/poetry/puzzle/provider.py:541:1: E800 Found commented out code
src/poetry/puzzle/provider.py:544:1: E800 Found commented out code
src/poetry/puzzle/provider.py:550:1: E800 Found commented out code
src/poetry/puzzle/provider.py:551:1: E800 Found commented out code
```

When extending the whitelist, you have to ask yourself how specific or general you want the regex to be.