### PR TITLE
add `--why` option to `poetry show`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -439,6 +439,7 @@ required by
 ### Options
 
 * `--without`: The dependency groups to ignore.
+* `--why`: Include reverse dependencies where applicable.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
 * `--default`: Only include the main dependencies. (**Deprecated**)

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -39,7 +39,7 @@ class ShowCommand(GroupCommand):
         option(
             "why",
             None,
-            "When listing the tree for a single package, show also show parents.",
+            "When listing the tree for a single package, start from parents.",
         ),
         option("latest", "l", "Show the latest version."),
         option(

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -96,8 +96,8 @@ lists all packages available."""
 
             if not self.option("tree") and package:
                 self.line_error(
-                    "<error>Error: --why cannot be used when displaying a single"
-                    " package.</error>"
+                    "<error>Error: --why cannot be used without --tree when displaying"
+                    " a single package.</error>"
                 )
 
                 return 1

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -36,6 +36,11 @@ class ShowCommand(GroupCommand):
             "Do not list the development dependencies. (<warning>Deprecated</warning>)",
         ),
         option("tree", "t", "List the dependencies as a tree."),
+        option(
+            "why",
+            None,
+            "When listing the tree for a single package, show also show parents.",
+        ),
         option("latest", "l", "Show the latest version."),
         option(
             "outdated",
@@ -69,6 +74,13 @@ lists all packages available."""
         if self.option("tree"):
             self.init_styles(self.io)
 
+        if self.option("why") and package is None:
+            self.line_error(
+                "<error>Error: --why requires specifying a package name.</error>"
+            )
+
+            return 1
+
         if self.option("outdated"):
             self._io.input.set_option("latest", True)
 
@@ -83,7 +95,7 @@ lists all packages available."""
         root = self.project_with_activated_groups_only()
 
         # Show tree view if requested
-        if self.option("tree") and not package:
+        if self.option("tree") and package is None:
             requires = root.all_requires
             packages = locked_repo.packages
             for p in packages:
@@ -121,17 +133,43 @@ lists all packages available."""
             if not pkg:
                 raise ValueError(f"Package {package} not found")
 
-            if self.option("tree"):
-                self.display_package_tree(self.io, pkg, locked_repo)
-
-                return 0
-
             required_by = {}
             for locked in locked_packages:
                 dependencies = {d.name: d.pretty_constraint for d in locked.requires}
 
                 if pkg.name in dependencies:
                     required_by[locked.pretty_name] = dependencies[pkg.name]
+
+            if self.option("tree"):
+                if self.option("why"):
+                    # The default case if there's no reverse dependencies is to query
+                    # the subtree for pkg but if any rev-deps exist we'll query for each
+                    # of them in turn
+                    packages = [pkg]
+                    if required_by:
+                        packages = [
+                            p
+                            for p in locked_packages
+                            for r in required_by.keys()
+                            if p.name == r
+                        ]
+                    else:
+                        # if no rev-deps exist we'll make this clear as it can otherwise
+                        # look very odd for packages that also have no or few direct
+                        # dependencies
+                        self._io.write_line(
+                            f"Package {package} is a direct dependency."
+                        )
+
+                    for p in packages:
+                        self.display_package_tree(
+                            self._io, p, locked_repo, why_package=pkg
+                        )
+
+                else:
+                    self.display_package_tree(self._io, pkg, locked_repo)
+
+                return 0
 
             rows = [
                 ["<info>name</>", f" : <c1>{pkg.pretty_name}</>"],
@@ -288,7 +326,11 @@ lists all packages available."""
         return None
 
     def display_package_tree(
-        self, io: IO, package: Package, installed_repo: Repository
+        self,
+        io: IO,
+        package: Package,
+        installed_repo: Repository,
+        why_package: Package | None = None,
     ) -> None:
         io.write(f"<c1>{package.pretty_name}</c1>")
         description = ""
@@ -297,11 +339,15 @@ lists all packages available."""
 
         io.write_line(f" <b>{package.pretty_version}</b>{description}")
 
-        dependencies = package.requires
-        dependencies = sorted(
-            dependencies,
-            key=lambda x: x.name,  # type: ignore[no-any-return]
-        )
+        if why_package is not None:
+            dependencies = [p for p in package.requires if p.name == why_package.name]
+        else:
+            dependencies = package.requires
+            dependencies = sorted(
+                dependencies,
+                key=lambda x: x.name,  # type: ignore[no-any-return]
+            )
+
         tree_bar = "├"
         total = len(dependencies)
         for i, dependency in enumerate(dependencies, 1):

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -267,7 +267,7 @@ lists all packages available."""
                         required_by = reverse_deps(locked, locked_repo)
                         required_by_length = max(
                             required_by_length,
-                            len("via " + ",".join(required_by.keys())),
+                            len(" from " + ",".join(required_by.keys())),
                         )
             else:
                 name_length = max(name_length, current_length)
@@ -288,14 +288,12 @@ lists all packages available."""
 
         write_version = name_length + version_length + 3 <= width
         write_latest = name_length + version_length + latest_length + 3 <= width
-        write_why = self.option("why") and (
-            name_length + version_length + latest_length + required_by_length + 3
-            <= width
+
+        why_end_column = (
+            name_length + version_length + latest_length + required_by_length
         )
-        write_description = (
-            name_length + version_length + latest_length + required_by_length + 24
-            <= width
-        )
+        write_why = self.option("why") and (why_end_column + 3) <= width
+        write_description = (why_end_column + 24) <= width
 
         for locked in locked_packages:
             color = "cyan"

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -85,13 +85,22 @@ lists all packages available."""
         if self.option("tree"):
             self.init_styles(self.io)
 
-        if self.option("why") and self.option("tree") and package is None:
-            self.line_error(
-                "<error>Error: --why requires a package when combined with"
-                " --tree.</error>"
-            )
+        if self.option("why"):
+            if self.option("tree") and package is None:
+                self.line_error(
+                    "<error>Error: --why requires a package when combined with"
+                    " --tree.</error>"
+                )
 
-            return 1
+                return 1
+
+            if not self.option("tree") and package:
+                self.line_error(
+                    "<error>Error: --why cannot be used when displaying a single"
+                    " package.</error>"
+                )
+
+                return 1
 
         if self.option("outdated"):
             self._io.input.set_option("latest", True)

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1686,6 +1686,64 @@ cachy 0.2.0
     assert tester.io.fetch_output() == expected
 
 
+def test_show_tree_why(tester: CommandTester, poetry: Poetry, installed: Repository):
+    poetry.package.add_dependency(Factory.create_dependency("a", "=0.0.1"))
+
+    a = get_package("a", "0.0.1")
+    installed.add_package(a)
+    a.add_dependency(Factory.create_dependency("b", "=0.0.1"))
+
+    b = get_package("b", "0.0.1")
+    a.add_dependency(Factory.create_dependency("c", "=0.0.1"))
+    installed.add_package(b)
+
+    c = get_package("c", "0.0.1")
+    installed.add_package(c)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "a",
+                    "version": "0.0.1",
+                    "dependencies": {"b": "=0.0.1"},
+                    "python-versions": "*",
+                    "optional": False,
+                },
+                {
+                    "name": "b",
+                    "version": "0.0.1",
+                    "dependencies": {"c": "=0.0.1"},
+                    "python-versions": "*",
+                    "optional": False,
+                },
+                {
+                    "name": "c",
+                    "version": "0.0.1",
+                    "python-versions": "*",
+                    "optional": False,
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"a": [], "b": [], "c": []},
+            },
+        }
+    )
+
+    tester.execute("--tree --why b")
+
+    expected = """\
+a 0.0.1
+└── b =0.0.1
+    └── c =0.0.1
+"""
+
+    assert tester.io.fetch_output() == expected
+
+
 def test_show_required_by_deps(
     tester: CommandTester, poetry: Poetry, installed: Repository
 ):

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1686,7 +1686,9 @@ cachy 0.2.0
     assert tester.io.fetch_output() == expected
 
 
-def test_show_tree_why(tester: CommandTester, poetry: Poetry, installed: Repository):
+def test_show_tree_why_package(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+):
     poetry.package.add_dependency(Factory.create_dependency("a", "=0.0.1"))
 
     a = get_package("a", "0.0.1")
@@ -1738,8 +1740,63 @@ def test_show_tree_why(tester: CommandTester, poetry: Poetry, installed: Reposit
     expected = """\
 a 0.0.1
 └── b =0.0.1
-    └── c =0.0.1
-"""
+    └── c =0.0.1 \n"""
+
+    assert tester.io.fetch_output() == expected
+
+
+def test_show_tree_why(tester: CommandTester, poetry: Poetry, installed: Repository):
+    poetry.package.add_dependency(Factory.create_dependency("a", "=0.0.1"))
+
+    a = get_package("a", "0.0.1")
+    installed.add_package(a)
+    a.add_dependency(Factory.create_dependency("b", "=0.0.1"))
+
+    b = get_package("b", "0.0.1")
+    a.add_dependency(Factory.create_dependency("c", "=0.0.1"))
+    installed.add_package(b)
+
+    c = get_package("c", "0.0.1")
+    installed.add_package(c)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "a",
+                    "version": "0.0.1",
+                    "dependencies": {"b": "=0.0.1"},
+                    "python-versions": "*",
+                    "optional": False,
+                },
+                {
+                    "name": "b",
+                    "version": "0.0.1",
+                    "dependencies": {"c": "=0.0.1"},
+                    "python-versions": "*",
+                    "optional": False,
+                },
+                {
+                    "name": "c",
+                    "version": "0.0.1",
+                    "python-versions": "*",
+                    "optional": False,
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"a": [], "b": [], "c": []},
+            },
+        }
+    )
+
+    tester.execute("--why")
+
+    # this has to be on a single line due to the padding whitespace, which gets stripped
+    # by pre-commit.
+    expected = """a 0.0.1        \nb 0.0.1 from a \nc 0.0.1 from b \n"""
 
     assert tester.io.fetch_output() == expected
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5396

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code. (none found for poetry show)

This adds a `--why` option which when combined with `--tree` and a single package starts the tree at the parent level to show why a specific dependency is included. Optimally this'd walk the tree to the root; but that requires a graph-like structure to easily do/filter, and feels out of scope for this PR. 

# Example output

Without `--why`:
```
$ poetry show requests --tree
requests 2.27.1 Python HTTP for Humans.
├── certifi >=2017.4.17
├── charset-normalizer >=2.0.0,<2.1.0
├── idna >=2.5,<4
└── urllib3 >=1.21.1,<1.27
```

With `--why`:
```
$ poetry show requests --tree --why
cachecontrol 0.12.10 httplib2 caching for requests
└── requests *
    ├── certifi >=2017.4.17
    ├── charset-normalizer >=2.0.0,<2.1.0
    ├── idna >=2.5,<4
    └── urllib3 >=1.21.1,<1.27
requests-toolbelt 0.9.1 A utility belt for advanced users of python-requests
└── requests >=2.0.1,<3.0.0
    ├── certifi >=2017.4.17
    ├── charset-normalizer >=2.0.0,<2.1.0
    ├── idna >=2.5,<4
    └── urllib3 >=1.21.1,<1.27
```

On a package with no parent:

```
$ poetry show --tree cachy --why
Package cachy is a direct dependency.
cachy 0.3.0 Cachy provides a simple yet effective caching library.
```

Forgetting to specify package:
```
$ poetry show --tree --why
Error: --why requires specifying a package name.
```