### PR TITLE
chore(repositories): remove type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ module = [
   'poetry.installation.executor',
   'poetry.installation.installer',
   'poetry.installation.pip_installer',
-  'poetry.repositories.installed_repository',
   'poetry.utils.env',
 ]
 ignore_errors = true

--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -106,7 +106,7 @@ class InstalledRepository(Repository):
     ) -> Package:
         # We first check for a direct_url.json file to determine
         # the type of package.
-        path = Path(str(distribution._path))
+        path = Path(str(distribution._path))  # type: ignore[attr-defined]
 
         if (
             path.name.endswith(".dist-info")
@@ -172,7 +172,7 @@ class InstalledRepository(Repository):
 
     @classmethod
     def create_package_from_pep610(cls, distribution: metadata.Distribution) -> Package:
-        path = Path(str(distribution._path))
+        path = Path(str(distribution._path))  # type: ignore[attr-defined]
         source_type = None
         source_url = None
         source_reference = None
@@ -233,14 +233,14 @@ class InstalledRepository(Repository):
         for entry in reversed(env.sys_path):
             for distribution in sorted(
                 metadata.distributions(path=[entry]),
-                key=lambda d: str(d._path),
+                key=lambda d: str(d._path),  # type: ignore[attr-defined]
             ):
                 name = canonicalize_name(distribution.metadata["name"])
 
                 if name in seen:
                     continue
 
-                path = Path(str(distribution._path))
+                path = Path(str(distribution._path))  # type: ignore[attr-defined]
 
                 try:
                     path.relative_to(_VENDORS)


### PR DESCRIPTION
[`Distribution`](https://github.com/python/importlib_metadata/blob/14cce75299645467adcd17352cb07caada32c444/importlib_metadata/__init__.py#L513) seems to be mostly an abstract class, with a single concrete [`PathDistribution`](https://github.com/python/importlib_metadata/blob/14cce75299645467adcd17352cb07caada32c444/importlib_metadata/__init__.py#L910). We assume we're working with a`PathDistribution`, which has a `_path` but [not publicly typed](https://github.com/python/typeshed/blob/cf3ea5b6e651cea36c3539f66fdb33b585fc85d8/stdlib/importlib/metadata/__init__.pyi#L187-L190), so not sure what else to do besides `type: ignore`
