### PR TITLE
Documentation improvement for issue #4844

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -341,6 +341,10 @@ poetry add "requests[security,socks]~=2.22.0"
 poetry add "git+https://github.com/pallets/flask.git@1.1.1[dotenv,dev]"
 ```
 
+{{% warning %}}
+Be aware that some shells (in particular Mac Zsh) may not recognise the package name without quotes - for example `poetry add requests[security,socks]`. In this case try instead with quotes `poetry add "requests[security,socks]"`
+{{% /warning %}}
+
 If you want to add a package to a specific group of dependencies, you can use the `--group (-G)` option:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -342,7 +342,7 @@ poetry add "git+https://github.com/pallets/flask.git@1.1.1[dotenv,dev]"
 ```
 
 {{% warning %}}
-Be aware that some shells (in particular Mac Zsh) may not recognise the package name without quotes - for example `poetry add requests[security,socks]`. In this case try instead with quotes `poetry add "requests[security,socks]"`
+Some shells may treat square braces (`[` and `]`) as special characters. It is suggested to always quote arguments containing these characters to prevent unexpected shell expansion.
 {{% /warning %}}
 
 If you want to add a package to a specific group of dependencies, you can use the `--group (-G)` option:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -336,7 +336,7 @@ If the package(s) you want to install provide extras, you can specify them
 when adding the package:
 
 ```bash
-poetry add requests[security,socks]
+poetry add "requests[security,socks]"
 poetry add "requests[security,socks]~=2.22.0"
 poetry add "git+https://github.com/pallets/flask.git@1.1.1[dotenv,dev]"
 ```


### PR DESCRIPTION

Resolves: #4844

Small docs fix that adds a warning box to suggest using quotes on some shells such as Mac Zsh.  

- [ ] Added **tests** for changed code.  NO CHANGED CODE - ONLY DOCS IN PR
- [x] Updated **documentation** for changed code.

