### PR TITLE
adds no-root to config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,16 @@ If not set explicitly (default), `poetry` will use the virtualenv from the `.ven
 directory when one is available. If set to `false`, `poetry` will ignore any
 existing `.venv` directory.
 
+### `virtualenvs.no-root`
+
+**Type**: boolean
+
+Do not install the root package.
+Equivalent to `--no-root` option in `install` command.
+Defaults to `False`.
+
+If the `install` `--no-root` option is set, it overrides the config's default value.
+
 ### `virtualenvs.path`
 
 **Type**: string

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -137,6 +137,7 @@ class Config:
         if name in {
             "virtualenvs.create",
             "virtualenvs.in-project",
+            "virtualenvs.no-root",
             "virtualenvs.options.always-copy",
             "virtualenvs.options.system-site-packages",
             "virtualenvs.options.prefer-active-python",

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -65,6 +65,7 @@ To remove a repository (repo is a short alias for repositories):
             ),
             "virtualenvs.create": (boolean_validator, boolean_normalizer, True),
             "virtualenvs.in-project": (boolean_validator, boolean_normalizer, False),
+            "virtualenvs.no-root": (boolean_validator, boolean_normalizer, False),
             "virtualenvs.options.always-copy": (
                 boolean_validator,
                 boolean_normalizer,

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -171,7 +171,10 @@ dependencies and not including the current project, run the command with the
         if return_code != 0:
             return return_code
 
-        if self.option("no-root") or self.option("only"):
+        no_root = self.option("no-root") or self.poetry.config.get(
+            "virtualenvs.no-root", False
+        )
+        if no_root or self.option("only"):
             return 0
 
         try:

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from cleo.testers.command_tester import CommandTester
     from pytest_mock import MockerFixture
 
+    from tests.conftest import Config
     from tests.types import CommandTesterFactory
 
 
@@ -41,3 +42,24 @@ def test_sync_option_is_passed_to_the_installer(
     tester.execute("--sync")
 
     assert tester.command.installer._requires_synchronization
+
+
+def test_no_root(tester: "CommandTester", mocker: "MockerFixture"):
+    mocker.patch.object(tester.command.installer, "run", return_value=0)
+    from poetry.masonry.builders import EditableBuilder
+
+    mock = mocker.patch.object(EditableBuilder, "__init__")
+    tester.execute("--no-root")
+    mock.assert_not_called()
+
+
+def test_no_root_config(
+    tester: "CommandTester", mocker: "MockerFixture", config: "Config"
+):
+    mocker.patch.object(tester.command.installer, "run", return_value=0)
+    from poetry.masonry.builders import EditableBuilder
+
+    mock = mocker.patch.object(EditableBuilder, "__init__")
+    config.merge({"virtualenvs": {"no-root": True}})
+    tester.execute("")
+    mock.assert_not_called()


### PR DESCRIPTION
# Pull Request Check List
I have a project where I don't want to install the root package and i keep forgetting to add --no-root to the install command. Being able to set no-root in the local config would make life easier. 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
