### PR TITLE
Fix problem with deleting temporary folders on Windows (re-created patch #1032)

### DIFF
--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 
     from poetry.config.config import Config
 
-
 _canonicalize_regex = re.compile("[-_]+")
 
 
@@ -73,7 +72,7 @@ def _on_rm_error(func: Callable, path: str, exc_info: Exception) -> None:
     func(path)
 
 
-def robust_rmtree(path: str, onerror=None, max_timeout=1) -> None:
+def robust_rmtree(path: str, onerror: Callable = None, max_timeout: float = 1) -> None:
     """
     Robustly tries to delete paths.
     Retries several times if an OSError occurs.
@@ -98,7 +97,9 @@ def safe_rmtree(path: str) -> None:
     if Path(path).is_symlink():
         return os.unlink(str(path))
 
-    shutil.rmtree(path, onerror=_on_rm_error)  # maybe we could call robust_rmtree here just in case ?
+    shutil.rmtree(
+        path, onerror=_on_rm_error
+    )  # maybe we could call robust_rmtree here just in case ?
 
 
 def merge_dicts(d1: Dict, d2: Dict) -> None:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,15 +1,16 @@
 import tempfile
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 from poetry.core.utils.helpers import parse_requires
-from src.poetry.utils.helpers import robust_rmtree
 
 from poetry.utils.helpers import canonicalize_name
 from poetry.utils.helpers import get_cert
 from poetry.utils.helpers import get_client_cert
+from src.poetry.utils.helpers import robust_rmtree
 
 
 if TYPE_CHECKING:
@@ -17,16 +18,23 @@ if TYPE_CHECKING:
 
 
 def test_robust_rmtree(mocker):
-    mocked_rmtree = mocker.patch('shutil.rmtree')
+    mocked_rmtree = mocker.patch("shutil.rmtree")
 
     # this should work after an initial exception
     name = tempfile.mkdtemp()
-    mocked_rmtree.side_effect = [OSError("Couldn't delete file yet, waiting for references to clear", "mocked path"), None]
+    mocked_rmtree.side_effect = [
+        OSError(
+            "Couldn't delete file yet, waiting for references to clear", "mocked path"
+        ),
+        None,
+    ]
     robust_rmtree(name)
 
     # this should give up after retrying multiple times
     name = tempfile.mkdtemp()
-    mocked_rmtree.side_effect = OSError("Couldn't delete file yet, this error won't go away after first attempt")
+    mocked_rmtree.side_effect = OSError(
+        "Couldn't delete file yet, this error won't go away after first attempt"
+    )
     with pytest.raises(OSError):
         robust_rmtree(name, max_timeout=0.04)
 


### PR DESCRIPTION
When deleting temporary directories on Windows try a few times so we get around a Windows error, see issue #1031 for more details.

# Pull Request Check List

Resolves: #1031, #1032
Pull request #1032 is stale, but I took out the code from that and made the requested changes from comments (decreased timeout to 1s and added a test)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
