### PR TITLE
Write errors and warnings to stderr (instead of stdout)

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -95,11 +95,10 @@ You can specify a package in the following forms:
 
         packages = self.argument("name")
         if self.option("dev"):
-            self.line(
+            self.line_error(
                 "<warning>The --dev option is deprecated, "
                 "use the `--group dev` notation instead.</warning>"
             )
-            self.line("")
             group = "dev"
         else:
             group = self.option("group")

--- a/src/poetry/console/commands/cache/list.py
+++ b/src/poetry/console/commands/cache/list.py
@@ -20,5 +20,5 @@ class CacheListCommand(Command):
                     self.line(f"<info>{cache.name}</>")
                 return 0
 
-        self.line("<warning>No caches found</>")
+        self.line_error("<warning>No caches found</>")
         return None

--- a/src/poetry/console/commands/check.py
+++ b/src/poetry/console/commands/check.py
@@ -23,9 +23,9 @@ class CheckCommand(Command):
             return 0
 
         for error in check_result["errors"]:
-            self.line(f"<error>Error: {error}</error>")
+            self.line_error(f"<error>Error: {error}</error>")
 
         for error in check_result["warnings"]:
-            self.line(f"<warning>Warning: {error}</warning>")
+            self.line_error(f"<warning>Warning: {error}</warning>")
 
         return 1

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -81,14 +81,14 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         if pyproject.file.exists():
             if pyproject.is_poetry_project():
-                self.line(
+                self.line_error(
                     "<error>A pyproject.toml file with a poetry section already"
                     " exists.</error>"
                 )
                 return 1
 
             if pyproject.data.get("build-system"):
-                self.line(
+                self.line_error(
                     "<error>A pyproject.toml file with a defined build-system already"
                     " exists.</error>"
                 )
@@ -235,7 +235,7 @@ You can specify a package in the following forms:
             self.line("")
 
         if not self.confirm("Do you confirm generation?", True):
-            self.line("<error>Command aborted</error>")
+            self.line_error("<error>Command aborted</error>")
 
             return 1
 
@@ -292,7 +292,7 @@ You can specify a package in the following forms:
                 canonicalized_name = canonicalize_name(constraint["name"])
                 matches = self._get_pool().search(canonicalized_name)
                 if not matches:
-                    self.line("<error>Unable to find package</error>")
+                    self.line_error("<error>Unable to find package</error>")
                     package = False
                 else:
                     choices = self._generate_choice_list(matches, canonicalized_name)

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -110,14 +110,14 @@ dependencies and not including the current project, run the command with the
         included_groups = []
         only_groups = []
         if self.option("no-dev"):
-            self.line(
+            self.line_error(
                 "<warning>The `<fg=yellow;options=bold>--no-dev</>` option is"
                 " deprecated, use the `<fg=yellow;options=bold>--without dev</>`"
                 " notation instead.</warning>"
             )
             excluded_groups.append("dev")
         elif self.option("dev-only"):
-            self.line(
+            self.line_error(
                 "<warning>The `<fg=yellow;options=bold>--dev-only</>` option is"
                 " deprecated, use the `<fg=yellow;options=bold>--only dev</>` notation"
                 " instead.</warning>"
@@ -151,7 +151,7 @@ dependencies and not including the current project, run the command with the
 
         with_synchronization = self.option("sync")
         if self.option("remove-untracked"):
-            self.line(
+            self.line_error(
                 "<warning>The `<fg=yellow;options=bold>--remove-untracked</>` option is"
                 " deprecated, use the `<fg=yellow;options=bold>--sync</>` option"
                 " instead.</warning>"

--- a/src/poetry/console/commands/lock.py
+++ b/src/poetry/console/commands/lock.py
@@ -40,7 +40,7 @@ file.
             if self.poetry.locker.is_locked() and self.poetry.locker.is_fresh():
                 self.line("poetry.lock is consistent with pyproject.toml.")
                 return 0
-            self.line(
+            self.line_error(
                 "<error>"
                 "Error: poetry.lock is not consistent with pyproject.toml. "
                 "Run `poetry lock [--no-update]` to fix it."

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -36,11 +36,10 @@ list of installed packages
         packages = self.argument("packages")
 
         if self.option("dev"):
-            self.line(
+            self.line_error(
                 "<warning>The --dev option is deprecated, "
                 "use the `--group dev` notation instead.</warning>"
             )
-            self.line("")
             group = "dev"
         else:
             group = self.option("group")

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -98,7 +98,7 @@ lists all packages available."""
         included_groups = []
         only_groups = []
         if self.option("no-dev"):
-            self.line(
+            self.line_error(
                 "<warning>The `<fg=yellow;options=bold>--no-dev</>` option is"
                 " deprecated, use the `<fg=yellow;options=bold>--without dev</>`"
                 " notation instead.</warning>"

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -256,7 +256,7 @@ class Installer:
             locked_repository = self._locker.locked_repository(True)
 
             if not self._locker.is_fresh():
-                self._io.write_line(
+                self._io.write_error_line(
                     "<warning>"
                     "Warning: poetry.lock is not consistent with pyproject.toml. "
                     "You may be getting improper dependencies. "

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -83,7 +83,7 @@ class EditableBuilder(Builder):
         has_setup = setup.exists()
 
         if has_setup:
-            self._io.write_line(
+            self._io.write_error_line(
                 "<warning>A setup.py file already exists. Using it.</warning>"
             )
         else:

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -860,7 +860,7 @@ class EnvManager:
                     self._poetry.package.python_versions, python_patch
                 )
 
-            io.write_line(
+            io.write_error_line(
                 f"<warning>The currently activated Python version {python_patch} is not"
                 f" supported by the project ({self._poetry.package.python_versions}).\n"
                 "Trying to find and use a compatible version.</warning> "
@@ -936,7 +936,7 @@ class EnvManager:
             create_venv = False
             if force:
                 if not env.is_sane():
-                    io.write_line(
+                    io.write_error_line(
                         f"<warning>The virtual environment found in {env.path} seems to"
                         " be broken.</warning>"
                     )

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -857,9 +857,11 @@ def test_add_to_dev_section_deprecated(
 
     tester.execute("cachy --dev")
 
-    expected = """\
+    warning = """\
 The --dev option is deprecated, use the `--group dev` notation instead.
+"""
 
+    expected = """\
 Using version ^0.2.0 for cachy
 
 Updating dependencies
@@ -872,6 +874,7 @@ Package operations: 1 install, 0 updates, 0 removals
   • Installing cachy (0.2.0)
 """
 
+    assert tester.io.fetch_error() == warning
     assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
 

--- a/tests/console/commands/test_cache.py
+++ b/tests/console/commands/test_cache.py
@@ -68,4 +68,4 @@ def test_cache_list_empty(tester: "CommandTester", repository_cache_dir: "Path")
 No caches found
 """
 
-    assert tester.io.fetch_output() == expected
+    assert tester.io.fetch_error() == expected

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -45,4 +45,4 @@ Warning: The "pendulum" dependency specifies the "allows-prereleases" property,\
  which is deprecated. Use "allow-prereleases" instead.
 """
 
-    assert tester.io.fetch_output() == expected
+    assert tester.io.fetch_error() == expected

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -811,7 +811,7 @@ build-backend = "setuptools.build_meta"
     pyproject_file.write_text(decode(existing_section))
     tester.execute(inputs=init_basic_inputs)
     assert (
-        tester.io.fetch_output().strip()
+        tester.io.fetch_error().strip()
         == "A pyproject.toml file with a defined build-system already exists."
     )
     assert existing_section in pyproject_file.read_text()

--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -86,7 +86,7 @@ def test_lock_check_outdated(
         "Run `poetry lock [--no-update]` to fix it.\n"
     )
 
-    assert tester.io.fetch_output() == expected
+    assert tester.io.fetch_error() == expected
 
     # exit with an error
     assert status_code == 1


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5177

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Currently, warnings are often (not always) written to stdout. Sometimes even errors are written to stdout.

Probably, errors and warnings should be written to stderr. See [this Stack Overflow post](https://stackoverflow.com/questions/1430956/should-i-output-warnings-to-stderr-or-stdout) for example.