### PR TITLE
add prefetching of index in PEP503 repositories

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -237,7 +237,7 @@ Note the trailing `/simple/`. This is important when configuring
 
 {{% /note %}}
 
-Repositories following the [PEP503](https://peps.python.org/pep-0503/)
+Repositories following the [PEP 503](https://peps.python.org/pep-0503/)
 specification should expose a root page with individual links for each
 package it serves. This isn't reliably implemented everywhere, which
 leads to increased network traffic and slower resolve times. If you're

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -237,6 +237,20 @@ Note the trailing `/simple/`. This is important when configuring
 
 {{% /note %}}
 
+Repositories following the [PEP503](https://peps.python.org/pep-0503/)
+specification should expose a root page with individual links for each
+package it serves. This isn't reliably implemented everywhere, which
+leads to increased network traffic and slower resolve times. If you're
+using a repository which has a valid listing, you can add the
+`indexed` property to let Poetry prefetch and cache this package list.
+
+```toml
+[[tool.poetry.source]]
+name = "foo"
+url = "https://foo.bar/simple/"
+indexed = true
+```
+
 In addition to [PEP 503](https://peps.python.org/pep-0503/), Poetry can also handle simple API
 repositories that implement [PEP 658](https://peps.python.org/pep-0658/) (*Introduced in 1.2.0*).
 This is helpful in reducing dependency resolution time for packages from these sources as Poetry can

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -185,6 +185,7 @@ class Factory(BaseFactory):
             raise RuntimeError("Missing [name] in source.")
         name = source["name"]
         url = source["url"]
+        indexed = bool(source.get("indexed", False))
 
         repository_class = LegacyRepository
 
@@ -196,6 +197,7 @@ class Factory(BaseFactory):
             url,
             config=auth_config,
             disable_cache=disable_cache,
+            indexed=indexed,
         )
 
     @classmethod

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -174,6 +174,7 @@ class Factory(BaseFactory):
     def create_package_source(
         cls, source: dict[str, str], auth_config: Config, disable_cache: bool = False
     ) -> LegacyRepository:
+        from poetry.repositories.indexed import IndexedLegacyRepository
         from poetry.repositories.legacy_repository import LegacyRepository
         from poetry.repositories.single_page_repository import SinglePageRepository
 
@@ -191,13 +192,18 @@ class Factory(BaseFactory):
 
         if re.match(r".*\.(htm|html)$", url):
             repository_class = SinglePageRepository
+            if indexed:
+                raise RuntimeError(
+                    "cannot set indexed=True for a single-page repository"
+                )
+        elif indexed:
+            repository_class = IndexedLegacyRepository
 
         return repository_class(
             name,
             url,
             config=auth_config,
             disable_cache=disable_cache,
-            indexed=indexed,
         )
 
     @classmethod

--- a/src/poetry/repositories/indexed.py
+++ b/src/poetry/repositories/indexed.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from poetry.core.packages.package import Package
-
 from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.link_sources.html import SimpleIndexPage
@@ -11,6 +9,7 @@ from poetry.repositories.link_sources.html import SimpleIndexPage
 
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
+    from poetry.core.packages.package import Package
 
     from poetry.config.config import Config
 

--- a/src/poetry/repositories/indexed.py
+++ b/src/poetry/repositories/indexed.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from poetry.core.packages.package import Package
+
+from poetry.repositories.exceptions import RepositoryError
+from poetry.repositories.legacy_repository import LegacyRepository
+from poetry.repositories.link_sources.html import SimpleIndexPage
+
+
+if TYPE_CHECKING:
+    from poetry.core.packages.dependency import Dependency
+
+    from poetry.config.config import Config
+
+
+class IndexedLegacyRepository(LegacyRepository):
+    def __init__(
+        self,
+        name: str,
+        url: str,
+        config: Config | None = None,
+        disable_cache: bool = False,
+    ) -> None:
+        super().__init__(name, url.rstrip("/"), config, disable_cache)
+
+        self._index_page = self._get_index_page()
+
+    def find_packages(self, dependency: Dependency) -> list[Package]:
+        if not self._index_page.serves_package(dependency.name):
+            return []
+
+        return super().find_packages(dependency)
+
+    def _get_index_page(self) -> SimpleIndexPage | None:
+        response = self._get_response("")
+        if not response:
+            raise RepositoryError(
+                f"Failed fetching index page for repository {self.name}"
+            )
+        return SimpleIndexPage(response.url, response.text)

--- a/src/poetry/repositories/indexed.py
+++ b/src/poetry/repositories/indexed.py
@@ -33,7 +33,7 @@ class IndexedLegacyRepository(LegacyRepository):
 
         return super().find_packages(dependency)
 
-    def _get_index_page(self) -> SimpleIndexPage | None:
+    def _get_index_page(self) -> SimpleIndexPage:
         response = self._get_response("")
         if not response:
             raise RepositoryError(

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -9,7 +9,6 @@ from poetry.core.semver.version import Version
 from poetry.inspection.info import PackageInfo
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.http import HTTPRepository
-from poetry.repositories.link_sources.html import SimpleIndexPage
 from poetry.repositories.link_sources.html import SimpleRepositoryPage
 from poetry.utils.helpers import canonicalize_name
 
@@ -28,16 +27,11 @@ class LegacyRepository(HTTPRepository):
         url: str,
         config: Config | None = None,
         disable_cache: bool = False,
-        indexed: bool = False,
     ) -> None:
         if name == "pypi":
             raise ValueError("The name [pypi] is reserved for repositories")
 
         super().__init__(name, url.rstrip("/"), config, disable_cache)
-
-        self._index_page = None
-        if indexed:
-            self._index_page = self._get_index_page()
 
     def find_packages(self, dependency: Dependency) -> list[Package]:
         packages = []
@@ -54,11 +48,6 @@ class LegacyRepository(HTTPRepository):
         if self._cache.store("matches").has(key):
             versions = self._cache.store("matches").get(key)
         else:
-            if self._index_page is not None and not self._index_page.serves_package(
-                dependency.name
-            ):
-                return []
-
             page = self._get_page(f"/{dependency.name.replace('.', '-')}/")
             if page is None:
                 return []
@@ -158,9 +147,3 @@ class LegacyRepository(HTTPRepository):
         if not response:
             return None
         return SimpleRepositoryPage(response.url, response.text)
-
-    def _get_index_page(self) -> SimpleIndexPage | None:
-        response = self._get_response("")
-        if not response:
-            return None
-        return SimpleIndexPage(response.url, response.text)

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -69,7 +69,10 @@ class SimpleIndexPage:
         # case-insensitive. For simplicity, we'll do lookups using
         # lowercase-naming, and treating - and _ equivalently.
         for anchor in self._parsed.findall(".//a"):
-            text: str = anchor.text
+            text: str | None = anchor.text
+            if text is None:
+                continue
+
             yield text.lower().replace("-", "_")
 
     def serves_package(self, name: str) -> bool:

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -49,7 +49,7 @@ class SimpleRepositoryPage(HTMLPage):
 
 
 class SimpleIndexPage:
-    """Describes the root page of a PEP503 compliant repository.
+    """Describes the root page of a PEP 503 compliant repository.
 
     This contains a list of links, each one corresponding to a served project.
     """

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -46,3 +46,30 @@ class SimpleRepositoryPage(HTMLPage):
         if not url.endswith("/"):
             url += "/"
         super().__init__(url=url, content=content)
+
+
+class SimpleIndexPage:
+    """Describes the root page of a PEP503 compliant repository.
+
+    This contains a list of links, each one corresponding to a served project.
+    """
+
+    def __init__(self, url: str, content: str) -> None:
+        if not url.endswith("/"):
+            url += "/"
+
+        self._url = url
+        self._content = content
+        self._parsed = html5lib.parse(content, namespaceHTMLElements=False)
+        self._cached_packages = set(self.links)
+
+    @property
+    def links(self) -> Iterator[Link]:
+        # Note: PEP426 specifies that comparisons should be
+        # case-insensitive. For simplicity, we'll do lookups using
+        # lowercase-naming, and treating - and _ equivalently.
+        for anchor in self._parsed.findall(".//a"):
+            yield anchor.text.lower().replace("-", "_")
+
+    def serves_package(self, name: str) -> bool:
+        return name.lower().replace("-", "_") in self._cached_packages

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from poetry.core.packages.utils.link import Link
 
 from poetry.repositories.link_sources.base import LinkSource
+from poetry.utils.helpers import canonicalize_name
 
 
 if TYPE_CHECKING:
@@ -73,7 +74,7 @@ class SimpleIndexPage:
             if text is None:
                 continue
 
-            yield text.lower().replace("-", "_")
+            yield canonicalize_name(text)
 
     def serves_package(self, name: str) -> bool:
-        return name.lower().replace("-", "_") in self._cached_packages
+        return canonicalize_name(name) in self._cached_packages

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -64,12 +64,13 @@ class SimpleIndexPage:
         self._cached_packages = set(self.links)
 
     @property
-    def links(self) -> Iterator[Link]:
+    def links(self) -> Iterator[str]:
         # Note: PEP426 specifies that comparisons should be
         # case-insensitive. For simplicity, we'll do lookups using
         # lowercase-naming, and treating - and _ equivalently.
         for anchor in self._parsed.findall(".//a"):
-            yield anchor.text.lower().replace("-", "_")
+            text: str = anchor.text
+            yield text.lower().replace("-", "_")
 
     def serves_package(self, name: str) -> bool:
         return name.lower().replace("-", "_") in self._cached_packages

--- a/tests/mixology/version_solver/test_dependency_cache.py
+++ b/tests/mixology/version_solver/test_dependency_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from poetry.factory import Factory
@@ -34,8 +35,10 @@ def test_solver_dependency_cache_respects_source_type(
     cache.search_for(dependency_git)
     assert not cache.search_for.cache_info().hits
 
-    packages_pypi = cache.search_for(dependency_pypi)
-    packages_git = cache.search_for(dependency_git)
+    # increase test coverage by searching for copies
+    # (when searching for the exact same object, __eq__ is never called)
+    packages_pypi = cache.search_for(deepcopy(dependency_pypi))
+    packages_git = cache.search_for(deepcopy(dependency_git))
 
     assert cache.search_for.cache_info().hits == 2
     assert cache.search_for.cache_info().currsize == 2
@@ -90,8 +93,10 @@ def test_solver_dependency_cache_respects_subdirectories(
     cache.search_for(dependency_one_copy)
     assert not cache.search_for.cache_info().hits
 
-    packages_one = cache.search_for(dependency_one)
-    packages_one_copy = cache.search_for(dependency_one_copy)
+    # increase test coverage by searching for copies
+    # (when searching for the exact same object, __eq__ is never called)
+    packages_one = cache.search_for(deepcopy(dependency_one))
+    packages_one_copy = cache.search_for(deepcopy(dependency_one_copy))
 
     assert cache.search_for.cache_info().hits == 2
     assert cache.search_for.cache_info().currsize == 2

--- a/tests/repositories/fixtures/legacy/index.html
+++ b/tests/repositories/fixtures/legacy/index.html
@@ -1,0 +1,3 @@
+<a href="pyyaml/">pyyaml</a>
+<a href="missing-version/">missing-version</a>
+<a href="black/">black</a>


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4885, partially

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

# Description

This PR adds a new keyword `indexed` when defining a LegacyRepository (e.g. PEP503) source. The `indexed` keyword enables the use of a prefetched and cached index, which will limit the amount of unnecessary calls. 

Currently, if one configures a secondary repository for Poetry it'll get queried for all dependencies, no matter whether it's default, primary, or secondary. For projects with lots of dependencies (transitive or direct) this leads to a lot of unnecessary calls to a host which can't serve the requested package. One such case is using GPU-based packages from https://download.pytorch.org/whl/, where most other packages should be served from Pypi. This leads to user confusion due to error messages; and takes a *lot* of time.

While update-time on a cold cache is dominated by downloading every possible GPU package; this PR changes *noop* `poetry update` time from 30-40 seconds to <5 seconds. In total, this repository has 89 dependencies (reported by `poetry show`). 

Also, it removes all errors from querying subpages that don't exist. 

This depends on a PR to `poetry-core`, and thus a release there: https://github.com/python-poetry/poetry-core/pull/323

## Timing

### Poetry==1.2.0b1

```
===> multitime results
1: poetry update
            Mean        Std.Dev.    Min         Median      Max
real        36.818      2.927       32.470      36.176      44.032
user        3.478       0.040       3.408       3.480       3.568
sys         0.126       0.030       0.075       0.123       0.181
```


### This PR

```
===> multitime results
1: poetry update
            Mean        Std.Dev.    Min         Median      Max
real        4.617       0.211       4.410       4.588       5.165
user        3.362       0.162       3.235       3.301       3.813
sys         0.097       0.027       0.059       0.099       0.151
```