### PR TITLE
Normalize path before hashing ...

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1072,7 +1072,8 @@ class EnvManager:
     def generate_env_name(cls, name: str, cwd: str) -> str:
         name = name.lower()
         sanitized_name = re.sub(r'[ $`!*@"\\\r\n\t]', "_", name)[:42]
-        h = hashlib.sha256(encode(cwd)).digest()
+        normalized_cwd = os.path.normcase(cwd)
+        h = hashlib.sha256(encode(normalized_cwd)).digest()
         h = base64.urlsafe_b64encode(h).decode()[:8]
 
         return f"{sanitized_name}-{h}"

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1120,3 +1120,12 @@ def test_create_venv_accepts_fallback_version_w_nonzero_patchlevel(
         with_setuptools=True,
         with_wheel=True,
     )
+
+
+def test_generate_env_name_ignores_case_for_case_insensitive_fs(tmp_dir):
+    venv_name1 = EnvManager.generate_env_name("simple-project", "MyDiR")
+    venv_name2 = EnvManager.generate_env_name("simple-project", "mYdIr")
+    if sys.platform == "win32":
+        assert venv_name1 == venv_name2
+    else:
+        assert venv_name1 != venv_name2


### PR DESCRIPTION
.... so that the generated venv name is independent of case on Windows

# Pull Request Check List

Resolves #2419
Resolves #3829
Resolves #2161

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
Based on original PR #2421 with consent of its author

Normalizes the path before hashing so that the generated venv name is independent of case on Windows.

Without normalization, it is possible to unintentionally create multiple virtualenvs for the same path when (accidentally or due to certain tools) using an alternative spelling. It may also happen that an existing virtualenv is not found.

**Attention:** This change only affects Windows because [os.path.normcase](https://docs.python.org/3/library/os.path.html#os.path.normcase) just returns the unchanged path on other operating systems (independent of the fact if the file system is case sensitive or not).