### PR TITLE
Automatically detect local certificates

### DIFF
--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import ssl
 
 from typing import TYPE_CHECKING
 from typing import Any
@@ -50,6 +51,13 @@ class UploadError(Exception):
         super().__init__(message)
 
 
+class SSLContextAdapter(adapters.HTTPAdapter):
+    def init_poolmanager(self, *args, **kwargs):
+        context = ssl.create_default_context()
+        kwargs['ssl_context'] = context
+        return super(SSLContextAdapter, self).init_poolmanager(*args, **kwargs)
+
+
 class Uploader:
     def __init__(self, poetry: Poetry, io: NullIO) -> None:
         self._poetry = poetry
@@ -71,7 +79,7 @@ class Uploader:
             status_forcelist=[500, 501, 502, 503],
         )
 
-        return adapters.HTTPAdapter(max_retries=retry)
+        return SSLContextAdapter(max_retries=retry)
 
     @property
     def files(self) -> list[Path]:


### PR DESCRIPTION
Specifying the `REQUESTS_CA_BUNDLE` is a useful way to include self signed certificates for non-Windows platforms, however on Windows things are a bit trickier. This change proposes to use [`create_default_context()`](https://docs.python.org/3/library/ssl.html#ssl.create_default_context) (which in turn calls, [`load_default_certs()`](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs) from the Python SSL library to include the required certificates for us.

For background, I'm on a Windows machine in a corporate environment trying (and otherwise failing) to `poetry publish` to an internal Artifactory repo. All credit to [this](https://stackoverflow.com/a/50215614/895029) Stack Overflow answer for the code.

Thanks

First time contributing - will have a look at tests and docs over the weekend to get myself more familiar. Hope that's alright.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
