### PR TITLE
allow configuration of sources in global config

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -722,6 +722,7 @@ You cannot use the name `pypi` as it is reserved for use by the default PyPI sou
 
 * `--default`: Set this source as the [default]({{< relref "repositories#disabling-the-pypi-repository" >}}) (disable PyPI).
 * `--secondary`: Set this source as a [secondary]({{< relref "repositories#install-dependencies-from-a-private-repository" >}}) source.
+* `--global`: Set this source to be global in the [poetry config]({{< relref "repositories#using-poetry-config" >}}).
 
 {{% note %}}
 You cannot set a source as both `default` and `secondary`.
@@ -741,8 +742,12 @@ Optionally, you can show information of one or more sources by specifying their 
 poetry source show pypi-test
 ```
 
+#### Options
+* `--global`: Show only sources set in poetry config
+* `--all`: Show sources in poetry config and `pyproject.toml`
+
 {{% note %}}
-This command will only show sources configured via the `pyproject.toml` and does not include PyPI.
+By default, this command will only show sources configured via the `pyproject.toml` and does not include PyPI.
 {{% /note %}}
 
 ### `source remove`
@@ -752,3 +757,6 @@ The `source remove` command removes a configured source from your `pyproject.tom
 ```bash
 poetry source remove pypi-test
 ```
+
+#### Options
+* `--global`: Remove the source from the poetry config.

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -170,14 +170,13 @@ The following command will use foo system-wide and also disable PyPI.
 poetry source add --global --default foo "https://foo.bar/simple/"
 ```
 Sources listed in the config follow the same logic as updating your `pyproject.toml`.
-At run time, poetry will merge global, local and pypi accordingly. 
+At run time, poetry will merge global, local and pypi accordingly.
 
 {{% warning %}}
 
 Errors because of conflicting settings between config and `pyproject.toml` sources
-generated on the next run of poetry.  
-
-An example error would be having a default source globally and locally.
+generated on the next run of poetry. An example error would be having a
+default source globally and locally.
 
 {{% /warning %}}
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -172,6 +172,11 @@ poetry source add --global --default foo "https://foo.bar/simple/"
 Sources listed in the config follow the same logic as updating your `pyproject.toml`.
 At run time, poetry will merge global, local and pypi accordingly.
 
+Sources can be removed using remove command
+```bash
+poetry source remove --global foo
+```
+
 {{% warning %}}
 
 Errors because of conflicting settings between config and `pyproject.toml` sources

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -125,12 +125,17 @@ poetry config certificates.foo.client-cert /path/to/client.pem
 Now that you can publish to your private repository, you need to be able to
 install dependencies from it.
 
-For that, you have to edit your `pyproject.toml` file, like so
+For that, you have to edit your `pyproject.toml` or `poetry config`
 
+#### Using pyproject.toml
 ```toml
 [[tool.poetry.source]]
 name = "foo"
 url = "https://foo.bar/simple/"
+```
+Alternatively, you can use the source command to update the `pyproject.toml`:
+```bash
+poetry source add foo "https://foo.bar/simple/"
 ```
 
 From now on, Poetry will also look for packages in your private repository.
@@ -156,6 +161,25 @@ a custom certificate authority or client certificates, similarly refer to the ex
 `certificates` section. Poetry will use these values to authenticate to your private repository when downloading or
 looking for packages.
 
+#### Using Poetry Config
+By adding the source to the poetry config, you can avoid having to add the
+same source to every project on a single machine.
+
+The following command will use foo system-wide and also disable PyPI.
+```bash
+poetry source add --global --default foo "https://foo.bar/simple/"
+```
+Sources listed in the config follow the same logic as updating your `pyproject.toml`.
+At run time, poetry will merge global, local and pypi accordingly. 
+
+{{% warning %}}
+
+Errors because of conflicting settings between config and `pyproject.toml` sources
+generated on the next run of poetry.  
+
+An example error would be having a default source globally and locally.
+
+{{% /warning %}}
 
 ### Disabling the PyPI repository
 

--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -51,7 +51,12 @@ class SourceAddCommand(Command):
         return source_table
 
     def handle(self) -> Optional[int]:
+        from pathlib import Path
+
+        from poetry.core.toml.file import TOMLFile
+
         from poetry.factory import Factory
+        from poetry.locations import CONFIG_DIR
         from poetry.repositories import Pool
 
         name = self.argument("name")
@@ -127,6 +132,12 @@ class SourceAddCommand(Command):
             return 1
 
         if is_global:
+            # create system config file if needed.
+            config_file = TOMLFile(Path(CONFIG_DIR) / "config.toml")
+            if not config_file.exists():
+                config_file.path.parent.mkdir(parents=True, exist_ok=True)
+                config_file.path.touch(mode=0o0600)
+
             # only add/update new values
             self.poetry.config.config_source.add_property(f"sources.{name}.url", url)
             self.poetry.config.config_source.add_property(

--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -90,7 +90,7 @@ class SourceAddCommand(Command):
             if new_source == source:
                 self.line(
                     f"Identical source with name <c1>{name}</c1> already exists. "
-                    f"Skipping addition."
+                    "Skipping addition."
                 )
                 return 0
 
@@ -100,8 +100,9 @@ class SourceAddCommand(Command):
                 new_source = None
             elif source.default and new_source.default:
                 self.line_error(
-                    f"<error>Source with name <c1>{name}</c1> is already set to default. "
-                    f"Only one default source can be configured at a time.</error>"
+                    f"<error>Source with name <c1>{name}</c1> is already set to"
+                    " default. Only one default source can be configured at a"
+                    " time.</error>"
                 )
                 return 1
             sources_updated.append(source)

--- a/src/poetry/console/commands/source/show.py
+++ b/src/poetry/console/commands/source/show.py
@@ -1,7 +1,9 @@
 from typing import Optional
 
 from cleo.helpers import argument
+from cleo.helpers import option
 
+from poetry.config.source import Source
 from poetry.console.commands.command import Command
 
 
@@ -17,10 +19,23 @@ class SourceShowCommand(Command):
             multiple=True,
         ),
     ]
+    options = [
+        option("global", "g", "Show global sources"),
+        option("all", "a", "Show all sources for project"),
+    ]
 
     def handle(self) -> Optional[int]:
-        sources = self.poetry.get_sources()
         names = self.argument("source")
+        is_global = self.option("global")
+        show_all = self.option("all")
+        sources = []
+        if not is_global or show_all:
+            sources.extend(self.poetry.get_sources())
+
+        if is_global or show_all:
+            global_sources = self.poetry.config.get("sources", {})
+            for name, source in global_sources.items():
+                sources.append(Source(name=name, **source))
 
         if not sources:
             self.line("No sources configured for this project.")

--- a/tests/console/commands/plugin/conftest.py
+++ b/tests/console/commands/plugin/conftest.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+from typing import Dict
 
 import pytest
 
@@ -35,7 +36,11 @@ def installed() -> InstalledRepository:
 
 def configure_sources_factory(repo: "TestRepository") -> "SourcesFactory":
     def _configure_sources(
-        poetry: "Poetry", sources: "Source", config: "Config", io: "IO"
+        poetry: "Poetry",
+        sources: "Source",
+        config: "Config",
+        io: "IO",
+        global_sources: Dict[str, Dict[str, str]],
     ) -> None:
         pool = Pool()
         pool.add_repository(repo)

--- a/tests/console/commands/source/conftest.py
+++ b/tests/console/commands/source/conftest.py
@@ -6,6 +6,7 @@ from poetry.config.source import Source
 
 
 if TYPE_CHECKING:
+    from poetry.config.config import Config
     from poetry.poetry import Poetry
     from tests.types import CommandTesterFactory
     from tests.types import ProjectFactory
@@ -37,6 +38,11 @@ _existing_source = Source(name="existing", url="https://existing.com")
 @pytest.fixture
 def source_existing() -> Source:
     return _existing_source
+
+
+@pytest.fixture
+def source_existing_global() -> Source:
+    return Source(name="existing_global", url="https://existing_global.com")
 
 
 PYPROJECT_WITH_SOURCES = f"""
@@ -72,3 +78,19 @@ def add_multiple_sources(
     add = command_tester_factory("source add", poetry=poetry_with_source)
     for source in [source_one, source_two]:
         add.execute(f"{source.name} {source.url}")
+
+
+@pytest.fixture
+def config_with_source(config: "Config", source_existing_global: Source) -> "Config":
+    config.merge(
+        {
+            "sources": {
+                source_existing_global.name: {
+                    "url": source_existing_global.url,
+                    "default": source_existing_global.default,
+                    "secondary": source_existing_global.secondary,
+                }
+            }
+        }
+    )
+    return config

--- a/tests/console/commands/source/test_show.py
+++ b/tests/console/commands/source/test_show.py
@@ -6,6 +6,7 @@ import pytest
 if TYPE_CHECKING:
     from cleo.testers.command_tester import CommandTester
 
+    from poetry.config.config import Config
     from poetry.config.source import Source
     from poetry.poetry import Poetry
     from tests.types import CommandTesterFactory
@@ -89,3 +90,46 @@ def test_source_show_error(tester: "CommandTester"):
     tester.execute("error")
     assert tester.io.fetch_error().strip() == "No source found with name(s): error"
     assert tester.status_code == 1
+
+
+def test_source_show_global(tester: "CommandTester", config_with_source: "Config"):
+    tester.execute("-g")
+    expected = """\
+name       : existing_global
+url        : https://existing_global.com
+default    : no
+secondary  : no
+""".splitlines()
+    assert (
+        list(map(lambda l: l.strip(), tester.io.fetch_output().strip().splitlines()))
+        == expected
+    )
+
+
+def test_source_show_all(tester: "CommandTester", config_with_source: "Config"):
+    tester.execute("-a")
+    expected = """\
+name       : existing
+url        : https://existing.com
+default    : no
+secondary  : no
+
+name       : one
+url        : https://one.com
+default    : no
+secondary  : no
+
+name       : two
+url        : https://two.com
+default    : no
+secondary  : no
+
+name       : existing_global
+url        : https://existing_global.com
+default    : no
+secondary  : no
+""".splitlines()
+    assert (
+        list(map(lambda l: l.strip(), tester.io.fetch_output().strip().splitlines()))
+        == expected
+    )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -14,7 +14,6 @@ from poetry.repositories.pypi_repository import PyPiRepository
 
 
 if TYPE_CHECKING:
-    from _pytest.monkeypatch import MonkeyPatch
     from cleo.io.io import IO
     from pytest_mock import MockerFixture
 


### PR DESCRIPTION
# Pull Request Check List

Partially Resolves: #1070 (mostly discussion that happened in the comments)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Comments:
- Why sources and not repositories in global config? Repositories in poetry config are currently only used for publishing and I didn't want to add more confusion there by using them for source definitions as well. 
- The merging of config and pyproject sources is weird and could cause a lot of user headaches. I am open to suggestions. Maybe we don't use the config if sources are defined in pyproject.toml?

