### PR TITLE
Issue #5107: Support multiple respositories on same host with different credentials.

### DIFF
--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -158,7 +158,7 @@ class Authenticator:
         parsed_repository_url = urllib.parse.urlsplit(repository_url)
         parsed_package_url = urllib.parse.urlsplit(url)
 
-        if parsed_package_url is None or (
+        if url is None or (
             parsed_repository_url.netloc == parsed_package_url.netloc
             and parsed_repository_url.path in parsed_package_url.path
         ):

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -207,6 +207,14 @@ class Authenticator:
                 "password": cred.password,
             }
 
+        parsed_url = urllib.parse.urlsplit(url)
+        cred = keyring.get_credential(parsed_url.netloc, username)
+        if cred is not None:
+            return {
+                "username": cred.username,
+                "password": cred.password,
+            }
+
         if username:
             return {
                 "username": username,

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -160,7 +160,7 @@ class Authenticator:
 
         if url is None or (
             parsed_repository_url.netloc == parsed_package_url.netloc
-            and parsed_repository_url.path in parsed_package_url.path
+            and parsed_package_url.path.startswith(parsed_repository_url.path)
         ):
             auth = self._password_manager.get_http_auth(name)
 

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -111,7 +111,7 @@ def test_authenticator_uses_credentials_from_config_with_at_sign_in_path(
     config.merge(
         {
             "repositories": {
-                "foo": {"url": "https://foo.bar/files/simple/"},
+                "foo": {"url": "https://foo.bar/beta/files/simple/"},
             },
             "http-basic": {
                 "foo": {"username": "bar", "password": "baz"},


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5107

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Motivation: when using a private package registry (f.e. GitLab), you often end up with multiple registries with different credentials hosted on the same domain. Poetry is using only netloc part of the URL to determine what credentials to use.

Fix: Replace netloc with repository URL, then credentials can be looked up by finding matching netlocs and checking if the repository URL path is a substring of the package URL path.