### PR TITLE
mypy type checks in password_manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ module = [
   'poetry.utils.authenticator',
   'poetry.utils.env',
   'poetry.utils.exporter',
-  'poetry.utils.password_manager',
   'poetry.utils.setup_reader',
 ]
 ignore_errors = true

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -121,10 +121,10 @@ class KeyRing:
 class PasswordManager:
     def __init__(self, config: Config) -> None:
         self._config = config
-        self._keyring = None
+        self._keyring: KeyRing | None = None
 
     @property
-    def keyring(self) -> KeyRing | None:
+    def keyring(self) -> KeyRing:
         if self._keyring is None:
             self._keyring = KeyRing("poetry-repository")
             if not self._keyring.is_available():
@@ -140,7 +140,7 @@ class PasswordManager:
         else:
             self.keyring.set_password(name, "__token__", token)
 
-    def get_pypi_token(self, name: str) -> str:
+    def get_pypi_token(self, name: str) -> str | None:
         if not self.keyring.is_available():
             return self._config.get(f"pypi-token.{name}")
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5017 

This PR fixes the annotation errors causing mypy failure on `password_manager.py` and removes password_manager from the mypy overrides in `pyproject.toml`. 


- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

