### PR TITLE
Removing unused and unnecessary code

### DIFF
--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import enum
 import time
 
 from collections import defaultdict
@@ -195,17 +194,11 @@ class DFSNode:
         return str(self.id)
 
 
-class VisitedState(enum.Enum):
-    Unvisited = 0
-    PartiallyVisited = 1
-    Visited = 2
-
-
 def depth_first_search(
     source: PackageNode, aggregator: Callable
 ) -> list[tuple[Package, int]]:
     back_edges: dict[DFSNodeID, list[PackageNode]] = defaultdict(list)
-    visited: dict[DFSNodeID, VisitedState] = {}
+    visited: set[DFSNodeID] = set()
     topo_sorted_nodes: list[PackageNode] = []
 
     dfs_visit(source, back_edges, visited, topo_sorted_nodes)
@@ -233,23 +226,17 @@ def depth_first_search(
 def dfs_visit(
     node: PackageNode,
     back_edges: dict[DFSNodeID, list[PackageNode]],
-    visited: dict[DFSNodeID, VisitedState],
+    visited: set[DFSNodeID],
     sorted_nodes: list[PackageNode],
 ) -> bool:
-    if visited.get(node.id, VisitedState.Unvisited) == VisitedState.Visited:
+    if node.id in visited:
         return True
-    if visited.get(node.id, VisitedState.Unvisited) == VisitedState.PartiallyVisited:
-        # We have a circular dependency.
-        # Since the dependencies are resolved we can
-        # simply skip it because we already have it
-        return True
+    visited.add(node.id)
 
-    visited[node.id] = VisitedState.PartiallyVisited
     for neighbor in node.reachable():
         back_edges[neighbor.id].append(node)
         if not dfs_visit(neighbor, back_edges, visited, sorted_nodes):
             return False
-    visited[node.id] = VisitedState.Visited
     sorted_nodes.insert(0, node)
     return True
 

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -205,10 +205,8 @@ def depth_first_search(
 
     # Combine the nodes by name
     combined_nodes = defaultdict(list)
-    name_children = defaultdict(list)
     for node in topo_sorted_nodes:
         node.visit(back_edges[node.id])
-        name_children[node.name].extend(node.reachable())
         combined_nodes[node.name].append(node)
 
     combined_topo_sorted_nodes = [
@@ -217,10 +215,7 @@ def depth_first_search(
         if node.name in combined_nodes
     ]
 
-    return [
-        aggregator(nodes, name_children[nodes[0].name])
-        for nodes in combined_topo_sorted_nodes
-    ]
+    return [aggregator(nodes) for nodes in combined_topo_sorted_nodes]
 
 
 def dfs_visit(
@@ -355,19 +350,15 @@ class PackageNode(DFSNode):
         )
 
 
-def aggregate_package_nodes(
-    nodes: list[PackageNode], children: list[PackageNode]
-) -> tuple[Package, int]:
+def aggregate_package_nodes(nodes: list[PackageNode]) -> tuple[Package, int]:
     package = nodes[0].package
     depth = max(node.depth for node in nodes)
     groups: list[str] = []
     for node in nodes:
         groups.extend(node.groups)
 
-    category = (
-        "main" if any("default" in node.groups for node in children + nodes) else "dev"
-    )
-    optional = all(node.optional for node in children + nodes)
+    category = "main" if any("default" in node.groups for node in nodes) else "dev"
+    optional = all(node.optional for node in nodes)
     for node in nodes:
         node.depth = depth
         node.category = category

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -139,12 +139,9 @@ class Solver:
         except SolveFailure as e:
             raise SolverProblemError(e)
 
-        # NOTE passing explicit empty set for seen to reset between invocations during
-        # update + install cycle
         results = dict(
             depth_first_search(
-                PackageNode(self._package, packages, seen=set()),
-                aggregate_package_nodes,
+                PackageNode(self._package, packages), aggregate_package_nodes
             )
         )
 
@@ -239,7 +236,6 @@ class PackageNode(DFSNode):
         self,
         package: Package,
         packages: list[Package],
-        seen: set[Package],
         previous: PackageNode | None = None,
         previous_dep: None
         | (
@@ -260,7 +256,6 @@ class PackageNode(DFSNode):
     ) -> None:
         self.package = package
         self.packages = packages
-        self.seen = seen
 
         self.previous = previous
         self.previous_dep = previous_dep
@@ -286,12 +281,6 @@ class PackageNode(DFSNode):
 
     def reachable(self) -> list[PackageNode]:
         children: list[PackageNode] = []
-
-        # skip already traversed packages
-        if self.package in self.seen:
-            return []
-
-        self.seen.add(self.package)
 
         if (
             self.dep
@@ -329,7 +318,6 @@ class PackageNode(DFSNode):
                         PackageNode(
                             pkg,
                             self.packages,
-                            self.seen,
                             self,
                             dependency,
                             self.dep or dependency,

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -228,17 +228,15 @@ def dfs_visit(
     back_edges: dict[DFSNodeID, list[PackageNode]],
     visited: set[DFSNodeID],
     sorted_nodes: list[PackageNode],
-) -> bool:
+) -> None:
     if node.id in visited:
-        return True
+        return
     visited.add(node.id)
 
     for neighbor in node.reachable():
         back_edges[neighbor.id].append(node)
-        if not dfs_visit(neighbor, back_edges, visited, sorted_nodes):
-            return False
+        dfs_visit(neighbor, back_edges, visited, sorted_nodes)
     sorted_nodes.insert(0, node)
-    return True
 
 
 class PackageNode(DFSNode):

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -140,11 +140,12 @@ class Solver:
         except SolveFailure as e:
             raise SolverProblemError(e)
 
-        # NOTE passing explicit empty array for seen to reset between invocations during
+        # NOTE passing explicit empty set for seen to reset between invocations during
         # update + install cycle
         results = dict(
             depth_first_search(
-                PackageNode(self._package, packages, seen=[]), aggregate_package_nodes
+                PackageNode(self._package, packages, seen=set()),
+                aggregate_package_nodes,
             )
         )
 
@@ -258,7 +259,7 @@ class PackageNode(DFSNode):
         self,
         package: Package,
         packages: list[Package],
-        seen: list[Package],
+        seen: set[Package],
         previous: PackageNode | None = None,
         previous_dep: None
         | (
@@ -309,8 +310,8 @@ class PackageNode(DFSNode):
         # skip already traversed packages
         if self.package in self.seen:
             return []
-        else:
-            self.seen.append(self.package)
+
+        self.seen.add(self.package)
 
         if (
             self.dep


### PR DESCRIPTION
# Pull Request Check List

A follow-up to my remark in #5305 that `seen` looked redundant on the node in the solver's depth first search, because the surrounding search already had a `visited`.

The doubt in my mind was that there was a second caller of `reachable()`, [here](https://github.com/python-poetry/poetry/blob/6485bc23d6497c7731e0f1a635f960b33f2ae99e/src/poetry/puzzle/solver.py#L217), and I hadn't taken the time to figure out the effect on that call site.

On reflection it is clear that the `seen` cache will be populated by the time we get to that second caller - which happens after the depth-first search has completed.  As a result, that second `reachable()` never returns anything other than an empty list.

(I also confirmed this by asserting as much in the code, and verifying that the test suite still passed)

Since nothing seems to be broken by that list being empty, I've assumed that we don't need that second `reachable()` call after all; and then it is clear that `seen` is indeed redundant.  So I've made two commits:

- remove the code which was made useless by `seen`
- remove `seen`

(I probably have given myself a small merge conflict with #5305, happy to sort that out if and when the first of these is merged).