### PR TITLE
rename safe_rmtree and ensure remove_directory is used instead of shutil.rmtree

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -25,7 +25,7 @@ from poetry.utils._compat import decode
 from poetry.utils.authenticator import Authenticator
 from poetry.utils.env import EnvCommandError
 from poetry.utils.helpers import pluralize
-from poetry.utils.helpers import safe_rmtree
+from poetry.utils.helpers import remove_directory
 from poetry.utils.pip import pip_install
 
 
@@ -488,7 +488,7 @@ class Executor:
         if package.source_type == "git":
             src_dir = self._env.path / "src" / package.name
             if src_dir.exists():
-                safe_rmtree(str(src_dir))
+                remove_directory(src_dir, force=True)
 
         try:
             return self.run_pip("uninstall", package.name, "-y")
@@ -588,7 +588,7 @@ class Executor:
 
         src_dir = self._env.path / "src" / package.name
         if src_dir.exists():
-            safe_rmtree(str(src_dir))
+            remove_directory(src_dir, force=True)
 
         src_dir.parent.mkdir(exist_ok=True)
 

--- a/src/poetry/installation/pip_installer.py
+++ b/src/poetry/installation/pip_installer.py
@@ -13,7 +13,7 @@ from poetry.core.pyproject.toml import PyProjectTOML
 
 from poetry.installation.base_installer import BaseInstaller
 from poetry.utils._compat import encode
-from poetry.utils.helpers import safe_rmtree
+from poetry.utils.helpers import remove_directory
 from poetry.utils.pip import pip_install
 
 
@@ -128,7 +128,7 @@ class PipInstaller(BaseInstaller):
         if package.source_type == "git":
             src_dir = self._env.path / "src" / package.name
             if src_dir.exists():
-                safe_rmtree(str(src_dir))
+                remove_directory(src_dir, force=True)
 
     def run(self, *args: Any, **kwargs: Any) -> str:
         return self._env.run_pip(*args, **kwargs)
@@ -252,7 +252,7 @@ class PipInstaller(BaseInstaller):
 
         src_dir = self._env.path / "src" / package.name
         if src_dir.exists():
-            safe_rmtree(str(src_dir))
+            remove_directory(src_dir, force=True)
 
         src_dir.parent.mkdir(exist_ok=True)
 

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -34,7 +34,7 @@ from poetry.packages import DependencyPackage
 from poetry.packages.package_collection import PackageCollection
 from poetry.puzzle.exceptions import OverrideNeeded
 from poetry.utils.helpers import download_file
-from poetry.utils.helpers import safe_rmtree
+from poetry.utils.helpers import remove_directory
 
 
 if TYPE_CHECKING:
@@ -211,7 +211,7 @@ class Provider:
         except Exception:
             raise
         finally:
-            safe_rmtree(str(tmp_dir))
+            remove_directory(tmp_dir, force=True)
 
         return package
 

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -7,7 +7,6 @@ import json
 import os
 import platform
 import re
-import shutil
 import subprocess
 import sys
 import sysconfig
@@ -44,6 +43,7 @@ from poetry.utils._compat import list_to_shell_command
 from poetry.utils._compat import metadata
 from poetry.utils.helpers import is_dir_writable
 from poetry.utils.helpers import paths_csv
+from poetry.utils.helpers import remove_directory
 from poetry.utils.helpers import temporary_directory
 
 
@@ -341,7 +341,7 @@ class SitePackages:
                     file.unlink()
 
             if distribution._path.exists():
-                shutil.rmtree(str(distribution._path))
+                remove_directory(str(distribution._path), force=True)
 
             paths.append(distribution._path)
 
@@ -1046,7 +1046,7 @@ class EnvManager:
             path = Path(path)
         assert path.is_dir()
         try:
-            shutil.rmtree(str(path))
+            remove_directory(path)
             return
         except OSError as e:
             # Continue only if e.errno == 16
@@ -1061,7 +1061,7 @@ class EnvManager:
             if file_path.is_file() or file_path.is_symlink():
                 file_path.unlink()
             elif file_path.is_dir():
-                shutil.rmtree(str(file_path))
+                remove_directory(file_path, force=True)
 
     @classmethod
     def get_system_env(cls, naive: bool = False) -> SystemEnv | GenericEnv:

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import sys
 
@@ -28,6 +27,7 @@ from poetry.utils.env import InvalidCurrentPythonVersionError
 from poetry.utils.env import NoCompatiblePythonVersionFound
 from poetry.utils.env import SystemEnv
 from poetry.utils.env import VirtualEnv
+from poetry.utils.helpers import remove_directory
 
 
 if TYPE_CHECKING:
@@ -692,19 +692,19 @@ def test_remove_keeps_dir_if_not_deleteable(
         side_effect=check_output_wrapper(Version.parse("3.6.6")),
     )
 
-    original_rmtree = shutil.rmtree
-
-    def err_on_rm_venv_only(path: str, *args: Any, **kwargs: Any) -> None:
-        if path == str(venv_path):
+    def err_on_rm_venv_only(path: Path | str, *args: Any, **kwargs: Any) -> None:
+        if str(path) == str(venv_path):
             raise OSError(16, "Test error")  # ERRNO 16: Device or resource busy
         else:
-            original_rmtree(path)
+            remove_directory(path)
 
-    m = mocker.patch("shutil.rmtree", side_effect=err_on_rm_venv_only)
+    m = mocker.patch(
+        "poetry.utils.env.remove_directory", side_effect=err_on_rm_venv_only
+    )
 
     venv = manager.remove(f"{venv_name}-py3.6")
 
-    m.assert_any_call(str(venv_path))
+    m.assert_any_call(venv_path)
 
     assert venv_path == venv.path
     assert venv_path.exists()
@@ -713,7 +713,7 @@ def test_remove_keeps_dir_if_not_deleteable(
     assert not file1_path.exists()
     assert not file2_path.exists()
 
-    m.side_effect = original_rmtree  # Avoid teardown using `err_on_rm_venv_only`
+    m.side_effect = remove_directory  # Avoid teardown using `err_on_rm_venv_only`
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Symlinks are not support for Windows")


### PR DESCRIPTION
This change renames `safe_rmtree` into a more appropriate name with  relevant arguments. We ensure that the force behaviour is opt-in and not the default to avoid ambiguity.

This combines the work done in https://github.com/python-poetry/poetry/commit/c12d86b7 and #520.