### PR TITLE
workaround pypi empty responses by disabling cache control

### DIFF
--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Iterator
 from typing import List
+from typing import Mapping
 from typing import Optional
 from urllib.parse import quote
 
@@ -40,8 +41,6 @@ from poetry.utils.patterns import wheel_file_re
 
 
 if TYPE_CHECKING:
-    import requests.structures
-
     from poetry.core.packages.dependency import Dependency
 
 with warnings.catch_warnings():
@@ -62,9 +61,7 @@ class Page:
         ".tar",
     ]
 
-    def __init__(
-        self, url: str, content: bytes, headers: requests.structures.CaseInsensitiveDict
-    ) -> None:
+    def __init__(self, url: str, content: bytes, headers: Mapping) -> None:
         if not url.endswith("/"):
             url += "/"
 

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -8,8 +8,6 @@ from collections import defaultdict
 from html import unescape
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Any
-from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -42,6 +40,8 @@ from poetry.utils.patterns import wheel_file_re
 
 
 if TYPE_CHECKING:
+    import requests.structures
+
     from poetry.core.packages.dependency import Dependency
 
 with warnings.catch_warnings():
@@ -62,7 +62,9 @@ class Page:
         ".tar",
     ]
 
-    def __init__(self, url: str, content: str, headers: Dict[str, Any]) -> None:
+    def __init__(
+        self, url: str, content: bytes, headers: requests.structures.CaseInsensitiveDict
+    ) -> None:
         if not url.endswith("/"):
             url += "/"
 

--- a/tests/fixtures/git/github.com/demo/demo/demo.egg-info/PKG-INFO
+++ b/tests/fixtures/git/github.com/demo/demo/demo.egg-info/PKG-INFO
@@ -6,8 +6,7 @@ Home-page: https://github.com/demo/demo
 Author: Sébastien Eustace
 Author-email: sebastien@eustace.io
 License: MIT
+Description: UNKNOWN
 Platform: UNKNOWN
-Provides-Extra: foo
 Provides-Extra: bar
-
-UNKNOWN
+Provides-Extra: foo

--- a/tests/fixtures/git/github.com/demo/demo/demo.egg-info/PKG-INFO
+++ b/tests/fixtures/git/github.com/demo/demo/demo.egg-info/PKG-INFO
@@ -6,7 +6,8 @@ Home-page: https://github.com/demo/demo
 Author: Sébastien Eustace
 Author-email: sebastien@eustace.io
 License: MIT
-Description: UNKNOWN
 Platform: UNKNOWN
-Provides-Extra: bar
 Provides-Extra: foo
+Provides-Extra: bar
+
+UNKNOWN

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -24,8 +24,6 @@ except ImportError:
 if TYPE_CHECKING:
     import httpretty
 
-    from _pytest.monkeypatch import MonkeyPatch
-
 
 class MockRepository(LegacyRepository):
 
@@ -356,4 +354,3 @@ def test_get_5xx_raises(http: Type["httpretty.httpretty"]):
 
     with pytest.raises(RepositoryError):
         repo._get_page("/foo")
-

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -3,7 +3,6 @@ import shutil
 from pathlib import Path
 
 import pytest
-import requests
 
 from poetry.core.packages.dependency import Dependency
 from poetry.factory import Factory
@@ -346,17 +345,3 @@ def test_get_5xx_raises(http):
 
     with pytest.raises(RepositoryError):
         repo._get_page("/foo")
-
-
-def test_get_redirected_response_url(http, monkeypatch):
-    repo = MockHttpRepository({"/foo": 200}, http)
-    redirect_url = "http://legacy.redirect.bar"
-
-    def get_mock(url):
-        response = requests.Response()
-        response.status_code = 200
-        response.url = redirect_url + "/foo"
-        return response
-
-    monkeypatch.setattr(repo.session, "get", get_mock)
-    assert repo._get_page("/foo")._url == "http://legacy.redirect.bar/foo/"

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -2,7 +2,6 @@ import json
 import shutil
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Dict
 from typing import Optional
 
@@ -11,10 +10,6 @@ import pytest
 from poetry.core.packages.dependency import Dependency
 from poetry.factory import Factory
 from poetry.repositories.pypi_repository import PyPiRepository
-
-
-if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
 
 
 class MockRepository(PyPiRepository):
@@ -206,6 +201,7 @@ def test_invalid_versions_ignored():
     # and a correct one.
     packages = repo.find_packages(Factory.create_dependency("pygame-music-grid", "*"))
     assert len(packages) == 1
+
 
 def test_urls():
     repository = PyPiRepository()

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -1,18 +1,13 @@
 import json
 import shutil
 
-from io import BytesIO
 from pathlib import Path
 
 import pytest
 
-from requests.exceptions import TooManyRedirects
-from requests.models import Response
-
 from poetry.core.packages.dependency import Dependency
 from poetry.factory import Factory
 from poetry.repositories.pypi_repository import PyPiRepository
-from poetry.utils._compat import encode
 
 
 class MockRepository(PyPiRepository):
@@ -202,22 +197,6 @@ def test_invalid_versions_ignored():
     # and a correct one.
     packages = repo.find_packages(Factory.create_dependency("pygame-music-grid", "*"))
     assert len(packages) == 1
-
-
-def test_get_should_invalid_cache_on_too_many_redirects_error(mocker):
-    delete_cache = mocker.patch("cachecontrol.caches.file_cache.FileCache.delete")
-
-    response = Response()
-    response.encoding = "utf-8"
-    response.raw = BytesIO(encode('{"foo": "bar"}'))
-    mocker.patch(
-        "cachecontrol.adapter.CacheControlAdapter.send",
-        side_effect=[TooManyRedirects(), response],
-    )
-    repository = PyPiRepository()
-    repository._get("https://pypi.org/pypi/async-timeout/json")
-
-    assert delete_cache.called
 
 
 def test_urls():


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4821 
Alternative to: #4822 and #4717 

This is a work-around fix for https://github.com/pypa/warehouse/issues/10387 . Thanks @j-martin for also looking at this.

This disables cache control for package metadata due to issues observed that pypi can return empty responses. The package artifact is still maintained. The diff is a little larger due to need to keeping type checker happy and removing tests assuming cache control usage.


<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ x ] Added **tests** for changed code.
- [ x ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
