### PR TITLE
add handling for non-sha hash in lock file and/or repository metadata when choosing a link

### DIFF
--- a/src/poetry/installation/chooser.py
+++ b/src/poetry/installation/chooser.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from packaging.tags import Tag
 
+from poetry.repositories.pypi_repository import PyPiRepository
 from poetry.utils.patterns import wheel_file_re
 
 
@@ -100,6 +101,15 @@ class Chooser:
         selected_links = []
         for link in links:
             if not link.hash:
+                selected_links.append(link)
+                continue
+
+            if (
+                link.hash_name
+                and not link.hash_name.startswith("sha")
+                and isinstance(repository, PyPiRepository)
+                and repository.get_sha_hash_from_link(link) in hashes
+            ):
                 selected_links.append(link)
                 continue
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -15,6 +15,7 @@ from cleo.io.buffered_io import BufferedIO
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 
+from poetry.installation.chef import Chef
 from poetry.installation.executor import Executor
 from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall
@@ -582,3 +583,91 @@ def test_executor_should_be_initialized_with_correct_workers(
     executor = Executor(tmp_venv, pool, config, io)
 
     assert executor._max_workers == expected_workers
+
+
+def test_executor_should_check_every_possible_hash_types(
+    config: Config,
+    io: BufferedIO,
+    pool: Pool,
+    mocker: MockerFixture,
+    fixture_dir: FixtureDirGetter,
+    tmp_dir: str,
+):
+    mocker.patch.object(
+        Chef,
+        "get_cached_archive_for_link",
+        side_effect=lambda link: link,
+    )
+    mocker.patch.object(
+        Executor,
+        "_download_archive",
+        return_value=fixture_dir("distributions").joinpath(
+            "demo-0.1.0-py2.py3-none-any.whl"
+        ),
+    )
+
+    env = MockEnv(path=Path(tmp_dir))
+    executor = Executor(env, pool, config, io)
+
+    package = Package("demo", "0.1.0")
+    package.files = [
+        {
+            "file": "demo-0.1.0-py2.py3-none-any.whl",
+            "hash": "md5:15507846fd4299596661d0197bfb4f90",
+        }
+    ]
+
+    archive = executor._download_link(
+        Install(package), Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl")
+    )
+
+    assert archive == fixture_dir("distributions").joinpath(
+        "demo-0.1.0-py2.py3-none-any.whl"
+    )
+
+
+def test_executor_should_check_every_possible_hash_types_before_failing(
+    config: Config,
+    io: BufferedIO,
+    pool: Pool,
+    mocker: MockerFixture,
+    fixture_dir: FixtureDirGetter,
+    tmp_dir: str,
+):
+    mocker.patch.object(
+        Chef,
+        "get_cached_archive_for_link",
+        side_effect=lambda link: link,
+    )
+    mocker.patch.object(
+        Executor,
+        "_download_archive",
+        return_value=fixture_dir("distributions").joinpath(
+            "demo-0.1.0-py2.py3-none-any.whl"
+        ),
+    )
+
+    env = MockEnv(path=Path(tmp_dir))
+    executor = Executor(env, pool, config, io)
+
+    package = Package("demo", "0.1.0")
+    package.files = [
+        {"file": "demo-0.1.0-py2.py3-none-any.whl", "hash": "md5:123456"},
+        {"file": "demo-0.1.0-py2.py3-none-any.whl", "hash": "sha256:123456"},
+    ]
+
+    expected_message = (
+        "Invalid hashes "
+        "("
+        "md5:15507846fd4299596661d0197bfb4f90, "
+        "sha256:70e704135718fffbcbf61ed1fc45933cfd86951a744b681000eaaa75da31f17a"
+        ") "
+        "for demo (0.1.0) using archive demo-0.1.0-py2.py3-none-any.whl. "
+        "Expected one of md5:123456, sha256:123456."
+    )
+
+    with pytest.raises(RuntimeError, match=re.escape(expected_message)):
+        executor._download_link(
+            Install(package),
+            Link("https://example.com/demo-0.1.0-py2.py3-none-any.whl"),
+        )

--- a/tests/repositories/fixtures/legacy/md5-package.html
+++ b/tests/repositories/fixtures/legacy/md5-package.html
@@ -1,0 +1,15 @@
+<!-- fake metadata simulating the response from a private repository (take from Nexus) -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Links for md5-package</title>
+  </head>
+  <body>
+    <h1>Links for md5-package</h1>
+    <a
+      href="../../packages/md5-package/1.2.3/md5-package-1.2.3.tar.gz#md5=1234"
+      data-requires-python="&gt;=3.6"
+      >md5-package-1.2.3.tar.gz</a
+    ><br />
+  </body>
+</html>


### PR DESCRIPTION
This PR moves existing logic into a new method for reuse, pulls the logic from #4529 forward into 1.2, and adds a condition to handle legacy repositories (Sonatype Nexus) returning md5 hashes in its metadata instead of sha256 like poetry expects.

resolves #4523 
resolves #4578
resolves #4085 
supersedes #4740 

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->