### PR TITLE
Solver fixes

### DIFF
--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -339,7 +339,7 @@ class PackageNode(DFSNode):
                         and dependency.constraint.allows(pkg.version.stable)
                     )
                     and not any(
-                        child.package.name == pkg.name
+                        child.package.complete_name == pkg.complete_name
                         and child.groups == dependency.groups
                         for child in children
                     )


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4683
Resolves: #5019

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

A series of commits tidying up the depth-first search in the solver, and a fix for #4683 (and its duplicate #5019)

- `seen` on the `PackageNode` should clearly be a set rather than a list, for efficient lookup
  -  (actually I suspect that this is redundant because of `visited` in the search, and should be removed altogether... maybe another time)

- `visited` in the search was strangely and unnecessarily complicated, I made it normal

- `dfs_visit()` always returned `True`; it has no need of a return value at all

- A testcase and fix for #4683: in the language of the added testcase, the fix is to make sure that we visit both `B` and `B[bar]` in the search