### PR TITLE
Rename implicit group "default" to "main"

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -218,7 +218,7 @@ option is used.
 * `--without`: The dependency groups to ignore.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
-* `--default`: Only include the default dependencies. (**Deprecated**)
+* `--default`: Only include the main dependencies. (**Deprecated**)
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
 * `--no-root`: Do not install the root package (your project).
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
@@ -258,7 +258,7 @@ update the constraint, for example `^2.3`. You can do this using the `add` comma
 * `--without`: The dependency groups to ignore.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
-* `--default`: Only include the default dependencies. (**Deprecated**)
+* `--default`: Only include the main dependencies. (**Deprecated**)
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
 * `--no-dev` : Do not update the development dependencies. (**Deprecated**)
 * `--lock` : Do not perform install (only update the lockfile).
@@ -439,7 +439,7 @@ required by
 * `--without`: The dependency groups to ignore.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
-* `--default`: Only include the default dependencies. (**Deprecated**)
+* `--default`: Only include the main dependencies. (**Deprecated**)
 * `--no-dev`: Do not list the dev dependencies. (**Deprecated**)
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
@@ -626,7 +626,7 @@ and is also available as a pre-commit hook. See [pre-commit hooks](/docs/pre-com
 {{% /note %}}
 
 {{% note %}}
-Unlike the `install` command, this command only includes the project's dependencies defined in the implicit `default`
+Unlike the `install` command, this command only includes the project's dependencies defined in the implicit `main`
 group defined in `tool.poetry.dependencies` when used without specifying any options.
 {{% /note %}}
 
@@ -641,7 +641,7 @@ group defined in `tool.poetry.dependencies` when used without specifying any opt
 * `--without`: The dependency groups to ignore.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
-* `--default`: Only include the default dependencies. (**Deprecated**)
+* `--default`: Only include the main dependencies. (**Deprecated**)
 * `--without-hashes`: Exclude hashes from the exported file.
 * `--without-urls`: Exclude source repository urls from the exported file.
 * `--with-credentials`: Include credentials for extra indices.

--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -37,10 +37,10 @@ the dependencies logically.
 {{% /note %}}
 
 {{% note %}}
-The dependencies declared in `tool.poetry.dependencies` are part of an implicit `default` group.
+The dependencies declared in `tool.poetry.dependencies` are part of an implicit `main` group.
 
 ```toml
-[tool.poetry.dependencies]  # Default dependency group
+[tool.poetry.dependencies]  # main dependency group
 httpx = "*"
 pendulum = "*"
 
@@ -115,7 +115,7 @@ If the group does not already exist, it will be created automatically.
 `poetry install`.
 
 {{% note %}}
-The default set of dependencies for a project includes the implicit `default` group defined in
+The default set of dependencies for a project includes the implicit `main` group defined in
 `tool.poetry.dependencies` as well as all groups that are not explicitly marked as an
 [optional group]({{< relref "#optional-groups" >}}).
 {{% /note %}}
@@ -151,10 +151,10 @@ poetry install --only docs
 
 {{% note %}}
 If you only want to install the project's runtime dependencies, you can do so  with the
-`--only default` notation:
+`--only main` notation:
 
 ```bash
-poetry install --only default
+poetry install --only main
 ```
 {{% /note %}}
 

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -7,6 +7,12 @@ from typing import cast
 from cleo.helpers import argument
 from cleo.helpers import option
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry.console.commands.init import InitCommand
 from poetry.console.commands.installer_command import InstallerCommand
 
@@ -23,7 +29,7 @@ class AddCommand(InstallerCommand, InitCommand):
             "-G",
             "The group to add the dependency to.",
             flag=False,
-            default="default",
+            default=MAIN_GROUP,
         ),
         option("dev", "D", "Add as a development dependency."),
         option("editable", "e", "Add vcs/path dependencies as editable."),
@@ -111,7 +117,7 @@ You can specify a package in the following forms:
         content = self.poetry.file.read()
         poetry_content = content["tool"]["poetry"]
 
-        if group == "default":
+        if group == MAIN_GROUP:
             if "dependencies" not in poetry_content:
                 poetry_content["dependencies"] = table()
 

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -4,6 +4,12 @@ from typing import TYPE_CHECKING
 
 from cleo.helpers import option
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry.console.commands.env_command import EnvCommand
 
 
@@ -34,8 +40,7 @@ class GroupCommand(EnvCommand):
             option(
                 "default",
                 None,
-                "Only include the default dependencies."
-                " (<warning>Deprecated</warning>)",
+                "Only include the main dependencies. (<warning>Deprecated</warning>)",
             ),
             option(
                 "only",
@@ -67,10 +72,10 @@ class GroupCommand(EnvCommand):
             }
 
         for opt, new, group in [
-            ("default", "only", "default"),
-            ("no-dev", "only", "default"),
+            ("default", "only", MAIN_GROUP),
+            ("no-dev", "only", MAIN_GROUP),
             ("dev", "with", "dev"),
-            ("dev-only", "without", "default"),
+            ("dev-only", "without", MAIN_GROUP),
         ]:
             if self.io.input.has_option(opt) and self.option(opt):
                 self.line_error(

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -61,6 +61,15 @@ class GroupCommand(EnvCommand):
         }
 
     @property
+    def default_groups(self) -> set[str]:
+        """
+        The groups that are considered by the command by default.
+
+        Can be overridden to adapt behavior.
+        """
+        return self.non_optional_groups
+
+    @property
     def activated_groups(self) -> set[str]:
         groups = {}
 
@@ -93,9 +102,9 @@ class GroupCommand(EnvCommand):
                 "</warning>"
             )
 
-        return groups["only"] or self.non_optional_groups.union(
-            groups["with"]
-        ).difference(groups["without"])
+        return groups["only"] or self.default_groups.union(groups["with"]).difference(
+            groups["without"]
+        )
 
     def project_with_activated_groups_only(self) -> ProjectPackage:
         return self.poetry.package.with_dependency_groups(

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -5,6 +5,12 @@ from typing import Any
 from cleo.helpers import argument
 from cleo.helpers import option
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry.console.commands.installer_command import InstallerCommand
 
 
@@ -55,10 +61,10 @@ list of installed packages
             ]
 
             for group_name, section in [
-                ("default", poetry_content["dependencies"])
+                (MAIN_GROUP, poetry_content["dependencies"])
             ] + group_sections:
                 removed += self._remove_packages(packages, section, group_name)
-                if group_name != "default":
+                if group_name != MAIN_GROUP:
                     if not section:
                         del poetry_content["group"][group_name]
                     else:

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -14,6 +14,12 @@ from typing import Iterator
 from typing import Sequence
 
 from poetry.core.packages.dependency import Dependency
+
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
 from poetry.core.packages.package import Package
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version import Version
@@ -121,7 +127,7 @@ class Locker:
             )
             package.description = info.get("description", "")
             package.category = info.get("category", "main")
-            package.groups = info.get("groups", ["default"])
+            package.groups = info.get("groups", [MAIN_GROUP])
             package.optional = info["optional"]
             if "hashes" in lock_data["metadata"]:
                 # Old lock so we create dummy files from the hashes

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -10,6 +10,12 @@ from typing import FrozenSet
 from typing import Iterator
 from typing import Tuple
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry.mixology import resolve_version
 from poetry.mixology.failure import SolveFailure
 from poetry.packages import DependencyPackage
@@ -270,7 +276,7 @@ class PackageNode(DFSNode):
             self.groups: frozenset[str] = frozenset()
             self.optional = True
         elif dep:
-            self.category = "main" if "default" in dep.groups else "dev"
+            self.category = "main" if MAIN_GROUP in dep.groups else "dev"
             self.groups = dep.groups
             self.optional = dep.is_optional()
         else:
@@ -348,7 +354,7 @@ def aggregate_package_nodes(nodes: list[PackageNode]) -> tuple[Package, int]:
     for node in nodes:
         groups.extend(node.groups)
 
-    category = "main" if any("default" in node.groups for node in nodes) else "dev"
+    category = "main" if any(MAIN_GROUP in node.groups for node in nodes) else "dev"
     optional = all(node.optional for node in nodes)
     for node in nodes:
         node.depth = depth

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -7,6 +7,11 @@ import pytest
 from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
 
 
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 if TYPE_CHECKING:
     from cleo.testers.command_tester import CommandTester
     from pytest_mock import MockerFixture
@@ -65,23 +70,23 @@ def tester(
 @pytest.mark.parametrize(
     ("options", "groups"),
     [
-        ("", {"default", "foo", "bar", "baz", "bim"}),
-        ("--only default", {"default"}),
+        ("", {MAIN_GROUP, "foo", "bar", "baz", "bim"}),
+        (f"--only {MAIN_GROUP}", {MAIN_GROUP}),
         ("--only foo", {"foo"}),
         ("--only foo,bar", {"foo", "bar"}),
         ("--only bam", {"bam"}),
-        ("--with bam", {"default", "foo", "bar", "baz", "bim", "bam"}),
-        ("--without foo,bar", {"default", "baz", "bim"}),
-        ("--without default", {"foo", "bar", "baz", "bim"}),
+        ("--with bam", {MAIN_GROUP, "foo", "bar", "baz", "bim", "bam"}),
+        ("--without foo,bar", {MAIN_GROUP, "baz", "bim"}),
+        (f"--without {MAIN_GROUP}", {"foo", "bar", "baz", "bim"}),
         ("--with foo,bar --without baz --without bim --only bam", {"bam"}),
         # net result zero options
-        ("--with foo", {"default", "foo", "bar", "baz", "bim"}),
-        ("--without bam", {"default", "foo", "bar", "baz", "bim"}),
-        ("--with bam --without bam", {"default", "foo", "bar", "baz", "bim"}),
-        ("--with foo --without foo", {"default", "bar", "baz", "bim"}),
+        ("--with foo", {MAIN_GROUP, "foo", "bar", "baz", "bim"}),
+        ("--without bam", {MAIN_GROUP, "foo", "bar", "baz", "bim"}),
+        ("--with bam --without bam", {MAIN_GROUP, "foo", "bar", "baz", "bim"}),
+        ("--with foo --without foo", {MAIN_GROUP, "bar", "baz", "bim"}),
         # deprecated options
-        ("--default", {"default"}),
-        ("--no-dev", {"default"}),
+        ("--default", {MAIN_GROUP}),
+        ("--no-dev", {MAIN_GROUP}),
         ("--dev-only", {"foo", "bar", "baz", "bim"}),
     ],
 )

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -6,6 +6,12 @@ import pytest
 
 from poetry.core.packages.dependency_group import DependencyGroup
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry.factory import Factory
 from tests.helpers import get_package
 
@@ -197,13 +203,13 @@ cachy 0.1.0 Cachy package
 """,
         ),
         (
-            "--without default",
+            f"--without {MAIN_GROUP}",
             """\
 pytest 3.7.3 Pytest package
 """,
         ),
         (
-            "--only default",
+            f"--only {MAIN_GROUP}",
             """\
 cachy 0.1.0 Cachy package
 """,
@@ -228,7 +234,7 @@ pendulum 2.0.0 Pendulum package
 """,
         ),
         (
-            "--with time --without default,test",
+            f"--with time --without {MAIN_GROUP},test",
             """\
 pendulum 2.0.0 Pendulum package
 """,

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -20,6 +20,12 @@ from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.toml.file import TOMLFile
 
+
+try:
+    from poetry.core.packages.dependency_group import MAIN_GROUP
+except ImportError:
+    MAIN_GROUP = "default"
+
 from poetry.factory import Factory
 from poetry.installation import Installer as BaseInstaller
 from poetry.installation.executor import Executor as BaseExecutor
@@ -383,10 +389,10 @@ def _configure_run_install_dev(
         ([], 0, 0, 3, True),
         (["dev"], 1, 0, 0, False),
         (["dev"], 0, 0, 2, True),
-        (["default"], 2, 0, 0, False),
-        (["default"], 0, 0, 1, True),
-        (["default", "dev"], 3, 0, 0, False),
-        (["default", "dev"], 0, 0, 0, True),
+        ([MAIN_GROUP], 2, 0, 0, False),
+        ([MAIN_GROUP], 0, 0, 1, True),
+        ([MAIN_GROUP, "dev"], 3, 0, 0, False),
+        ([MAIN_GROUP, "dev"], 0, 0, 0, True),
     ],
 )
 def test_run_install_with_dependency_groups(

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -980,7 +980,7 @@ def test_solver_sub_dependencies_with_not_supported_python_version_transitive(
     )
 
 
-def test_solver_with_dependency_in_both_default_and_dev_dependencies(
+def test_solver_with_dependency_in_both_main_and_dev_dependencies(
     solver: Solver, repo: Repository, package: Package
 ):
     solver.provider.set_package_python_versions("^3.5")


### PR DESCRIPTION
This is done in order to avoid ambiguity between "default group" and "default dependencies" (the groups that are considered by a command by default)

Has to be considered together with python-poetry/poetry-core#326 and python-poetry/poetry-plugin-export#52