### PR TITLE
fix(link_sources): don't bail on an invalid version

### DIFF
--- a/tests/repositories/fixtures/legacy/invalid-version.html
+++ b/tests/repositories/fixtures/legacy/invalid-version.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Links for poetry</title>
+  </head>
+  <body>
+    <h1>Links for poetry</h1>
+    <a href="poetry-21.07.28.5ffb65e2ff8067c732e2b178d03b707c7fb27855-py3-none-any.whl#sha256=1d85132efab8ead3c6f69202843da40a03823992091c29f8d65a31af68940163" data-requires-python="&gt;=3.6.0">poetry-21.07.28.5ffb65e2ff8067c732e2b178d03b707c7fb27855-py3-none-any.whl</a><br/>
+    <a href="poetry-0.1.0-py3-none-any.whl#sha256=1d85132efab8ead3c6f69202843da40a03823992091c29f8d65a31af68940163" data-requires-python="&gt;=3.6.0">poetry-0.1.0-py3-none-any.whl</a><br/>
+    </body>
+</html>
+<!--SERIAL 3907384-->

--- a/tests/repositories/link_sources/test_base.py
+++ b/tests/repositories/link_sources/test_base.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Iterable
+from unittest.mock import PropertyMock
+
+import pytest
+
+from poetry.core.packages.package import Package
+from poetry.core.packages.utils.link import Link
+from poetry.core.semver.version import Version
+
+from poetry.repositories.link_sources.base import LinkSource
+
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def link_source(mocker: MockerFixture) -> LinkSource:
+    url = "https://example.org"
+    link_source = LinkSource(url)
+    mocker.patch(
+        f"{LinkSource.__module__}.{LinkSource.__qualname__}.links",
+        new_callable=PropertyMock,
+        return_value=iter(
+            [
+                Link(f"{url}/demo-0.1.0.tar.gz"),
+                Link(f"{url}/demo-0.1.0_invalid.tar.gz"),
+                Link(f"{url}/invalid.tar.gz"),
+                Link(f"{url}/demo-0.1.0-py2.py3-none-any.whl"),
+                Link(f"{url}/demo-0.1.1.tar.gz"),
+            ]
+        ),
+    )
+    return link_source
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("demo-0.1.0-py2.py3-none-any.whl", Package("demo", "0.1.0")),
+        ("demo-0.1.0.tar.gz", Package("demo", "0.1.0")),
+        ("demo-0.1.0.egg", Package("demo", "0.1.0")),
+        ("demo-0.1.0_invalid-py2.py3-none-any.whl", None),  # invalid version
+        ("demo-0.1.0_invalid.egg", None),  # invalid version
+        ("no-package-at-all.txt", None),
+    ],
+)
+def test_link_package_data(filename: str, expected: Package | None) -> None:
+    link = Link(f"https://example.org/{filename}")
+    assert LinkSource.link_package_data(link) == expected
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("demo", {Version.parse("0.1.0"), Version.parse("0.1.1")}),
+        ("invalid", set()),
+    ],
+)
+def test_versions(name: str, expected: set[Version], link_source: LinkSource) -> None:
+    assert set(link_source.versions(name)) == expected
+
+
+def test_packages(link_source: LinkSource) -> None:
+    expected = {
+        Package("demo", "0.1.0"),
+        Package("demo", "0.1.0"),
+        Package("demo", "0.1.1"),
+    }
+    assert set(link_source.packages) == expected
+
+
+@pytest.mark.parametrize(
+    "version_string, filenames",
+    [
+        ("0.1.0", ["demo-0.1.0.tar.gz", "demo-0.1.0-py2.py3-none-any.whl"]),
+        ("0.1.1", ["demo-0.1.1.tar.gz"]),
+        ("0.1.2", []),
+    ],
+)
+def test_links_for_version(
+    version_string: str, filenames: Iterable[str], link_source: LinkSource
+) -> None:
+    version = Version.parse(version_string)
+    expected = {Link(f"{link_source.url}/{name}") for name in filenames}
+    assert set(link_source.links_for_version("demo", version)) == expected

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -82,6 +82,37 @@ def test_page_clean_link():
     assert cleaned == "https://legacy.foo.bar/test%20/the%22/cleaning%00"
 
 
+def test_page_invalid_version_link():
+    repo = MockRepository()
+
+    page = repo._get_page("/invalid-version")
+
+    links = list(page.links)
+    assert len(links) == 2
+
+    versions = list(page.versions("poetry"))
+    assert len(versions) == 1
+    assert versions[0].to_string() == "0.1.0"
+
+    invalid_link = None
+
+    for link in links:
+        if link.filename.startswith("poetry-21"):
+            invalid_link = link
+            break
+
+    links_010 = list(page.links_for_version("poetry", versions[0]))
+    assert invalid_link not in links_010
+
+    assert invalid_link
+    assert not page.link_package_data(invalid_link)
+
+    packages = list(page.packages)
+    assert len(packages) == 1
+    assert packages[0].name == "poetry"
+    assert packages[0].version.to_string() == "0.1.0"
+
+
 def test_sdist_format_support():
     repo = MockRepository()
     page = repo._get_page("/relative")


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5476

Registries can have packages with broken versions, which we need to just ignore.
As-is the code will hard-fail when it encounters anything with a version it
cannot parse.
