### PR TITLE
cmd/plugin/show: use entrypoint distro name

### DIFF
--- a/src/poetry/console/commands/plugin/show.py
+++ b/src/poetry/console/commands/plugin/show.py
@@ -52,7 +52,7 @@ class PluginShowCommand(Command):
             if issubclass(plugin, ApplicationPlugin):
                 category = "application_plugins"
 
-            package = packages_by_name[canonicalize_name(entry_point.name)]
+            package = packages_by_name[canonicalize_name(entry_point.distro.name)]
             plugins[package.pretty_name]["package"] = package
             plugins[package.pretty_name][category].append(entry_point)
 

--- a/tests/console/commands/plugin/test_show.py
+++ b/tests/console/commands/plugin/test_show.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from entrypoints import Distribution
 from entrypoints import EntryPoint as _EntryPoint
 from poetry.core.packages.package import Package
 
@@ -35,33 +36,49 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
     return command_tester_factory("plugin show")
 
 
+@pytest.fixture()
+def plugin_package() -> Package:
+    return Package("poetry-plugin", "1.2.3")
+
+
+@pytest.fixture()
+def plugin_distro(plugin_package: Package) -> Distribution:
+    return Distribution(plugin_package.name, plugin_package.version.to_string(True))
+
+
+@pytest.mark.parametrize("entrypoint_name", ["poetry-plugin", "not-package-name"])
 def test_show_displays_installed_plugins(
     app: PoetryTestApplication,
     tester: CommandTester,
     installed: Repository,
     mocker: MockerFixture,
+    plugin_package: Package,
+    plugin_distro: Distribution,
+    entrypoint_name: str,
 ):
     mocker.patch(
         "entrypoints.get_group_all",
         side_effect=[
             [
                 EntryPoint(
-                    "poetry-plugin",
+                    entrypoint_name,
                     "poetry_plugin.plugins:ApplicationPlugin",
                     "FirstApplicationPlugin",
+                    distro=plugin_distro,
                 )
             ],
             [
                 EntryPoint(
-                    "poetry-plugin",
+                    entrypoint_name,
                     "poetry_plugin.plugins:Plugin",
                     "FirstPlugin",
+                    distro=plugin_distro,
                 )
             ],
         ],
     )
 
-    installed.add_package(Package("poetry-plugin", "1.2.3"))
+    installed.add_package(plugin_package)
 
     tester.execute("")
 
@@ -78,6 +95,8 @@ def test_show_displays_installed_plugins_with_multiple_plugins(
     tester: CommandTester,
     installed: Repository,
     mocker: MockerFixture,
+    plugin_package: Package,
+    plugin_distro: Distribution,
 ):
     mocker.patch(
         "entrypoints.get_group_all",
@@ -87,11 +106,13 @@ def test_show_displays_installed_plugins_with_multiple_plugins(
                     "poetry-plugin",
                     "poetry_plugin.plugins:ApplicationPlugin",
                     "FirstApplicationPlugin",
+                    distro=plugin_distro,
                 ),
                 EntryPoint(
                     "poetry-plugin",
                     "poetry_plugin.plugins:ApplicationPlugin",
                     "SecondApplicationPlugin",
+                    distro=plugin_distro,
                 ),
             ],
             [
@@ -99,17 +120,19 @@ def test_show_displays_installed_plugins_with_multiple_plugins(
                     "poetry-plugin",
                     "poetry_plugin.plugins:Plugin",
                     "FirstPlugin",
+                    distro=plugin_distro,
                 ),
                 EntryPoint(
                     "poetry-plugin",
                     "poetry_plugin.plugins:Plugin",
                     "SecondPlugin",
+                    distro=plugin_distro,
                 ),
             ],
         ],
     )
 
-    installed.add_package(Package("poetry-plugin", "1.2.3"))
+    installed.add_package(plugin_package)
 
     tester.execute("")
 
@@ -126,6 +149,8 @@ def test_show_displays_installed_plugins_with_dependencies(
     tester: CommandTester,
     installed: Repository,
     mocker: MockerFixture,
+    plugin_package: Package,
+    plugin_distro: Distribution,
 ):
     mocker.patch(
         "entrypoints.get_group_all",
@@ -135,6 +160,7 @@ def test_show_displays_installed_plugins_with_dependencies(
                     "poetry-plugin",
                     "poetry_plugin.plugins:ApplicationPlugin",
                     "FirstApplicationPlugin",
+                    distro=plugin_distro,
                 )
             ],
             [
@@ -142,15 +168,15 @@ def test_show_displays_installed_plugins_with_dependencies(
                     "poetry-plugin",
                     "poetry_plugin.plugins:Plugin",
                     "FirstPlugin",
+                    distro=plugin_distro,
                 )
             ],
         ],
     )
 
-    plugin = Package("poetry-plugin", "1.2.3")
-    plugin.add_dependency(Factory.create_dependency("foo", ">=1.2.3"))
-    plugin.add_dependency(Factory.create_dependency("bar", "<4.5.6"))
-    installed.add_package(plugin)
+    plugin_package.add_dependency(Factory.create_dependency("foo", ">=1.2.3"))
+    plugin_package.add_dependency(Factory.create_dependency("bar", "<4.5.6"))
+    installed.add_package(plugin_package)
 
     tester.execute("")
 


### PR DESCRIPTION
Prior to this change the `plugin show` command assumed the entrypoint
name to be the same as the package providing the plugin. This change
makes use of the `entrypoint.distro.name` instead to derive the source
package.

Resolves: #5417
