### PR TITLE
fix: set `naive=True` when trying to get poetry environment on update

### DIFF
--- a/src/poetry/console/commands/self/update.py
+++ b/src/poetry/console/commands/self/update.py
@@ -176,7 +176,7 @@ class SelfUpdateCommand(Command):
         from poetry.repositories.installed_repository import InstalledRepository
         from poetry.utils.env import EnvManager
 
-        env = EnvManager.get_system_env()
+        env = EnvManager.get_system_env(naive=True)
         installed = InstalledRepository.load(env)
 
         root = ProjectPackage("poetry-updater", "0.0.0")


### PR DESCRIPTION
Poetry doesn't find it's own venv on `poetry self update`. This is due to the missing parameter `naive=True`.

Port to stable is here: https://github.com/python-poetry/poetry/pull/5048

# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/5046
