### PR TITLE
Introduce poetry-lock-no-update hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,6 +15,15 @@
   language_version: python3
   pass_filenames: false
 
+- id: poetry-lock-no-update
+  name: poetry-check
+  description: run poetry lock --no-update to validate the lock file
+  entry: poetry lock --no-update
+  language: python
+  language_version: python3
+  pass_filenames: false
+  files: 'pyproject\.toml$|poetry\.lock$'
+
 - id: poetry-export
   name: poetry-export
   description: run poetry export to sync lock file with requirements.txt


### PR DESCRIPTION
Every once in a while, people mess with `pyproject.toml` directly. This can lead to lockfile drift.

This hook helps people catch those mistakes.

# Pull Request Check List

Resolves: #issue-number-here

I didn't create an issue. I did search for issues and PRs, and came out empty-handed.

I was using https://github.com/pkoch/mirrors-poetry/ and wanted to migrate to using this repo instead, but noticed we're missing this particular use case.

- [ ] Added **tests** for changed code.
   This doesn't really change code.
- [ ] Updated **documentation** for changed code.
  I didn't find any pre-commit hook docs. Maybe I missed them?
