### PR TITLE
Fix the files pattern in Poetry pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
   language: python
   language_version: python3
   pass_filenames: false
-  files: '^.*/pyproject\.toml$'
+  files: ^pyproject.toml$
 
 - id: poetry-lock
   name: poetry-lock
@@ -22,5 +22,5 @@
   language: python
   language_version: python3
   pass_filenames: false
-  files: '^.*/poetry\.lock$'
+  files: ^poetry.lock$
   args: ["-f", "requirements.txt", "-o", "requirements.txt"]


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/pull/2511#issuecomment-996846667

Affected hooks:
- poetry-check
- poetry-export

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code. **not necessary**
- [x] Updated **documentation** for changed code. **already present**

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


What a surprise. Poetry-based pre-commit hooks are going to be backed into Poetry itself! 🎉

I've just given them a spin this way:

```yaml
# export python requirements
- repo: https://github.com/python-poetry/poetry
  rev: 2fa6c17 # put here the next release with the hooks
  hooks:
    - id: poetry-export
```

but it didn't work. The output is:

```bash
$ pre-commit run poetry-export --files poetry.lock
poetry-export........................................(no files to check)Skipped
```

It looks like `poetry.lock` doesn't match the `files` pattern and skips the files. 
This quick PR fix this problem.

Tests pointing at my PR with `pre-commit 2.16.0` on a *nix enviroment:

```yaml
repos:
  - repo: https://github.com/floatingpurr/poetry
    rev: 26651c8
    hooks:
      - id: poetry-export

  - repo: https://github.com/floatingpurr/poetry
    rev: 26651c8
    hooks:
      - id: poetry-check
```

```bash
$ pre-commit run poetry-export --files poetry.lock
poetry-export............................................................Passed
$ pre-commit run poetry-check --files pyproject.toml
poetry-check.............................................................Passed
```

Hope this helps