### PR TITLE
fix: set `naive=True` when trying to get poetry environment on update (Port)

### DIFF
--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -323,7 +323,7 @@ class SelfUpdateCommand(Command):
         from poetry.repositories.installed_repository import InstalledRepository
         from poetry.utils.env import EnvManager
 
-        env = EnvManager.get_system_env()
+        env = EnvManager.get_system_env(naive=True)
         installed = InstalledRepository.load(env)
 
         root = ProjectPackage("poetry-updater", "0.0.0")


### PR DESCRIPTION
Poetry doesn't find it's own venv on `poetry self update`. This is due to the missing parameter `naive=True`.

This is a port of https://github.com/python-poetry/poetry/pull/5049

# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/5046
