### PR TITLE
chore(black): replace deprecated experimental_string_processing option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ extend_skip = ["setup.py"]
 
 [tool.black]
 target-version = ['py37']
-experimental_string_processing = true
+preview = true
 force-exclude = '''
 .*/setup\.py$
 '''


### PR DESCRIPTION
black's `experimental_string_processing` option is deprecated and should be replaced by `preview`.