### PR TITLE
Test: dependencies not matching the project's python constraint are ignored

### DIFF
--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -418,6 +418,30 @@ def test_solver_fails_if_mismatch_root_python_versions(
         solver.solve()
 
 
+def test_solver_ignores_python_restricted_if_mismatch_root_package_python_versions(
+    solver: Solver, repo: Repository, package: ProjectPackage
+):
+    solver.provider.set_package_python_versions("~3.8")
+    package.add_dependency(
+        Factory.create_dependency("A", {"version": "1.0", "python": "<3.8"})
+    )
+    package.add_dependency(
+        Factory.create_dependency(
+            "B", {"version": "1.0", "markers": "python_version < '3.8'"}
+        )
+    )
+
+    package_a = get_package("A", "1.0")
+    package_b = get_package("B", "1.0")
+
+    repo.add_package(package_a)
+    repo.add_package(package_b)
+
+    transaction = solver.solve()
+
+    check_solver_result(transaction, [])
+
+
 def test_solver_solves_optional_and_compatible_packages(
     solver: Solver, repo: Repository, package: ProjectPackage
 ):


### PR DESCRIPTION
(no matter if the python version is specified by "python" keyword or by "markers")

# Pull Request Check List

Relates-to: #4958

Increases test coverage.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Picks up the test case from #4958 to increase test coverage. The fix from #4958 is not required because the issue had already been fixed upstream. This upstream fix has been made available via poetry-core 1.1.0a7.