### PR TITLE
fix(run): improve error when command not found

### DIFF
--- a/src/poetry/console/commands/run.py
+++ b/src/poetry/console/commands/run.py
@@ -29,7 +29,11 @@ class RunCommand(EnvCommand):
         if scripts and script in scripts:
             return self.run_script(scripts[script], args)
 
-        return self.env.execute(*args)
+        try:
+            return self.env.execute(*args)
+        except FileNotFoundError:
+            self.line_error(f"<error>Command not found: <c1>{script}</c1></error>")
+            return 1
 
     @property
     def _module(self) -> "Module":

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -37,3 +37,14 @@ def test_run_keeps_options_passed_before_command(
         app_tester.application.long_version + "\n"
     )
     assert [] == env.executed
+
+
+def test_run_has_helpful_error_when_command_not_found(
+    app_tester: "ApplicationTester", env: "MockEnv"
+):
+    env._execute = True
+    app_tester.execute("run nonexistent-command")
+
+    assert env.executed == [["nonexistent-command"]]
+    assert app_tester.status_code == 1
+    assert app_tester.io.fetch_error() == "Command not found: nonexistent-command\n"


### PR DESCRIPTION
`poetry run` currently throws a cryptic `FileNotFoundError` when the command is not found on PATH. This PR adds a more succinct and hopefully more helpful error message.

Before:

```
$ poetry run nonexistent-command

  FileNotFoundError

  [Errno 2] No such file or directory: b'/Library/Apple/usr/bin/nonexistent-command'

  at /usr/local/Cellar/python@3.10/3.10.2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/os.py:607 in _execvpe
       603│         path_list = map(fsencode, path_list)
       604│     for dir in path_list:
       605│         fullname = path.join(dir, file)
       606│         try:
    →  607│             exec_func(fullname, *argrest)
       608│         except (FileNotFoundError, NotADirectoryError) as e:
       609│             last_exc = e
       610│         except OSError as e:
       611│             last_exc = e
```

After:

```console
$ poetry run nonexistent-command
Command not found: nonexistent-command
```

# Pull Request Check List

Resolves: #1567

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
