### PR TITLE
Fix flicker when displaying executor operations

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -677,6 +677,7 @@ class Executor:
 
         if progress:
             with self._lock:
+                self._sections[id(operation)].clear()
                 progress.start()
 
         done = 0


### PR DESCRIPTION
This fixes an issue where operations lines when installing appeared to "flicker" due to the fact that the download progress bar was written to a new line in the operation output.

The fix was to clear the operation first before displaying the progress bar.

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
