### PR TITLE
cli: add global --no-cache option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,8 @@ then `--help` combined with any of those can give you more information.
 * `--no-ansi`: Disable ANSI output.
 * `--version (-V)`: Display this application version.
 * `--no-interaction (-n)`: Do not ask any interactive question.
+* `--no-plugins`: Disables plugins.
+* `--no-cache`: Disables Poetry source caches.
 
 
 ## new

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -96,6 +96,7 @@ class Application(BaseApplication):
         self._poetry: Poetry | None = None
         self._io: IO | None = None
         self._disable_plugins = False
+        self._disable_cache = False
         self._plugins_loaded = False
 
         dispatcher = EventDispatcher()
@@ -117,7 +118,10 @@ class Application(BaseApplication):
             return self._poetry
 
         self._poetry = Factory().create_poetry(
-            Path.cwd(), io=self._io, disable_plugins=self._disable_plugins
+            Path.cwd(),
+            io=self._io,
+            disable_plugins=self._disable_plugins,
+            disable_cache=self._disable_cache,
         )
 
         return self._poetry
@@ -168,6 +172,7 @@ class Application(BaseApplication):
 
     def _run(self, io: IO) -> int:
         self._disable_plugins = io.input.parameter_option("--no-plugins")
+        self._disable_cache = io.input.has_parameter_option("--no-cache")
 
         self._load_plugins(io)
 
@@ -345,6 +350,12 @@ class Application(BaseApplication):
 
         definition.add_option(
             Option("--no-plugins", flag=True, description="Disables plugins.")
+        )
+
+        definition.add_option(
+            Option(
+                "--no-cache", flag=True, description="Disables Poetry source caches."
+            )
         )
 
         return definition

--- a/tests/console/commands/plugin/conftest.py
+++ b/tests/console/commands/plugin/conftest.py
@@ -37,7 +37,11 @@ def installed() -> InstalledRepository:
 
 def configure_sources_factory(repo: TestRepository) -> SourcesFactory:
     def _configure_sources(
-        poetry: Poetry, sources: Source, config: Config, io: IO
+        poetry: Poetry,
+        sources: Source,
+        config: Config,
+        io: IO,
+        disable_cache: bool = False,
     ) -> None:
         pool = Pool()
         pool.add_repository(repo)

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -4,6 +4,8 @@ import re
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from cleo.testers.application_tester import ApplicationTester
 from entrypoints import EntryPoint
 
@@ -108,3 +110,23 @@ def test_application_execute_plugin_command_with_plugins_disabled(
     assert tester.io.fetch_output() == ""
     assert tester.io.fetch_error() == '\nThe command "foo" does not exist.\n'
     assert tester.status_code == 1
+
+
+@pytest.mark.parametrize("disable_cache", [True, False])
+def test_application_verify_source_cache_flag(disable_cache: bool):
+    app = Application()
+
+    tester = ApplicationTester(app)
+    command = "debug info"
+
+    if disable_cache:
+        command = f"{command} --no-cache"
+
+    assert not app._poetry
+
+    tester.execute(command)
+
+    assert app.poetry.pool.repositories
+
+    for repo in app.poetry.pool.repositories:
+        assert repo._disable_cache == disable_cache


### PR DESCRIPTION
This change adds a global command option `--no-cache` to the CLI. This presently disables artifact caches, but with #5518 will also disable cache control caches.