### PR TITLE
refactor(provider): move code to merge dependencies by constraint to separate method

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -530,43 +530,20 @@ class Provider:
             self.debug(f"<debug>Duplicate dependencies for {dep_name}</debug>")
 
             deps = self._merge_dependencies_by_marker(deps)
+            deps = self._merge_dependencies_by_constraint(deps)
 
-            # Merging dependencies by constraint
-            by_constraint: dict[VersionConstraint, list[Dependency]] = defaultdict(list)
-            for dep in deps:
-                by_constraint[dep.constraint].append(dep)
-            for constraint, _deps in by_constraint.items():
-                new_markers = []
-                for dep in _deps:
-                    marker = dep.marker.without_extras()
-                    if marker.is_any():
-                        # No marker or only extras
-                        continue
-
-                    new_markers.append(marker)
-
-                if not new_markers:
-                    continue
-
-                dep = _deps[0]
-                dep.marker = dep.marker.union(MarkerUnion(*new_markers))
-                by_constraint[constraint] = [dep]
-
-                continue
-
-            if len(by_constraint) == 1:
+            if len(deps) == 1:
                 self.debug(f"<debug>Merging requirements for {deps[0]!s}</debug>")
-                dependencies.append(list(by_constraint.values())[0][0])
+                dependencies.append(deps[0])
                 continue
 
             # We leave dependencies as-is if they have the same
             # python/platform constraints.
             # That way the resolver will pickup the conflict
             # and display a proper error.
-            _deps = [value[0] for value in by_constraint.values()]
             seen = set()
-            for _dep in _deps:
-                pep_508_dep = _dep.to_pep_508(False)
+            for dep in deps:
+                pep_508_dep = dep.to_pep_508(False)
                 if ";" not in pep_508_dep:
                     _requirements = ""
                 else:
@@ -575,9 +552,9 @@ class Provider:
                 if _requirements not in seen:
                     seen.add(_requirements)
 
-            if len(_deps) != len(seen):
-                for _dep in _deps:
-                    dependencies.append(_dep)
+            if len(deps) != len(seen):
+                for dep in deps:
+                    dependencies.append(dep)
 
                 continue
 
@@ -592,7 +569,6 @@ class Provider:
             # with the following overrides:
             #   - {<Package foo (1.2.3): {"bar": <Dependency bar (>=2.0)>}
             #   - {<Package foo (1.2.3): {"bar": <Dependency bar (<2.0)>}
-            _deps = [_dep[0] for _dep in by_constraint.values()]
 
             def fmt_warning(d: Dependency) -> str:
                 marker = d.marker if not d.marker.is_any() else "*"
@@ -601,8 +577,8 @@ class Provider:
                     f" with markers <b>{marker}</b>"
                 )
 
-            warnings = ", ".join(fmt_warning(d) for d in _deps[:-1])
-            warnings += f" and {fmt_warning(_deps[-1])}"
+            warnings = ", ".join(fmt_warning(d) for d in deps[:-1])
+            warnings += f" and {fmt_warning(deps[-1])}"
             self.debug(
                 f"<warning>Different requirements found for {warnings}.</warning>"
             )
@@ -624,8 +600,8 @@ class Provider:
             #   - foo (!= 1.2.1) ; python == 3.10
             #
             # the constraint for the second entry will become (!= 1.2.1, >= 1.2)
-            any_markers_dependencies = [d for d in _deps if d.marker.is_any()]
-            other_markers_dependencies = [d for d in _deps if not d.marker.is_any()]
+            any_markers_dependencies = [d for d in deps if d.marker.is_any()]
+            other_markers_dependencies = [d for d in deps if not d.marker.is_any()]
 
             marker = other_markers_dependencies[0].marker
             for other_dep in other_markers_dependencies[1:]:
@@ -651,22 +627,22 @@ class Provider:
                 #
                 # the last dependency would be missed without this,
                 # because the intersection with both foo dependencies is empty
-                inverted_marker_dep = _deps[0].with_constraint(EmptyConstraint())
+                inverted_marker_dep = deps[0].with_constraint(EmptyConstraint())
                 inverted_marker_dep.marker = inverted_marker
-                _deps.append(inverted_marker_dep)
+                deps.append(inverted_marker_dep)
 
             overrides = []
             overrides_marker_intersection = AnyMarker()
             for dep_overrides in self._overrides.values():
-                for _dep in dep_overrides.values():
+                for dep in dep_overrides.values():
                     overrides_marker_intersection = (
-                        overrides_marker_intersection.intersect(_dep.marker)
+                        overrides_marker_intersection.intersect(dep.marker)
                     )
-            for _dep in _deps:
-                if not overrides_marker_intersection.intersect(_dep.marker).is_empty():
+            for dep in deps:
+                if not overrides_marker_intersection.intersect(dep.marker).is_empty():
                     current_overrides = self._overrides.copy()
                     package_overrides = current_overrides.get(package, {}).copy()
-                    package_overrides.update({_dep.name: _dep})
+                    package_overrides.update({dep.name: dep})
                     current_overrides.update({package: package_overrides})
                     overrides.append(current_overrides)
 
@@ -811,6 +787,31 @@ class Provider:
                 yield
 
         self._in_progress = False
+
+    def _merge_dependencies_by_constraint(
+        self, dependencies: Iterable[Dependency]
+    ) -> list[Dependency]:
+        by_constraint: dict[VersionConstraint, list[Dependency]] = defaultdict(list)
+        for dep in dependencies:
+            by_constraint[dep.constraint].append(dep)
+        for constraint, _deps in by_constraint.items():
+            new_markers = []
+            for dep in _deps:
+                marker = dep.marker.without_extras()
+                if marker.is_any():
+                    # No marker or only extras
+                    continue
+
+                new_markers.append(marker)
+
+            if not new_markers:
+                continue
+
+            dep = _deps[0]
+            dep.marker = dep.marker.union(MarkerUnion(*new_markers))
+            by_constraint[constraint] = [dep]
+
+        return [value[0] for value in by_constraint.values()]
 
     def _merge_dependencies_by_marker(
         self, dependencies: Iterable[Dependency]


### PR DESCRIPTION
Just a simple refactoring to reduce the length of `Provider.complete_package()`. Move some of its code into a new method `_merge_dependencies_by_constraint` in analogy to the existing method `_merge_dependencies_by_marker`.