### PR TITLE
Backport mingw bin dir correction to poetry 1.1.x

### DIFF
--- a/poetry/utils/env.py
+++ b/poetry/utils/env.py
@@ -923,9 +923,13 @@ class Env(object):
 
     def __init__(self, path, base=None):  # type: (Path, Optional[Path]) -> None
         self._is_windows = sys.platform == "win32"
+        self._is_mingw = sysconfig.get_platform().startswith("mingw")
 
+        if not self._is_windows or self._is_mingw:
+            bin_dir = "bin"
+        else:
+            bin_dir = "Scripts"
         self._path = path
-        bin_dir = "bin" if not self._is_windows else "Scripts"
         self._bin_dir = self._path / bin_dir
 
         self._base = base or path


### PR DESCRIPTION
In #3713 and its follow-up #4482, the path to `python.exe` and `poetry.exe` was corrected for Windows + MinGW on the `poetry` `master` branch.

This is a backport of those same changes, for users running `poetry 1.1.x`

----

#### Pull Request Check List

Related: #3713, #4482

- [ ] ~Added **tests** for changed code.~
    - I think a test for this would require a suitable CI environment (Windows+MinGW) to be set up. However setting that up is a bit beyond the scope of this PR, related as it may be.
- [ ] ~Updated **documentation** for changed code.~
    - No documentation change needed.