### PR TITLE
plugins: cleanup and rename type to group

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -313,9 +313,10 @@ class Application(BaseApplication):
         self._disable_plugins = io.input.has_parameter_option("--no-plugins")
 
         if not self._disable_plugins:
+            from poetry.plugins.application_plugin import ApplicationPlugin
             from poetry.plugins.plugin_manager import PluginManager
 
-            manager = PluginManager("application.plugin")
+            manager = PluginManager(ApplicationPlugin.group)
             manager.load_plugins()
             manager.activate(self)
 

--- a/src/poetry/console/commands/plugin/show.py
+++ b/src/poetry/console/commands/plugin/show.py
@@ -19,6 +19,7 @@ class PluginShowCommand(Command):
 
     def handle(self) -> int:
         from poetry.plugins.application_plugin import ApplicationPlugin
+        from poetry.plugins.plugin import Plugin
         from poetry.plugins.plugin_manager import PluginManager
         from poetry.repositories.installed_repository import InstalledRepository
         from poetry.utils.env import EnvManager
@@ -34,8 +35,8 @@ class PluginShowCommand(Command):
         )
 
         entry_points = (
-            PluginManager("application.plugin").get_plugin_entry_points()
-            + PluginManager("plugin").get_plugin_entry_points()
+            PluginManager(ApplicationPlugin.group).get_plugin_entry_points()
+            + PluginManager(Plugin.group).get_plugin_entry_points()
         )
 
         system_env = EnvManager.get_system_env(naive=True)

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -12,6 +12,7 @@ from poetry.config.file_config_source import FileConfigSource
 from poetry.locations import CONFIG_DIR
 from poetry.packages.locker import Locker
 from poetry.packages.project_package import ProjectPackage
+from poetry.plugins.plugin import Plugin
 from poetry.plugins.plugin_manager import PluginManager
 from poetry.poetry import Poetry
 
@@ -77,7 +78,7 @@ class Factory(BaseFactory):
             poetry, poetry.local_config.get("source", []), config, io
         )
 
-        plugin_manager = PluginManager("plugin", disable_plugins=disable_plugins)
+        plugin_manager = PluginManager(Plugin.group, disable_plugins=disable_plugins)
         plugin_manager.load_plugins()
         poetry.set_plugin_manager(plugin_manager)
         plugin_manager.activate(poetry, io)

--- a/src/poetry/plugins/application_plugin.py
+++ b/src/poetry/plugins/application_plugin.py
@@ -7,14 +7,20 @@ from poetry.plugins.base_plugin import BasePlugin
 
 if TYPE_CHECKING:
     from poetry.console.application import Application
+    from poetry.console.commands.command import Command
 
 
 class ApplicationPlugin(BasePlugin):
     """
-    Base class for plugins.
+    Base class for application plugins.
     """
 
-    type = "application.plugin"
+    group = "poetry.application.plugin"
+
+    @property
+    def commands(self) -> list[type[Command]]:
+        return []
 
     def activate(self, application: Application) -> None:
-        raise NotImplementedError()
+        for command in self.commands:
+            application.command_loader.register_factory(command.name, lambda: command())

--- a/src/poetry/plugins/base_plugin.py
+++ b/src/poetry/plugins/base_plugin.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+from abc import abstractmethod
+
 
 class BasePlugin:
     """
     Base class for all plugin types
+
+    The `activate()` method must be implemented and receives the Poetry instance.
     """
 
     PLUGIN_API_VERSION = "1.0.0"
+
+    @property
+    @abstractmethod
+    def group(self) -> str:
+        """
+        Name of entrypoint group the plugin belongs to.
+        """
+        raise NotImplementedError()

--- a/src/poetry/plugins/plugin.py
+++ b/src/poetry/plugins/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 from poetry.plugins.base_plugin import BasePlugin
@@ -14,11 +15,10 @@ if TYPE_CHECKING:
 class Plugin(BasePlugin):
     """
     Generic plugin not related to the console application.
-    The activate() method must be implemented and receives
-    the Poetry instance.
     """
 
-    type = "plugin"
+    group = "poetry.plugin"
 
+    @abstractmethod
     def activate(self, poetry: Poetry, io: IO) -> None:
         raise NotImplementedError()

--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -18,8 +18,8 @@ class PluginManager:
     This class registers and activates plugins.
     """
 
-    def __init__(self, type: str, disable_plugins: bool = False) -> None:
-        self._type = type
+    def __init__(self, group: str, disable_plugins: bool = False) -> None:
+        self._group = group
         self._disable_plugins = disable_plugins
         self._plugins: list[Plugin] = []
 
@@ -33,7 +33,7 @@ class PluginManager:
             self._load_plugin_entrypoint(entrypoint)
 
     def get_plugin_entry_points(self) -> list[entrypoints.EntryPoint]:
-        return entrypoints.get_group_all(f"poetry.{self._type}")
+        return entrypoints.get_group_all(self._group)
 
     def add_plugin(self, plugin: Plugin) -> None:
         if not isinstance(plugin, (Plugin, ApplicationPlugin)):

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -28,8 +28,7 @@ class FooCommand(Command):
 
 
 class AddCommandPlugin(ApplicationPlugin):
-    def activate(self, application: Application) -> None:
-        application.command_loader.register_factory("foo", lambda: FooCommand())
+    commands = [FooCommand]
 
 
 def test_application_with_plugins(mocker: MockerFixture):

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -26,7 +26,7 @@ CWD = Path(__file__).parent.parent / "fixtures" / "simple_project"
 
 
 class ManagerFactory(Protocol):
-    def __call__(self, type: str = "plugin") -> PluginManager:
+    def __call__(self, group: str = Plugin.group) -> PluginManager:
         ...
 
 
@@ -37,9 +37,7 @@ class MyPlugin(Plugin):
 
 
 class MyCommandPlugin(ApplicationPlugin):
-    @property
-    def commands(self) -> list[str]:
-        return []
+    commands = []
 
 
 class InvalidPlugin:
@@ -68,15 +66,15 @@ def io() -> BufferedIO:
 
 @pytest.fixture()
 def manager_factory(poetry: Poetry, io: BufferedIO) -> ManagerFactory:
-    def _manager(type: str = "plugin") -> PluginManager:
-        return PluginManager(type)
+    def _manager(group: str = Plugin.group) -> PluginManager:
+        return PluginManager(group)
 
     return _manager
 
 
 @pytest.fixture()
 def no_plugin_manager(poetry: Poetry, io: BufferedIO) -> PluginManager:
-    return PluginManager("plugin", disable_plugins=True)
+    return PluginManager(Plugin.group, disable_plugins=True)
 
 
 def test_load_plugins_and_activate(


### PR DESCRIPTION
Minor improvements to plugin implementation to make downstream implementations a bit easier for application plugins. The main change here is the renaming of `type` property to `group`. This reflects reality more as this is referring to the [entrypoint group](https://packaging.python.org/en/latest/specifications/entry-points/#data-model) the plugin is made available under and avoids shadowing built-in `type`.
