### PR TITLE
Issue #3483 Add cert retrieval for requests

### DIFF
--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -6,7 +6,7 @@ import urllib.parse
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Generator
+from typing import Iterator
 
 import requests
 import requests.auth
@@ -171,7 +171,7 @@ class Authenticator:
             return auth
 
     def _get_credentials_for_netloc(self, netloc: str) -> tuple[str | None, str | None]:
-        for (repository_name, _) in self._get_repository_netlocs():
+        for repository_name, _ in self._get_repository_netlocs():
             auth = self._get_http_auth(repository_name, netloc)
 
             if auth is None:
@@ -181,7 +181,7 @@ class Authenticator:
 
         return None, None
 
-    def get_certs_for_url(self, url: str) -> dict[str, Path]:
+    def get_certs_for_url(self, url: str) -> dict[str, Path | None]:
         parsed_url = urllib.parse.urlsplit(url)
 
         netloc = parsed_url.netloc
@@ -191,7 +191,7 @@ class Authenticator:
             self._get_certs_for_netloc_from_config(netloc),
         )
 
-    def _get_repository_netlocs(self) -> Generator[tuple[str, str], None, None]:
+    def _get_repository_netlocs(self) -> Iterator[tuple[str, str]]:
         for repository_name in self._config.get("repositories", []):
             url = self._config.get(f"repositories.{repository_name}.url")
             parsed_url = urllib.parse.urlsplit(url)
@@ -224,10 +224,10 @@ class Authenticator:
 
         return None
 
-    def _get_certs_for_netloc_from_config(self, netloc: str) -> dict[str, Path]:
+    def _get_certs_for_netloc_from_config(self, netloc: str) -> dict[str, Path | None]:
         certs = {"cert": None, "verify": None}
 
-        for (repository_name, repository_netloc) in self._get_repository_netlocs():
+        for repository_name, repository_netloc in self._get_repository_netlocs():
             if netloc == repository_netloc:
                 certs["cert"] = get_client_cert(self._config, repository_name)
                 certs["verify"] = get_cert(self._config, repository_name)

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -6,16 +6,24 @@ import urllib.parse
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import Optional
+from typing import Tuple
 
 import requests
 import requests.auth
 import requests.exceptions
 
 from poetry.exceptions import PoetryException
+from poetry.utils.helpers import get_cert
+from poetry.utils.helpers import get_client_cert
 from poetry.utils.password_manager import PasswordManager
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from cleo.io.io import IO
 
     from poetry.config.config import Config
@@ -30,6 +38,7 @@ class Authenticator:
         self._io = io
         self._session = None
         self._credentials = {}
+        self._certs = {}
         self._password_manager = PasswordManager(self._config)
 
     def _log(self, message: str, level: str = "debug") -> None:
@@ -61,8 +70,16 @@ class Authenticator:
 
         proxies = kwargs.get("proxies", {})
         stream = kwargs.get("stream")
-        verify = kwargs.get("verify")
-        cert = kwargs.get("cert")
+
+        certs = self.get_certs_for_url(url)
+        verify = kwargs.get("verify") or certs.get("verify")
+        cert = kwargs.get("cert") or certs.get("cert")
+
+        if cert is not None:
+            cert = str(cert)
+
+        if verify is not None:
+            verify = str(verify)
 
         settings = session.merge_environment_settings(
             prepared_request.url, proxies, stream, verify, cert
@@ -156,8 +173,12 @@ class Authenticator:
 
             return auth
 
-    def _get_credentials_for_netloc(self, netloc: str) -> tuple[str | None, str | None]:
-        for repository_name in self._config.get("repositories", []):
+    def _get_credentials_for_netloc(
+        self, netloc: str
+    ) -> Tuple[Optional[str], Optional[str]]:
+        credentials = (None, None)
+
+        for (repository_name, _) in self._get_repository_netlocs():
             auth = self._get_http_auth(repository_name, netloc)
 
             if auth is None:
@@ -165,7 +186,26 @@ class Authenticator:
 
             return auth["username"], auth["password"]
 
-        return None, None
+        return credentials
+
+    def get_certs_for_url(self, url: str) -> Dict[str, "Path"]:
+        parsed_url = urllib.parse.urlsplit(url)
+
+        netloc = parsed_url.netloc
+
+        return self._certs.setdefault(
+            netloc,
+            self._get_certs_for_netloc_from_config(netloc),
+        )
+
+    def _get_repository_netlocs(self) -> Generator[Tuple[str, str], None, None]:
+        for repository_name in self._config.get("repositories", []):
+            url = self._config.get(f"repositories.{repository_name}.url")
+            parsed_url = urllib.parse.urlsplit(url)
+            yield (
+                repository_name,
+                parsed_url.netloc,
+            )
 
     def _get_credentials_for_netloc_from_keyring(
         self, url: str, netloc: str, username: str | None
@@ -193,3 +233,14 @@ class Authenticator:
             }
 
         return None
+
+    def _get_certs_for_netloc_from_config(self, netloc: str) -> Dict[str, "Path"]:
+        certs = {"cert": None, "verify": None}
+
+        for (repository_name, repository_netloc) in self._get_repository_netlocs():
+            if netloc == repository_netloc:
+                certs["cert"] = get_client_cert(self._config, repository_name)
+                certs["verify"] = get_cert(self._config, repository_name)
+                break
+
+        return certs

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -6,10 +6,7 @@ import urllib.parse
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
 from typing import Generator
-from typing import Optional
-from typing import Tuple
 
 import requests
 import requests.auth
@@ -173,11 +170,7 @@ class Authenticator:
 
             return auth
 
-    def _get_credentials_for_netloc(
-        self, netloc: str
-    ) -> Tuple[Optional[str], Optional[str]]:
-        credentials = (None, None)
-
+    def _get_credentials_for_netloc(self, netloc: str) -> tuple[str | None, str | None]:
         for (repository_name, _) in self._get_repository_netlocs():
             auth = self._get_http_auth(repository_name, netloc)
 
@@ -186,9 +179,9 @@ class Authenticator:
 
             return auth["username"], auth["password"]
 
-        return credentials
+        return None, None
 
-    def get_certs_for_url(self, url: str) -> Dict[str, "Path"]:
+    def get_certs_for_url(self, url: str) -> dict[str, Path]:
         parsed_url = urllib.parse.urlsplit(url)
 
         netloc = parsed_url.netloc
@@ -198,14 +191,11 @@ class Authenticator:
             self._get_certs_for_netloc_from_config(netloc),
         )
 
-    def _get_repository_netlocs(self) -> Generator[Tuple[str, str], None, None]:
+    def _get_repository_netlocs(self) -> Generator[tuple[str, str], None, None]:
         for repository_name in self._config.get("repositories", []):
             url = self._config.get(f"repositories.{repository_name}.url")
             parsed_url = urllib.parse.urlsplit(url)
-            yield (
-                repository_name,
-                parsed_url.netloc,
-            )
+            yield repository_name, parsed_url.netloc
 
     def _get_credentials_for_netloc_from_keyring(
         self, url: str, netloc: str, username: str | None
@@ -234,7 +224,7 @@ class Authenticator:
 
         return None
 
-    def _get_certs_for_netloc_from_config(self, netloc: str) -> Dict[str, "Path"]:
+    def _get_certs_for_netloc_from_config(self, netloc: str) -> dict[str, Path]:
         certs = {"cert": None, "verify": None}
 
         for (repository_name, repository_netloc) in self._get_repository_netlocs():

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -4,13 +4,9 @@ import re
 import uuid
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Type
-from typing import Union
-from pathlib import Path
 
 import httpretty
 import pytest
@@ -323,12 +319,12 @@ def test_authenticator_uses_env_provided_credentials(
     ],
 )
 def test_authenticator_uses_certs_from_config_if_not_provided(
-    config: "Config",
-    mock_remote: Type[httpretty.httpretty],
-    http: Type[httpretty.httpretty],
-    mocker: "MockerFixture",
-    cert: Union[str, None],
-    client_cert: Union[str, None],
+    config: Config,
+    mock_remote: type[httpretty.httpretty],
+    http: type[httpretty.httpretty],
+    mocker: MockerFixture,
+    cert: str | None,
+    client_cert: str | None,
 ):
     configured_cert = "/path/to/cert"
     configured_client_cert = "/path/to/client-cert"

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -6,6 +6,11 @@ import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Dict
+from typing import List
+from typing import Type
+from typing import Union
+from pathlib import Path
 
 import httpretty
 import pytest
@@ -306,3 +311,46 @@ def test_authenticator_uses_env_provided_credentials(
     request = http.last_request()
 
     assert request.headers["Authorization"] == "Basic YmFyOmJheg=="
+
+
+@pytest.mark.parametrize(
+    "cert,client_cert",
+    [
+        (None, None),
+        (None, "path/to/provided/client-cert"),
+        ("/path/to/provided/cert", None),
+        ("/path/to/provided/cert", "path/to/provided/client-cert"),
+    ],
+)
+def test_authenticator_uses_certs_from_config_if_not_provided(
+    config: "Config",
+    mock_remote: Type[httpretty.httpretty],
+    http: Type[httpretty.httpretty],
+    mocker: "MockerFixture",
+    cert: Union[str, None],
+    client_cert: Union[str, None],
+):
+    configured_cert = "/path/to/cert"
+    configured_client_cert = "/path/to/client-cert"
+    config.merge(
+        {
+            "repositories": {"foo": {"url": "https://foo.bar/simple/"}},
+            "http-basic": {"foo": {"username": "bar", "password": "baz"}},
+            "certificates": {
+                "foo": {"cert": configured_cert, "client-cert": configured_client_cert}
+            },
+        }
+    )
+
+    authenticator = Authenticator(config, NullIO())
+    session_send = mocker.patch.object(authenticator.session, "send")
+    authenticator.request(
+        "get",
+        "https://foo.bar/files/foo-0.1.0.tar.gz",
+        verify=cert,
+        cert=client_cert,
+    )
+    kwargs = session_send.call_args[1]
+
+    assert Path(kwargs["verify"]) == Path(cert or configured_cert)
+    assert Path(kwargs["cert"]) == Path(client_cert or configured_client_cert)


### PR DESCRIPTION
The authenticator.py code already retrieves credentials from the config for every request based on url matching.
This change makes the authenticator also retrieve certs from the config for each request based on url matching.

Also includes unit tests.

supersedes #3490 by rebasing to current master.

If accepted, I can also backport it to the 1.1 branch to ship this feature sooner than the 1.2 release as its a blocker for some users of private repositories.

# Pull Request Check List

Resolves #3483

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->