### PR TITLE
Update documentation commands to use new installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also install Poetry for a `git` repository by using the `--git` option:
 curl -sSL https://install.python-poetry.org | python - --git https://github.com/python-poetry/poetry.git@master
 ````
 
-**Note**: Note that the installer does not support Python < 3.6.
+_Note that the installer does not support Python < 3.6._
 
 ## Updating `poetry`
 

--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ authors = [
     "Sébastien Eustace <sebastien@eustace.io>"
 ]
 
-readme = 'README.md'  # Markdown files are supported
+readme = "README.md"  # Markdown files are supported
 
 repository = "https://github.com/python-poetry/poetry"
 homepage = "https://github.com/python-poetry/poetry"
 
-keywords = ['packaging', 'poetry']
+keywords = ["packaging", "poetry"]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.2"  # Compatible python versions must be declared here
@@ -195,7 +195,7 @@ pytest = "^3.0"
 pytest-cov = "^2.4"
 
 [tool.poetry.scripts]
-my-script = 'my_package:main'
+my-script = "my_package:main"
 ```
 
 There are some things we can notice here:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from the rest of your system.
 
 ### osx / linux / bashonwindows install instructions
 ```bash
-curl -sSL https://install.python-poetry.org | python -
+curl -sSL https://install.python-poetry.org | python3 -
 ```
 ### windows powershell install instructions
 ```powershell
@@ -55,37 +55,37 @@ by running the installer again with the `--uninstall` option or by setting
 the `POETRY_UNINSTALL` environment variable before executing the installer.
 
 ```bash
-curl -sSL https://install.python-poetry.org | python - --uninstall
-curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python -
+curl -sSL https://install.python-poetry.org | python3 - --uninstall
+curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python3 -
 ```
 
 By default, Poetry is installed into the user's platform-specific home directory.
 If you wish to change this, you may define the `POETRY_HOME` environment variable:
 
 ```bash
-curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python -
+curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 -
 ```
 
 If you want to install prerelease versions, you can do so by passing `--preview` option to `install-poetry.py`
 or by using the `POETRY_PREVIEW` environment variable:
 
 ```bash
-curl -sSL https://install.python-poetry.org | python - --preview
-curl -sSL https://install.python-poetry.org | POETRY_PREVIEW=1 python -
+curl -sSL https://install.python-poetry.org | python3 - --preview
+curl -sSL https://install.python-poetry.org | POETRY_PREVIEW=1 python3 -
 ```
 
 Similarly, if you want to install a specific version, you can use `--version` option or the `POETRY_VERSION`
 environment variable:
 
 ```bash
-curl -sSL https://install.python-poetry.org | python - --version 1.2.0
-curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.0 python -
+curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
+curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.0 python3 -
 ```
 
 You can also install Poetry for a `git` repository by using the `--git` option:
 
 ```bash
-curl -sSL https://install.python-poetry.org | python - --git https://github.com/python-poetry/poetry.git@master
+curl -sSL https://install.python-poetry.org | python3 - --git https://github.com/python-poetry/poetry.git@master
 ````
 
 _Note that the installer does not support Python < 3.6._

--- a/README.md
+++ b/README.md
@@ -55,37 +55,37 @@ by running the installer again with the `--uninstall` option or by setting
 the `POETRY_UNINSTALL` environment variable before executing the installer.
 
 ```bash
-python install-poetry.py --uninstall
-POETRY_UNINSTALL=1 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python - --uninstall
+curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python -
 ```
 
 By default, Poetry is installed into the user's platform-specific home directory.
 If you wish to change this, you may define the `POETRY_HOME` environment variable:
 
 ```bash
-POETRY_HOME=/etc/poetry python install-poetry.py
+curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python -
 ```
 
 If you want to install prerelease versions, you can do so by passing `--preview` option to `install-poetry.py`
 or by using the `POETRY_PREVIEW` environment variable:
 
 ```bash
-python install-poetry.py --preview
-POETRY_PREVIEW=1 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python - --preview
+curl -sSL https://install.python-poetry.org | POETRY_PREVIEW=1 python -
 ```
 
 Similarly, if you want to install a specific version, you can use `--version` option or the `POETRY_VERSION`
 environment variable:
 
 ```bash
-python install-poetry.py --version 1.2.0
-POETRY_VERSION=1.2.0 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python - --version 1.2.0
+curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.0 python -
 ```
 
 You can also install Poetry for a `git` repository by using the `--git` option:
 
 ```bash
-python install-poetry.py --git https://github.com/python-poetry/poetry.git@master
+curl -sSL https://install.python-poetry.org | python - --git https://github.com/python-poetry/poetry.git@master
 ````
 
 **Note**: Note that the installer does not support Python < 3.6.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -28,7 +28,7 @@ from the rest of your system.
 
 ### osx / linux / bashonwindows install instructions
 ```bash
-curl -sSL https://install.python-poetry.org | python -
+curl -sSL https://install.python-poetry.org | python3 -
 ```
 ### windows powershell install instructions
 ```powershell
@@ -62,37 +62,37 @@ by running the installer again with the `--uninstall` option or by setting
 the `POETRY_UNINSTALL` environment variable before executing the installer.
 
 ```bash
-curl -sSL https://install.python-poetry.org | python - --uninstall
-curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python -
+curl -sSL https://install.python-poetry.org | python3 - --uninstall
+curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python3 -
 ```
 
 By default, Poetry is installed into the user's platform-specific home directory.
 If you wish to change this, you may define the `POETRY_HOME` environment variable:
 
 ```bash
-curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python -
+curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 -
 ```
 
 If you want to install prerelease versions, you can do so by passing `--preview` option to `install-poetry.py`
 or by using the `POETRY_PREVIEW` environment variable:
 
 ```bash
-curl -sSL https://install.python-poetry.org | python - --preview
-curl -sSL https://install.python-poetry.org | POETRY_PREVIEW=1 python -
+curl -sSL https://install.python-poetry.org | python3 - --preview
+curl -sSL https://install.python-poetry.org | POETRY_PREVIEW=1 python3 -
 ```
 
 Similarly, if you want to install a specific version, you can use `--version` option or the `POETRY_VERSION`
 environment variable:
 
 ```bash
-curl -sSL https://install.python-poetry.org | python - --version 1.2.0
-curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.0 python -
+curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
+curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.0 python3 -
 ```
 
 You can also install Poetry for a `git` repository by using the `--git` option:
 
 ```bash
-curl -sSL https://install.python-poetry.org | python - --git https://github.com/python-poetry/poetry.git@master
+curl -sSL https://install.python-poetry.org | python3 - --git https://github.com/python-poetry/poetry.git@master
 ````
 
 {{% note %}}

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -62,8 +62,8 @@ by running the installer again with the `--uninstall` option or by setting
 the `POETRY_UNINSTALL` environment variable before executing the installer.
 
 ```bash
-python install-poetry.py --uninstall
-POETRY_UNINSTALL=1 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python - --uninstall
+curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python -
 ```
 
 By default, Poetry is installed into the user's platform-specific home directory.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -70,29 +70,29 @@ By default, Poetry is installed into the user's platform-specific home directory
 If you wish to change this, you may define the `POETRY_HOME` environment variable:
 
 ```bash
-POETRY_HOME=/etc/poetry python install-poetry.py
+curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python -
 ```
 
 If you want to install prerelease versions, you can do so by passing `--preview` option to `install-poetry.py`
 or by using the `POETRY_PREVIEW` environment variable:
 
 ```bash
-python install-poetry.py --preview
-POETRY_PREVIEW=1 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python - --preview
+curl -sSL https://install.python-poetry.org | POETRY_PREVIEW=1 python -
 ```
 
 Similarly, if you want to install a specific version, you can use `--version` option or the `POETRY_VERSION`
 environment variable:
 
 ```bash
-python install-poetry.py --version 1.2.0
-POETRY_VERSION=1.2.0 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python - --version 1.2.0
+curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.0 python -
 ```
 
 You can also install Poetry for a `git` repository by using the `--git` option:
 
 ```bash
-python install-poetry.py --git https://github.com/python-poetry/poetry.git@master
+curl -sSL https://install.python-poetry.org | python - --git https://github.com/python-poetry/poetry.git@master
 ````
 
 {{% note %}}


### PR DESCRIPTION
# Pull Request Check List

- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Since the new installer seems to be the supported way of installing/updating/removing Poetry, and the documentation was updated for the installation process, I believe that other commands for installing/updating/removing Poetry should also use the new installer.