### PR TITLE
change importlib-metadata dependency to >=1.6.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -705,7 +705,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a9b760bb9c29d1bd8835504dde250fae18549ecb21127219d6daf4e6cd26c2e9"
+content-hash = "ee10e5e287aa89d59319a991a8d7b821dbe70499d1f040b6f50bd27cb065e889"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ cleo = "^1.0.0a4"
 crashtest = "^0.3.0"
 entrypoints = "^0.3"
 html5lib = "^1.0"
-importlib-metadata = { version = "^1.6.0", python = "<3.8" }
+importlib-metadata = { version = ">=1.6.0", python = "<3.8" }
 keyring = ">=21.2.0"
 packaging = "^20.4"
 pexpect = "^4.7.0"


### PR DESCRIPTION
Changes version constraint for `importlib-metadata` to `>=1.6.0`, because dependencies like `keyring` starts to depend on more recent major versions if it.

Related: https://github.com/python-poetry/poetry/issues/5226