### PR TITLE
Incremental improvement to application logging

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -212,6 +212,7 @@ class Application(BaseApplication):
     def register_command_loggers(
         self, event: ConsoleCommandEvent, event_name: str, _: Any
     ) -> None:
+        from poetry.console.logging.filters import POETRY_FILTER
         from poetry.console.logging.io_formatter import IOFormatter
         from poetry.console.logging.io_handler import IOHandler
 
@@ -240,6 +241,10 @@ class Application(BaseApplication):
             level = logging.INFO
 
         logging.basicConfig(level=level, handlers=[handler])
+
+        # only log third-party packages when very verbose
+        if not io.is_very_verbose():
+            handler.addFilter(POETRY_FILTER)
 
         for name in loggers:
             logger = logging.getLogger(name)

--- a/src/poetry/console/logging/filters.py
+++ b/src/poetry/console/logging/filters.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+import logging
+
+
+POETRY_FILTER = logging.Filter(name="poetry")

--- a/src/poetry/console/logging/io_formatter.py
+++ b/src/poetry/console/logging/io_formatter.py
@@ -4,6 +4,7 @@ import logging
 
 from typing import TYPE_CHECKING
 
+from poetry.console.logging.filters import POETRY_FILTER
 from poetry.console.logging.formatters import FORMATTERS
 
 
@@ -31,5 +32,9 @@ class IOFormatter(logging.Formatter):
                 msg = f"<{self._colors[level]}>{msg}</>"
 
             record.msg = msg
+
+        if not POETRY_FILTER.filter(record):
+            # prefix third-party packages with name for easier debugging
+            record.msg = f"[{record.name}] {record.msg}"
 
         return super().format(record)

--- a/src/poetry/console/logging/io_formatter.py
+++ b/src/poetry/console/logging/io_formatter.py
@@ -30,6 +30,6 @@ class IOFormatter(logging.Formatter):
             elif level in self._colors:
                 msg = f"<{self._colors[level]}>{msg}</>"
 
-            return msg
+            record.msg = msg
 
         return super().format(record)

--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -114,9 +114,8 @@ class Repository:
         return constraint, allow_prereleases
 
     def _log(self, msg: str, level: str = "info") -> None:
-        getattr(logging.getLogger(self.__class__.__name__), level)(
-            f"<debug>{self.name}:</debug> {msg}"
-        )
+        logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+        getattr(logger, level)(f"<debug>{self.name}:</debug> {msg}")
 
     def __len__(self) -> int:
         return len(self._packages)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
@@ -402,3 +403,14 @@ def project_factory(
 @pytest.fixture
 def project_root() -> Path:
     return Path(__file__).parent.parent
+
+
+@pytest.fixture(autouse=True)
+def set_simple_log_formatter() -> None:
+    """
+    This fixture removes any formatting added via IOFormatter.
+    """
+    for name in logging.Logger.manager.loggerDict:
+        for handler in logging.getLogger(name).handlers:
+            # replace formatter with simple formatter for testing
+            handler.setFormatter(logging.Formatter(fmt="%(message)s"))


### PR DESCRIPTION
This builds on top of #5503 by 

1. Handling record formatting correctly. Without this change `log.info("%s", "hello")` will be logged as `%s`.
2. Log only poetry specific messages unless `-vvv` is used.
3. Prefix third-party packages with logger name for easy debugging.
4. Ensure use of simple log formatting for testing.

**Example output with `-vv`**
```console
Using virtualenv: /tmp/foobar/.venv
Updating dependencies
Resolving dependencies...
   1: fact: foobar is 0.1.0
   1: derived: foobar
   1: fact: foobar depends on httpx (^0.22.0)
   1: selecting foobar (0.1.0)
   1: derived: httpx (>=0.22.0,<0.23.0)
torch: Authorization error accessing https://download.pytorch.org/whl/cu113/httpx/
```

**Example output with `-vvv`**

```console
Loading configuration file /home/abn/.config/pypoetry/config.toml
Loading configuration file /home/abn/.config/pypoetry/auth.toml
[keyring.backend] Loading KWallet
[keyring.backend] Loading SecretService
[keyring.backend] Loading Windows
[keyring.backend] Loading chainer
[keyring.backend] Loading libsecret
[keyring.backend] Loading macOS
Adding repository torch (https://download.pytorch.org/whl/cu113) and setting it as secondary
Using virtualenv: /tmp/foobar/.venv
Updating dependencies
Resolving dependencies...
   1: fact: foobar is 0.1.0
   1: derived: foobar
   1: fact: foobar depends on httpx (^0.22.0)
   1: selecting foobar (0.1.0)
   1: derived: httpx (>=0.22.0,<0.23.0)
[urllib3.connectionpool] Starting new HTTPS connection (1): pypi.org:443
[urllib3.connectionpool] https://pypi.org:443 "GET /pypi/httpx/json HTTP/1.1" 304 0
PyPI: No release information found for httpx-0.0.1, skipping
PyPI: 1 packages found for httpx >=0.22.0,<0.23.0
[urllib3.connectionpool] Starting new HTTPS connection (1): download.pytorch.org:443
[urllib3.connectionpool] https://download.pytorch.org:443 "GET /whl/cu113/httpx/ HTTP/1.1" 403 None
torch: Authorization error accessing https://download.pytorch.org/whl/cu113/httpx/
```
