### PR TITLE
Lazy load credentials for legacy repositories

### DIFF
--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -94,7 +94,9 @@ def pool() -> Pool:
 
     pool.add_repository(PyPiRepository(disable_cache=True))
     pool.add_repository(
-        LegacyRepository("foo", "https://user1:password1@foo.bar/simple/", disable_cache=True)
+        LegacyRepository(
+            "foo", "https://user1:password1@foo.bar/simple/", disable_cache=True
+        )
     )
 
     return pool

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -94,7 +94,7 @@ def pool() -> Pool:
 
     pool.add_repository(PyPiRepository(disable_cache=True))
     pool.add_repository(
-        LegacyRepository("foo", "https://foo.bar/simple/", disable_cache=True)
+        LegacyRepository("foo", "https://user1:password1@foo.bar/simple/", disable_cache=True)
     )
 
     return pool
@@ -113,7 +113,7 @@ def test_chooser_chooses_universal_wheel_link_if_available(
             package.version.text,
             source_type="legacy",
             source_reference="foo",
-            source_url="https://foo.bar/simple/",
+            source_url="https://user1:password1@foo.bar/simple/",
         )
 
     link = chooser.choose_for(package)

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -331,7 +331,7 @@ def test_get_package_retrieves_packages_with_no_hashes():
 
 class MockHttpRepository(LegacyRepository):
     def __init__(self, endpoint_responses: dict, http: type[httpretty.httpretty]):
-        base_url = "http://legacy.foo.bar"
+        base_url = "http://testuser1:password1@legacy.foo.bar"
         super().__init__("legacy", url=base_url, disable_cache=True)
 
         for endpoint, response in endpoint_responses.items():


### PR DESCRIPTION
Move loading credentials from LegacyRepository.__init__() separate function and call it from _get_page() and authenticated_url()
This avoids loading credentials for commands that don't use them (e. g. poetry env list). This helps to avoid annoying users that have to unlock their keyring and if such commands are called as background tasks (CI pipelines, VS-Code environment detection).

Questions and remarks from my side:
- Because of the current implementation I assumed that legacy repositories always have basic auth. If authentication is optional, I would need help to figure out possible cases and to adapt (parameterize) the tests. My pytest knowledge is very limited.
- Are you appreciating the more verbose docstring/comment on `authenticated_url()`? I'm fine with removing it.
- I was not sure if `_set_authentication_creds()` should be a private or public function. Tell me if you prefer it to become `set_authentication_creds()`

Resolves: #4874

- [ x ] ~~Added~~ changed **tests** for changed code.
- [ ] Updated **documentation** for changed code.

