### PR TITLE
Allow root package non-editable installation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -213,6 +213,12 @@ poetry install --no-root
 Installation of your project's package is also skipped when the `--only`
 option is used.
 
+If you do not want to install the current project in [editable](https://pip.pypa.io/en/stable/cli/pip_install/#install-editable) mode, run the `install` command with the `--no-editable` flag:
+
+```bash
+poetry install --no-editable
+```
+
 ### Options
 
 * `--without`: The dependency groups to ignore for installation.
@@ -223,6 +229,7 @@ option is used.
 * `--no-root`: Do not install the root package (your project).
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
 * `--extras (-E)`: Features to install (multiple values allowed).
+* `--no-editable`: Do not install the root package in editable mode.
 * `--no-dev`: Do not install dev dependencies. (**Deprecated**)
 * `--dev-only`: Only install dev dependencies. (**Deprecated**)
 * `--remove-untracked`: Remove dependencies not presented in the lock file. (**Deprecated**)

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -95,10 +95,10 @@ dependencies and not including the current project, run the command with the
     _loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]
 
     def handle(self) -> int:
+        from poetry.core.masonry.builders.sdist import SdistBuilder
         from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
 
         from poetry.masonry.builders import EditableBuilder
-        from poetry.core.masonry.builders.sdist import SdistBuilder
         from poetry.utils.pip import pip_install
 
         self._installer.use_executor(

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -43,17 +43,11 @@ def test_sync_option_is_passed_to_the_installer(
     assert tester.command.installer._requires_synchronization
 
 
-def test_no_editable_option(
-    tester: "CommandTester", mocker: "MockerFixture"
-):
+def test_no_editable_option(tester: "CommandTester", mocker: "MockerFixture"):
     mocker.patch.object(tester.command.installer, "run", return_value=0)
     pip_install_mock = mocker.patch("poetry.utils.pip.pip_install")
-    builder_mock = mocker.patch(
-        "poetry.core.masonry.builders.sdist.SdistBuilder"
-    )
-    editable_builder_mock = mocker.patch(
-        "poetry.masonry.builders.EditableBuilder"
-    )
+    builder_mock = mocker.patch("poetry.core.masonry.builders.sdist.SdistBuilder")
+    editable_builder_mock = mocker.patch("poetry.masonry.builders.EditableBuilder")
 
     tester.execute("--no-editable")
 

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -41,3 +41,28 @@ def test_sync_option_is_passed_to_the_installer(
     tester.execute("--sync")
 
     assert tester.command.installer._requires_synchronization
+
+
+def test_no_editable_option(
+    tester: "CommandTester", mocker: "MockerFixture"
+):
+    mocker.patch.object(tester.command.installer, "run", return_value=0)
+    pip_install_mock = mocker.patch("poetry.utils.pip.pip_install")
+    builder_mock = mocker.patch(
+        "poetry.core.masonry.builders.sdist.SdistBuilder"
+    )
+    editable_builder_mock = mocker.patch(
+        "poetry.masonry.builders.EditableBuilder"
+    )
+
+    tester.execute("--no-editable")
+
+    pip_install_mock.assert_called_once_with(
+        path=tester.command.poetry.package.root_dir,
+        environment=tester.command.env,
+        deps=False,
+        upgrade=True,
+    )
+    builder_mock.assert_called_once_with(tester.command.poetry)
+    builder_mock.return_value.setup_py.assert_called_once()
+    editable_builder_mock.assert_not_called()


### PR DESCRIPTION
# Pull Request Check List

Partially Resolves: #1382 (Implemented `--no-editable` for install command)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
If `--no-editable` flag is present, use `SdistBuilder` as a builder, build `setup.py`, then finally run `pip_install` utility method without deps and without editable mode.

I did some manual tests by trying to install back and forth with and without editable mode, which at first glance seems to work. However, after installing in editable mode again, the package directory (`.venv/lib/python3.x/site-packages/package_name`) seems still to exists but it's empty:
```shell
$ $ poetry run poetry install --no-editable
...
$ tree ../../.venv/lib/python3.9/site-packages/demo/
../../.venv/lib/python3.9/site-packages/demo/
├── cli
│   ├── cli.py
│   ├── commands
│   │   ├── __init__.py
│   │   └── __pycache__
│   │       └── __init__.cpython-39.pyc
│   ├── conftest.py
│   ├── __init__.py
│   └── __pycache__
│       ├── cli.cpython-39.pyc
│       ├── conftest.cpython-39.pyc
│       └── __init__.cpython-39.pyc
├── __init__.py
├── __main__.py
├── __pycache__
│   ├── __init__.cpython-39.pyc
│   ├── __main__.cpython-39.pyc
│   └── version.cpython-39.pyc
└── version.py
$ $ poetry run poetry install
...
$ tree ../../.venv/lib/python3.9/site-packages/demo/
../../.venv/lib/python3.9/site-packages/demo/
├── cli
│   ├── commands
│   │   └── __pycache__
│   └── __pycache__
└── __pycache__
```
It doesn't break the installation, but I just wanted to point that out. Lastly, the `*.pth` file is cleaned correctly.
