### PR TITLE
Prefer compatible wheels over source distribution for legacy repository dependency resolution

### DIFF
--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -7,7 +7,6 @@ import urllib
 
 from abc import ABC
 from collections import defaultdict
-from packaging.tags import sys_tags, Tag
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
@@ -16,6 +15,8 @@ import requests
 import requests.auth
 
 from cachecontrol import CacheControl
+from packaging.tags import Tag
+from packaging.tags import sys_tags
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.utils.link import Link
 from poetry.core.version.markers import parse_marker

--- a/tests/repositories/fixtures/legacy/pyyaml.html
+++ b/tests/repositories/fixtures/legacy/pyyaml.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Links for python-language-server</title>
+    <title>Links for PyYAML</title>
   </head>
   <body>
-    <h1>Links for python-language-server</h1>
+    <h1>Links for PyYAML</h1>
     <a href="https://files.pythonhosted.org/packages/5c/ed/d6557f70daaaab6ee5cd2f8ccf7bedd63081e522e38679c03840e1acc114/PyYAML-3.13-cp37-cp37m-win32.whl#sha256=e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531">PyYAML-3.13-cp37-cp37m-win32.whl</a><br/>
     <a href="https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz#sha256=3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf">PyYAML-3.13.tar.gz</a><br/>
     <a href="https://files.pythonhosted.org/packages/0f/9d/f98ed0a460dc540f720bbe5c6e076f025595cdfa3e318fad27165db13cf9/PyYAML-4.2b2.tar.gz#sha256=406b717f739e2d00c49873068b71f5454c2420157db51b082d4d2beb17ffffb6">PyYAML-4.2b2.tar.gz</a><br/>
     </body>
 </html>
-<!--SERIAL 4245719-->
+<!--SERIAL 11716096-->


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4439 and #3464

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code. (not needed)

PyPi repositories use the pypi.org JSON api for fetching dependencies, where for an external repo (legacy repo) the dependencies are determined by going through the files available in the repo and inspecting the metadata (actually PyPi repositories also use this method as fallback when requires_dist is None). Universal wheels are prefered, then source distribution and only after that a desperate attempt (# Pick the first wheel available and hope for the best) is made to extract the dependencies from a platform specific wheel.

It is cumbersome to retrieve this from source, the file needs to be extracted, which takes a long time, and even after it is not always certain the correct ones can be determined, due to  lack of standardization and arbitrary code execution in setup.py. So either this step has to be improved, implying all past and future build systems need to be supported, or another option is to use a well defined package distribution format, which already exist. The wheel does not need to be reinvented, it just needs to be used.

As dependencies could potentially differ (although could not find an example of this easily) depending on the platform and python version, only the appropriate wheels are considered by matching with compatibility tags. 

-> Using compatible wheels over sdist will result in a more correct dependency resolution at a greater speed.

for example PyQt5 (5.15.4) requires_dist
 * pypi  ['PyQt5-sip (>=12.8, <13)', 'PyQt5-Qt5 (>=5.15)'] 
 * bdist ['PyQt5-sip (>=12.8, <13)', 'PyQt5-Qt5 (>=5.15)'] 
 * sdist None

wheel : ~3s not cached, ~0.2s cached
tar.gz: ~10s both not cached and cached (needs to be extracted everytime)

