### PR TITLE
improve http request handling for sources and support multiple paths on same netloc

### DIFF
--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -184,8 +184,6 @@ class Factory(BaseFactory):
         cls, source: dict[str, str], auth_config: Config, disable_cache: bool = False
     ) -> LegacyRepository:
         from poetry.repositories.legacy_repository import LegacyRepository
-        from poetry.utils.helpers import get_cert
-        from poetry.utils.helpers import get_client_cert
 
         if "url" not in source:
             raise RuntimeError("Unsupported source specified")
@@ -200,8 +198,6 @@ class Factory(BaseFactory):
             name,
             url,
             config=auth_config,
-            cert=get_cert(auth_config, name),
-            client_cert=get_client_cert(auth_config, name),
             disable_cache=disable_cache,
         )
 

--- a/src/poetry/installation/pip_installer.py
+++ b/src/poetry/installation/pip_installer.py
@@ -12,6 +12,7 @@ from typing import Any
 from poetry.core.pyproject.toml import PyProjectTOML
 
 from poetry.installation.base_installer import BaseInstaller
+from poetry.repositories.http import HTTPRepository
 from poetry.utils._compat import encode
 from poetry.utils.helpers import remove_directory
 from poetry.utils.pip import pip_install
@@ -57,23 +58,28 @@ class PipInstaller(BaseInstaller):
                 )
                 args += ["--trusted-host", parsed.hostname]
 
-            if repository.cert:
-                args += ["--cert", str(repository.cert)]
+            if isinstance(repository, HTTPRepository):
+                if repository.cert:
+                    args += ["--cert", str(repository.cert)]
 
-            if repository.client_cert:
-                args += ["--client-cert", str(repository.client_cert)]
+                if repository.client_cert:
+                    args += ["--client-cert", str(repository.client_cert)]
 
-            index_url = repository.authenticated_url
+                index_url = repository.authenticated_url
 
-            args += ["--index-url", index_url]
+                args += ["--index-url", index_url]
+
             if (
                 self._pool.has_default()
                 and repository.name != self._pool.repositories[0].name
             ):
-                args += [
-                    "--extra-index-url",
-                    self._pool.repositories[0].authenticated_url,
-                ]
+                first_repository = self._pool.repositories[0]
+
+                if isinstance(first_repository, HTTPRepository):
+                    args += [
+                        "--extra-index-url",
+                        first_repository.authenticated_url,
+                    ]
 
         if update:
             args.append("-U")

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -69,14 +69,14 @@ class Publisher:
                     logger.debug(
                         f"Found authentication information for {repository_name}."
                     )
-                    username = auth["username"]
-                    password = auth["password"]
+                    username = auth.username
+                    password = auth.password
 
         resolved_client_cert = client_cert or get_client_cert(
             self._poetry.config, repository_name
         )
         # Requesting missing credentials but only if there is not a client cert defined.
-        if not resolved_client_cert:
+        if not resolved_client_cert and hasattr(self._io, "ask"):
             if username is None:
                 username = self._io.ask("Username:")
 

--- a/src/poetry/repositories/cached.py
+++ b/src/poetry/repositories/cached.py
@@ -4,7 +4,6 @@ from abc import ABC
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from cachecontrol.caches import FileCache
 from cachy import CacheManager
 from poetry.core.semver.helpers import parse_constraint
 
@@ -21,7 +20,7 @@ if TYPE_CHECKING:
 class CachedRepository(Repository, ABC):
     CACHE_VERSION = parse_constraint("1.0.0")
 
-    def __init__(self, name: str, cache_group: str, disable_cache: bool = False):
+    def __init__(self, name: str, disable_cache: bool = False):
         super().__init__(name)
         self._disable_cache = disable_cache
         self._cache_dir = REPOSITORY_CACHE_DIR / name
@@ -36,7 +35,6 @@ class CachedRepository(Repository, ABC):
                 },
             }
         )
-        self._cache_control_cache = FileCache(str(self._cache_dir / cache_group))
 
     @abstractmethod
     def _get_release_info(self, name: str, version: str) -> dict:

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -13,8 +13,6 @@ from poetry.utils.helpers import canonicalize_name
 
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.utils.link import Link
 
@@ -28,15 +26,11 @@ class LegacyRepository(HTTPRepository):
         url: str,
         config: Config | None = None,
         disable_cache: bool = False,
-        cert: Path | None = None,
-        client_cert: Path | None = None,
     ) -> None:
         if name == "pypi":
             raise ValueError("The name [pypi] is reserved for repositories")
 
-        super().__init__(
-            name, url.rstrip("/"), config, disable_cache, cert, client_cert
-        )
+        super().__init__(name, url.rstrip("/"), config, disable_cache)
 
     def find_packages(self, dependency: Dependency) -> list[Package]:
         packages = []

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -232,7 +232,7 @@ class PyPiRepository(HTTPRepository):
         except requests.exceptions.TooManyRedirects:
             # Cache control redirect loop.
             # We try to remove the cache and try again
-            self._cache_control_cache.delete(self._base_url + endpoint)
+            self.session.delete_cache(self._base_url + endpoint)
             json_response = self.session.get(self._base_url + endpoint)
 
         if json_response.status_code == 404:

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from requests import Session
 
     from poetry.config.config import Config
+    from poetry.utils.authenticator import Authenticator
 
 
 _canonicalize_regex = re.compile("[-_]+")
@@ -94,7 +95,7 @@ def merge_dicts(d1: dict, d2: dict) -> None:
 def download_file(
     url: str,
     dest: str,
-    session: Session | None = None,
+    session: Authenticator | Session | None = None,
     chunk_size: int = 1024,
 ) -> None:
     import requests

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 
 from contextlib import suppress
@@ -22,6 +23,12 @@ class KeyRingError(Exception):
     pass
 
 
+@dataclasses.dataclass
+class HTTPAuthCredential:
+    username: str | None = dataclasses.field(default=None)
+    password: str | None = dataclasses.field(default=None)
+
+
 class KeyRing:
     def __init__(self, namespace: str) -> None:
         self._namespace = namespace
@@ -31,6 +38,25 @@ class KeyRing:
 
     def is_available(self) -> bool:
         return self._is_available
+
+    def get_credential(
+        self, *names: str, username: str | None = None
+    ) -> HTTPAuthCredential:
+        default = HTTPAuthCredential(username=username, password=None)
+
+        if not self.is_available():
+            return default
+
+        import keyring
+
+        for name in names:
+            credential = keyring.get_credential(name, username)
+            if credential:
+                return HTTPAuthCredential(
+                    username=credential.username, password=credential.password
+                )
+
+        return default
 
     def get_password(self, name: str, username: str) -> str | None:
         if not self.is_available():

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -405,7 +405,7 @@ def test_get_redirected_response_url(
     repo = MockHttpRepository({"/foo": 200}, http)
     redirect_url = "http://legacy.redirect.bar"
 
-    def get_mock(url: str) -> requests.Response:
+    def get_mock(url: str, raise_for_status: bool = True) -> requests.Response:
         response = requests.Response()
         response.status_code = 200
         response.url = redirect_url + "/foo"

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
 
 
+@pytest.fixture(autouse=True)
+def _use_simple_keyring(with_simple_keyring: None) -> None:
+    pass
+
+
 class MockRepository(LegacyRepository):
 
     FIXTURES = Path(__file__).parent / "fixtures" / "legacy"

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -218,10 +218,11 @@ def test_get_should_invalid_cache_on_too_many_redirects_error(mocker: MockerFixt
     delete_cache = mocker.patch("cachecontrol.caches.file_cache.FileCache.delete")
 
     response = Response()
+    response.status_code = 200
     response.encoding = "utf-8"
     response.raw = BytesIO(encode('{"foo": "bar"}'))
     mocker.patch(
-        "cachecontrol.adapter.CacheControlAdapter.send",
+        "poetry.utils.authenticator.Authenticator.get",
         side_effect=[TooManyRedirects(), response],
     )
     repository = PyPiRepository()

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -22,6 +22,11 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+@pytest.fixture(autouse=True)
+def _use_simple_keyring(with_simple_keyring: None) -> None:
+    pass
+
+
 class MockRepository(PyPiRepository):
 
     JSON_FIXTURES = Path(__file__).parent / "fixtures" / "pypi.org" / "json"

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import re
 import uuid
 
@@ -286,19 +287,16 @@ def test_authenticator_request_retries_on_status_code(
     assert sleep.call_count == attempts
 
 
-@pytest.fixture
-def environment_repository_credentials(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setenv("POETRY_HTTP_BASIC_FOO_USERNAME", "bar")
-    monkeypatch.setenv("POETRY_HTTP_BASIC_FOO_PASSWORD", "baz")
-
-
 def test_authenticator_uses_env_provided_credentials(
     config: Config,
     environ: None,
     mock_remote: type[httpretty.httpretty],
     http: type[httpretty.httpretty],
-    environment_repository_credentials: None,
+    monkeypatch: MonkeyPatch,
 ):
+    monkeypatch.setenv("POETRY_HTTP_BASIC_FOO_USERNAME", "bar")
+    monkeypatch.setenv("POETRY_HTTP_BASIC_FOO_PASSWORD", "baz")
+
     config.merge({"repositories": {"foo": {"url": "https://foo.bar/simple/"}}})
 
     authenticator = Authenticator(config, NullIO())
@@ -352,3 +350,177 @@ def test_authenticator_uses_certs_from_config_if_not_provided(
 
     assert Path(kwargs["verify"]) == Path(cert or configured_cert)
     assert Path(kwargs["cert"]) == Path(client_cert or configured_client_cert)
+
+
+def test_authenticator_uses_credentials_from_config_matched_by_url_path(
+    config: Config, mock_remote: None, http: type[httpretty.httpretty]
+):
+    config.merge(
+        {
+            "repositories": {
+                "foo-alpha": {"url": "https://foo.bar/alpha/files/simple/"},
+                "foo-beta": {"url": "https://foo.bar/beta/files/simple/"},
+            },
+            "http-basic": {
+                "foo-alpha": {"username": "bar", "password": "alpha"},
+                "foo-beta": {"username": "baz", "password": "beta"},
+            },
+        }
+    )
+
+    authenticator = Authenticator(config, NullIO())
+    authenticator.request("get", "https://foo.bar/alpha/files/simple/foo-0.1.0.tar.gz")
+
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b"bar:alpha").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+
+    # Make request on second repository with the same netloc but different credentials
+    authenticator.request("get", "https://foo.bar/beta/files/simple/foo-0.1.0.tar.gz")
+
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b"baz:beta").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+
+
+def test_authenticator_uses_credentials_from_config_with_at_sign_in_path(
+    config: Config, mock_remote: None, http: type[httpretty.httpretty]
+):
+    config.merge(
+        {
+            "repositories": {
+                "foo": {"url": "https://foo.bar/beta/files/simple/"},
+            },
+            "http-basic": {
+                "foo": {"username": "bar", "password": "baz"},
+            },
+        }
+    )
+    authenticator = Authenticator(config, NullIO())
+    authenticator.request("get", "https://foo.bar/beta/files/simple/f@@-0.1.0.tar.gz")
+
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b"bar:baz").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+
+
+def test_authenticator_falls_back_to_keyring_url_matched_by_path(
+    config: Config,
+    mock_remote: None,
+    http: type[httpretty.httpretty],
+    with_simple_keyring: None,
+    dummy_keyring: DummyBackend,
+):
+    config.merge(
+        {
+            "repositories": {
+                "foo-alpha": {"url": "https://foo.bar/alpha/files/simple/"},
+                "foo-beta": {"url": "https://foo.bar/beta/files/simple/"},
+            }
+        }
+    )
+
+    dummy_keyring.set_password(
+        "https://foo.bar/alpha/files/simple/", None, SimpleCredential(None, "bar")
+    )
+    dummy_keyring.set_password(
+        "https://foo.bar/beta/files/simple/", None, SimpleCredential(None, "baz")
+    )
+
+    authenticator = Authenticator(config, NullIO())
+
+    authenticator.request("get", "https://foo.bar/alpha/files/simple/foo-0.1.0.tar.gz")
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b":bar").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+
+    authenticator.request("get", "https://foo.bar/beta/files/simple/foo-0.1.0.tar.gz")
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b":baz").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+
+
+def test_authenticator_uses_env_provided_credentials_matched_by_url_path(
+    config: Config,
+    environ: None,
+    mock_remote: type[httpretty.httpretty],
+    http: type[httpretty.httpretty],
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setenv("POETRY_HTTP_BASIC_FOO_ALPHA_USERNAME", "bar")
+    monkeypatch.setenv("POETRY_HTTP_BASIC_FOO_ALPHA_PASSWORD", "alpha")
+    monkeypatch.setenv("POETRY_HTTP_BASIC_FOO_BETA_USERNAME", "baz")
+    monkeypatch.setenv("POETRY_HTTP_BASIC_FOO_BETA_PASSWORD", "beta")
+
+    config.merge(
+        {
+            "repositories": {
+                "foo-alpha": {"url": "https://foo.bar/alpha/files/simple/"},
+                "foo-beta": {"url": "https://foo.bar/beta/files/simple/"},
+            }
+        }
+    )
+
+    authenticator = Authenticator(config, NullIO())
+
+    authenticator.request("get", "https://foo.bar/alpha/files/simple/foo-0.1.0.tar.gz")
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b"bar:alpha").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+
+    authenticator.request("get", "https://foo.bar/beta/files/simple/foo-0.1.0.tar.gz")
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b"baz:beta").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+
+
+def test_authenticator_azure_feed_guid_credentials(
+    config: Config,
+    mock_remote: None,
+    http: type[httpretty.httpretty],
+    with_simple_keyring: None,
+    dummy_keyring: DummyBackend,
+):
+    config.merge(
+        {
+            "repositories": {
+                "alpha": {
+                    "url": "https://foo.bar/org-alpha/_packaging/feed/pypi/simple/"
+                },
+                "beta": {
+                    "url": "https://foo.bar/org-beta/_packaging/feed/pypi/simple/"
+                },
+            },
+            "http-basic": {
+                "alpha": {"username": "foo", "password": "bar"},
+                "beta": {"username": "baz", "password": "qux"},
+            },
+        }
+    )
+
+    authenticator = Authenticator(config, NullIO())
+
+    authenticator.request(
+        "get",
+        "https://foo.bar/org-alpha/_packaging/GUID/pypi/simple/a/1.0.0/a-1.0.0.whl",
+    )
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b"foo:bar").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+
+    authenticator.request(
+        "get",
+        "https://foo.bar/org-beta/_packaging/GUID/pypi/simple/b/1.0.0/a-1.0.0.whl",
+    )
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b"baz:qux").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -339,10 +339,12 @@ def test_authenticator_uses_certs_from_config_if_not_provided(
     )
 
     authenticator = Authenticator(config, NullIO())
-    session_send = mocker.patch.object(authenticator.session, "send")
+    url = "https://foo.bar/files/foo-0.1.0.tar.gz"
+    session = authenticator.get_session(url)
+    session_send = mocker.patch.object(session, "send")
     authenticator.request(
         "get",
-        "https://foo.bar/files/foo-0.1.0.tar.gz",
+        url,
         verify=cert,
         cert=client_cert,
     )


### PR DESCRIPTION
This change refactors HTTP repository source implementations. The following changes have been made.

- CacheControl cache now lives within Authenticator.
- Authenticator manages unique sessions for individual netloc.
- CacheControl usage now respects disable cache parameter in repos.
- Certificate and authentication logic is now managed solely within
  Authenticator for source repositories taking advantage of recent
  enhancements.
- Support same netloc with multiple path's in Authenticator.
- Clean up and unifiy redundant logic in credential access.

These changes should allow for better handling of cases like those described in #3041. Additionally, this forms the foundation for unifying HTTP specific logic within the code base and possibly allowing for migration of requests etc. if/when required.

Additionally, also cleans up some type hinting issues pertaining to http repo only attributes.

Co-Authors: @Darsstar @agni-sairent

Closes: #5108
Closes: #5463