### PR TITLE
Reorganize installation instructions

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -17,28 +17,46 @@ It allows you to declare the libraries your project depends on and it will manag
 
 ## System requirements
 
-Poetry requires Python 3.6+. It is multi-platform and the goal is to make it work equally well
+Poetry requires **Python 3.6+**. It is multi-platform and the goal is to make it work equally well
 on Windows, Linux and OSX.
 
-
 ## Installation
+
+{{< tabs tabTotal="3" tabID1="installing-with-the-official-installer" tabID2="installing-with-pipx" tabID3="installing-with-pip" tabName1="With the official installer" tabName2="With pipx" tabName3="With pip" >}}
+
+{{< tab tabID="installing-with-the-official-installer" >}}
 
 Poetry provides a custom installer that will install `poetry` isolated
 from the rest of your system.
 
-### osx / linux / bashonwindows install instructions
+{{< steps >}}
+{{< step >}}
+**Install Poetry**
+
+Install Poetry by downloading and executing the [installation script](https://install.python-poetry.org).
+
+**osx / linux / bashonwindows install instructions**
+
 ```bash
 curl -sSL https://install.python-poetry.org | python3 -
 ```
-### windows powershell install instructions
+
+**windows powershell install instructions**
 ```powershell
 (Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -
 ```
+
+{{% note %}}
+Note that the installer does not support Python < 3.6.
+{{% /note %}}
 
 {{% warning %}}
 The previous `get-poetry.py` installer is now deprecated, if you are currently using it
 you should migrate to the new, supported, `install-poetry.py` installer.
 {{% /warning %}}
+{{< /step >}}
+{{< step >}}
+**Add Poetry to your PATH**
 
 The installer installs the `poetry` tool to Poetry's `bin` directory. This location depends on your system:
 
@@ -49,6 +67,10 @@ If this directory is not on your `PATH`, you will need to add it manually
 if you want to invoke Poetry with simply `poetry`.
 
 Alternatively, you can use the full path to `poetry` to use it.
+{{< /step >}}
+
+{{< step >}}
+**Check the installation**
 
 Once Poetry is installed you can execute the following:
 
@@ -57,14 +79,10 @@ poetry --version
 ```
 
 If you see something like `Poetry (version 1.2.0)` then you are ready to use Poetry.
-If you decide Poetry isn't your thing, you can completely remove it from your system
-by running the installer again with the `--uninstall` option or by setting
-the `POETRY_UNINSTALL` environment variable before executing the installer.
+{{< /step >}}
 
-```bash
-curl -sSL https://install.python-poetry.org | python3 - --uninstall
-curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python3 -
-```
+{{< step >}}
+**Configure the installation**
 
 By default, Poetry is installed into the user's platform-specific home directory.
 If you wish to change this, you may define the `POETRY_HOME` environment variable:
@@ -94,58 +112,10 @@ You can also install Poetry for a `git` repository by using the `--git` option:
 ```bash
 curl -sSL https://install.python-poetry.org | python3 - --git https://github.com/python-poetry/poetry.git@master
 ````
+{{< /step >}}
 
-{{% note %}}
-Note that the installer does not support Python < 3.6.
-{{% /note %}}
-
-
-### Alternative installation methods
-
-#### Installing with `pipx`
-
-Using [`pipx`](https://github.com/pipxproject/pipx) to install Poetry is also possible.
-`pipx` is used to install Python CLI applications globally while still isolating them in virtual environments.
-This allows for clean upgrades and uninstalls.
-
-```bash
-pipx install poetry
-```
-
-```bash
-pipx upgrade poetry
-```
-
-```bash
-pipx uninstall poetry
-```
-
-
-#### Installing with `pip`
-
-Using `pip` to install Poetry is possible.
-
-```bash
-pip install --user poetry
-```
-
-{{% warning %}}
-Be aware that it will also install Poetry's dependencies
-which might cause conflicts with other packages.
-{{% /warning %}}
-
-## Updating `poetry`
-
-Updating Poetry to the latest stable version is as simple as calling the `self update` command.
-
-```bash
-poetry self update
-```
-
-{{% warning %}}
-Poetry versions installed using the now deprecated `get-poetry.py` installer will not be able to use this
-command to update to 1.2 releases or later. Migrate to using the `install-poetry.py` installer or `pipx`.
-{{% /warning %}}
+{{< step >}}
+**Update Poetry**
 
 If you want to install pre-release versions, you can use the `--preview` option.
 
@@ -159,6 +129,79 @@ to `self update`.
 ```bash
 poetry self update 1.2.0
 ```
+
+{{% warning %}}
+Poetry versions installed using the now deprecated `get-poetry.py` installer will not be able to use this
+command to update to 1.2 releases or later. Migrate to using the `install-poetry.py` installer or `pipx`.
+{{% /warning %}}
+{{< /step >}}
+
+{{< step >}}
+**Uninstall Poetry**
+
+If you decide Poetry isn't your thing, you can completely remove it from your system
+by running the installer again with the `--uninstall` option or by setting
+the `POETRY_UNINSTALL` environment variable before executing the installer.
+
+```bash
+curl -sSL https://install.python-poetry.org | python3 - --uninstall
+curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python3 -
+```
+{{< /step >}}
+
+{{< /steps >}}
+
+{{< /tab >}}
+
+{{< tab tabID="installing-with-pipx" >}}
+
+Using [`pipx`](https://github.com/pipxproject/pipx) to install Poetry is also possible.
+
+`pipx` is used to install Python CLI applications globally while still isolating them in virtual environments.
+This allows for clean upgrades and uninstalls.
+
+{{< steps >}}
+{{< step >}}
+**Install Poetry**
+
+```bash
+pipx install poetry
+```
+{{< /step >}}
+{{< step >}}
+**Update Poetry**
+
+```bash
+pipx upgrade poetry
+```
+{{< /step >}}
+{{< step >}}
+**Uninstall Poetry**
+
+```bash
+pipx uninstall poetry
+```
+{{< /step >}}
+{{< /steps >}}
+
+{{< /tab >}}
+
+{{< tab tabID="installing-with-pip" >}}
+
+Using `pip` to install Poetry is possible.
+
+```bash
+pip install --user poetry
+```
+
+{{% warning %}}
+Be aware that it will also install Poetry's dependencies
+which might cause conflicts with other packages.
+{{% /warning %}}
+
+{{< /tab >}}
+
+{{< /tabs >}}
 
 
 ## Enable tab completion for Bash, Fish, or Zsh


### PR DESCRIPTION
This PR reorganizes slightly the installation instructions by displaying steps for the official installer and `pipx`.

It also displays all methods of installation at the same level, via tabs, so that no particular one is shown as preferred.

![Screenshot 2021-12-23 at 22-57-49 Introduction master Documentation Poetry - Python dependency management and packaging mad](https://user-images.githubusercontent.com/555648/147296247-39be2d7f-93a8-4e76-ab34-8f76c6b30f66.png)


## Pull Request Check List

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
