### PR TITLE
Solver performance

### DIFF
--- a/src/poetry/mixology/partial_solution.py
+++ b/src/poetry/mixology/partial_solution.py
@@ -147,7 +147,9 @@ class PartialSolution:
         name = assignment.dependency.complete_name
         old_positive = self._positive.get(name)
         if old_positive is not None:
-            self._positive[name] = old_positive.intersect(assignment)
+            value = old_positive.intersect(assignment)
+            assert value is not None
+            self._positive[name] = value
 
             return
 

--- a/src/poetry/mixology/term.py
+++ b/src/poetry/mixology/term.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+
 from typing import TYPE_CHECKING
 
 from poetry.mixology.set_relation import SetRelation
@@ -46,6 +48,7 @@ class Term:
             and self.relation(other) == SetRelation.SUBSET
         )
 
+    @functools.lru_cache(maxsize=None)
     def relation(self, other: Term) -> int:
         """
         Returns the relationship between the package versions
@@ -108,6 +111,7 @@ class Term:
                 # not foo ^1.5.0 is a superset of not foo ^1.0.0
                 return SetRelation.OVERLAPPING
 
+    @functools.lru_cache(maxsize=None)
     def intersect(self, other: Term) -> Term | None:
         """
         Returns a Term that represents the packages

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -67,7 +67,6 @@ class Provider:
         self._io = io
         self._env = env
         self._python_constraint = package.python_constraint
-        self._search_for: dict[Dependency, list[Package]] = {}
         self._is_debugging = self._io.is_debug() or self._io.is_very_verbose()
         self._in_progress = False
         self._overrides: dict = {}
@@ -119,28 +118,6 @@ class Provider:
         if dependency.is_root:
             return PackageCollection(dependency, [self._package])
 
-        for constraint in self._search_for:
-            if (
-                constraint.is_same_package_as(dependency)
-                and constraint.constraint.intersect(dependency.constraint)
-                == dependency.constraint
-            ):
-                packages = [
-                    p
-                    for p in self._search_for[constraint]
-                    if dependency.constraint.allows(p.version)
-                ]
-
-                packages.sort(
-                    key=lambda p: (
-                        not p.is_prerelease() and not dependency.allows_prereleases(),
-                        p.version,
-                    ),
-                    reverse=True,
-                )
-
-                return PackageCollection(dependency, packages)
-
         if dependency.is_vcs():
             packages = self.search_for_vcs(dependency)
         elif dependency.is_file():
@@ -159,8 +136,6 @@ class Provider:
                 ),
                 reverse=True,
             )
-
-        self._search_for[dependency] = packages
 
         return PackageCollection(dependency, packages)
 

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -584,7 +584,7 @@ def test_show_outdated_has_prerelease_and_allowed(
 ):
     poetry.package.add_dependency(
         Factory.create_dependency(
-            "cachy", {"version": "^0.1.0", "allow-prereleases": True}
+            "cachy", {"version": ">=0.0.1", "allow-prereleases": True}
         )
     )
     poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))


### PR DESCRIPTION
Some performance improvements derived from investigating #5217.

At time of writing, `poetry install localstack['runtime']` is unusably slow.
What happens is something like this:

- that package has a dependency on `pyyaml>=5.1`, which poetry resolves early on
  by picking pyyaml 6.0
- that package also has a dependency on `awscli>=1.14.18`
- there are a huge number of versions of `awscli` satisfying that constraint,
  every single one of them depending on a version of pyyaml that is older than
  6.0.

Poetry spends absolutely forever trying to find a compatible version of awscli,
and failing.
Eventually it will decide that they all fail, backtrack, and get to a solution -
but not fast!

(It could be more complicated than that: I think that there may be more than one
package playing the pyyaml role in this story.)

The first commit in this MR just tidies up a testcase that I encountered going
wrong while working out a fix.
The testcase says that cachy at `^0.1.0` was requested and that `0.1.0.dev1` was
installed.
But that would never happen, because poetry treats `0.1.0.dev1` as being earlier
than `0.1.0`.

The second commit borrows from <https://github.com/pubgrub-rs/pubgrub/pull/88>
to considerably speed up propagation of incompatibilities.

The third commit improves our repeated searches for suitable packages.
During the search, once a package has been rejected it can only become a valid
candidate again if we backtrack.
Since we build up constraints linear in size with the number of rejected
packages - like `>=1.14.18,<1.14.19 || >1.14.19,<1.14.20 || >1.14.20,...` - the
repeated work to reject non-matching packages becomes expensive.
I've avoided that by introducing a cache that discards packages as we go.

The fourth commit puts a cache on some `Term` methods that were showing up as
expensive.
(In spite of this, `Term.satisfies()` remains prominent in the profiling.
Probably these two caches should be seen as a sticking plaster trying - but not
fully succeeding - to compensate for something expensive in the algorithm.)

I have mostly been testing with a pyproject.toml that contains the following two
constraints:

```
awscli = ">=1.19.0"
localstack = { version = "0.14.1.1", extras = ["runtime"] }
```

where the first of these is to keep a cap on the number of `awscli` packages
that we must check.

The fixes in this MR take solution of the above from about 11 minutes to about 1
minute for me.
(Not counting download time, I'm testing with a populated cache.)

That's still a long time: and removing the awscli line so that we have only the
localstack requirement, we still take longer than I was willing to wait to get
to a solution...

These fixes all should be clear improvements; but I don't have a good sense for
whether the things that they address are relatively common, or rare.
