### PR TITLE
fixes mypy issue on windows

### DIFF
--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -72,7 +72,7 @@ class Shell:
         bin_dir = "Scripts" if WINDOWS else "bin"
         activate_path = env.path / bin_dir / activate_script
 
-        if WINDOWS:
+        if sys.platform == "win32":
             if self._name in ("powershell", "pwsh"):
                 args = ["-NoExit", "-File", str(activate_path)]
             else:

--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -72,6 +72,8 @@ class Shell:
         bin_dir = "Scripts" if WINDOWS else "bin"
         activate_path = env.path / bin_dir / activate_script
 
+        # mypy requires using sys.platform instead of WINDOWS constant
+        # in if statements to properly type check on Windows
         if sys.platform == "win32":
             if self._name in ("powershell", "pwsh"):
                 args = ["-NoExit", "-File", str(activate_path)]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
mypy on windows was complaining about non-existent attributes. 
![image](https://user-images.githubusercontent.com/3230744/151928639-73f83177-333e-44ca-b04a-7a3ad9bff783.png)

It looks like mypy doesn't honor the Windows boolean that was being previously used. By performing a sys.platform check in the if statement, mypy properly handles the early exit on windows. 
