### PR TITLE
Fix format string for url cleaning of other sources

### DIFF
--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -144,7 +144,7 @@ class Page:
         """Makes sure a link is fully encoded.  That is, if a ' ' shows up in
         the link, it will be rewritten to %20 (while not over-quoting
         % or other characters)."""
-        return self._clean_re.sub(lambda match: f"%{match.group(0):2x}", url)
+        return self._clean_re.sub(lambda match: f"%{ord(match.group(0)):02x}", url)
 
 
 # TODO: revisit whether the LegacyRepository should inherit from PyPiRepository.

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -73,6 +73,15 @@ def test_page_absolute_links_path_are_correct():
         assert link.path.startswith("/packages/")
 
 
+def test_page_clean_link():
+    repo = MockRepository()
+
+    page = repo._get_page("/relative")
+
+    cleaned = page.clean_link('https://legacy.foo.bar/test /the"/cleaning\0')
+    assert cleaned == "https://legacy.foo.bar/test%20/the%22/cleaning%00"
+
+
 def test_sdist_format_support():
     repo = MockRepository()
     page = repo._get_page("/relative")


### PR DESCRIPTION
In 5814e335221047bbd5ca4d7def6994acc0a9c1ca a regression has been introduced that new code using f-strings omitted the call of `ord()` to clean the url of other sources included.

At the same time I observed that the format string option to add an leading zero for numbers < 10 is missing. It may be unlikely to happen in the real world but without the flag the encoding of the ASCII symbols 0-9 would have a space in the output (e,g,"\0" -> "% 0" and not "%00" as expected).