### PR TITLE
ci: preview release builds on relevant changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - '*.*.*'
+  pull_request:
+    paths:
+      - '!**'
+      - '.github/workflows/release.yml'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - 'sonnet'
+      - 'make-nix-release.sh'
 
 jobs:
 
@@ -15,20 +23,24 @@ jobs:
     - name: Get tag
       id: tag
       run: |
-        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+        if [[ ${GITHUB_EVENT_NAME} == "tag" ]]; then
+          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+        else
+          echo ::set-output name=tag::${GITHUB_SHA::7}
+        fi
     - name: Building release
       run: |
         make linux_release
     - name: Upload release file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: poetry-${{ steps.tag.outputs.tag }}-linux.tar.gz
-        path: releases/poetry-${{ steps.tag.outputs.tag }}-linux.tar.gz
+        path: releases/poetry-*-linux.tar.gz
     - name: Upload checksum file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: poetry-${{ steps.tag.outputs.tag }}-linux.sha256sum
-        path: releases/poetry-${{ steps.tag.outputs.tag }}-linux.sha256sum
+        path: releases/poetry-*-linux.sha256sum
 
   MacOS:
     runs-on: macos-latest
@@ -38,7 +50,11 @@ jobs:
     - name: Get tag
       id: tag
       run: |
-        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+        if [[ ${GITHUB_EVENT_NAME} == "tag" ]]; then
+          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+        else
+          echo ::set-output name=tag::${GITHUB_SHA::7}
+        fi
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -72,15 +88,15 @@ jobs:
         source $HOME/.poetry/env
         poetry run python sonnet make release --ansi -P "2.7:python-2.7.18/bin/python" -P "3.5:python-3.5.9/bin/python" -P "3.6:python-3.6.8/bin/python" -P "3.7:python-3.7.6/bin/python" -P "3.8:python-3.8.3/bin/python" -P "3.9:python-3.9.5/bin/python" -P "3.10:python-3.10.2/bin/python"
     - name: Upload release file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: poetry-${{ steps.tag.outputs.tag }}-darwin.tar.gz
-        path: releases/poetry-${{ steps.tag.outputs.tag }}-darwin.tar.gz
+        path: releases/poetry-*-darwin.tar.gz
     - name: Upload checksum file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: poetry-${{ steps.tag.outputs.tag }}-darwin.sha256sum
-        path: releases/poetry-${{ steps.tag.outputs.tag }}-darwin.sha256sum
+        path: releases/poetry-*-darwin.sha256sum
 
   Windows:
     runs-on: windows-latest
@@ -91,7 +107,11 @@ jobs:
       id: tag
       shell: bash
       run: |
-        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+        if [[ ${GITHUB_EVENT_NAME} == "tag" ]]; then
+          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+        else
+          echo ::set-output name=tag::${GITHUB_SHA::7}
+        fi
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -132,19 +152,20 @@ jobs:
         $env:Path += ";$env:Userprofile\.poetry\bin"
         poetry run python sonnet make release --ansi -P "2.7:python-2.7.17\python.exe" -P "3.5:python-3.5.4\python.exe" -P "3.6:python-3.6.8\python.exe" -P "3.7:python-3.7.6\python.exe" -P "3.8:python-3.8.3\python.exe" -P "3.9:python-3.9.5\python.exe" -P "3.10:python-3.10.2\python.exe"
     - name: Upload release file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: poetry-${{ steps.tag.outputs.tag }}-win32.tar.gz
-        path: releases/poetry-${{ steps.tag.outputs.tag }}-win32.tar.gz
+        path: releases/poetry-*-win32.tar.gz
     - name: Upload checksum file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: poetry-${{ steps.tag.outputs.tag }}-win32.sha256sum
-        path: releases/poetry-${{ steps.tag.outputs.tag }}-win32.sha256sum
+        path: releases/poetry-*-win32.sha256sum
 
   Release:
     needs: [Linux, MacOS, Windows]
     runs-on: ubuntu-latest
+    if: github.event_name == 'tag'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
         7z x python-3.6.8.tar
         7z x python-3.7.6.tar
         7z x python-3.8.3.tar
+        7z x python-3.9.5.tar
         7z x python-3.10.2.tar
     - name: Build specific release
       run: |

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,13 @@ linux_release:
 	docker pull quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5
 	docker pull quay.io/pypa/manylinux2010_x86_64:2022-02-05-4cb577c
 	docker run --rm -i -v `pwd`:/io \
+		-e VENDOR_ONLY=1 \
 		-e PYTHON=/opt/python/cp38-cp38/bin/python \
 		-e PYTHON27=/opt/python/cp27-cp27m/bin/python \
 		-e PYTHON35=/opt/python/cp35-cp35m/bin/python \
 		quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5 sh -c "cd /io && ./make-nix-release.sh"
 	docker run --rm -i -v `pwd`:/io \
+		-e VENDOR_REUSE=1 \
 		-e PYTHON=/opt/python/cp38-cp38/bin/python \
 		-e PYTHON36=/opt/python/cp36-cp36m/bin/python \
 		-e PYTHON37=/opt/python/cp37-cp37m/bin/python \

--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,20 @@ wheel:
 
 linux_release:
 	docker pull quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5
+	docker pull quay.io/pypa/manylinux2010_x86_64:2022-02-05-4cb577c
 	docker run --rm -i -v `pwd`:/io \
 		-e PYTHON=/opt/python/cp38-cp38/bin/python \
 		-e PYTHON27=/opt/python/cp27-cp27m/bin/python \
 		-e PYTHON35=/opt/python/cp35-cp35m/bin/python \
+		quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5 sh -c "cd /io && ./make-nix-release.sh"
+	docker run --rm -i -v `pwd`:/io \
+		-e PYTHON=/opt/python/cp38-cp38/bin/python \
 		-e PYTHON36=/opt/python/cp36-cp36m/bin/python \
 		-e PYTHON37=/opt/python/cp37-cp37m/bin/python \
 		-e PYTHON38=/opt/python/cp38-cp38/bin/python \
 		-e PYTHON39=/opt/python/cp39-cp39/bin/python \
-		quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5 sh -c "cd /io && ./make-nix-release.sh"
+		-e PYTHON310=/opt/python/cp310-cp310/bin/python \
+		quay.io/pypa/manylinux2010_x86_64:2022-02-05-4cb577c sh -c "cd /io && ./make-nix-release.sh"
 
 # run tests against all supported python versions
 tox:

--- a/sonnet
+++ b/sonnet
@@ -14,6 +14,8 @@ from clikit.api.formatter import Style
 
 
 WINDOWS = sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt")
+VENDOR_ONLY = "VENDOR_ONLY" in os.environ
+VENDOR_REUSE = "VENDOR_REUSE" in os.environ
 
 
 class MakeReleaseCommand(Command):
@@ -69,17 +71,27 @@ class MakeReleaseCommand(Command):
         pool.add_repository(project.locker.locked_repository(with_dev_reqs=True))
 
         vcs = get_vcs(Path(__file__).parent)
+        poetry_vendor_relative = os.path.join("poetry", "_vendor")
+
         if vcs:
-            vcs_excluded = [str(f) for f in vcs.get_ignored_files()]
+            # if vendor reuse is enabled do not exclude these files
+            vcs_excluded = [
+                str(f)
+                for f in vcs.get_ignored_files()
+                if not (VENDOR_REUSE and str(f).startswith(poetry_vendor_relative))
+            ]
         else:
             vcs_excluded = []
 
         created_files = []
+        poetry_dir_src = os.path.join(os.path.dirname(__file__), "poetry")
+        poetry_vendor_src = os.path.join(poetry_dir_src, "_vendor")
+
         with temporary_directory() as tmp_dir:
             # Copy poetry to tmp dir
             poetry_dir = os.path.join(tmp_dir, "poetry")
             shutil.copytree(
-                os.path.join(os.path.dirname(__file__), "poetry"),
+                poetry_dir_src,
                 poetry_dir,
                 ignore=lambda dir_, names: set(vcs_excluded).intersection(
                     set([os.path.join(dir_, name) for name in names])
@@ -128,6 +140,16 @@ class MakeReleaseCommand(Command):
                     ]
 
                 self.line("")
+
+            if VENDOR_ONLY:
+                self.line("<info>Preserving generated vendor directory</info>")
+                shutil.copytree(
+                    os.path.join(poetry_dir, "_vendor"),
+                    poetry_vendor_src,
+                    dirs_exist_ok=True,
+                )
+                self.line("<info>Skipping packaging</info>")
+                return
 
             self.line("<info>Packaging files</info>")
             with temporary_directory() as tmp_dir2:


### PR DESCRIPTION
This change enables a preview build of release artefacts when relevant sources change. This is only triggerred on PRs as we do not want the artefacts for every branch.

This also includes a few dirty workarounds to add support for 3.10. See also #5163 and #5167. Additionally, broken windows builds are also fixed.
