### PR TITLE
feat(console/commands): add --all-groups

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -163,6 +163,13 @@ It's also possible to only install specific dependency groups by using the `only
 poetry install --only test,docs
 ```
 
+You may also enable all available dependency groups with the `--all-groups`
+option:
+
+```bash
+poetry install --all-groups
+```
+
 {{% note %}}
 The `--dev-only` option is now deprecated. You should use the `--only dev` notation instead.
 {{% /note %}}

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -18,6 +18,11 @@ class GroupCommand(EnvCommand):
     def _group_dependency_options() -> list[Option]:
         return [
             option(
+                "all-groups",
+                None,
+                "Include all dependency groups.",
+            ),
+            option(
                 "without",
                 None,
                 "The dependency groups to ignore.",
@@ -57,6 +62,9 @@ class GroupCommand(EnvCommand):
 
     @property
     def activated_groups(self) -> set[str]:
+        if self.option("all-groups"):
+            return self.poetry.package._dependency_groups
+
         groups = {}
 
         for key in {"with", "without", "only"}:

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -66,6 +66,7 @@ def tester(
     ("options", "groups"),
     [
         ("", {"default", "foo", "bar", "baz", "bim"}),
+        ("--all-groups", {"default", "foo", "bar", "baz", "bim", "bam"}),
         ("--only default", {"default"}),
         ("--only foo", {"foo"}),
         ("--only foo,bar", {"foo", "bar"}),


### PR DESCRIPTION
# Pull Request Check List

Resolves: N/A

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This adds a utility flag `--all-groups` to `install` which enables all available
dependency groups.

It's handy if you have lots of groups which you almost always want.
