### PR TITLE
PEP610: handle optional vcs_info.requested_version

### DIFF
--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -201,8 +201,10 @@ class InstalledRepository(Repository):
             # VCS distribution
             source_type = url_reference["vcs_info"]["vcs"]
             source_url = url_reference["url"]
-            source_reference = url_reference["vcs_info"]["requested_revision"]
             source_resolved_reference = url_reference["vcs_info"]["commit_id"]
+            source_reference = url_reference["vcs_info"].get(
+                "requested_revision", source_resolved_reference
+            )
 
         package = Package(
             distribution.metadata["name"],

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/git_pep_610_no_requested_version-1.2.3.dist-info/METADATA
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/git_pep_610_no_requested_version-1.2.3.dist-info/METADATA
@@ -1,0 +1,6 @@
+Metadata-Version: 2.1
+Name: git-pep-610-no-requested-version
+Version: 1.2.3
+Summary: Foo
+License: MIT
+Requires-Python: >=3.6

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/git_pep_610_no_requested_version-1.2.3.dist-info/direct_url.json
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/git_pep_610_no_requested_version-1.2.3.dist-info/direct_url.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/demo/git-pep-610-no-requested-version.git",
+  "vcs_info": {
+    "vcs": "git",
+    "commit_id": "123456"
+  }
+}

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -34,6 +34,9 @@ INSTALLED_RESULTS = [
     metadata.PathDistribution(SITE_PLATLIB / "lib64-2.3.4.dist-info"),
     metadata.PathDistribution(SITE_PLATLIB / "bender-2.0.5.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "git_pep_610-1.2.3.dist-info"),
+    metadata.PathDistribution(
+        SITE_PURELIB / "git_pep_610_no_requested_version-1.2.3.dist-info"
+    ),
     metadata.PathDistribution(SITE_PURELIB / "url_pep_610-1.2.3.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "file_pep_610-1.2.3.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "directory_pep_610-1.2.3.dist-info"),
@@ -187,6 +190,25 @@ def test_load_pep_610_compliant_git_packages(repository: InstalledRepository):
     assert package.source_url == "https://github.com/demo/git-pep-610.git"
     assert package.source_reference == "my-branch"
     assert package.source_resolved_reference == "123456"
+
+
+def test_load_pep_610_compliant_git_packages_no_requested_version(
+    repository: InstalledRepository,
+):
+    package = get_package_from_repository(
+        "git-pep-610-no-requested-version", repository
+    )
+
+    assert package is not None
+    assert package.name == "git-pep-610-no-requested-version"
+    assert package.version.text == "1.2.3"
+    assert package.source_type == "git"
+    assert (
+        package.source_url
+        == "https://github.com/demo/git-pep-610-no-requested-version.git"
+    )
+    assert package.source_resolved_reference == "123456"
+    assert package.source_reference == package.source_resolved_reference
 
 
 def test_load_pep_610_compliant_url_packages(repository: InstalledRepository):

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -995,7 +995,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility_with_executable(
 
 
 def test_create_venv_fails_if_current_python_version_is_not_supported(
-    manager: EnvManager, poetry: "Poetry"
+    manager: EnvManager, poetry: Poetry
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]


### PR DESCRIPTION
As per PEP610, presence of `vcs_info.requested_version` is optional in
direct_url.json for vcs packages. Prior to this change, Poetry would
crash when loading an environment with a vcs package not installed by
Poetry.

This PR also contains a linting fix for issue introduced in #4520.

**Reference:**
https://www.python.org/dev/peps/pep-0610/#specification
> A requested_revision key (type string) MAY be present naming a branch/tag/ref/commit/revision/etc (in a format compatible with the VCS) to install.