### PR TITLE
Do not use cache control when querying pypi JSON API

### DIFF
--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -312,12 +312,12 @@ class PyPiRepository(RemoteRepository):
 
     def _get(self, endpoint):  # type: (str) -> Union[dict, None]
         try:
-            json_response = self.session.get(self._base_url + endpoint)
+            json_response = requests.session().get(self._base_url + endpoint)
         except requests.exceptions.TooManyRedirects:
             # Cache control redirect loop.
             # We try to remove the cache and try again
             self._cache_control_cache.delete(self._base_url + endpoint)
-            json_response = self.session.get(self._base_url + endpoint)
+            json_response = requests.session().get(self._base_url + endpoint)
 
         if json_response.status_code == 404:
             return None


### PR DESCRIPTION
It seems to be returning empty bytes `b""` instead of a proper JSON object.

Resolves: #4821 alternative to https://github.com/python-poetry/poetry/pull/4717