### PR TITLE
factory: cleanup creation from package

### DIFF
--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -116,14 +116,16 @@ You can specify a package in the following forms:
 
                 break
 
-        root_package.python_versions = ".".join(  # type: ignore[union-attr]
+        assert root_package is not None
+
+        root_package.python_versions = ".".join(
             str(v) for v in system_env.version_info[:3]
         )
         # We create a `pyproject.toml` file based on all the information
         # we have about the current environment.
         if not env_dir.joinpath("pyproject.toml").exists():
             Factory.create_pyproject_from_package(
-                root_package,  # type: ignore[arg-type]
+                root_package,
                 env_dir,
             )
 

--- a/tests/fixtures/simple_project/pyproject.toml
+++ b/tests/fixtures/simple_project/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "MIT"
 
-readme = "README.rst"
+readme = ["README.rst"]
 
 homepage = "https://python-poetry.org"
 repository = "https://github.com/python-poetry/poetry"
@@ -31,5 +31,5 @@ fox = "fuz.foo:bar.baz"
 
 
 [build-system]
-requires = ["poetry-core>=1.0.2"]
+requires = ["poetry-core>=1.1.0a7"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This change ensures that generated toml file from packages contain all relevant metadata and handles groups correct.

Split from #5450