### PR TITLE
Replace `python-check-blanket-type-ignore` with `ignore-without-code` in `mypy`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
     hooks:
       - id: python-check-mock-methods
       - id: python-use-type-annotations
-      - id: python-check-blanket-type-ignore
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/asottile/yesqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ force-exclude = '''
 files = "src"
 show_error_codes = true
 strict = true
+enable_error_code = ["ignore-without-code"]
 
 # The following whitelist is used to allow for incremental adoption
 # of Mypy. Modules should be removed from this whitelist as and when


### PR DESCRIPTION
The repository today relies on `python-check-blanket-type-ignore` from https://github.com/pre-commit/pygrep-hooks to ensure that all `# type: ignore` ignore specific error codes.

While this works, version `0.940` of `mypy` added a way to enforce that through an optional error code (https://github.com/python/mypy/pull/11633).

The main advantage of using this rather than the regex is that the error code indicates the specific error code(s) to ignore in case a too broad `# type: ignore` is added.
To showcase that, you can see `pre-commit` output [here](https://github.com/mkniewallner/poetry/runs/6343669103?check_suite_focus=true), extracted from [this change](https://github.com/mkniewallner/poetry/pull/4/commits/79eaccdea5209b84e768ca8dbe8df184f9077e05) based on this PR's branch.

# Pull Request Check List

- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable