### PR TITLE
Ignore dependencies not matching the project's python constraint...

### DIFF
--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -70,6 +70,7 @@ class VersionSolver:
         """
         start = time.time()
         root_dependency = Dependency(self._root.name, self._root.version)
+        root_dependency.python_versions = self._root.python_versions
         root_dependency.is_root = True
 
         self._add_incompatibility(

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -420,6 +420,30 @@ def test_solver_fails_if_mismatch_root_python_versions(
         solver.solve()
 
 
+def test_solver_ignores_python_restricted_if_mismatch_root_package_python_versions(
+    solver: Solver, repo: Repository, package: ProjectPackage
+):
+    solver.provider.set_package_python_versions("~3.8")
+    package.add_dependency(
+        Factory.create_dependency("A", {"version": "1.0", "python": "<3.8"})
+    )
+    package.add_dependency(
+        Factory.create_dependency(
+            "B", {"version": "1.0", "markers": "python_version < '3.8'"}
+        )
+    )
+
+    package_a = get_package("A", "1.0")
+    package_b = get_package("B", "1.0")
+
+    repo.add_package(package_a)
+    repo.add_package(package_b)
+
+    transaction = solver.solve()
+
+    check_solver_result(transaction, [])
+
+
 def test_solver_solves_optional_and_compatible_packages(
     solver: Solver, repo: Repository, package: ProjectPackage
 ):


### PR DESCRIPTION
...no matter if the python version is specified by "python" keyword or by "markers"

# Pull Request Check List

Relates-to: #4952

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Currently, the following equivalent dependency specifications result in different lock files:

```
[tool.poetry.dependencies]
python = "~3.8"
pandas = {version="1.3.*", python="~3.9"}
```

```
[tool.poetry.dependencies]
python = "~3.8"
pandas = {version="1.3.*", markers="python_version=='3.9.*'"}
```

When using `python` the pandas dependency not matching the project's python constraint is ignored. When using `markers` the dependency is not ignored.

This PR harmonizes the behaviour between both variants.