### PR TITLE
Remove pip_editable_install wrapper in favor of editable=True

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -26,7 +26,6 @@ from poetry.utils.authenticator import Authenticator
 from poetry.utils.env import EnvCommandError
 from poetry.utils.helpers import pluralize
 from poetry.utils.helpers import safe_rmtree
-from poetry.utils.pip import pip_editable_install
 from poetry.utils.pip import pip_install
 
 
@@ -115,12 +114,8 @@ class Executor:
     def pip_install(
         self, req: Path | Link, upgrade: bool = False, editable: bool = False
     ) -> int:
-        func = pip_install
-        if editable:
-            func = pip_editable_install
-
         try:
-            func(req, self._env, upgrade=upgrade)
+            pip_install(req, self._env, upgrade=upgrade, editable=editable)
         except EnvCommandError as e:
             output = decode(e.e.output)
             if (
@@ -572,11 +567,11 @@ class Executor:
 
                 with builder.setup_py():
                     if package.develop:
-                        return self.pip_install(req, editable=True)
+                        return self.pip_install(req, upgrade=True, editable=True)
                     return self.pip_install(req, upgrade=True)
 
         if package.develop:
-            return self.pip_install(req, editable=True)
+            return self.pip_install(req, upgrade=True, editable=True)
 
         return self.pip_install(req, upgrade=True)
 

--- a/src/poetry/installation/pip_installer.py
+++ b/src/poetry/installation/pip_installer.py
@@ -14,7 +14,6 @@ from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.installation.base_installer import BaseInstaller
 from poetry.utils._compat import encode
 from poetry.utils.helpers import safe_rmtree
-from poetry.utils.pip import pip_editable_install
 from poetry.utils.pip import pip_install
 
 
@@ -231,15 +230,20 @@ class PipInstaller(BaseInstaller):
 
                 with builder.setup_py():
                     if package.develop:
-                        return pip_editable_install(
-                            directory=req, environment=self._env
+                        return pip_install(
+                            directory=req,
+                            environment=self._env,
+                            upgrade=True,
+                            editable=True,
                         )
                     return pip_install(
                         path=req, environment=self._env, deps=False, upgrade=True
                     )
 
         if package.develop:
-            return pip_editable_install(directory=req, environment=self._env)
+            return pip_install(
+                directory=req, environment=self._env, upgrade=True, editable=True
+            )
         return pip_install(path=req, environment=self._env, deps=False, upgrade=True)
 
     def install_git(self, package: Package) -> None:

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -16,7 +16,7 @@ from poetry.core.semver.version import Version
 from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import decode
 from poetry.utils.helpers import is_dir_writable
-from poetry.utils.pip import pip_editable_install
+from poetry.utils.pip import pip_install
 
 
 if TYPE_CHECKING:
@@ -93,14 +93,14 @@ class EditableBuilder(Builder):
 
         try:
             if self._env.pip_version < Version.from_parts(19, 0):
-                pip_editable_install(self._path, self._env)
+                pip_install(self._path, self._env, upgrade=True, editable=True)
             else:
                 # Temporarily rename pyproject.toml
                 shutil.move(
                     str(self._poetry.file), str(self._poetry.file.with_suffix(".tmp"))
                 )
                 try:
-                    pip_editable_install(self._path, self._env)
+                    pip_install(self._path, self._env, upgrade=True, editable=True)
                 finally:
                     shutil.move(
                         str(self._poetry.file.with_suffix(".tmp")),

--- a/src/poetry/utils/pip.py
+++ b/src/poetry/utils/pip.py
@@ -53,9 +53,3 @@ def pip_install(
         return environment.run_pip(*args)
     except EnvCommandError as e:
         raise PoetryException(f"Failed to install {path.as_posix()}") from e
-
-
-def pip_editable_install(directory: Path | Link, environment: Env) -> int | str:
-    return pip_install(
-        path=directory, environment=environment, editable=True, deps=False, upgrade=True
-    )

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -106,9 +106,7 @@ def test_execute_executes_a_batch_of_operations(
     mock_file_downloads: None,
     env: MockEnv,
 ):
-    pip_editable_install = mocker.patch(
-        "poetry.installation.executor.pip_editable_install"
-    )
+    pip_install = mocker.patch("poetry.installation.executor.pip_install")
 
     config.merge({"cache-dir": tmp_dir})
 
@@ -171,9 +169,10 @@ Package operations: 4 installs, 1 update, 1 removal
     expected = set(expected.splitlines())
     output = set(io.fetch_output().splitlines())
     assert output == expected
-    assert len(env.executed) == 5
+    assert len(env.executed) == 1
     assert return_code == 0
-    pip_editable_install.assert_called_once()
+    assert pip_install.call_count == 5
+    assert pip_install.call_args.kwargs == {"upgrade": True, "editable": True}
 
 
 def test_execute_shows_skipped_operations_if_verbose(

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -172,7 +172,8 @@ Package operations: 4 installs, 1 update, 1 removal
     assert len(env.executed) == 1
     assert return_code == 0
     assert pip_install.call_count == 5
-    assert pip_install.call_args.kwargs == {"upgrade": True, "editable": True}
+    assert pip_install.call_args.kwargs.get("upgrade", False)
+    assert pip_install.call_args.kwargs.get("editable", False)
 
 
 def test_execute_shows_skipped_operations_if_verbose(

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -192,15 +192,13 @@ if __name__ == '__main__':
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(
     mocker: MockerFixture, extended_poetry: Poetry, tmp_dir: str
 ):
-    pip_editable_install = mocker.patch(
-        "poetry.masonry.builders.editable.pip_editable_install"
-    )
+    pip_install = mocker.patch("poetry.masonry.builders.editable.pip_install")
     env = MockEnv(path=Path(tmp_dir) / "foo")
     builder = EditableBuilder(extended_poetry, env, NullIO())
 
     builder.build()
-    pip_editable_install.assert_called_once_with(
-        extended_poetry.pyproject.file.path.parent, env
+    pip_install.assert_called_once_with(
+        extended_poetry.pyproject.file.path.parent, env, upgrade=True, editable=True
     )
     assert [] == env.executed
 


### PR DESCRIPTION
Follows the suggestion in [this comment](https://github.com/python-poetry/poetry/issues/4265#issuecomment-954226668).

 * Testing code was modified to reflect the removal of `pip_editable_install`. Where `pip_install` is now mocked instead, some call checks had to be updated.
 * Calls to `pip_install` where `editable=True` (also `self.pip_install` within `Executor`) have been updated to explicitly set `upgrade=True` to maintain the previous behavior, although I am not sure it that is actually the desired behavior in all cases.

# Pull Request Check List

Resolves: python-poetry#4265

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
