### PR TITLE
Displaying a more informative error message in case of broken libraries in the interpreter

### DIFF
--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -234,7 +234,10 @@ class InstalledRepository(Repository):
                 metadata.distributions(path=[entry]),
                 key=lambda d: str(d._path),
             ):
-                name = canonicalize_name(distribution.metadata["name"])
+                name = distribution.metadata["name"]
+                if name is None:
+                    raise RuntimeError(f"Corrupted lib at {distribution._path}")
+                name = canonicalize_name(name)
 
                 if name in seen:
                     continue


### PR DESCRIPTION
Sometimes the installation of libraries via pip ends with errors (e.g. permission error). As a result, a folder with damaged libraries appears in the site-packages. Poetry gives unreadable error messages in this case (executing poetry install command).
This merge request allows you to see more readable error messages.
Before:
![image](https://user-images.githubusercontent.com/3264643/147993321-2567167a-d901-462d-a3a8-10d74f3ef8fc.png)
After:
![image](https://user-images.githubusercontent.com/3264643/147993328-28ca0d5d-84cd-4ca4-b117-b4ca8790daf9.png)
