### PR TITLE
Add sane error when "run" is used without arguments

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -201,6 +201,10 @@ class Application(BaseApplication):
 
             input = cast(ArgvInput, io.input)
             run_input = RunArgvInput([self._name or ""] + input._tokens)
+            
+            if 1 == len(input._tokens):
+                raise ValueError("Missing arguments; try `poetry run python your_script.py`")
+            
             # For the run command reset the definition
             # with only the set options (i.e. the options given before the command)
             for option_name, value in input.options.items():

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -25,6 +25,13 @@ def patches(mocker: "MockerFixture", env: "MockEnv") -> None:
 def test_run_passes_all_args(app_tester: "ApplicationTester", env: "MockEnv"):
     app_tester.execute("run python -V")
     assert [["python", "-V"]] == env.executed
+    
+def test_run_fails_no_args(app_tester: "ApplicationTester", env: "MockEnv"):
+    with pytest.raises(ValueError) as e:
+        app_tester.execute("run")
+    
+    assert str(e.value) == "Missing arguments; try `poetry run python your_script.py`"
+
 
 
 def test_run_keeps_options_passed_before_command(


### PR DESCRIPTION
When someone writes:
`poetry run` (with nothing else)

Before the fix, they'd get this long thing:

```
  FileNotFoundError

  [Errno 2] No such file or directory: b'/Users/my_user/.rvm/bin/run'

  at /Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/os.py:604 in _execvpe
       600│         path_list = map(fsencode, path_list)
       601│     for dir in path_list:
       602│         fullname = path.join(dir, file)
       603│         try:
    →  604│             exec_func(fullname, *argrest)
       605│         except (FileNotFoundError, NotADirectoryError) as e:
       606│             last_exc = e
       607│         except OSError as e:
       608│             last_exc = e
```

After the fix, they get:
```
Missing arguments; try `poetry run python your_script.py`
```

Added a test, but didn't change the documentation.

(This is my first contribution, feel free to say/fix if I did something wrong)

Thanks to @noa-weiss for helping

Resolves: #4963