### PR TITLE
misc. improvements to group filtering logic and related options

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -215,10 +215,10 @@ option is used.
 
 ### Options
 
-* `--without`: The dependency groups to ignore for installation.
-* `--with`: The optional dependency groups to include for installation.
-* `--only`: The only dependency groups to install.
-* `--default`: Only install the default dependencies.
+* `--without`: The dependency groups to ignore.
+* `--with`: The optional dependency groups to include.
+* `--only`: The only dependency groups to include.
+* `--default`: Only include the default dependencies. (**Deprecated**)
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
 * `--no-root`: Do not install the root package (your project).
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
@@ -227,6 +227,9 @@ option is used.
 * `--dev-only`: Only install dev dependencies. (**Deprecated**)
 * `--remove-untracked`: Remove dependencies not presented in the lock file. (**Deprecated**)
 
+{{% note %}}
+When `--only` is specified, `--with` and `--without` options are ignored.
+{{% /note %}}
 
 ## update
 
@@ -252,9 +255,17 @@ update the constraint, for example `^2.3`. You can do this using the `add` comma
 
 ### Options
 
+* `--without`: The dependency groups to ignore.
+* `--with`: The optional dependency groups to include.
+* `--only`: The only dependency groups to include.
+* `--default`: Only include the default dependencies. (**Deprecated**)
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
-* `--no-dev` : Do not install dev dependencies.
+* `--no-dev` : Do not update the development dependencies. (**Deprecated**)
 * `--lock` : Do not perform install (only update the lockfile).
+
+{{% note %}}
+When `--only` is specified, `--with` and `--without` options are ignored.
+{{% /note %}}
 
 ## add
 
@@ -425,15 +436,18 @@ required by
 
 ### Options
 
-* `--without`: Do not show the information of the specified groups' dependencies.
-* `--with`: Show the information of the specified optional groups' dependencies as well.
-* `--only`: Only show the information of dependencies belonging to the specified groups.
-* `--default`: Only show the information of the default dependencies.
-* `--no-dev`: Do not list the dev dependencies.
+* `--without`: The dependency groups to ignore.
+* `--with`: The optional dependency groups to include.
+* `--only`: The only dependency groups to include.
+* `--default`: Only include the default dependencies. (**Deprecated**)
+* `--no-dev`: Do not list the dev dependencies. (**Deprecated**)
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.
 
+{{% note %}}
+When `--only` is specified, `--with` and `--without` options are ignored.
+{{% /note %}}
 
 ## build
 

--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -36,6 +36,7 @@ on whether their dependencies will be resolved and installed **by default**, the
 the dependencies logically.
 {{% /note %}}
 
+{{% note %}}
 The dependencies declared in `tool.poetry.dependencies` are part of an implicit `default` group.
 
 ```toml
@@ -47,6 +48,7 @@ pendulum = "*"
 pytest = "^6.0.0"
 pytest-mock = "*"
 ```
+{{% /note %}}
 
 {{% note %}}
 **A note about the `dev-dependencies` section**
@@ -109,7 +111,14 @@ If the group does not already exist, it will be created automatically.
 
 ### Installing group dependencies
 
-**By default**, dependencies across **all groups** will be installed when executing `poetry install`.
+**By default**, dependencies across **all non-optional groups** will be installed when executing
+`poetry install`.
+
+{{% note %}}
+The default set of dependencies for a project includes the implicit `default` group defined in
+`tool.poetry.dependencies` as well as all groups that are not explicitly marked as an
+[optional group]({{< relref "#optional-groups" >}}).
+{{% /note %}}
 
 You can **exclude** one or more groups with the `--without` option:
 
@@ -123,20 +132,22 @@ You can also opt in [optional groups]({{< relref "#optional-groups" >}}) by usin
 poetry install --with docs
 ```
 
-If you only want to install the **default**, non-grouped, dependencies, you can do so
-with the `--default` option:
-
-```bash
-poetry install --default
-```
-
 Finally, in some case you might want to install **only specific groups** of dependencies
-without installing the default dependencies. For that purpose, you can use
+without installing the default set of dependencies. For that purpose, you can use
 the `--only` option.
 
 ```bash
 poetry install --only docs
 ```
+
+{{% note %}}
+If you only want to install the project's runtime dependencies, you can do so  with the
+`--only default` notation:
+
+```bash
+poetry install --only default
+```
+{{% /note %}}
 
 ### Removing dependencies from a group
 

--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -132,6 +132,15 @@ You can also opt in [optional groups]({{< relref "#optional-groups" >}}) by usin
 poetry install --with docs
 ```
 
+{{% warning %}}
+When used together, `--without` takes precedence over `--with`. For example, the following command
+will only install the dependencies specified in the `test` group.
+
+```bash
+poetry install --with docs --without test,docs
+```
+{{% /warning %}}
+
 Finally, in some case you might want to install **only specific groups** of dependencies
 without installing the default set of dependencies. For that purpose, you can use
 the `--only` option.

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -80,6 +80,14 @@ class GroupCommand(EnvCommand):
                 )
                 groups[new].add(group)
 
+        if groups["only"] and (groups["with"] or groups["without"]):
+            self.line_error(
+                "<warning>The `<fg=yellow;options=bold>--with</>` and "
+                "`<fg=yellow;options=bold>--without</>` options are ignored when used"
+                " along with the `<fg=yellow;options=bold>--only</>` option."
+                "</warning>"
+            )
+
         return groups["only"] or self.non_optional_groups.union(
             groups["with"]
         ).difference(groups["without"])

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cleo.helpers import option
+
+from poetry.console.commands.env_command import EnvCommand
+
+
+if TYPE_CHECKING:
+    from cleo.io.inputs.option import Option
+
+    from poetry.packages.project_package import ProjectPackage
+
+
+class GroupCommand(EnvCommand):
+    @staticmethod
+    def _group_dependency_options() -> list[Option]:
+        return [
+            option(
+                "without",
+                None,
+                "The dependency groups to ignore for installation.",
+                flag=False,
+                multiple=True,
+            ),
+            option(
+                "with",
+                None,
+                "The optional dependency groups to include for installation.",
+                flag=False,
+                multiple=True,
+            ),
+            option("default", None, "Only install the default dependencies."),
+            option(
+                "only",
+                None,
+                "The only dependency groups to install.",
+                flag=False,
+                multiple=True,
+            ),
+        ]
+
+    @property
+    def non_optional_groups(self) -> set[str]:
+        # TODO: this should move into poetry-core
+        return {
+            group.name
+            for group in self.poetry.package._dependency_groups.values()
+            if not group.is_optional()
+        }
+
+    @property
+    def activated_groups(self) -> set[str]:
+        groups = {}
+
+        for key in {"with", "without", "only"}:
+            groups[key] = {
+                group.strip()
+                for groups in self.option(key)
+                for group in groups.split(",")
+            }
+
+        if self.option("default"):
+            groups["only"].add("default")
+
+        for opt, new, group in [
+            ("no-dev", "only", "default"),
+            ("dev", "without", "default"),
+            ("dev-only", "without", "default"),
+        ]:
+            if self.io.input.has_option(opt) and self.option(opt):
+                self.line_error(
+                    f"<warning>The `<fg=yellow;options=bold>--{opt}</>` option is"
+                    f" deprecated, use the `<fg=yellow;options=bold>--{new} {group}</>`"
+                    " notation instead.</warning>"
+                )
+                groups[new].add(group)
+
+        return groups["only"] or self.non_optional_groups.union(
+            groups["with"]
+        ).difference(groups["without"])
+
+    def project_with_activated_groups_only(self) -> ProjectPackage:
+        return self.poetry.package.with_dependency_groups(
+            list(self.activated_groups), only=True
+        )

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -31,7 +31,12 @@ class GroupCommand(EnvCommand):
                 flag=False,
                 multiple=True,
             ),
-            option("default", None, "Only install the default dependencies."),
+            option(
+                "default",
+                None,
+                "Only install the default dependencies."
+                " (<warning>Deprecated</warning>)",
+            ),
             option(
                 "only",
                 None,
@@ -61,10 +66,8 @@ class GroupCommand(EnvCommand):
                 for group in groups.split(",")
             }
 
-        if self.option("default"):
-            groups["only"].add("default")
-
         for opt, new, group in [
+            ("default", "only", "default"),
             ("no-dev", "only", "default"),
             ("dev", "without", "default"),
             ("dev-only", "without", "default"),

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -20,27 +20,27 @@ class GroupCommand(EnvCommand):
             option(
                 "without",
                 None,
-                "The dependency groups to ignore for installation.",
+                "The dependency groups to ignore.",
                 flag=False,
                 multiple=True,
             ),
             option(
                 "with",
                 None,
-                "The optional dependency groups to include for installation.",
+                "The optional dependency groups to include.",
                 flag=False,
                 multiple=True,
             ),
             option(
                 "default",
                 None,
-                "Only install the default dependencies."
+                "Only include the default dependencies."
                 " (<warning>Deprecated</warning>)",
             ),
             option(
                 "only",
                 None,
-                "The only dependency groups to install.",
+                "The only dependency groups to include.",
                 flag=False,
                 multiple=True,
             ),

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -174,7 +174,7 @@ dependencies and not including the current project, run the command with the
         if return_code != 0:
             return return_code
 
-        if self.option("no-root") or self.option("only"):
+        if self.option("no-root"):
             return 0
 
         try:

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -63,7 +63,8 @@ class InstallCommand(InstallerCommand):
         option(
             "remove-untracked",
             None,
-            "Removes packages not present in the lock file.",
+            "Removes packages not present in the lock file."
+            " (<warning>Deprecated</warning>)",
         ),
         option(
             "extras",

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -11,28 +11,7 @@ class InstallCommand(InstallerCommand):
     description = "Installs the project dependencies."
 
     options = [
-        option(
-            "without",
-            None,
-            "The dependency groups to ignore for installation.",
-            flag=False,
-            multiple=True,
-        ),
-        option(
-            "with",
-            None,
-            "The optional dependency groups to include for installation.",
-            flag=False,
-            multiple=True,
-        ),
-        option("default", None, "Only install the default dependencies."),
-        option(
-            "only",
-            None,
-            "The only dependency groups to install.",
-            flag=False,
-            multiple=True,
-        ),
+        *InstallerCommand._group_dependency_options(),
         option(
             "no-dev",
             None,
@@ -109,49 +88,6 @@ dependencies and not including the current project, run the command with the
 
         self._installer.extras(extras)
 
-        excluded_groups = []
-        included_groups = []
-        only_groups = []
-        if self.option("no-dev"):
-            self.line_error(
-                "<warning>The `<fg=yellow;options=bold>--no-dev</>` option is"
-                " deprecated, use the `<fg=yellow;options=bold>--without dev</>`"
-                " notation instead.</warning>"
-            )
-            excluded_groups.append("dev")
-        elif self.option("dev-only"):
-            self.line_error(
-                "<warning>The `<fg=yellow;options=bold>--dev-only</>` option is"
-                " deprecated, use the `<fg=yellow;options=bold>--only dev</>` notation"
-                " instead.</warning>"
-            )
-            only_groups.append("dev")
-
-        excluded_groups.extend(
-            [
-                group.strip()
-                for groups in self.option("without")
-                for group in groups.split(",")
-            ]
-        )
-        included_groups.extend(
-            [
-                group.strip()
-                for groups in self.option("with")
-                for group in groups.split(",")
-            ]
-        )
-        only_groups.extend(
-            [
-                group.strip()
-                for groups in self.option("only")
-                for group in groups.split(",")
-            ]
-        )
-
-        if self.option("default"):
-            only_groups.append("default")
-
         with_synchronization = self.option("sync")
         if self.option("remove-untracked"):
             self.line_error(
@@ -162,9 +98,7 @@ dependencies and not including the current project, run the command with the
 
             with_synchronization = True
 
-        self._installer.only_groups(only_groups)
-        self._installer.without_groups(excluded_groups)
-        self._installer.with_groups(included_groups)
+        self._installer.only_groups(self.activated_groups)
         self._installer.dry_run(self.option("dry-run"))
         self._installer.requires_synchronization(with_synchronization)
         self._installer.verbose(self._io.is_verbose())

--- a/src/poetry/console/commands/installer_command.py
+++ b/src/poetry/console/commands/installer_command.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from poetry.console.commands.env_command import EnvCommand
+from poetry.console.commands.group_command import GroupCommand
 
 
 if TYPE_CHECKING:
     from poetry.installation.installer import Installer
 
 
-class InstallerCommand(EnvCommand):
+class InstallerCommand(GroupCommand):
     def __init__(self) -> None:
         # Set in poetry.console.application.Application.configure_installer
         self._installer: Installer = None  # type: ignore[assignment]

--- a/src/poetry/console/commands/update.py
+++ b/src/poetry/console/commands/update.py
@@ -17,7 +17,13 @@ class UpdateCommand(InstallerCommand):
         argument("packages", "The packages to update", optional=True, multiple=True)
     ]
     options = [
-        option("no-dev", None, "Do not update the development dependencies."),
+        *InstallerCommand._group_dependency_options(),
+        option(
+            "no-dev",
+            None,
+            "Do not update the development dependencies."
+            " (<warning>Deprecated</warning>)",
+        ),
         option(
             "dry-run",
             None,
@@ -39,9 +45,7 @@ class UpdateCommand(InstallerCommand):
         if packages:
             self._installer.whitelist({name: "*" for name in packages})
 
-        if self.option("no-dev"):
-            self._installer.with_groups(["dev"])
-
+        self._installer.only_groups(self.activated_groups)
         self._installer.dry_run(self.option("dry-run"))
         self._installer.execute_operations(not self.option("lock"))
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -54,9 +54,7 @@ class Installer:
         self._update = False
         self._verbose = False
         self._write_lock = True
-        self._without_groups = None
-        self._with_groups = None
-        self._only_groups = None
+        self._groups: Iterable[str] | None = None
 
         self._execute_operations = True
         self._lock = False
@@ -138,18 +136,8 @@ class Installer:
     def is_verbose(self) -> bool:
         return self._verbose
 
-    def without_groups(self, groups: list[str]) -> Installer:
-        self._without_groups = groups
-
-        return self
-
-    def with_groups(self, groups: list[str]) -> Installer:
-        self._with_groups = groups
-
-        return self
-
-    def only_groups(self, groups: list[str]) -> Installer:
-        self._only_groups = groups
+    def only_groups(self, groups: Iterable[str]) -> Installer:
+        self._groups = groups
 
         return self
 
@@ -281,18 +269,8 @@ class Installer:
                 # If we are only in lock mode, no need to go any further
                 return 0
 
-        if self._without_groups or self._with_groups or self._only_groups:
-            if self._with_groups:
-                # Default dependencies and opted-in optional dependencies
-                root = self._package.with_dependency_groups(self._with_groups)
-            elif self._without_groups:
-                # Default dependencies without selected groups
-                root = self._package.without_dependency_groups(self._without_groups)
-            else:
-                # Only selected groups
-                root = self._package.with_dependency_groups(
-                    self._only_groups, only=True
-                )
+        if self._groups is not None:
+            root = self._package.with_dependency_groups(list(self._groups), only=True)
         else:
             root = self._package.without_optional_dependency_groups()
 

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -40,6 +40,9 @@ baz = "^1.2"
 [tool.poetry.group.bim.dependencies]
 bim = "^1.3"
 
+[tool.poetry.group.bam]
+optional = true
+
 [tool.poetry.group.bam.dependencies]
 bam = "^1.4"
 """
@@ -57,21 +60,34 @@ def tester(
     return command_tester_factory("install")
 
 
+@pytest.mark.parametrize(
+    ("options", "groups"),
+    [
+        ("", {"default", "foo", "bar", "baz", "bim"}),
+        ("--only default", {"default"}),
+        ("--only foo", {"foo"}),
+        ("--only foo,bar", {"foo", "bar"}),
+        ("--only bam", {"bam"}),
+        ("--with bam", {"default", "foo", "bar", "baz", "bim", "bam"}),
+        ("--without foo,bar", {"default", "baz", "bim"}),
+        ("--with foo,bar --without baz --without bim --only bam", {"bam"}),
+    ],
+)
 def test_group_options_are_passed_to_the_installer(
-    tester: CommandTester, mocker: MockerFixture
+    options: str, groups: set[str], tester: CommandTester, mocker: MockerFixture
 ):
     """
     Group options are passed properly to the installer.
     """
     mocker.patch.object(tester.command.installer, "run", return_value=1)
 
-    tester.execute("--with foo,bar --without baz --without bim --only bam")
+    tester.execute(options)
 
     package_groups = set(tester.command.poetry.package._dependency_groups.keys())
     installer_groups = set(tester.command.installer._groups)
 
     assert installer_groups <= package_groups
-    assert set(installer_groups) == {"bam"}
+    assert set(installer_groups) == groups
 
 
 def test_sync_option_is_passed_to_the_installer(

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -63,22 +63,29 @@ def tester(
 
 
 @pytest.mark.parametrize(
-    ("options", "groups", "with_root"),
+    ("options", "groups"),
     [
-        case + (with_root,)
-        for case in [
-            ("", {"default", "foo", "bar", "baz", "bim"}),
-            ("--only default", {"default"}),
-            ("--only foo", {"foo"}),
-            ("--only foo,bar", {"foo", "bar"}),
-            ("--only bam", {"bam"}),
-            ("--with bam", {"default", "foo", "bar", "baz", "bim", "bam"}),
-            ("--without foo,bar", {"default", "baz", "bim"}),
-            ("--with foo,bar --without baz --without bim --only bam", {"bam"}),
-        ]
-        for with_root in {True, False}
+        ("", {"default", "foo", "bar", "baz", "bim"}),
+        ("--only default", {"default"}),
+        ("--only foo", {"foo"}),
+        ("--only foo,bar", {"foo", "bar"}),
+        ("--only bam", {"bam"}),
+        ("--with bam", {"default", "foo", "bar", "baz", "bim", "bam"}),
+        ("--without foo,bar", {"default", "baz", "bim"}),
+        ("--without default", {"foo", "bar", "baz", "bim"}),
+        ("--with foo,bar --without baz --without bim --only bam", {"bam"}),
+        # net result zero options
+        ("--with foo", {"default", "foo", "bar", "baz", "bim"}),
+        ("--without bam", {"default", "foo", "bar", "baz", "bim"}),
+        ("--with bam --without bam", {"default", "foo", "bar", "baz", "bim"}),
+        ("--with foo --without foo", {"default", "bar", "baz", "bim"}),
+        # deprecated options
+        ("--default", {"default"}),
+        ("--no-dev", {"default"}),
+        ("--dev-only", {"foo", "bar", "baz", "bim"}),
     ],
 )
+@pytest.mark.parametrize("with_root", [True, False])
 def test_group_options_are_passed_to_the_installer(
     options: str,
     groups: set[str],

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -381,7 +381,7 @@ def test_run_install_no_group(
 ):
     _configure_run_install_dev(locker, repo, package, installed)
 
-    installer.without_groups(["dev"])
+    installer.only_groups([])
     installer.run()
 
     assert installer.executor.installations_count == 0
@@ -647,7 +647,7 @@ def test_run_install_with_optional_group_selected(
         locker, repo, package, installed, with_optional_group=True
     )
 
-    installer.with_groups(["dev"])
+    installer.only_groups(["default", "dev"])
     installer.run()
 
     assert installer.executor.installations_count == 0

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -312,7 +312,7 @@ def test_run_install_no_group(
     package.add_dependency(Factory.create_dependency("B", "~1.1"))
     package.add_dependency(Factory.create_dependency("C", "~1.2", groups=["dev"]))
 
-    installer.without_groups(["dev"])
+    installer.only_groups([])
     installer.run()
 
     installs = installer.installer.installs


### PR DESCRIPTION
- Fix `install --only` logic to no longer implicitly disable root package installation. (added test coverage)
- Dedupe logic for group aware command and improve "active" group determination.
- Reduce cognitive load for installer by removing `without` and `with` group specifications, replacing with `only` group logic.
- Improve test cases to more reliably verify installer logic and increase coverage.
- Increase coverage for `install` command with group filtering options.
- Improve documenration relating to dependency group to further highlight distinction between `default` group and `default dependencies`.
- Get documentation in sync with cli `--help` output and warning around combining `--only` with `--with | --without`.
- Deprecate the use of `--default` option to reduce CLI cognitive load on users.
- Mark `install --remove-untracked` as deprecated
- Improve test coverage for show command with groups.
- Translate legacy options correctly. `--no-dev` => `--only default`, `--only-dev` => `--without default` etc.  

Closes: #4361
Resolves: #4577

Discussion: https://github.com/orgs/python-poetry/teams/core/discussions/8

PS: Commits are separated by functional changes.