### PR TITLE
test: isolate environment from user config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,3 +84,5 @@ jobs:
 
       - name: Run pytest
         run: poetry run python -m pytest -p no:sugar -q tests/
+        env:
+          POETRY_VIRTUALENVS_IN_PROJECT: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,5 +84,3 @@ jobs:
 
       - name: Run pytest
         run: poetry run python -m pytest -p no:sugar -q tests/
-        env:
-          POETRY_VIRTUALENVS_IN_PROJECT: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,21 @@ def environ() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
+def isolate_environ() -> Iterator[None]:
+    """Ensure the environment is isolated from user configuration."""
+    original_environ = dict(os.environ)
+
+    for var in os.environ:
+        if var.startswith("POETRY_"):
+            del os.environ[var]
+
+    yield
+
+    os.environ.clear()
+    os.environ.update(original_environ)
+
+
+@pytest.fixture(autouse=True)
 def git_mock(mocker: MockerFixture) -> None:
     # Patch git module to not actually clone projects
     mocker.patch("poetry.core.vcs.git.Git.clone", new=mock_clone)


### PR DESCRIPTION
I use environment variables to configure poetry, and noticed this causes test failures.
As a fix, this adds a fixture to isolate the test environment from any poetry-related configuration.
