### PR TITLE
fix formatting by pyupgrade

### DIFF
--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -42,7 +42,7 @@ def test_run_keeps_options_passed_before_command(
 
 
 def test_run_has_helpful_error_when_command_not_found(
-    app_tester: "ApplicationTester", env: "MockEnv"
+    app_tester: ApplicationTester, env: MockEnv
 ):
     env._execute = True
     app_tester.execute("run nonexistent-command")

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1589,7 +1589,7 @@ required by
     assert actual == expected
 
 
-def test_show_errors_without_lock_file(tester: "CommandTester", poetry: "Poetry"):
+def test_show_errors_without_lock_file(tester: CommandTester, poetry: Poetry):
     assert not poetry.locker.lock.exists()
 
     tester.execute()


### PR DESCRIPTION
https://github.com/python-poetry/poetry/pull/5088 add `from __future__ import annotations` to several files, which results in unquoted type annotations.

The commits merged to master afterwards succeeded the pre-commit before merge the change was introduce but now results in a failing pipeline.