### PR TITLE
support for POETRY_CONFIG_DIR, POETRY_DATA_DIR and POETRY_CACHE_DIR environment variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,34 @@ This also works for secret settings, like credentials:
 export POETRY_HTTP_BASIC_MY_REPOSITORY_PASSWORD=secret
 ```
 
+## Default Directories
+
+Poetry uses the following default directories:
+
+### Config Directory
+
+- Linux: `$XDG_CONFIG_HOME/pypoetry` or `~/.config/pypoetry`
+- Windows: `%APPDATA%\pypoetry`
+- MacOS: `~/Library/Preferences/pypoetry`
+
+You can override the Config directory by setting the `POETRY_CONFIG_DIR` environment variable.
+
+### Data Directory
+
+- Linux: `$XDG_DATA_HOME/pypoetry` or `~/.local/share/pypoetry`
+- Windows: `%APPDATA%\pypoetry`
+- MacOS: `~/Library/Application Support/pypoetry`
+
+You can override the Data directory by setting the `POETRY_DATA_DIR` or `POETRY_HOME` environment variables. If `POETRY_HOME` is set, it will be given higher priority.
+
+### Cache Directory
+
+- Linux: `$XDG_CACHE_HOME/pypoetry` or `~/.cache/pypoetry`
+- Windows: `%APPDATA%\pypoetry\Cache`
+- MacOS: `~/Library/Caches/pypoetry`
+
+You can override the Cache directory by setting the `POETRY_CACHE_DIR` environment variable.
+
 ## Available settings
 
 ### `cache-dir`


### PR DESCRIPTION
* use PROJECT_HOME if available instead of XDG variables in unix systems

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

I have created this new PR as I'm not at all satisfied modifying XDG variables in order to make poetry properly set its cache dir under my preferred directory. For some reason, my previous PR https://github.com/python-poetry/poetry/pull/3550 was rejected because I tried to modify depreciated get-poetry.py (which is silly because when that PR created, get-poetry.py was the primary way to install poetry) and I tried to use the already available POETRY_HOME variable to achieve my purpose. 

Anyway, I rectified both  issues and creating this PR in hope that poetry devs understand XDG variables are common variables used by many application and should be used as fallback rather then expecting users to modify XDG in order to make poetry store its cache under their preferred directory.

May fix https://github.com/python-poetry/poetry/issues/2445