### PR TITLE
Add (experimental) option to use current active python to create venv ("pyenv way")

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,7 @@ virtualenvs.in-project = null
 virtualenvs.options.always-copy = true
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = "{cache-dir}/virtualenvs"  # /path/to/cache/directory/virtualenvs
+virtualenvs.prefer-shell-python = false
 ```
 
 ## Displaying a single configuration setting
@@ -187,6 +188,13 @@ Defaults to `false`.
 Give the virtual environment access to the system site-packages directory.
 Applies on virtualenv creation.
 Defaults to `false`.
+
+### `virtualenvs.prefer-shell-python`
+
+**Type**: boolean
+
+Use currently activated Python version to create a new venv.
+Defaults to `false`, which means Python version used during Poetry installation is used.
 
 ### `repositories.<name>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ virtualenvs.in-project = null
 virtualenvs.options.always-copy = true
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = "{cache-dir}/virtualenvs"  # /path/to/cache/directory/virtualenvs
-virtualenvs.prefer-shell-python = false
+virtualenvs.prefer-active-python = false
 ```
 
 ## Displaying a single configuration setting
@@ -189,7 +189,7 @@ Give the virtual environment access to the system site-packages directory.
 Applies on virtualenv creation.
 Defaults to `false`.
 
-### `virtualenvs.prefer-shell-python`
+### `virtualenvs.prefer-active-python` (experimental)
 
 **Type**: boolean
 

--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -18,13 +18,28 @@ To achieve this, it will first check if it's currently running inside a virtual 
 If it is, it will use it directly without creating a new one. But if it's not, it will use
 one that it has already created or create a brand new one for you.
 
-By default, Poetry will try to use the currently activated Python version
+By default, Poetry will try to use the Python version used during Poetry's installation
 to create the virtual environment for the current project.
 
 However, for various reasons, this Python version might not be compatible
 with the `python` requirement of the project. In this case, Poetry will try
 to find one that is and use it. If it's unable to do so then you will be prompted
 to activate one explicitly, see [Switching environments](#switching-between-environments).
+
+{{% note %}}
+To easily switch between Python versions, it is recommended to
+use [pyenv](https://github.com/pyenv/pyenv) or similar tools.
+
+For instance, if your project requires a newer Python than is available with
+your system, a standard workflow would be:
+
+```bash
+pyenv install 3.9.8
+pyenv local 3.9.8  # Activate Python 3.9 for the current project
+poetry install
+```
+This requires setting the `virtualenvs.prefer-shell-python` option to `true`.
+{{% /note %}}
 
 ## Switching between environments
 

--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -27,8 +27,9 @@ to find one that is and use it. If it's unable to do so then you will be prompte
 to activate one explicitly, see [Switching environments](#switching-between-environments).
 
 {{% note %}}
-To easily switch between Python versions, it is recommended to
-use [pyenv](https://github.com/pyenv/pyenv) or similar tools.
+If you use a tool like [pyenv](https://github.com/pyenv/pyenv) to manage different Python versions,
+you can set the experimental `virtualenvs.prefer-active-python` option to `true`. Poetry
+than will try to find the current `python` of your shell.
 
 For instance, if your project requires a newer Python than is available with
 your system, a standard workflow would be:
@@ -38,7 +39,6 @@ pyenv install 3.9.8
 pyenv local 3.9.8  # Activate Python 3.9 for the current project
 poetry install
 ```
-This requires setting the `virtualenvs.prefer-shell-python` option to `true`.
 {{% /note %}}
 
 ## Switching between environments

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -38,6 +38,7 @@ class Config:
             "in-project": None,
             "path": os.path.join("{cache-dir}", "virtualenvs"),
             "options": {"always-copy": False, "system-site-packages": False},
+            "prefer-shell-python": False,
         },
         "experimental": {"new-installer": True},
         "installer": {"parallel": True, "max-workers": None},
@@ -138,6 +139,7 @@ class Config:
             "virtualenvs.in-project",
             "virtualenvs.options.always-copy",
             "virtualenvs.options.system-site-packages",
+            "virtualenvs.options.prefer-shell-python",
             "experimental.new-installer",
             "installer.parallel",
         }:

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -38,7 +38,7 @@ class Config:
             "in-project": None,
             "path": os.path.join("{cache-dir}", "virtualenvs"),
             "options": {"always-copy": False, "system-site-packages": False},
-            "prefer-shell-python": False,
+            "prefer-active-python": False,
         },
         "experimental": {"new-installer": True},
         "installer": {"parallel": True, "max-workers": None},
@@ -139,7 +139,7 @@ class Config:
             "virtualenvs.in-project",
             "virtualenvs.options.always-copy",
             "virtualenvs.options.system-site-packages",
-            "virtualenvs.options.prefer-shell-python",
+            "virtualenvs.options.prefer-active-python",
             "experimental.new-installer",
             "installer.parallel",
         }:

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -286,18 +286,30 @@ class Application(BaseApplication):
 
         io = event.io
         poetry = command.poetry
-        executable = None
 
+        executable = None
+        find_compatible = None
+
+        # add on option to trigger this
         with contextlib.suppress(CalledProcessError):
             executable = decode(
                 subprocess.check_output(
-                    list_to_shell_command(["pyenv", "which", "python"]),
+                    list_to_shell_command(
+                        [
+                            "python",
+                            "-c",
+                            '"import sys; print(sys.executable)"',
+                        ]
+                    ),
                     shell=True,
                 ).strip()
             )
+            find_compatible = True
 
         env_manager = EnvManager(poetry)
-        env = env_manager.create_venv(io, executable=executable)
+        env = env_manager.create_venv(
+            io, executable=executable, find_compatible=find_compatible
+        )
 
         if env.is_venv() and io.is_verbose():
             io.write_line(f"Using virtualenv: <comment>{env.path}</>")

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -78,6 +78,11 @@ To remove a repository (repo is a short alias for repositories):
                 lambda val: str(Path(val)),
                 str(Path(CACHE_DIR) / "virtualenvs"),
             ),
+            "virtualenvs.prefer-shell-python": (
+                boolean_validator,
+                boolean_normalizer,
+                False,
+            ),
             "experimental.new-installer": (
                 boolean_validator,
                 boolean_normalizer,

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -78,7 +78,7 @@ To remove a repository (repo is a short alias for repositories):
                 lambda val: str(Path(val)),
                 str(Path(CACHE_DIR) / "virtualenvs"),
             ),
-            "virtualenvs.prefer-shell-python": (
+            "virtualenvs.prefer-active-python": (
                 boolean_validator,
                 boolean_normalizer,
                 False,

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -767,6 +767,7 @@ class EnvManager:
         name: Optional[str] = None,
         executable: Optional[str] = None,
         force: bool = False,
+        find_compatible: Optional[bool] = None,
     ) -> Union["SystemEnv", "VirtualEnv"]:
         if self._env is not None and not force:
             return self._env
@@ -820,7 +821,7 @@ class EnvManager:
             # If an executable has been specified, we stop there
             # and notify the user of the incompatibility.
             # Otherwise, we try to find a compatible Python version.
-            if executable:
+            if executable and not find_compatible:
                 raise NoCompatiblePythonVersionFound(
                     self._poetry.package.python_versions, python_patch
                 )

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -30,6 +30,7 @@ import packaging.tags
 import tomlkit
 import virtualenv
 
+from cleo.io.outputs.output import Verbosity
 from packaging.tags import Tag
 from packaging.tags import interpreter_name
 from packaging.tags import interpreter_version
@@ -456,6 +457,30 @@ class EnvManager:
     def __init__(self, poetry: "Poetry") -> None:
         self._poetry = poetry
 
+    def _detect_active_python(self, io: "IO") -> str:
+        executable = None
+
+        try:
+            io.write_line(
+                "Trying to detect current active python executable as specified in the config.",
+                verbosity=Verbosity.VERBOSE,
+            )
+            executable = decode(
+                subprocess.check_output(
+                    list_to_shell_command(
+                        ["python", "-c", '"import sys; print(sys.executable)"']
+                    ),
+                    shell=True,
+                ).strip()
+            )
+            io.write_line(f"Found: {executable}", verbosity=Verbosity.VERBOSE)
+        except CalledProcessError:
+            io.write_line(
+                "Unable to detect the current active python executable. Falling back to default.",
+                verbosity=Verbosity.VERBOSE,
+            )
+        return executable
+
     def activate(self, python: str, io: "IO") -> "Env":
         venv_path = self._poetry.config.get("virtualenvs.path")
         if venv_path is None:
@@ -767,7 +792,6 @@ class EnvManager:
         name: Optional[str] = None,
         executable: Optional[str] = None,
         force: bool = False,
-        find_compatible: Optional[bool] = None,
     ) -> Union["SystemEnv", "VirtualEnv"]:
         if self._env is not None and not force:
             return self._env
@@ -785,6 +809,12 @@ class EnvManager:
         create_venv = self._poetry.config.get("virtualenvs.create")
         root_venv = self._poetry.config.get("virtualenvs.in-project")
         venv_path = self._poetry.config.get("virtualenvs.path")
+        prefer_active_python = self._poetry.config.get(
+            "virtualenvs.prefer-active-python"
+        )
+
+        if not executable and prefer_active_python:
+            executable = self._detect_active_python(io)
 
         if root_venv:
             venv_path = cwd / ".venv"
@@ -821,7 +851,7 @@ class EnvManager:
             # If an executable has been specified, we stop there
             # and notify the user of the incompatibility.
             # Otherwise, we try to find a compatible Python version.
-            if executable and not find_compatible:
+            if executable and not prefer_active_python:
                 raise NoCompatiblePythonVersionFound(
                     self._poetry.package.python_versions, python_patch
                 )

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -56,6 +56,7 @@ virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
+virtualenvs.prefer-shell-python = false
 """
 
     assert expected == tester.io.fetch_output()
@@ -79,6 +80,7 @@ virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
+virtualenvs.prefer-shell-python = false
 """
 
     assert config.set_config_source.call_count == 0
@@ -126,6 +128,7 @@ virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
+virtualenvs.prefer-shell-python = false
 """
 
     assert config.set_config_source.call_count == 1

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -56,7 +56,7 @@ virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-shell-python = false
+virtualenvs.prefer-active-python = false
 """
 
     assert expected == tester.io.fetch_output()
@@ -80,7 +80,7 @@ virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-shell-python = false
+virtualenvs.prefer-active-python = false
 """
 
     assert config.set_config_source.call_count == 0
@@ -128,7 +128,7 @@ virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-shell-python = false
+virtualenvs.prefer-active-python = false
 """
 
     assert config.set_config_source.call_count == 1


### PR DESCRIPTION
The "pyenv-way" for switching/creating venvs as described in the [docs](https://python-poetry.org/docs/managing-environments/) doesn't work anymore when using the `install-poetry.py` script.

<strike>This Draft-PR is a proof-of-concept to see if it's possible to detect the current running python in the shell, set by pyenv and bring back that functionality and make it also available when installing poetry via `pipx`. </strike>

<strike>It will probably  never be included in poetry like this, as we don't want to rely on third-party tools if not necessary. But this could be a starting point to find out how to integrate it via a plugin.</strike>(Maybe it can be implemented, because I've found a generic way. So it's up to @sdispater if such a solution will be included.)

This PR adds in opt-in option `virtualenvs.prefer-active-python`. If set to `true` poetry will try to use the current running `python` of the shell for creating the venv.

Would be happy if some people could test their usecase with this MR. 

Install with `pipx`:

```
pip install pipx
pipx install --suffix=@pyenv 'poetry @ git+https://github.com/finswimmer/poetry.git@proof-of-concept-pyenv'
poetry@pyenv --version
```

Install with `install-poetry.py` script:

```
curl -sSL https://install.python-poetry.org | python3 - --git "https://github.com/finswimmer/poetry.git@proof-of-concept-pyenv"
```

Closes: #4199