### PR TITLE
Backport PR #3337 - Fix handling errors 401, 403 when looking for repositories

### DIFF
--- a/poetry/repositories/legacy_repository.py
+++ b/poetry/repositories/legacy_repository.py
@@ -386,18 +386,17 @@ class LegacyRepository(PyPiRepository):
         url = self._url + endpoint
         try:
             response = self.session.get(url)
+            if response.status_code in (401, 403):
+                self._log(
+                    "Authorization error accessing {url}".format(url=url),
+                    level="warning",
+                )
+                return
             if response.status_code == 404:
                 return
             response.raise_for_status()
         except requests.HTTPError as e:
             raise RepositoryError(e)
-
-        if response.status_code in (401, 403):
-            self._log(
-                "Authorization error accessing {url}".format(url=response.url),
-                level="warn",
-            )
-            return
 
         if response.url != url:
             self._log(

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -320,19 +320,18 @@ def test_get_200_returns_page(http):
     assert repo._get("/foo")
 
 
-def test_get_404_returns_none(http):
-    repo = MockHttpRepository({"/foo": 404}, http)
+@pytest.mark.parametrize("status_code", [401, 403, 404])
+def test_get_40x_and_returns_none(http, status_code):
+    repo = MockHttpRepository({"/foo": status_code}, http)
 
     assert repo._get("/foo") is None
 
 
-def test_get_4xx_and_5xx_raises(http):
-    endpoints = {"/{}".format(code): code for code in {401, 403, 500}}
-    repo = MockHttpRepository(endpoints, http)
+def test_get_5xx_raises(http):
+    repo = MockHttpRepository({"/foo": 500}, http)
 
-    for endpoint in endpoints:
-        with pytest.raises(RepositoryError):
-            repo._get(endpoint)
+    with pytest.raises(RepositoryError):
+        repo._get("/foo")
 
 
 def test_get_redirected_response_url(http, mocker):


### PR DESCRIPTION
Backport of #3337 which fixes #3303 to the 1.1 branch, so that it can be part of the next 1.1.x release :slightly_smiling_face:

/cc @finswimmer