### PR TITLE
remove `__future__` import from src/poetry/__init__.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,11 @@ repos:
         name: "isort (python)"
         types: [python]
         args: [--add-import, from __future__ import annotations]
-        exclude: ^(install|get)-poetry.py$
+        exclude: |
+          (?x)(
+             ^(install|get)-poetry.py$
+              | ^src/poetry/__init__.py$
+          )
       - id: isort
         name: "isort (pyi)"
         types: [pyi]

--- a/src/poetry/__init__.py
+++ b/src/poetry/__init__.py
@@ -1,4 +1,5 @@
-from __future__ import annotations
-
-
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
+# When editing this file make sure line 1 keeps unchanged.
+# Setting __path__ must take place in the first line. No line breaks are allowed either.
+# Otherwise, IDEs like PyCharm are unable to follow imports to poetry.core.


### PR DESCRIPTION
Setting `__path__` in `src/poetry/__init__.py` must be the first line, otherwise IDEs like PyCharm cannot follow imports to `poetry.core`.