### PR TITLE
Add "pwsh" to shell.py

### DIFF
--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -103,6 +103,8 @@ class Shell:
             suffix = ".fish"
         elif self._name in ("csh", "tcsh"):
             suffix = ".csh"
+        elif self._name == "pwsh":
+            suffix = ".ps1"
         else:
             suffix = ""
 


### PR DESCRIPTION
Allow `poetry shell` to properly activate a python virtual environment when the user's shell is `pwsh`

`poetry shell` on `pwsh` (https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh) uses the default incompatible `/bin/activate`, which means you have to hack your way around with something like
```pwsh
. $($(poetry debug | sls Path).ToString().Trim() | % { $($_ -split '\s+', 0, 'regexmatch')[1] + '/bin/activate.ps1' })
```
instead.