### PR TITLE
more descriptive output when shell is active and venv is deactivated

### DIFF
--- a/src/poetry/console/commands/shell.py
+++ b/src/poetry/console/commands/shell.py
@@ -22,14 +22,18 @@ If one doesn't exist yet, it will be created.
         from poetry.utils.shell import Shell
 
         # Check if it's already activated or doesn't exist and won't be created
-        venv_activated = strtobool(environ.get("POETRY_ACTIVE", "0")) or getattr(
-            sys, "real_prefix", sys.prefix
-        ) == str(self.env.path)
-        if venv_activated:
-            self.line(
-                f"Virtual environment already activated: <info>{self.env.path}</>"
-            )
-
+        poetry_active = strtobool(environ.get("POETRY_ACTIVE", "0"))
+        venv_activated = getattr(sys, "real_prefix", sys.prefix) == str(self.env.path)
+        if poetry_active:
+            if venv_activated:
+                self.line(
+                    f"Virtual environment already activated: <info>{self.env.path}</>"
+                )
+            else:
+                self.line(
+                    "Poetry shell is active but venv is deactivated. "
+                    "Exit shell and re-launch."
+                )
             return
 
         self.line(f"Spawning shell within <info>{self.env.path}</>")

--- a/tests/console/commands/test_shell.py
+++ b/tests/console/commands/test_shell.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from poetry.utils.env import MockEnv
+    from tests.types import CommandTesterFactory
+
+
+@pytest.fixture
+def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
+    return command_tester_factory("shell")
+
+
+def test_shell_active_venv_deactivated(
+    tester: CommandTester, monkeypatch: MonkeyPatch
+) -> None:
+    monkeypatch.setenv("POETRY_ACTIVE", "1")
+    tester.execute("")
+    out = tester.io.fetch_output().strip()
+    assert (
+        out
+        == "Poetry shell is active but venv is deactivated. Exit shell and re-launch."
+    )
+
+
+def test_shell_active_venv_activated(
+    tester: CommandTester, monkeypatch: MonkeyPatch, env: MockEnv
+) -> None:
+    monkeypatch.setenv("POETRY_ACTIVE", "1")
+    monkeypatch.setattr(sys, "prefix", str(env.path))
+    tester.execute("")
+    out = tester.io.fetch_output().strip()
+    assert out == f"Virtual environment already activated: {env.path}"
+
+
+def test_shell_activate(
+    tester: CommandTester, mocker: MockerFixture, env: MockEnv
+) -> None:
+    mock = mocker.patch("poetry.utils.shell.Shell.activate")
+    tester.execute("")
+    mock.assert_called_with(env)


### PR DESCRIPTION
# Pull Request Check List

Relates to: #5323

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
It looks like there is confusion with how `poetry shell` and `deactivate` interact with each other. This changes the output to be a little more descriptive. Also adds minor tests to the shell command