### PR TITLE
Fix misuse of pretty_constraint, fix downstream test (poetry-core)

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -236,16 +236,16 @@ class Locker:
             if locked_package:
                 # create dependency from locked package to retain dependency metadata
                 # if this is not done, we can end-up with incorrect nested dependencies
+                constraint = requirement.constraint
+                pretty_constraint = requirement.pretty_constraint
                 marker = requirement.marker
                 requirement = locked_package.to_dependency()
                 requirement.marker = requirement.marker.intersect(marker)
 
-                key = (requirement.name, requirement.pretty_constraint)
+                key = (requirement.name, pretty_constraint)
 
-                if pinned_versions:
-                    requirement.set_constraint(
-                        locked_package.to_dependency().constraint
-                    )
+                if not pinned_versions:
+                    requirement.set_constraint(constraint)
 
                 for require in locked_package.requires:
                     if require.marker.is_empty():


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4919

The pretty_constraint fix in python-poetry/poetry-core@af08f1c broke a downstream test (test_exporter_can_export_requirements_txt_with_nested_packages_and_markers_any), exposing a misuse of the fact that pretty_constraint was not updated when setting the constraint. This PR fixes the downstream test by fixing the misuse.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
