### PR TITLE
show poetry and poetry-core version in output of `poetry about`

### DIFF
--- a/src/poetry/console/commands/about.py
+++ b/src/poetry/console/commands/about.py
@@ -10,9 +10,14 @@ class AboutCommand(Command):
     description = "Shows information about Poetry."
 
     def handle(self) -> None:
+        from poetry.utils._compat import metadata
+
         self.line(
-            """\
-<info>Poetry - Package Management for Python</info>
+            f"""\
+<info>Poetry - Package Management for Python
+
+Version: {metadata.version('poetry')}
+Poetry-Core Version: {metadata.version('poetry-core')}</info>
 
 <comment>Poetry is a dependency manager tracking local dependencies of your projects\
  and libraries.

--- a/tests/console/commands/test_about.py
+++ b/tests/console/commands/test_about.py
@@ -17,9 +17,15 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
 
 
 def test_about(tester: CommandTester):
+    from poetry.utils._compat import metadata
+
     tester.execute()
-    expected = """\
+
+    expected = f"""\
 Poetry - Package Management for Python
+
+Version: {metadata.version('poetry')}
+Poetry-Core Version: {metadata.version('poetry-core')}
 
 Poetry is a dependency manager tracking local dependencies of your projects and\
  libraries.


### PR DESCRIPTION
Adds info about the version of poetry and poetry-core to the output of `poetry about`.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
