### PR TITLE
Fix LegacyRepository search using wrong URL

### DIFF
--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -166,6 +166,7 @@ class LegacyRepository(PyPiRepository):
         self._packages = []
         self._name = name
         self._url = url.rstrip("/")
+        self._base_url = self._url + "/"
         self._client_cert = client_cert
         self._cert = cert
         self._cache_dir = REPOSITORY_CACHE_DIR / name

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -166,7 +166,7 @@ class PyPiRepository(RemoteRepository):
 
         search = {"q": query}
 
-        response = requests.session().get(self._base_url + "search", params=search)
+        response = requests.session().get(self._search_url(), params=search)
         content = parse(response.content, namespaceHTMLElements=False)
         for result in content.findall(".//*[@class='package-snippet']"):
             name = result.find("h3/*[@class='package-snippet__name']").text
@@ -454,3 +454,6 @@ class PyPiRepository(RemoteRepository):
 
     def _log(self, msg: str, level: str = "info") -> None:
         getattr(logger, level)(f"<debug>{self._name}:</debug> {msg}")
+
+    def _search_url(self) -> str:
+        return self._base_url + "search"

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -374,3 +374,9 @@ def test_get_redirected_response_url(
 
     monkeypatch.setattr(repo.session, "get", get_mock)
     assert repo._get_page("/foo")._url == "http://legacy.redirect.bar/foo/"
+
+
+def test_search(http: Type["httpretty.httpretty"]):
+    repository = MockHttpRepository({"/foo": 200}, http)
+
+    assert repository._search_url() == "http://legacy.foo.bar/search"

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -243,3 +243,9 @@ def test_use_pypi_pretty_name():
     package = repo.find_packages(Factory.create_dependency("twisted", "*"))
     assert len(package) == 1
     assert package[0].pretty_name == "Twisted"
+
+
+def test_search():
+    repository = PyPiRepository()
+
+    assert repository._search_url() == "https://pypi.org/search"


### PR DESCRIPTION
Resolves: #5132 

Remote repositories added under [[tool.poetry.source]] would try to search with the URL configured under PypiRepository, rather than with the supplied URL.


