### PR TITLE
application: set global log handlers

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -232,23 +232,30 @@ class Application(BaseApplication):
         handler = IOHandler(io)
         handler.setFormatter(IOFormatter())
 
+        level = logging.WARNING
+
+        if io.is_debug():
+            level = logging.DEBUG
+        elif io.is_very_verbose() or io.is_verbose():
+            level = logging.INFO
+
+        logging.basicConfig(level=level, handlers=[handler])
+
         for name in loggers:
             logger = logging.getLogger(name)
 
             logger.handlers = [handler]
 
-            level = logging.WARNING
+            _level = level
             # The builders loggers are special and we can actually
             # start at the INFO level.
-            if logger.name.startswith("poetry.core.masonry.builders"):
-                level = logging.INFO
+            if (
+                logger.name.startswith("poetry.core.masonry.builders")
+                and _level > logging.INFO
+            ):
+                _level = logging.INFO
 
-            if io.is_debug():
-                level = logging.DEBUG
-            elif io.is_very_verbose() or io.is_verbose():
-                level = logging.INFO
-
-            logger.setLevel(level)
+            logger.setLevel(_level)
 
     def configure_env(
         self, event: ConsoleCommandEvent, event_name: str, _: Any


### PR DESCRIPTION
This change sets log handlers to use the same ones used by the application.

For example, logging for repository 401/403 looks like this today.

```console
Resolving dependencies... (0.6s)<debug>torch:</debug> Authorization error accessing https://download.pytorch.org/whl/cu113/httpx/
```

With this fix, it looks like this.

```console
Resolving dependencies... (0.6s)torch: Authorization error accessing https://download.pytorch.org/whl/cu113/httpx/
```