### PR TITLE
fix(show): handle missing lockfile

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -130,6 +130,13 @@ lists all packages available."""
         if self.option("default"):
             only_groups.append("default")
 
+        if not self.poetry.locker.is_locked():
+            self.line_error(
+                "<error>Error: poetry.lock not found. Run `poetry lock` to create"
+                " it.</error>"
+            )
+            return 1
+
         locked_repo = self.poetry.locker.locked_repository(True)
 
         if only_groups:

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1587,3 +1587,13 @@ required by
 """.splitlines()
     actual = [line.rstrip() for line in tester.io.fetch_output().splitlines()]
     assert actual == expected
+
+
+def test_show_errors_without_lock_file(tester: "CommandTester", poetry: "Poetry"):
+    assert not poetry.locker.lock.exists()
+
+    tester.execute()
+
+    expected = "Error: poetry.lock not found. Run `poetry lock` to create it.\n"
+    assert tester.io.fetch_error() == expected
+    assert tester.status_code == 1


### PR DESCRIPTION
`poetry show` relies on the existence of `poetry.lock` to display dependencies, but it currently throws a `SolverProblemError` if this file doesn't exist yet. This checks if the lockfile is missing and errors, if needed.

# Pull Request Check List

Resolves: #5240

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
