### PR TITLE
Require --without-hashes for requirements.txt with VCS dependencies

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -619,6 +619,8 @@ This command is also available as a pre-commit hook. See [pre-commit hooks](/doc
 * `--dev`: Include development dependencies.
 * `--extras (-E)`: Extra sets of dependencies to include.
 * `--without-hashes`: Exclude hashes from the exported file.
+  This must be used if any VCS dependencies are present
+  because of pypa/pip#4995.
 * `--without-urls`: Exclude source repository urls from the exported file.
 * `--with-credentials`: Include credentials for extra indices.
 

--- a/src/poetry/console/commands/export.py
+++ b/src/poetry/console/commands/export.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import warnings
+
 from cleo.helpers import option
 
 from poetry.console.commands.command import Command
-from poetry.utils.exporter import Exporter
+from poetry.utils.exporter import Exporter, VCSHashesNotSupportedError
 
 
 class ExportCommand(Command):
@@ -68,13 +70,17 @@ class ExportCommand(Command):
             )
 
         exporter = Exporter(self.poetry)
-        exporter.export(
-            fmt,
-            self.poetry.file.parent,
-            output or self.io,
-            with_hashes=not self.option("without-hashes"),
-            dev=self.option("dev"),
-            extras=self.option("extras"),
-            with_credentials=self.option("with-credentials"),
-            with_urls=not self.option("without-urls"),
-        )
+        try:
+            exporter.export(
+                fmt,
+                self.poetry.file.parent,
+                output or self.io,
+                with_hashes=not self.option("without-hashes"),
+                dev=self.option("dev"),
+                extras=self.option("extras"),
+                with_credentials=self.option("with-credentials"),
+                with_urls=not self.option("without-urls"),
+            )
+        except VCSHashesNotSupportedError as e:
+            self.line_error(f"<error>Error: {e}</error>")
+            return 1


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2463

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This is a safer alternative to #3874. It will prevent Poetry from generating broken requirements.txt files, while also alleviating concerns on the previous pull request about potential security implications of hashes being automatically disabled without an explicit opt-in.