### PR TITLE
workaround namespace package inspection issues

### DIFF
--- a/src/poetry/__init__.py
+++ b/src/poetry/__init__.py
@@ -1,5 +1,1 @@
-from pkgutil import extend_path
-from typing import List
-
-
-__path__: List[str] = extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore[has-type]

--- a/src/poetry/config/file_config_source.py
+++ b/src/poetry/config/file_config_source.py
@@ -10,9 +10,8 @@ from poetry.config.config_source import ConfigSource
 
 
 if TYPE_CHECKING:
-    from tomlkit.toml_document import TOMLDocument
-
     from poetry.core.toml.file import TOMLFile
+    from tomlkit.toml_document import TOMLDocument
 
 
 class FileConfigSource(ConfigSource):

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -16,11 +16,11 @@ from cleo.events.event_dispatcher import EventDispatcher
 from cleo.exceptions import CleoException
 from cleo.formatters.style import Style
 from cleo.io.inputs.argv_input import ArgvInput
+from poetry.core.utils._compat import PY37
 
 from poetry.__version__ import __version__
 from poetry.console.command_loader import CommandLoader
 from poetry.console.commands.command import Command
-from poetry.core.utils._compat import PY37
 
 
 if TYPE_CHECKING:

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -76,11 +76,11 @@ class AddCommand(InstallerCommand, InitCommand):
     loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]
 
     def handle(self) -> int:
+        from poetry.core.semver.helpers import parse_constraint
         from tomlkit import inline_table
         from tomlkit import parse as parse_toml
         from tomlkit import table
 
-        from poetry.core.semver.helpers import parse_constraint
         from poetry.factory import Factory
 
         packages = self.argument("name")

--- a/src/poetry/console/commands/check.py
+++ b/src/poetry/console/commands/check.py
@@ -10,6 +10,7 @@ class CheckCommand(Command):
 
     def handle(self) -> int:
         from poetry.core.pyproject.toml import PyProjectTOML
+
         from poetry.factory import Factory
 
         # Load poetry config and display errors, if any

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -100,9 +100,10 @@ To remove a repository (repo is a short alias for repositories):
     def handle(self) -> Optional[int]:
         from pathlib import Path
 
-        from poetry.config.file_config_source import FileConfigSource
         from poetry.core.pyproject.exceptions import PyProjectException
         from poetry.core.toml.file import TOMLFile
+
+        from poetry.config.file_config_source import FileConfigSource
         from poetry.factory import Factory
         from poetry.locations import CONFIG_DIR
 

--- a/src/poetry/console/commands/debug/resolve.py
+++ b/src/poetry/console/commands/debug/resolve.py
@@ -37,8 +37,8 @@ class DebugResolveCommand(InitCommand):
 
     def handle(self) -> Optional[int]:
         from cleo.io.null_io import NullIO
-
         from poetry.core.packages.project_package import ProjectPackage
+
         from poetry.factory import Factory
         from poetry.puzzle import Solver
         from poetry.repositories.pool import Pool

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -67,6 +67,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.vcs.git import GitConfig
+
         from poetry.layouts import layout
         from poetry.utils.env import SystemEnv
 
@@ -383,6 +384,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
     def _parse_requirements(self, requirements: List[str]) -> List[Dict[str, str]]:
         from poetry.core.pyproject.exceptions import PyProjectException
+
         from poetry.puzzle.provider import Provider
 
         result = []

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -87,6 +87,7 @@ dependencies and not including the current project, run the command with the
 
     def handle(self) -> int:
         from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
+
         from poetry.masonry.builders import EditableBuilder
 
         self._installer.use_executor(

--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -29,6 +29,7 @@ class NewCommand(Command):
         from pathlib import Path
 
         from poetry.core.vcs.git import GitConfig
+
         from poetry.layouts import layout
         from poetry.utils.env import SystemEnv
 

--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -57,9 +57,9 @@ You can specify a package in the following forms:
 
         from cleo.io.inputs.string_input import StringInput
         from cleo.io.io import IO
-
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.semver.helpers import parse_constraint
+
         from poetry.factory import Factory
         from poetry.packages.project_package import ProjectPackage
         from poetry.repositories.installed_repository import InstalledRepository

--- a/src/poetry/console/commands/self/update.py
+++ b/src/poetry/console/commands/self/update.py
@@ -15,6 +15,7 @@ from poetry.console.commands.command import Command
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.semver.version import Version
+
     from poetry.repositories.pool import Pool
 
 
@@ -84,9 +85,10 @@ class SelfUpdateCommand(Command):
         return pool
 
     def handle(self) -> int:
-        from poetry.__version__ import __version__
         from poetry.core.packages.dependency import Dependency
         from poetry.core.semver.version import Version
+
+        from poetry.__version__ import __version__
 
         version = self.argument("version")
         if not version:
@@ -167,9 +169,10 @@ class SelfUpdateCommand(Command):
         self._make_bin()
 
     def _update(self, version: "Version") -> None:
-        from poetry.config.config import Config
         from poetry.core.packages.dependency import Dependency
         from poetry.core.packages.project_package import ProjectPackage
+
+        from poetry.config.config import Config
         from poetry.installation.installer import Installer
         from poetry.packages.locker import NullLocker
         from poetry.repositories.installed_repository import InstalledRepository

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -11,9 +11,9 @@ from poetry.console.commands.env_command import EnvCommand
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
+
     from poetry.packages.project_package import ProjectPackage
     from poetry.repositories import Repository
     from poetry.repositories.installed_repository import InstalledRepository

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -5,11 +5,11 @@ from typing import List
 from typing import Optional
 
 from cleo.io.null_io import NullIO
+from poetry.core.factory import Factory as BaseFactory
+from poetry.core.toml.file import TOMLFile
 
 from poetry.config.config import Config
 from poetry.config.file_config_source import FileConfigSource
-from poetry.core.factory import Factory as BaseFactory
-from poetry.core.toml.file import TOMLFile
 from poetry.locations import CONFIG_DIR
 from poetry.packages.locker import Locker
 from poetry.packages.project_package import ProjectPackage

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -21,6 +21,7 @@ from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.core.utils.helpers import parse_requires
 from poetry.core.utils.helpers import temporary_directory
 from poetry.core.version.markers import InvalidMarker
+
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import ephemeral_environment
 from poetry.utils.setup_reader import SetupReader

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -7,6 +7,7 @@ from typing import List
 from typing import Optional
 
 from poetry.core.packages.utils.link import Link
+
 from poetry.installation.chooser import InvalidWheelName
 from poetry.installation.chooser import Wheel
 

--- a/src/poetry/installation/chooser.py
+++ b/src/poetry/installation/chooser.py
@@ -13,6 +13,7 @@ from poetry.utils.patterns import wheel_file_re
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.packages.utils.link import Link
+
     from poetry.repositories.pool import Pool
     from poetry.utils.env import Env
 

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -16,11 +16,11 @@ from typing import Optional
 from typing import Union
 
 from cleo.io.null_io import NullIO
-
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.utils.link import Link
 from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.pyproject.toml import PyProjectTOML
+
 from poetry.installation.chef import Chef
 from poetry.installation.chooser import Chooser
 from poetry.utils._compat import decode
@@ -33,9 +33,9 @@ from poetry.utils.pip import pip_install
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
+    from poetry.core.packages.package import Package
 
     from poetry.config.config import Config
-    from poetry.core.packages.package import Package
     from poetry.installation.operations import OperationTypes
     from poetry.installation.operations.install import Install
     from poetry.installation.operations.operation import Operation

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -21,9 +21,9 @@ from poetry.utils.helpers import canonicalize_name
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
+    from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.config.config import Config
-    from poetry.core.packages.project_package import ProjectPackage
     from poetry.installation.base_installer import BaseInstaller
     from poetry.installation.operations import OperationTypes
     from poetry.installation.operations.operation import Operation

--- a/src/poetry/installation/pip_installer.py
+++ b/src/poetry/installation/pip_installer.py
@@ -9,6 +9,7 @@ from typing import Any
 from typing import Union
 
 from poetry.core.pyproject.toml import PyProjectTOML
+
 from poetry.installation.base_installer import BaseInstaller
 from poetry.utils._compat import encode
 from poetry.utils.helpers import safe_rmtree
@@ -18,8 +19,8 @@ from poetry.utils.pip import pip_install
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-
     from poetry.core.packages.package import Package
+
     from poetry.repositories.pool import Pool
     from poetry.utils.env import Env
 

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -13,9 +13,8 @@ from poetry.utils.helpers import module_name
 
 
 if TYPE_CHECKING:
-    from tomlkit.items import InlineTable
-
     from poetry.core.pyproject.toml import PyProjectTOML
+    from tomlkit.items import InlineTable
 
 
 POETRY_DEFAULT = """\

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -11,6 +11,7 @@ from poetry.core.masonry.builders.builder import Builder
 from poetry.core.masonry.builders.sdist import SdistBuilder
 from poetry.core.masonry.utils.package_include import PackageInclude
 from poetry.core.semver.version import Version
+
 from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import decode
 from poetry.utils.helpers import is_dir_writable
@@ -19,8 +20,8 @@ from poetry.utils.pip import pip_editable_install
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-
     from poetry.core.poetry import Poetry
+
     from poetry.utils.env import Env
 
 SCRIPT_TEMPLATE = """\

--- a/src/poetry/mixology/__init__.py
+++ b/src/poetry/mixology/__init__.py
@@ -7,6 +7,7 @@ from poetry.mixology.version_solver import VersionSolver
 
 if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
+
     from poetry.mixology.result import SolverResult
     from poetry.packages import DependencyPackage
     from poetry.puzzle.provider import Provider

--- a/src/poetry/mixology/assignment.py
+++ b/src/poetry/mixology/assignment.py
@@ -8,6 +8,7 @@ from poetry.mixology.term import Term
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
+
     from poetry.mixology.incompatibility import Incompatibility
 
 

--- a/src/poetry/mixology/failure.py
+++ b/src/poetry/mixology/failure.py
@@ -5,6 +5,7 @@ from typing import Optional
 from typing import Tuple
 
 from poetry.core.semver.helpers import parse_constraint
+
 from poetry.mixology.incompatibility_cause import ConflictCause
 from poetry.mixology.incompatibility_cause import PythonCause
 

--- a/src/poetry/mixology/partial_solution.py
+++ b/src/poetry/mixology/partial_solution.py
@@ -9,6 +9,7 @@ from poetry.mixology.set_relation import SetRelation
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
+
     from poetry.mixology.incompatibility import Incompatibility
     from poetry.mixology.term import Term
 

--- a/src/poetry/mixology/solutions/solutions/python_requirement_solution.py
+++ b/src/poetry/mixology/solutions/solutions/python_requirement_solution.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 class PythonRequirementSolution(Solution):
     def __init__(self, exception: "PackageNotFoundCause") -> None:
         from poetry.core.semver.helpers import parse_constraint
+
         from poetry.mixology.incompatibility_cause import PythonCause
 
         self._title = "Check your dependencies Python requirement."

--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -8,6 +8,7 @@ from typing import Tuple
 from typing import Union
 
 from poetry.core.packages.dependency import Dependency
+
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.incompatibility import Incompatibility
 from poetry.mixology.incompatibility_cause import ConflictCause
@@ -23,6 +24,7 @@ from poetry.mixology.term import Term
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.packages.project_package import ProjectPackage
+
     from poetry.puzzle.provider import Provider
 
 

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -17,13 +17,6 @@ from typing import Set
 from typing import Tuple
 from typing import Union
 
-from tomlkit import array
-from tomlkit import document
-from tomlkit import inline_table
-from tomlkit import item
-from tomlkit import table
-from tomlkit.exceptions import TOMLKitError
-
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.semver.helpers import parse_constraint
@@ -31,6 +24,13 @@ from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
 from poetry.core.version.markers import parse_marker
 from poetry.core.version.requirements import InvalidRequirement
+from tomlkit import array
+from tomlkit import document
+from tomlkit import inline_table
+from tomlkit import item
+from tomlkit import table
+from tomlkit.exceptions import TOMLKitError
+
 from poetry.packages import DependencyPackage
 from poetry.utils.extras import get_extra_package_names
 

--- a/src/poetry/poetry.py
+++ b/src/poetry/poetry.py
@@ -2,16 +2,18 @@ from typing import TYPE_CHECKING
 from typing import List
 from typing import Optional
 
+from poetry.core.poetry import Poetry as BasePoetry
+
 from poetry.__version__ import __version__
 from poetry.config.source import Source
-from poetry.core.poetry import Poetry as BasePoetry
 
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from poetry.config.config import Config
     from poetry.core.packages.project_package import ProjectPackage
+
+    from poetry.config.config import Config
     from poetry.packages.locker import Locker
     from poetry.plugins.plugin_manager import PluginManager
     from poetry.repositories.pool import Pool

--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -11,6 +11,10 @@ from typing import Union
 
 import requests
 
+from poetry.core.masonry.metadata import Metadata
+from poetry.core.masonry.utils.helpers import escape_name
+from poetry.core.masonry.utils.helpers import escape_version
+from poetry.core.utils.helpers import normalize_version
 from requests import adapters
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
@@ -20,10 +24,6 @@ from requests_toolbelt.multipart import MultipartEncoder
 from requests_toolbelt.multipart import MultipartEncoderMonitor
 
 from poetry.__version__ import __version__
-from poetry.core.masonry.metadata import Metadata
-from poetry.core.masonry.utils.helpers import escape_name
-from poetry.core.masonry.utils.helpers import escape_version
-from poetry.core.utils.helpers import normalize_version
 from poetry.utils.patterns import wheel_file_re
 
 

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -18,11 +18,11 @@ from typing import Set
 from typing import Union
 
 from cleo.ui.progress_indicator import ProgressIndicator
-
 from poetry.core.packages.utils.utils import get_python_constraint_from_marker
 from poetry.core.semver.version import Version
 from poetry.core.vcs.git import Git
 from poetry.core.version.markers import MarkerUnion
+
 from poetry.inspection.info import PackageInfo
 from poetry.inspection.info import PackageInfoError
 from poetry.mixology.incompatibility import Incompatibility
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.packages.url_dependency import URLDependency
     from poetry.core.packages.vcs_dependency import VCSDependency
+
     from poetry.repositories import Pool
     from poetry.utils.env import Env
 

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -23,7 +23,6 @@ from poetry.puzzle.provider import Provider
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.directory_dependency import DirectoryDependency
     from poetry.core.packages.file_dependency import FileDependency
@@ -31,6 +30,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
     from poetry.core.packages.url_dependency import URLDependency
     from poetry.core.packages.vcs_dependency import VCSDependency
+
     from poetry.puzzle.transaction import Transaction
     from poetry.repositories import Pool
     from poetry.repositories import Repository

--- a/src/poetry/puzzle/transaction.py
+++ b/src/poetry/puzzle/transaction.py
@@ -6,6 +6,7 @@ from typing import Tuple
 
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
+
     from poetry.installation.operations import OperationTypes
 
 

--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -11,6 +11,7 @@ from poetry.core.packages.package import Package
 from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.utils.helpers import canonicalize_name
 from poetry.core.utils.helpers import module_name
+
 from poetry.repositories.repository import Repository
 from poetry.utils._compat import metadata
 

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -21,14 +21,14 @@ import requests.exceptions
 from cachecontrol import CacheControl
 from cachecontrol.caches.file_cache import FileCache
 from cachy import CacheManager
-
-from poetry.config.config import Config
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version import Version
 from poetry.core.semver.version_constraint import VersionConstraint
 from poetry.core.semver.version_range import VersionRange
+
+from poetry.config.config import Config
 from poetry.inspection.info import PackageInfo
 from poetry.locations import REPOSITORY_CACHE_DIR
 from poetry.repositories.exceptions import PackageNotFound

--- a/src/poetry/repositories/pool.py
+++ b/src/poetry/repositories/pool.py
@@ -11,6 +11,7 @@ from poetry.repositories.exceptions import PackageNotFound
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
+
     from poetry.repositories.repository import Repository
 
 

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -16,7 +16,6 @@ from cachecontrol.caches.file_cache import FileCache
 from cachecontrol.controller import logger as cache_control_logger
 from cachy import CacheManager
 from html5lib.html5parser import parse
-
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
@@ -25,6 +24,7 @@ from poetry.core.semver.version_constraint import VersionConstraint
 from poetry.core.semver.version_range import VersionRange
 from poetry.core.version.exceptions import InvalidVersion
 from poetry.core.version.markers import parse_marker
+
 from poetry.locations import REPOSITORY_CACHE_DIR
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.remote_repository import RemoteRepository

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -34,11 +34,11 @@ from packaging.tags import Tag
 from packaging.tags import interpreter_name
 from packaging.tags import interpreter_version
 from packaging.tags import sys_tags
-from virtualenv.seed.wheels.embed import get_embed_wheel
-
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
+from virtualenv.seed.wheels.embed import get_embed_wheel
+
 from poetry.locations import CACHE_DIR
 from poetry.utils._compat import decode
 from poetry.utils._compat import encode
@@ -51,8 +51,8 @@ from poetry.utils.helpers import temporary_directory
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
-
     from poetry.core.version.markers import BaseMarker
+
     from poetry.poetry import Poetry
 
 

--- a/src/poetry/utils/exporter.py
+++ b/src/poetry/utils/exporter.py
@@ -6,6 +6,7 @@ from typing import Sequence
 from typing import Union
 
 from poetry.core.packages.utils.utils import path_to_url
+
 from poetry.utils._compat import decode
 
 

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -17,10 +17,10 @@ from typing import Optional
 
 
 if TYPE_CHECKING:
+    from poetry.core.packages.package import Package
     from requests import Session
 
     from poetry.config.config import Config
-    from poetry.core.packages.package import Package
 
 
 _canonicalize_regex = re.compile("[-_]+")

--- a/src/poetry/utils/pip.py
+++ b/src/poetry/utils/pip.py
@@ -6,6 +6,7 @@ from typing import Union
 
 from poetry.core.packages.utils.link import Link
 from poetry.core.packages.utils.utils import url_to_path
+
 from poetry.exceptions import PoetryException
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import ephemeral_environment

--- a/src/poetry/version/version_selector.py
+++ b/src/poetry/version/version_selector.py
@@ -7,6 +7,7 @@ from poetry.core.semver.version import Version
 
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
+
     from poetry.repositories import Pool
 
 

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -4,6 +4,7 @@ from typing import List
 import pytest
 
 from poetry.core.semver.version import Version
+
 from tests.console.commands.env.helpers import check_output_wrapper
 
 

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -9,6 +9,7 @@ import tomlkit
 
 from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
+
 from poetry.utils.env import MockEnv
 from tests.console.commands.env.helpers import build_venv
 from tests.console.commands.env.helpers import check_output_wrapper

--- a/tests/console/commands/plugin/conftest.py
+++ b/tests/console/commands/plugin/conftest.py
@@ -2,8 +2,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from poetry.__version__ import __version__
 from poetry.core.packages.package import Package
+
+from poetry.__version__ import __version__
 from poetry.factory import Factory
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.repositories.pool import Pool

--- a/tests/console/commands/plugin/test_add.py
+++ b/tests/console/commands/plugin/test_add.py
@@ -5,6 +5,7 @@ from typing import Union
 import pytest
 
 from poetry.core.packages.package import Package
+
 from poetry.factory import Factory
 
 

--- a/tests/console/commands/plugin/test_remove.py
+++ b/tests/console/commands/plugin/test_remove.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING
 import pytest
 import tomlkit
 
-from poetry.__version__ import __version__
 from poetry.core.packages.package import Package
+
+from poetry.__version__ import __version__
 from poetry.layouts.layout import POETRY_DEFAULT
 
 

--- a/tests/console/commands/plugin/test_show.py
+++ b/tests/console/commands/plugin/test_show.py
@@ -4,8 +4,8 @@ from typing import Type
 import pytest
 
 from entrypoints import EntryPoint as _EntryPoint
-
 from poetry.core.packages.package import Package
+
 from poetry.factory import Factory
 from poetry.plugins.application_plugin import ApplicationPlugin
 from poetry.plugins.plugin import Plugin

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -4,10 +4,11 @@ from typing import Type
 
 import pytest
 
-from poetry.__version__ import __version__
-from poetry.console.exceptions import PoetrySimpleConsoleException
 from poetry.core.packages.package import Package
 from poetry.core.semver.version import Version
+
+from poetry.__version__ import __version__
+from poetry.console.exceptions import PoetrySimpleConsoleException
 from poetry.factory import Factory
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.repositories.pool import Pool

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from poetry.core.semver.version import Version
+
 from poetry.repositories.legacy_repository import LegacyRepository
 from tests.helpers import get_dependency
 from tests.helpers import get_package

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from poetry.config.config_source import ConfigSource
 from poetry.core.pyproject.exceptions import PyProjectException
+
+from poetry.config.config_source import ConfigSource
 from poetry.factory import Factory
 
 

--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -4,6 +4,7 @@ import pytest
 import tomlkit
 
 from poetry.core.packages.package import Package
+
 from poetry.factory import Factory
 
 

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from poetry.core.packages.dependency_group import DependencyGroup
+
 from poetry.factory import Factory
 from tests.helpers import get_package
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,13 +10,14 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from poetry.console.application import Application
 from poetry.core.masonry.utils.helpers import escape_name
 from poetry.core.masonry.utils.helpers import escape_version
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.toml.file import TOMLFile
 from poetry.core.vcs.git import ParsedUrl
+
+from poetry.console.application import Application
 from poetry.factory import Factory
 from poetry.installation.executor import Executor
 from poetry.packages import Locker
@@ -26,11 +27,11 @@ from poetry.utils._compat import WINDOWS
 
 
 if TYPE_CHECKING:
-    from tomlkit.toml_document import TOMLDocument
-
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.types import DependencyTypes
     from poetry.core.semver.version import Version
+    from tomlkit.toml_document import TOMLDocument
+
     from poetry.installation.operations import OperationTypes
     from poetry.poetry import Poetry
 

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from packaging.tags import Tag
-
 from poetry.core.packages.utils.link import Link
+
 from poetry.installation.chef import Chef
 from poetry.utils.env import MockEnv
 

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -12,8 +12,8 @@ from typing import Union
 import pytest
 
 from packaging.tags import Tag
-
 from poetry.core.packages.package import Package
+
 from poetry.installation.chooser import Chooser
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -15,11 +15,11 @@ import pytest
 
 from cleo.formatters.style import Style
 from cleo.io.buffered_io import BufferedIO
-
-from poetry.config.config import Config
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.utils._compat import PY36
+
+from poetry.config.config import Config
 from poetry.installation.executor import Executor
 from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -18,11 +18,11 @@ from cleo.io.null_io import NullIO
 from cleo.io.outputs.buffered_output import BufferedOutput
 from cleo.io.outputs.output import Verbosity
 from deepdiff import DeepDiff
-
 from poetry.core.packages.dependency_group import DependencyGroup
 from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.toml.file import TOMLFile
+
 from poetry.factory import Factory
 from poetry.installation import Installer as BaseInstaller
 from poetry.installation.executor import Executor as BaseExecutor

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -11,9 +11,9 @@ import pytest
 
 from cleo.io.null_io import NullIO
 from deepdiff import DeepDiff
-
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.toml.file import TOMLFile
+
 from poetry.factory import Factory
 from poetry.installation import Installer as BaseInstaller
 from poetry.installation.noop_installer import NoopInstaller

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.io.null_io import NullIO
-
 from poetry.core.packages.package import Package
+
 from poetry.installation.pip_installer import PipInstaller
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool

--- a/tests/mixology/helpers.py
+++ b/tests/mixology/helpers.py
@@ -4,6 +4,7 @@ from typing import List
 from typing import Optional
 
 from poetry.core.packages.package import Package
+
 from poetry.factory import Factory
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.version_solver import VersionSolver

--- a/tests/mixology/solutions/providers/test_python_requirement_solution_provider.py
+++ b/tests/mixology/solutions/providers/test_python_requirement_solution_provider.py
@@ -1,4 +1,5 @@
 from poetry.core.packages.dependency import Dependency
+
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.incompatibility import Incompatibility
 from poetry.mixology.incompatibility_cause import NoVersionsCause

--- a/tests/mixology/solutions/solutions/test_python_requirement_solution.py
+++ b/tests/mixology/solutions/solutions/test_python_requirement_solution.py
@@ -1,6 +1,6 @@
 from cleo.io.buffered_io import BufferedIO
-
 from poetry.core.packages.dependency import Dependency
+
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.incompatibility import Incompatibility
 from poetry.mixology.incompatibility_cause import PythonCause

--- a/tests/mixology/version_solver/conftest.py
+++ b/tests/mixology/version_solver/conftest.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.io.null_io import NullIO
-
 from poetry.core.packages.project_package import ProjectPackage
+
 from poetry.puzzle.provider import Provider as BaseProvider
 from poetry.repositories import Pool
 from poetry.repositories import Repository

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -10,6 +10,7 @@ import tomlkit
 from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.semver.version import Version
+
 from poetry.factory import Factory
 from poetry.packages.locker import Locker
 from tests.helpers import get_dependency

--- a/tests/puzzle/conftest.py
+++ b/tests/puzzle/conftest.py
@@ -12,9 +12,8 @@ except ImportError:
     import urlparse
 
 if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
-
     from poetry.core.vcs import Git
+    from pytest_mock import MockerFixture
 
 
 def mock_clone(self: "Git", source: str, dest: Path) -> None:

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.io.null_io import NullIO
-
 from poetry.core.packages.directory_dependency import DirectoryDependency
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.packages.vcs_dependency import VCSDependency
+
 from poetry.inspection.info import PackageInfo
 from poetry.puzzle.provider import Provider
 from poetry.repositories.pool import Pool

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -9,12 +9,12 @@ from typing import Type
 import pytest
 
 from cleo.io.null_io import NullIO
-
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.version.markers import parse_marker
+
 from poetry.factory import Factory
 from poetry.puzzle import Solver
 from poetry.puzzle.exceptions import SolverProblemError

--- a/tests/puzzle/test_transaction.py
+++ b/tests/puzzle/test_transaction.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import List
 
 from poetry.core.packages.package import Package
+
 from poetry.puzzle.transaction import Transaction
 
 

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -13,9 +13,8 @@ from tests.compat import zipp
 
 
 if TYPE_CHECKING:
-    from pytest_mock.plugin import MockerFixture
-
     from poetry.core.packages.package import Package
+    from pytest_mock.plugin import MockerFixture
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 ENV_DIR = (FIXTURES_DIR / "installed").resolve()

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 
 from poetry.core.packages.dependency import Dependency
+
 from poetry.factory import Factory
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.exceptions import RepositoryError

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -9,10 +9,10 @@ from typing import Optional
 
 import pytest
 
+from poetry.core.packages.dependency import Dependency
 from requests.exceptions import TooManyRedirects
 from requests.models import Response
 
-from poetry.core.packages.dependency import Dependency
 from poetry.factory import Factory
 from poetry.repositories.pypi_repository import PyPiRepository
 from poetry.utils._compat import encode

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from entrypoints import EntryPoint
-
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.toml.file import TOMLFile
+
 from poetry.factory import Factory
 from poetry.plugins.plugin import Plugin
 from poetry.repositories.legacy_repository import LegacyRepository

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -16,9 +16,9 @@ import pytest
 import tomlkit
 
 from cleo.io.null_io import NullIO
-
 from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
+
 from poetry.factory import Factory
 from poetry.utils._compat import WINDOWS
 from poetry.utils.env import GET_BASE_PREFIX

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -14,6 +14,7 @@ import pytest
 
 from poetry.core.packages.dependency import Dependency
 from poetry.core.toml.file import TOMLFile
+
 from poetry.factory import Factory
 from poetry.packages import Locker as BaseLocker
 from poetry.repositories.legacy_repository import LegacyRepository

--- a/tests/utils/test_extras.py
+++ b/tests/utils/test_extras.py
@@ -4,6 +4,7 @@ from typing import List
 import pytest
 
 from poetry.core.packages.package import Package
+
 from poetry.factory import Factory
 from poetry.utils.extras import get_extra_package_names
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from poetry.core.utils.helpers import parse_requires
+
 from poetry.utils.helpers import get_cert
 from poetry.utils.helpers import get_client_cert
 

--- a/tests/utils/test_pip.py
+++ b/tests/utils/test_pip.py
@@ -6,6 +6,7 @@ import pytest
 
 from poetry.core.packages.utils.link import Link
 from poetry.core.packages.utils.utils import path_to_url
+
 from poetry.utils.pip import pip_install
 
 

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -5,6 +5,7 @@ from typing import Callable
 import pytest
 
 from poetry.core.version.exceptions import InvalidVersion
+
 from poetry.utils.setup_reader import SetupReader
 
 


### PR DESCRIPTION
Due to the wording in [1] the broader python tooling ecosystem
sometimes expects an exact match to the single line pkgutil extend_path
usage. This change replaces current pkgutil style namespace package
implementation with the one line implementation described in [1].

This change also causes an import order change as `poetry.core` is
correctly detected as a third-party package.

[1] https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages