### PR TITLE
remove note about switching python version by pyenv

### DIFF
--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -26,20 +26,6 @@ with the `python` requirement of the project. In this case, Poetry will try
 to find one that is and use it. If it's unable to do so then you will be prompted
 to activate one explicitly, see [Switching environments](#switching-between-environments).
 
-{{% note %}}
-To easily switch between Python versions, it is recommended to
-use [pyenv](https://github.com/pyenv/pyenv) or similar tools.
-
-For instance, if your project requires a newer Python than is available with
-your system, a standard workflow would be:
-
-```bash
-pyenv install 3.9.8
-pyenv local 3.9.8  # Activate Python 3.9 for the current project
-poetry install
-```
-{{% /note %}}
-
 ## Switching between environments
 
 Sometimes this might not be feasible for your system, especially Windows where `pyenv`


### PR DESCRIPTION
`pyenv` cannot be used anymore to switch the python version poetry uses to create a new venv. This PR removes the note from the docs.