### PR TITLE
Remove some workarounds not required anymore with poetry-core 1.1.0a7

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -189,12 +189,7 @@ class Provider:
 
         dependency._source_reference = package.source_reference
         dependency._source_resolved_reference = package.source_resolved_reference
-
-        if hasattr(package, "source_subdirectory") and hasattr(
-            dependency, "_source_subdirectory"
-        ):
-            # this is supported only for poetry-core >= 1.1.0a7
-            dependency._source_subdirectory = package.source_subdirectory
+        dependency._source_subdirectory = package.source_subdirectory
 
         self._deferred_cache[dependency] = package
 
@@ -671,10 +666,6 @@ class Provider:
                         dep_other.set_constraint(
                             dep_other.constraint.intersect(dep_any.constraint)
                         )
-                        # TODO: Setting _pretty_constraint can be removed once the
-                        # following issue has been fixed:
-                        # https://github.com/python-poetry/poetry/issues/4589
-                        dep_other._pretty_constraint = str(dep_other.constraint)
 
             overrides = []
             for _dep in _deps:

--- a/tests/utils/test_exporter.py
+++ b/tests/utils/test_exporter.py
@@ -1036,26 +1036,15 @@ def test_exporter_can_export_requirements_txt_with_nested_packages_and_multiple_
     with (Path(tmp_dir) / "requirements.txt").open(encoding="utf-8") as f:
         content = f.read()
 
-    expected = (
-        # expectation for poetry-core <= 1.1.0a6
-        textwrap.dedent(
-            """\
-            bar==7.8.9 ; platform_system != "Windows" or platform_system == "Windows"
-            baz==10.11.13 ; platform_system == "Windows"
-            foo==1.2.3
-            """
-        ),
-        # expectation for poetry-core > 1.1.0a6
-        textwrap.dedent(
-            """\
-            bar==7.8.9
-            baz==10.11.13 ; platform_system == "Windows"
-            foo==1.2.3
-            """
-        ),
+    expected = textwrap.dedent(
+        """\
+        bar==7.8.9
+        baz==10.11.13 ; platform_system == "Windows"
+        foo==1.2.3
+        """
     )
 
-    assert content in expected
+    assert content == expected
 
 
 def test_exporter_can_export_requirements_txt_with_git_packages_and_markers(


### PR DESCRIPTION
The title says it all, doesn't it? 😉