### PR TITLE
retire temporary_directory()

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -7,6 +7,7 @@ import tarfile
 import zipfile
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from typing import Iterator
 
@@ -17,7 +18,6 @@ from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.core.utils.helpers import parse_requires
-from poetry.core.utils.helpers import temporary_directory
 from poetry.core.version.markers import InvalidMarker
 
 from poetry.utils.env import EnvCommandError
@@ -285,7 +285,7 @@ class PackageInfo:
 
             context = tarfile.open
 
-        with temporary_directory() as tmp:
+        with TemporaryDirectory() as tmp:
             tmp = Path(tmp)
             with context(path.as_posix()) as archive:
                 archive.extractall(tmp.as_posix())

--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -8,6 +8,7 @@ import urllib
 from abc import ABC
 from collections import defaultdict
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
@@ -26,7 +27,6 @@ from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.link_sources.html import HTMLPage
 from poetry.utils.authenticator import Authenticator
 from poetry.utils.helpers import download_file
-from poetry.utils.helpers import temporary_directory
 from poetry.utils.patterns import wheel_file_re
 
 
@@ -111,7 +111,7 @@ class HTTPRepository(CachedRepository, ABC):
 
         filename = os.path.basename(wheel_name)
 
-        with temporary_directory() as temp_dir:
+        with TemporaryDirectory() as temp_dir:
             filepath = Path(temp_dir) / filename
             self._download(url, str(filepath))
 
@@ -127,7 +127,7 @@ class HTTPRepository(CachedRepository, ABC):
 
         filename = os.path.basename(sdist_name)
 
-        with temporary_directory() as temp_dir:
+        with TemporaryDirectory() as temp_dir:
             filepath = Path(temp_dir) / filename
             self._download(url, str(filepath))
 
@@ -247,7 +247,7 @@ class HTTPRepository(CachedRepository, ABC):
                 link.hash_name not in ("sha256", "sha384", "sha512")
                 and hasattr(hashlib, link.hash_name)
             ):
-                with temporary_directory() as temp_dir:
+                with TemporaryDirectory() as temp_dir:
                     filepath = Path(temp_dir) / link.filename
                     self._download(link.url, str(filepath))
 

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
 from subprocess import CalledProcessError
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ContextManager
@@ -43,7 +44,6 @@ from poetry.utils._compat import metadata
 from poetry.utils.helpers import is_dir_writable
 from poetry.utils.helpers import paths_csv
 from poetry.utils.helpers import remove_directory
-from poetry.utils.helpers import temporary_directory
 
 
 if TYPE_CHECKING:
@@ -1837,7 +1837,7 @@ def ephemeral_environment(
     with_wheel: bool | None = None,
     with_setuptools: bool | None = None,
 ) -> ContextManager[VirtualEnv]:
-    with temporary_directory() as tmp_dir:
+    with TemporaryDirectory() as tmp_dir:
         # TODO: cache PEP 517 build environment corresponding to each project venv
         venv_dir = Path(tmp_dir) / ".venv"
         EnvManager.build_venv(

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -7,12 +7,10 @@ import stat
 import tempfile
 
 from collections.abc import Mapping
-from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Iterator
 
 
 if TYPE_CHECKING:
@@ -31,15 +29,6 @@ def canonicalize_name(name: str) -> str:
 
 def module_name(name: str) -> str:
     return canonicalize_name(name).replace(".", "_").replace("-", "_")
-
-
-@contextmanager
-def temporary_directory(*args: Any, **kwargs: Any) -> Iterator[str]:
-    name = tempfile.mkdtemp(*args, **kwargs)
-
-    yield name
-
-    remove_directory(name, force=True)
 
 
 def get_cert(config: Config, repository_name: str) -> Path | None:
@@ -114,6 +103,7 @@ def get_package_version_display_string(
     package: Package, root: Path | None = None
 ) -> str:
     if package.source_type in ["file", "directory"] and root:
+        assert package.source_url is not None
         path = Path(os.path.relpath(package.source_url, root.as_posix())).as_posix()
         return f"{package.version} {path}"
 


### PR DESCRIPTION
removing poetry's own `temporary_directory()` implementation, prefer `tempfile.TemporaryDirectory()`.

There are already examples of `TemporaryDirectory()` in the codebase so this isn't breaking new ground.  I assume the other was legacy of python2 support or somesuch.