### PR TITLE
Fix asking for username/password in Publisher

### DIFF
--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -104,7 +104,10 @@ class Publisher:
         )
 
     def ask(
-        self, question: Union[str, "Question"], default: Optional[Any] = None, hidden: bool = False,
+        self,
+        question: Union[str, "Question"],
+        default: Optional[Any] = None,
+        hidden: bool = False,
     ) -> Any:
         """
         Prompt the user for input.

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -81,11 +81,13 @@ class Publisher:
         # Requesting missing credentials but only if there is not a client cert defined.
         if not resolved_client_cert:
             if username is None:
-                username = Question("Username:").ask()
+                username = Question("Username:").ask(self._io)
 
             # skip password input if no username is provided, assume unauthenticated
             if username and password is None:
-                password = Question("Password:", hidden=True).ask()
+                password_question = Question("Password:")
+                password_question.hide()
+                password = password_question.ask(self._io)
 
         self._uploader.auth(username, password)
 

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -1,7 +1,6 @@
 import logging
 
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import List
 from typing import Optional
 from typing import Union

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -1,6 +1,7 @@
 import logging
 
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import List
 from typing import Optional
 from typing import Union
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 
     from cleo.io import BufferedIO
     from cleo.io import ConsoleIO
+    from cleo.ui.question import Question
 
     from poetry.poetry import Poetry
 
@@ -78,11 +80,11 @@ class Publisher:
         # Requesting missing credentials but only if there is not a client cert defined.
         if not resolved_client_cert:
             if username is None:
-                username = self._io.ask("Username:")
+                username = self.ask("Username:")
 
             # skip password input if no username is provided, assume unauthenticated
             if username and password is None:
-                password = self._io.ask_hidden("Password:")
+                password = self.ask("Password:", hidden=True)
 
         self._uploader.auth(username, password)
 
@@ -100,3 +102,17 @@ class Publisher:
             client_cert=resolved_client_cert,
             dry_run=dry_run,
         )
+
+    def ask(
+        self, question: Union[str, "Question"], default: Optional[Any] = None, hidden: bool = False,
+    ) -> Any:
+        """
+        Prompt the user for input.
+        """
+        from cleo.ui.question import Question
+
+        if not isinstance(question, Question):
+            question = Question(question, default=default)
+            question.hide(hidden)
+
+        return question.ask(self._io)

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
     from cleo.io import BufferedIO
     from cleo.io import ConsoleIO
-    from cleo.ui.question import Question
 
     from poetry.poetry import Poetry
 
@@ -49,6 +48,8 @@ class Publisher:
         client_cert: Optional["Path"] = None,
         dry_run: bool = False,
     ) -> None:
+        from cleo.ui.question import Question
+
         if not repository_name:
             url = "https://upload.pypi.org/legacy/"
             repository_name = "pypi"
@@ -80,11 +81,11 @@ class Publisher:
         # Requesting missing credentials but only if there is not a client cert defined.
         if not resolved_client_cert:
             if username is None:
-                username = self.ask("Username:")
+                username = Question("Username:").ask()
 
             # skip password input if no username is provided, assume unauthenticated
             if username and password is None:
-                password = self.ask("Password:", hidden=True)
+                password = Question("Password:", hidden=True).ask()
 
         self._uploader.auth(username, password)
 
@@ -102,20 +103,3 @@ class Publisher:
             client_cert=resolved_client_cert,
             dry_run=dry_run,
         )
-
-    def ask(
-        self,
-        question: Union[str, "Question"],
-        default: Optional[Any] = None,
-        hidden: bool = False,
-    ) -> Any:
-        """
-        Prompt the user for input.
-        """
-        from cleo.ui.question import Question
-
-        if not isinstance(question, Question):
-            question = Question(question, default=default)
-            question.hide(hidden)
-
-        return question.ask(self._io)


### PR DESCRIPTION
Fixes #4790

Somewhere between Cleo 0.8.0 and 1.0.0a4, the `IO.ask()` and `IO.ask_hidden()` methods were removed. I added `Publisher.ask()` which is almost equivalent to Cleo's `Command.ask()`, only that it also accepts a `hidden` argument.
