### PR TITLE
de-glob mypy whitelist for 'utils' module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,12 @@ module = [
   'poetry.mixology.*',
   'poetry.packages.locker',
   'poetry.repositories.installed_repository',
-  'poetry.utils.*'
+  'poetry.utils.appdirs',
+  'poetry.utils.authenticator',
+  'poetry.utils.env',
+  'poetry.utils.exporter',
+  'poetry.utils.password_manager',
+  'poetry.utils.setup_reader',
 ]
 ignore_errors = true
 

--- a/src/poetry/utils/_compat.py
+++ b/src/poetry/utils/_compat.py
@@ -5,11 +5,11 @@ from typing import List
 from typing import Optional
 
 
-try:
-    from importlib import metadata
-except ImportError:
+if sys.version_info < (3, 8):
     # compatibility for python <3.8
-    import importlib_metadata as metadata  # noqa: F401, TC002
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata  # noqa: F401, TC002
 
 WINDOWS = sys.platform == "win32"
 


### PR DESCRIPTION
reduce the scope of the mypy whitelist by de-globbing the blanket 'allow' for the `utils` module
