### PR TITLE
Prefer actual-expected to expected-actual in assertions

### DIFF
--- a/tests/console/commands/debug/test_resolve.py
+++ b/tests/console/commands/debug/test_resolve.py
@@ -43,7 +43,7 @@ msgpack-python 0.5.3
 cachy          0.2.0
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_debug_resolve_tree_option_gives_the_dependency_tree(tester: "CommandTester"):
@@ -58,7 +58,7 @@ cachy 0.2.0
 └── msgpack-python >=0.5 <0.6
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_debug_resolve_git_dependency(tester: "CommandTester"):
@@ -73,4 +73,4 @@ pendulum 2.0.3
 demo     0.1.2
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -49,7 +49,7 @@ Path:       {Path('/base/prefix')}
 Executable: python
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_env_info_displays_path_only(tester: "CommandTester"):

--- a/tests/console/commands/env/test_list.py
+++ b/tests/console/commands/env/test_list.py
@@ -39,7 +39,7 @@ def test_none_activated(
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=env)
     tester.execute()
     expected = "\n".join(venvs_in_cache_dirs).strip()
-    assert expected == tester.io.fetch_output().strip()
+    assert tester.io.fetch_output().strip() == expected
 
 
 def test_activated(
@@ -52,10 +52,10 @@ def test_activated(
     expected = (
         "\n".join(venvs_in_cache_dirs).strip().replace("py3.7", "py3.7 (Activated)")
     )
-    assert expected == tester.io.fetch_output().strip()
+    assert tester.io.fetch_output().strip() == expected
 
 
 def test_in_project_venv(tester: "CommandTester", venvs_in_project_dir: List[str]):
     tester.execute()
     expected = ".venv (Activated)\n"
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -40,7 +40,7 @@ def test_remove_by_python_version(
     assert not (venv_cache / f"{venv_name}-py3.6").exists()
 
     expected = f"Deleted virtualenv: {venv_cache / venv_name}-py3.6\n"
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_remove_by_name(
@@ -58,7 +58,7 @@ def test_remove_by_name(
 
         expected += f"Deleted virtualenv: {venv_cache / name}\n"
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_remove_all(
@@ -72,7 +72,7 @@ def test_remove_all(
     for name in venvs_in_cache_dirs:
         assert not (venv_cache / name).exists()
         expected.add(f"Deleted virtualenv: {venv_cache / name}")
-    assert expected == set(tester.io.fetch_output().split("\n"))
+    assert set(tester.io.fetch_output().split("\n")) == expected
 
 
 def test_remove_all_and_version(
@@ -86,7 +86,7 @@ def test_remove_all_and_version(
     for name in venvs_in_cache_dirs:
         assert not (venv_cache / name).exists()
         expected.add(f"Deleted virtualenv: {venv_cache / name}")
-    assert expected == set(tester.io.fetch_output().split("\n"))
+    assert set(tester.io.fetch_output().split("\n")) == expected
 
 
 def test_remove_multiple(
@@ -104,4 +104,4 @@ def test_remove_multiple(
         expected.add(f"Deleted virtualenv: {venv_cache / name}")
     for name in remaining_envs:
         assert (venv_cache / name).exists()
-    assert expected == set(tester.io.fetch_output().split("\n"))
+    assert set(tester.io.fetch_output().split("\n")) == expected

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -87,7 +87,7 @@ Creating virtualenv {venv_py37.name} in {venv_py37.parent}
 Using virtualenv: {venv_py37}
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
@@ -115,7 +115,7 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
 Using virtualenv: {venv_dir}
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_get_prefers_explicitly_activated_non_existing_virtualenvs_over_env_var(
@@ -150,4 +150,4 @@ Creating virtualenv {venv_dir.name} in {venv_dir.parent}
 Using virtualenv: {venv_dir}
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_about.py
+++ b/tests/console/commands/test_about.py
@@ -24,4 +24,4 @@ Poetry is a dependency manager tracking local dependencies of your projects and\
 See https://github.com/python-poetry/poetry for more information.
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -58,7 +58,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -130,7 +130,7 @@ Failed to add packages. Only vcs/path dependencies support editable installs.\
 No changes were applied.
 """
     assert tester.status_code == 1
-    assert expected == tester.io.fetch_error()
+    assert tester.io.fetch_error() == expected
     assert tester.command.installer.executor.installations_count == 0
     assert content == app.poetry.file.read()["tool"]["poetry"]
 
@@ -155,7 +155,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.1.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
 
@@ -179,7 +179,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
 
@@ -210,7 +210,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing cachy (0.1.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
 
@@ -240,7 +240,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
 
@@ -270,7 +270,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -306,7 +306,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
 
@@ -339,7 +339,7 @@ Package operations: 4 installs, 0 updates, 0 removals
   • Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected.strip() == tester.io.fetch_output().strip()
+    assert tester.io.fetch_output().strip() == expected.strip()
     assert tester.command.installer.executor.installations_count == 4
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -380,7 +380,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -427,7 +427,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing demo (0.1.2 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -468,7 +468,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing demo (0.1.2 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
 
@@ -500,7 +500,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing demo (0.1.0 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -538,7 +538,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing demo (0.1.0 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -576,7 +576,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -617,7 +617,7 @@ Package operations: 2 installs, 0 updates, 0 removals
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 2
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -661,7 +661,7 @@ Package operations: 4 installs, 0 updates, 0 removals
     # Order might be different, split into lines and compare the overall output.
     expected = set(expected.splitlines())
     output = set(tester.io.fetch_output().splitlines())
-    assert expected == output
+    assert output == expected
     assert tester.command.installer.executor.installations_count == 4
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -697,7 +697,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -734,7 +734,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -769,7 +769,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -831,7 +831,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -872,7 +872,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -902,7 +902,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing pyyaml (3.13)
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 
     content = app.poetry.file.read()["tool"]["poetry"]
@@ -1032,7 +1032,7 @@ Resolving dependencies...
 Writing lock file
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
     assert content_hash != app.poetry.locker.lock_data["metadata"]["content-hash"]
 
 
@@ -1060,7 +1060,7 @@ Package operations: 1 install, 0 updates, 0 removals
   - Installing cachy (0.2.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 1
 
@@ -1093,7 +1093,7 @@ Package operations: 1 install, 0 updates, 0 removals
   - Installing cachy (0.1.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 1
 
@@ -1121,7 +1121,7 @@ Package operations: 1 install, 0 updates, 0 removals
   - Installing cachy (0.2.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 1
 
@@ -1156,7 +1156,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing cachy (0.1.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1190,7 +1190,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing cachy (0.2.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1219,7 +1219,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1254,7 +1254,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1286,7 +1286,7 @@ Package operations: 4 installs, 0 updates, 0 removals
   - Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 4
 
@@ -1323,7 +1323,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing demo (0.1.2 9cf87a2)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1365,7 +1365,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing demo (0.1.2 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1403,7 +1403,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing demo (0.1.2 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1436,7 +1436,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing demo (0.1.0 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1476,7 +1476,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing demo (0.1.0 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1518,7 +1518,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing cachy (0.2.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1561,7 +1561,7 @@ Package operations: 2 installs, 0 updates, 0 removals
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 2
 
@@ -1604,7 +1604,7 @@ Package operations: 4 installs, 0 updates, 0 removals
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 4
 
@@ -1644,7 +1644,7 @@ Package operations: 1 install, 0 updates, 0 removals
   - Installing cachy (0.2.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 1
 
@@ -1683,7 +1683,7 @@ Package operations: 1 install, 0 updates, 0 removals
   - Installing cachy (0.2.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 1
 
@@ -1722,7 +1722,7 @@ Package operations: 1 install, 0 updates, 0 removals
   - Installing cachy (0.2.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 1
 
@@ -1788,7 +1788,7 @@ Package operations: 1 install, 0 updates, 0 removals
   - Installing cachy (0.2.0)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 1
 
@@ -1822,7 +1822,7 @@ Package operations: 1 install, 0 updates, 0 removals
   - Installing pyyaml (3.13)
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
     assert len(installer.installs) == 1
 
@@ -1968,7 +1968,7 @@ Resolving dependencies...
 Writing lock file
 """
 
-    assert expected == old_tester.io.fetch_output()
+    assert old_tester.io.fetch_output() == expected
 
 
 def test_add_keyboard_interrupt_restore_content(

--- a/tests/console/commands/test_cache.py
+++ b/tests/console/commands/test_cache.py
@@ -58,7 +58,7 @@ def test_cache_list(
 {repository_two}
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_cache_list_empty(tester: "CommandTester", repository_cache_dir: "Path"):
@@ -68,4 +68,4 @@ def test_cache_list_empty(tester: "CommandTester", repository_cache_dir: "Path")
 No caches found
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -23,7 +23,7 @@ def test_check_valid(tester: "CommandTester"):
 All set!
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_check_invalid(mocker: "MockerFixture", tester: "CommandTester"):
@@ -45,4 +45,4 @@ Warning: The "pendulum" dependency specifies the "allows-prereleases" property,\
  which is deprecated. Use "allow-prereleases" instead.
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -59,7 +59,7 @@ virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
 virtualenvs.prefer-active-python = false
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_list_displays_set_get_setting(
@@ -84,7 +84,7 @@ virtualenvs.prefer-active-python = false
 """
 
     assert config.set_config_source.call_count == 0
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_display_single_setting(tester: "CommandTester", config: "Config"):
@@ -93,7 +93,7 @@ def test_display_single_setting(tester: "CommandTester", config: "Config"):
     expected = """true
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_display_single_local_setting(
@@ -107,7 +107,7 @@ def test_display_single_local_setting(
     expected = """false
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_list_displays_set_get_local_setting(
@@ -132,7 +132,7 @@ virtualenvs.prefer-active-python = false
 """
 
     assert config.set_config_source.call_count == 1
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_set_pypi_token(

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -85,7 +85,7 @@ def _export_requirements(tester: "CommandTester", poetry: "Poetry") -> None:
 foo==1.0.0
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_export_exports_requirements_txt_file_locks_if_no_lock_file(
@@ -113,7 +113,7 @@ def test_export_prints_to_stdout_by_default(tester: "CommandTester", do_lock: No
     expected = """\
 foo==1.0.0
 """
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_export_uses_requirements_txt_format_by_default(
@@ -123,7 +123,7 @@ def test_export_uses_requirements_txt_format_by_default(
     expected = """\
 foo==1.0.0
 """
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_export_includes_extras_by_flag(tester: "CommandTester", do_lock: None):
@@ -132,7 +132,7 @@ def test_export_includes_extras_by_flag(tester: "CommandTester", do_lock: None):
 bar==1.1.0
 foo==1.0.0
 """
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_export_with_urls(

--- a/tests/console/commands/test_search.py
+++ b/tests/console/commands/test_search.py
@@ -95,4 +95,4 @@ sqlalchemy-sqlany (1.0.3)
  SAP Sybase SQL Anywhere dialect for SQLAlchemy
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -96,7 +96,7 @@ pendulum 2.0.0 Pendulum package
 pytest   3.7.3 Pytest package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_basic_with_installed_packages_single(
@@ -194,7 +194,7 @@ cachy        0.1.0 Cachy package
 pendulum (!) 2.0.0 Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_basic_with_not_installed_packages_decorated(
@@ -250,7 +250,7 @@ def test_show_basic_with_not_installed_packages_decorated(
 \033[31mpendulum\033[39m \033[39;1m2.0.0\033[39;22m Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_latest_non_decorated(
@@ -320,7 +320,7 @@ cachy    0.1.0 0.2.0 Cachy package
 pendulum 2.0.0 2.0.1 Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_latest_decorated(
@@ -392,7 +392,7 @@ def test_show_latest_decorated(
  \033[31m2.0.1\033[39m Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_outdated(
@@ -458,7 +458,7 @@ def test_show_outdated(
 cachy 0.1.0 0.2.0 Cachy package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_outdated_with_only_up_to_date_packages(
@@ -500,7 +500,7 @@ def test_show_outdated_with_only_up_to_date_packages(
 
     expected = ""
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_outdated_has_prerelease_but_not_allowed(
@@ -571,7 +571,7 @@ def test_show_outdated_has_prerelease_but_not_allowed(
 cachy 0.1.0 0.2.0 Cachy package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_outdated_has_prerelease_and_allowed(
@@ -646,7 +646,7 @@ def test_show_outdated_has_prerelease_and_allowed(
 cachy 0.1.0.dev1 0.3.0.dev123 Cachy package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_outdated_formatting(
@@ -716,7 +716,7 @@ cachy    0.1.0 0.2.0 Cachy package
 pendulum 2.0.0 2.0.1 Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 @pytest.mark.parametrize("project_directory", ["project_with_local_dependencies"])
@@ -829,8 +829,9 @@ def test_show_outdated_local_dependencies(
 cachy              0.2.0                       0.3.0
 project-with-setup 0.1.1 ../project_with_setup 0.1.2 ../project_with_setup
 """
-    assert expected.rstrip() == "\n".join(
-        line.rstrip() for line in tester.io.fetch_output().splitlines()
+    assert (
+        "\n".join(line.rstrip() for line in tester.io.fetch_output().splitlines())
+        == expected.rstrip()
     )
 
 
@@ -933,7 +934,7 @@ cachy 0.1.0         0.2.0         Cachy package
 demo  0.1.1 9cf87a2 0.1.2 9cf87a2 Demo package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 @pytest.mark.parametrize("project_directory", ["project_with_git_dev_dependency"])
@@ -1031,7 +1032,7 @@ def test_show_outdated_no_dev_git_dev_dependency(
 cachy 0.1.0 0.2.0 Cachy package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_hides_incompatible_package(
@@ -1092,7 +1093,7 @@ def test_show_hides_incompatible_package(
 pendulum 2.0.0 Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_all_shows_incompatible_package(
@@ -1150,7 +1151,7 @@ cachy     0.1.0 Cachy package
 pendulum  2.0.0 Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_non_dev_with_basic_installed_packages(
@@ -1226,7 +1227,7 @@ cachy    0.1.0 Cachy package
 pendulum 2.0.0 Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_with_group_only(
@@ -1301,7 +1302,7 @@ def test_show_with_group_only(
 pytest 3.7.3 Pytest package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_with_optional_group(
@@ -1377,7 +1378,7 @@ cachy    0.1.0 Cachy package
 pendulum 2.0.0 Pendulum package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
     tester.execute("--with dev")
 
@@ -1387,7 +1388,7 @@ pendulum 2.0.0 Pendulum package
 pytest   3.7.3 Pytest package
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_tree(tester: "CommandTester", poetry: "Poetry", installed: "Repository"):
@@ -1439,7 +1440,7 @@ cachy 0.2.0
 `-- msgpack-python >=0.5 <0.6
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_tree_no_dev(
@@ -1508,7 +1509,7 @@ cachy 0.2.0
 └── msgpack-python >=0.5 <0.6
 """
 
-    assert expected == tester.io.fetch_output()
+    assert tester.io.fetch_output() == expected
 
 
 def test_show_required_by_deps(

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -50,7 +50,7 @@ def tester(command_tester_factory: "CommandTesterFactory") -> "CommandTester":
 def test_increment_version(
     version: str, rule: str, expected: str, command: VersionCommand
 ):
-    assert expected == command.increment_version(version, rule).text
+    assert command.increment_version(version, rule).text == expected
 
 
 def test_version_show(tester: "CommandTester"):

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -87,4 +87,4 @@ def test_get_cache_directory_for_link(config: "Config", config_cache_dir: Path):
         "283a3b3b7f95f05e9e6f84182d276f7bb0951d5b0cc24422b33f7a4648"
     )
 
-    assert expected == directory
+    assert directory == expected

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -173,7 +173,7 @@ Package operations: 4 installs, 1 update, 1 removal
 
     expected = set(expected.splitlines())
     output = set(io.fetch_output().splitlines())
-    assert expected == output
+    assert output == expected
     assert len(env.executed) == 5
     assert return_code == 0
     pip_editable_install.assert_called_once()
@@ -199,7 +199,7 @@ Package operations: 0 installs, 0 updates, 0 removals, 1 skipped
 
   • Removing clikit (0.2.3): Skipped for the following reason: Not currently installed
 """
-    assert expected == io.fetch_output()
+    assert io.fetch_output() == expected
     assert len(env.executed) == 0
 
 
@@ -299,7 +299,7 @@ Package operations: 1 install, 0 updates, 0 removals
 """
     expected = set(expected.splitlines())
     output = set(io_not_decorated.fetch_output().splitlines())
-    assert expected == output
+    assert output == expected
     assert return_code == 0
 
 
@@ -321,7 +321,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing clikit (0.2.3): Cancelled
 """
 
-    assert expected == io.fetch_output()
+    assert io.fetch_output() == expected
 
 
 def test_execute_should_gracefully_handle_io_error(

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -741,7 +741,7 @@ def test_run_install_with_synchronization(
         *managed_reserved_package_names,
     }
 
-    assert expected_removals == {r.name for r in installer.executor.removals}
+    assert {r.name for r in installer.executor.removals} == expected_removals
 
 
 def test_run_whitelist_add(
@@ -2153,21 +2153,21 @@ def test_update_multiple_times_with_split_dependencies_is_idempotent(
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert locker.written_data == expected
 
     locker.mock_lock_data(locker.written_data)
 
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert locker.written_data == expected
 
     locker.mock_lock_data(locker.written_data)
 
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert locker.written_data == expected
 
 
 def test_installer_can_install_dependencies_from_forced_source(

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -1774,21 +1774,21 @@ def test_update_multiple_times_with_split_dependencies_is_idempotent(
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert locker.written_data == expected
 
     locker.mock_lock_data(locker.written_data)
 
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert locker.written_data == expected
 
     locker.mock_lock_data(locker.written_data)
 
     installer.update(True)
     installer.run()
 
-    assert expected == locker.written_data
+    assert locker.written_data == expected
 
 
 def test_installer_can_install_dependencies_from_forced_source(

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -62,7 +62,7 @@ def test_requirement(installer: PipInstaller):
         "\n"
     )
 
-    assert expected == result
+    assert result == expected
 
 
 def test_requirement_source_type_url():
@@ -78,7 +78,7 @@ def test_requirement_source_type_url():
     result = installer.requirement(foo, formatted=True)
     expected = f"{foo.source_url}#egg={foo.name}"
 
-    assert expected == result
+    assert result == expected
 
 
 def test_requirement_git_develop_false(installer: PipInstaller, package_git: Package):
@@ -86,7 +86,7 @@ def test_requirement_git_develop_false(installer: PipInstaller, package_git: Pac
     result = installer.requirement(package_git)
     expected = "git+git@github.com:demo/demo.git@master#egg=demo"
 
-    assert expected == result
+    assert result == expected
 
 
 def test_install_with_non_pypi_default_repository(pool: Pool, installer: PipInstaller):
@@ -182,7 +182,7 @@ def test_requirement_git_develop_true(installer: PipInstaller, package_git: Pack
     result = installer.requirement(package_git)
     expected = ["-e", "git+git@github.com:demo/demo.git@master#egg=demo"]
 
-    assert expected == result
+    assert result == expected
 
 
 def test_uninstall_git_package_nspkg_pth_cleanup(

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -103,7 +103,7 @@ B = []
 git-package = []
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_locker_properly_loads_extras(locker: Locker):
@@ -307,7 +307,7 @@ content-hash = "178f2cd01dc40e96be23a4a0ae1094816626346346618335e5ff4f0b2c0c5831
 A = []
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_lock_file_should_not_have_mixed_types(locker: Locker, root: ProjectPackage):
@@ -350,7 +350,7 @@ A = []
     with locker.lock.open(encoding="utf-8") as f:
         content = f.read()
 
-    assert expected == content
+    assert content == expected
 
 
 def test_reading_lock_file_should_raise_an_error_on_invalid_data(locker: Locker):
@@ -424,7 +424,7 @@ content-hash = "178f2cd01dc40e96be23a4a0ae1094816626346346618335e5ff4f0b2c0c5831
 A = []
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_locker_should_emit_warnings_if_lock_version_is_newer_but_allowed(
@@ -455,7 +455,7 @@ The lock file might not be compatible with the current version of Poetry.
 Upgrade Poetry to ensure the lock file is read properly or, alternatively, \
 regenerate the lock file with the `poetry lock` command.\
 """
-    assert expected == record.message
+    assert record.message == expected
 
 
 def test_locker_should_raise_an_error_if_lock_version_is_newer_and_not_allowed(
@@ -511,7 +511,7 @@ A = []
     with locker.lock.open(encoding="utf-8") as f:
         content = f.read()
 
-    assert expected == content
+    assert content == expected
 
 
 def test_locker_should_neither_emit_warnings_nor_raise_error_for_lower_compatible_versions(  # noqa: E501
@@ -602,7 +602,7 @@ content-hash = "178f2cd01dc40e96be23a4a0ae1094816626346346618335e5ff4f0b2c0c5831
 A = []
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_locked_repository_uses_root_dir_of_package(

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -120,7 +120,7 @@ def check_solver_result(
 
             result.append({"job": job, "package": op.package, "skipped": op.skipped})
 
-    assert expected == result
+    assert result == expected
 
     return ops
 

--- a/tests/puzzle/test_transaction.py
+++ b/tests/puzzle/test_transaction.py
@@ -37,7 +37,7 @@ def check_operations(
 
             result.append({"job": job, "package": op.package, "skipped": op.skipped})
 
-    assert expected == result
+    assert result == expected
 
 
 def test_it_should_calculate_operations_in_correct_order():

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -235,7 +235,7 @@ def test_get_package_from_both_py2_and_py3_specific_wheels():
         Dependency("win-unicode-console", ">=0.5"),
     ]
     required = [r for r in package.requires if not r.is_optional()]
-    assert expected == required
+    assert required == expected
 
     assert str(required[1].marker) == 'python_version == "2.7"'
     assert (
@@ -272,7 +272,7 @@ def test_get_package_with_dist_and_universal_py3_wheel():
         Dependency("win-unicode-console", ">=0.5"),
     ]
     required = [r for r in package.requires if not r.is_optional()]
-    assert expected == sorted(required, key=lambda dep: dep.name)
+    assert sorted(required, key=lambda dep: dep.name) == expected
 
 
 def test_get_package_retrieves_non_sha256_hashes():
@@ -291,7 +291,7 @@ def test_get_package_retrieves_non_sha256_hashes():
         },
     ]
 
-    assert expected == package.files
+    assert package.files == expected
 
 
 def test_get_package_retrieves_non_sha256_hashes_mismatching_known_hash():
@@ -314,7 +314,7 @@ def test_get_package_retrieves_non_sha256_hashes_mismatching_known_hash():
         },
     ]
 
-    assert expected == package.files
+    assert package.files == expected
 
 
 def test_get_package_retrieves_packages_with_no_hashes():

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -200,8 +200,8 @@ def test_pypi_repository_supports_reading_bz2_files():
     }
 
     for name in expected_extras.keys():
-        assert expected_extras[name] == sorted(
-            package.extras[name], key=lambda r: r.name
+        assert (
+            sorted(package.extras[name], key=lambda r: r.name) == expected_extras[name]
         )
 
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -288,7 +288,7 @@ def test_create_poetry_fails_on_invalid_configuration():
 The Poetry configuration is invalid:
   - 'description' is a required property
 """
-    assert expected == str(e.value)
+    assert str(e.value) == expected
 
 
 def test_create_poetry_with_local_config(fixture_dir: "FixtureDirGetter"):

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -576,8 +576,8 @@ def test_list(tmp_dir: str, manager: EnvManager, poetry: "Poetry", config: "Conf
     venvs = manager.list()
 
     assert len(venvs) == 2
-    assert (Path(tmp_dir) / f"{venv_name}-py3.6") == venvs[0].path
-    assert (Path(tmp_dir) / f"{venv_name}-py3.7") == venvs[1].path
+    assert venvs[0].path == (Path(tmp_dir) / f"{venv_name}-py3.6")
+    assert venvs[1].path == (Path(tmp_dir) / f"{venv_name}-py3.7")
 
 
 def test_remove_by_python_version(
@@ -600,8 +600,9 @@ def test_remove_by_python_version(
 
     venv = manager.remove("3.6")
 
-    assert (Path(tmp_dir) / f"{venv_name}-py3.6") == venv.path
-    assert not (Path(tmp_dir) / f"{venv_name}-py3.6").exists()
+    expected_venv_path = Path(tmp_dir) / f"{venv_name}-py3.6"
+    assert venv.path == expected_venv_path
+    assert not expected_venv_path.exists()
 
 
 def test_remove_by_name(
@@ -624,8 +625,9 @@ def test_remove_by_name(
 
     venv = manager.remove(f"{venv_name}-py3.6")
 
-    assert (Path(tmp_dir) / f"{venv_name}-py3.6") == venv.path
-    assert not (Path(tmp_dir) / f"{venv_name}-py3.6").exists()
+    expected_venv_path = Path(tmp_dir) / f"{venv_name}-py3.6"
+    assert venv.path == expected_venv_path
+    assert not expected_venv_path.exists()
 
 
 def test_remove_also_deactivates(
@@ -653,8 +655,9 @@ def test_remove_also_deactivates(
 
     venv = manager.remove("python3.6")
 
-    assert (Path(tmp_dir) / f"{venv_name}-py3.6") == venv.path
-    assert not (Path(tmp_dir) / f"{venv_name}-py3.6").exists()
+    expected_venv_path = Path(tmp_dir) / f"{venv_name}-py3.6"
+    assert venv.path == expected_venv_path
+    assert not expected_venv_path.exists()
 
     envs = envs_file.read()
     assert venv_name not in envs
@@ -884,7 +887,7 @@ def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
         'via the "env use" command.'
     )
 
-    assert expected_message == str(e.value)
+    assert str(e.value) == expected_message
     assert m.call_count == 0
 
 
@@ -910,7 +913,7 @@ def test_create_venv_does_not_try_to_find_compatible_versions_with_executable(
         "specified in the pyproject.toml file."
     )
 
-    assert expected_message == str(e.value)
+    assert str(e.value) == expected_message
     assert m.call_count == 0
 
 

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -133,7 +133,7 @@ bar==4.5.6
 foo==1.2.3
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_standard_packages_and_markers(
@@ -189,7 +189,7 @@ baz==7.8.9 ; sys_platform == "win32"
 foo==1.2.3 ; python_version < "3.7"
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_poetry(tmp_dir: str, poetry: "Poetry"):
@@ -571,7 +571,7 @@ foo==1.2.3 \\
     --hash=sha256:12345
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_standard_packages_and_hashes_disabled(  # noqa: E501
@@ -618,7 +618,7 @@ bar==4.5.6
 foo==1.2.3
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_exports_requirements_txt_without_dev_packages_by_default(
@@ -663,7 +663,7 @@ foo==1.2.3 \\
     --hash=sha256:12345
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_exports_requirements_txt_with_dev_packages_if_opted_in(
@@ -710,7 +710,7 @@ foo==1.2.3 \\
     --hash=sha256:12345
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_exports_requirements_txt_without_optional_packages(
@@ -755,7 +755,7 @@ foo==1.2.3 \\
     --hash=sha256:12345
 """
 
-    assert expected == content
+    assert content == expected
 
 
 @pytest.mark.parametrize(
@@ -867,7 +867,7 @@ def test_exporter_can_export_requirements_txt_with_git_packages(
 foo @ git+https://github.com/foo/foo.git@123456
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_nested_packages(
@@ -918,7 +918,7 @@ bar==4.5.6
 foo @ git+https://github.com/foo/foo.git@123456
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_nested_packages_cyclic(
@@ -974,7 +974,7 @@ baz==7.8.9
 foo==1.2.3
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_nested_packages_and_multiple_markers(
@@ -1103,7 +1103,7 @@ def test_exporter_can_export_requirements_txt_with_git_packages_and_markers(
 foo @ git+https://github.com/foo/foo.git@123456 ; python_version < "3.7"
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_directory_packages(
@@ -1145,7 +1145,7 @@ def test_exporter_can_export_requirements_txt_with_directory_packages(
 foo @ {working_directory.as_uri()}/tests/fixtures/sample_project
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_nested_directory_packages(
@@ -1213,7 +1213,7 @@ baz @ {working_directory.as_uri()}/tests/fixtures/project_with_nested_local
 foo @ {working_directory.as_uri()}/tests/fixtures/sample_project
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_directory_packages_and_markers(
@@ -1257,7 +1257,7 @@ foo @ {working_directory.as_uri()}/tests/fixtures/sample_project\
  ; python_version < "3.7"
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_file_packages(
@@ -1299,7 +1299,7 @@ def test_exporter_can_export_requirements_txt_with_file_packages(
 foo @ {working_directory.as_uri()}/tests/fixtures/distributions/demo-0.1.0.tar.gz
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_file_packages_and_markers(
@@ -1343,7 +1343,7 @@ foo @ {working_directory.as_uri()}/tests/fixtures/distributions/demo-0.1.0.tar.g
  ; python_version < "3.7"
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_exports_requirements_txt_with_legacy_packages(
@@ -1403,7 +1403,7 @@ foo==1.2.3 \\
     --hash=sha256:12345
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_exports_requirements_txt_with_url_false(
@@ -1463,7 +1463,7 @@ foo==1.2.3 \\
     --hash=sha256:12345
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_exports_requirements_txt_with_legacy_packages_trusted_host(
@@ -1514,7 +1514,7 @@ bar==4.5.6 \\
     --hash=sha256:67890
 """
 
-    assert expected == content
+    assert content == expected
 
 
 @pytest.mark.parametrize(
@@ -1662,7 +1662,7 @@ foo==1.2.3 \\
     --hash=sha256:12345
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_exports_requirements_txt_with_legacy_packages_and_credentials(
@@ -1731,7 +1731,7 @@ foo==1.2.3 \\
     --hash=sha256:12345
 """
 
-    assert expected == content
+    assert content == expected
 
 
 def test_exporter_exports_requirements_txt_to_standard_output(

--- a/tests/utils/test_extras.py
+++ b/tests/utils/test_extras.py
@@ -65,6 +65,7 @@ def test_get_extra_package_names(
     extra_names: List[str],
     expected_extra_package_names: List[str],
 ):
-    assert expected_extra_package_names == list(
-        get_extra_package_names(packages, extras, extra_names)
+    assert (
+        list(get_extra_package_names(packages, extras, extra_names))
+        == expected_extra_package_names
     )

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -44,11 +44,11 @@ def test_setup_reader_read_first_level_setup_call_with_direct_types(
     }
     expected_python_requires = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
-    assert expected_name == result["name"]
-    assert expected_version == result["version"]
-    assert expected_install_requires == result["install_requires"]
-    assert expected_extras_require == result["extras_require"]
-    assert expected_python_requires == result["python_requires"]
+    assert result["name"] == expected_name
+    assert result["version"] == expected_version
+    assert result["install_requires"] == expected_install_requires
+    assert result["extras_require"] == expected_extras_require
+    assert result["python_requires"] == expected_python_requires
 
 
 def test_setup_reader_read_first_level_setup_call_with_variables(
@@ -71,11 +71,11 @@ def test_setup_reader_read_first_level_setup_call_with_variables(
     }
     expected_python_requires = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
-    assert expected_name == result["name"]
-    assert expected_version == result["version"]
-    assert expected_install_requires == result["install_requires"]
-    assert expected_extras_require == result["extras_require"]
-    assert expected_python_requires == result["python_requires"]
+    assert result["name"] == expected_name
+    assert result["version"] == expected_version
+    assert result["install_requires"] == expected_install_requires
+    assert result["extras_require"] == expected_extras_require
+    assert result["python_requires"] == expected_python_requires
 
 
 def test_setup_reader_read_sub_level_setup_call_with_direct_types(
@@ -97,10 +97,10 @@ def test_setup_reader_read_sub_level_setup_call_with_direct_types(
         "mssql_pymssql": ["pymssql"],
     }
 
-    assert expected_name == result["name"]
-    assert expected_version == result["version"]
-    assert expected_install_requires == result["install_requires"]
-    assert expected_extras_require == result["extras_require"]
+    assert result["name"] == expected_name
+    assert result["version"] == expected_version
+    assert result["install_requires"] == expected_install_requires
+    assert result["extras_require"] == expected_extras_require
     assert result["python_requires"] is None
 
 
@@ -116,11 +116,11 @@ def test_setup_reader_read_setup_cfg(setup: Callable[[str], str]):
     }
     expected_python_requires = ">=2.6,!=3.0,!=3.1,!=3.2,!=3.3"
 
-    assert expected_name == result["name"]
-    assert expected_version == result["version"]
-    assert expected_install_requires == result["install_requires"]
-    assert expected_extras_require == result["extras_require"]
-    assert expected_python_requires == result["python_requires"]
+    assert result["name"] == expected_name
+    assert result["version"] == expected_version
+    assert result["install_requires"] == expected_install_requires
+    assert result["extras_require"] == expected_extras_require
+    assert result["python_requires"] == expected_python_requires
 
 
 def test_setup_reader_read_setup_cfg_with_attr(setup: Callable[[str], str]):
@@ -137,11 +137,11 @@ def test_setup_reader_read_setup_kwargs(setup: Callable[[str], str]):
     expected_extras_require = {':python_version < "3.5"': ["typing>=3.6,<4.0"]}
     expected_python_requires = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
-    assert expected_name == result["name"]
-    assert expected_version == result["version"]
-    assert expected_install_requires == result["install_requires"]
-    assert expected_extras_require == result["extras_require"]
-    assert expected_python_requires == result["python_requires"]
+    assert result["name"] == expected_name
+    assert result["version"] == expected_version
+    assert result["install_requires"] == expected_install_requires
+    assert result["extras_require"] == expected_extras_require
+    assert result["python_requires"] == expected_python_requires
 
 
 def test_setup_reader_read_setup_call_in_main(setup: Callable[[str], str]):
@@ -153,11 +153,11 @@ def test_setup_reader_read_setup_call_in_main(setup: Callable[[str], str]):
     expected_extras_require = {}
     expected_python_requires = None
 
-    assert expected_name == result["name"]
-    assert expected_version == result["version"]
-    assert expected_install_requires == result["install_requires"]
-    assert expected_extras_require == result["extras_require"]
-    assert expected_python_requires == result["python_requires"]
+    assert result["name"] == expected_name
+    assert result["version"] == expected_version
+    assert result["install_requires"] == expected_install_requires
+    assert result["extras_require"] == expected_extras_require
+    assert result["python_requires"] == expected_python_requires
 
 
 def test_setup_reader_read_extras_require_with_variables(setup: Callable[[str], str]):
@@ -169,11 +169,11 @@ def test_setup_reader_read_extras_require_with_variables(setup: Callable[[str], 
     expected_extras_require = {"test": ["pytest"]}
     expected_python_requires = None
 
-    assert expected_name == result["name"]
-    assert expected_version == result["version"]
-    assert expected_install_requires == result["install_requires"]
-    assert expected_extras_require == result["extras_require"]
-    assert expected_python_requires == result["python_requires"]
+    assert result["name"] == expected_name
+    assert result["version"] == expected_version
+    assert result["install_requires"] == expected_install_requires
+    assert result["extras_require"] == expected_extras_require
+    assert result["python_requires"] == expected_python_requires
 
 
 def test_setup_reader_setuptools(setup: Callable[[str], str]):
@@ -182,5 +182,5 @@ def test_setup_reader_setuptools(setup: Callable[[str], str]):
     expected_name = "my_package"
     expected_version = "0.1.2"
 
-    assert expected_name == result["name"]
-    assert expected_version == result["version"]
+    assert result["name"] == expected_name
+    assert result["version"] == expected_version


### PR DESCRIPTION
Relates-to: python-poetry/poetry#4776

As far as I know, there is no general convention about the order (actual-expected vs. expected-actual) in pytest assertions. However, I think a consistent order is desirable in order to quickly grasp what is going wrong in a failing test.

In my opinion, there is at least one strong argument for actual-expected:
`SIM300` of `flake8-simplify` is about avoiding yoda conditions. Thus, `age == 42` is preferred to `42 == age`. **Avoiding yoda conditions often results in actual-expected order.**

Further, most examples in pytest documentation are in actual-expected order, e.g. https://docs.pytest.org/en/6.2.x/index.html. (The same applies to unittest: https://docs.python.org/3/library/unittest.html) Probably, actual-expected is the more natural or at least more common order.

I am not aware if there is a linter that can help to keep actual-expected order because sometimes the context is required in order to decide which is actual and which is expected. At least, if most of the tests use a consistent order it will be more likely that this order is used in new tests.