### PR TITLE
replace existing dependency when adding dependency with version constraint

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from typing import Dict
 from typing import List
 
@@ -196,6 +198,12 @@ class AddCommand(InstallerCommand, InitCommand):
                 constraint = constraint["version"]
 
             section[_constraint["name"]] = constraint
+
+            with contextlib.suppress(ValueError):
+                self.poetry.package.dependency_group(group).remove_dependency(
+                    _constraint["name"]
+                )
+
             self.poetry.package.add_dependency(
                 Factory.create_dependency(
                     _constraint["name"],

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -67,6 +67,53 @@ Package operations: 1 install, 0 updates, 0 removals
     assert content["dependencies"]["cachy"] == "^0.2.0"
 
 
+def test_add_replace_by_constraint(
+    app: "PoetryTestApplication", repo: "TestRepository", tester: "CommandTester"
+):
+    repo.add_package(get_package("cachy", "0.1.0"))
+    repo.add_package(get_package("cachy", "0.2.0"))
+
+    tester.execute("cachy")
+
+    expected = """\
+Using version ^0.2.0 for cachy
+
+Updating dependencies
+Resolving dependencies...
+
+Writing lock file
+
+Package operations: 1 install, 0 updates, 0 removals
+
+  • Installing cachy (0.2.0)
+"""
+    assert tester.io.fetch_output() == expected
+    assert tester.command.installer.executor.installations_count == 1
+
+    content = app.poetry.file.read()["tool"]["poetry"]
+
+    assert "cachy" in content["dependencies"]
+    assert content["dependencies"]["cachy"] == "^0.2.0"
+
+    tester.execute("cachy@0.1.0")
+    expected = """
+Updating dependencies
+Resolving dependencies...
+
+Writing lock file
+
+Package operations: 1 install, 0 updates, 0 removals
+
+  • Installing cachy (0.1.0)
+"""
+    assert tester.io.fetch_output() == expected
+
+    content = app.poetry.file.read()["tool"]["poetry"]
+
+    assert "cachy" in content["dependencies"]
+    assert content["dependencies"]["cachy"] == "0.1.0"
+
+
 def test_add_no_constraint_editable_error(
     app: "PoetryTestApplication", repo: "TestRepository", tester: "CommandTester"
 ):


### PR DESCRIPTION
This PR fixes a regression, where adding a dependency with a version constraint or `@latest` wasn't possible anymore if this dependency already existed.

# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/4700

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
