### PR TITLE
Add note to documentation about version required for Poetry plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -20,6 +20,7 @@ or if you wish to accomplish something with Poetry in a way that is not desired 
 
 In these cases you could consider creating a plugin to handle your specific logic.
 
+> Note: The plugin interface is available in Poetry 1.2 or newer.
 
 ## Creating a plugin
 
@@ -39,7 +40,7 @@ version = "1.0.0"
 # ...
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.7"
-poetry = "^1.0"
+poetry = "^1.2"
 
 [tool.poetry.plugins."poetry.plugin"]
 demo = "poetry_demo_plugin.plugin:MyPlugin"


### PR DESCRIPTION
I was looking to create a Poetry plugin and got a wee bit confused that my Poetry version does not have a `plugins` subpackage. Turns out this was added as recent as `1.2.0a1`. I suggest that the documentation points out the minimum Poetry version that is needed to use the plugin interface. Version 1.2 doesn't seem to be released yet, happy to change the version number in the docs to `1.2.0a1`.

On a slightly different note; maybe it would be good if the Poetry documentation by default doesn't show the docs from "master" but the latest stable release instead?
