### PR TITLE
Issue #4667: msft has a different bin directory for python

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1122,6 +1122,7 @@ class Env:
 
     def __init__(self, path: Path, base: Path | None = None) -> None:
         self._is_windows = sys.platform == "win32"
+        self._is_windows_from_microsoft_store = Path.home() / 'AppData' / 'Local' / 'Microsoft' in Path(sys.executable).parents
         self._is_mingw = sysconfig.get_platform().startswith("mingw")
         self._is_conda = bool(os.environ.get("CONDA_DEFAULT_ENV"))
 
@@ -1130,7 +1131,7 @@ class Env:
         else:
             bin_dir = "Scripts"
         self._path = path
-        self._bin_dir = self._path / bin_dir
+        self._bin_dir = self._path if self._is_windows_from_microsoft_store else self._path / bin_dir
 
         self._executable = "python"
         self._pip_executable = "pip"


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4667 

Just adds another condition to check if it's in the default MSFT directory, which doesn't have the default /bin path for the python executable.