### PR TITLE
Reduce default errors verbosity

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -13,7 +13,8 @@ from typing import cast
 from cleo.application import Application as BaseApplication
 from cleo.events.console_events import COMMAND
 from cleo.events.event_dispatcher import EventDispatcher
-from cleo.exceptions import CleoException, CleoSimpleException
+from cleo.exceptions import CleoException
+from cleo.exceptions import CleoSimpleException
 from cleo.formatters.style import Style
 from cleo.io.inputs.argv_input import ArgvInput
 from cleo.io.null_io import NullIO

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -13,7 +13,7 @@ from typing import cast
 from cleo.application import Application as BaseApplication
 from cleo.events.console_events import COMMAND
 from cleo.events.event_dispatcher import EventDispatcher
-from cleo.exceptions import CleoException
+from cleo.exceptions import CleoException, CleoSimpleException
 from cleo.formatters.style import Style
 from cleo.io.inputs.argv_input import ArgvInput
 from cleo.io.null_io import NullIO
@@ -167,8 +167,13 @@ class Application(BaseApplication):
         # We set the solution provider repository here to load providers
         # only when an error occurs
         self.set_solution_provider_repository(self._get_solution_provider_repository())
-
-        super().render_error(error, io)
+        
+        # Wrap all errors in CleoSimpleException, unless --verbose flag is used to reduce output.
+        # Cleo will partially render a stack trace, unless CleoSimpleException is passed.
+        if io.is_verbose():
+            super().render_error(error, io)
+        else:
+            super().render_error(CleoSimpleException(*error.args), io)
 
     def _run(self, io: IO) -> int:
         self._disable_plugins = io.input.parameter_option("--no-plugins")

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -168,8 +168,8 @@ class Application(BaseApplication):
         # only when an error occurs
         self.set_solution_provider_repository(self._get_solution_provider_repository())
         
-        # Wrap all errors in CleoSimpleException, unless --verbose flag is used to reduce output.
-        # Cleo will partially render a stack trace, unless CleoSimpleException is passed.
+        # Wrap all errors in CleoSimpleException, unless --verbose flag is used,
+        # otherwise Cleo will render a partial stack trace.
         if io.is_verbose():
             super().render_error(error, io)
         else:

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -168,7 +168,7 @@ class Application(BaseApplication):
         # We set the solution provider repository here to load providers
         # only when an error occurs
         self.set_solution_provider_repository(self._get_solution_provider_repository())
-        
+
         # Wrap all errors in CleoSimpleException, unless --verbose flag is used,
         # otherwise Cleo will render a partial stack trace.
         if io.is_verbose():

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -35,10 +35,8 @@ def test_publish_returns_non_zero_code_for_upload_errors(
     expected_output = """
 Publishing simple-project (1.2.3) to PyPI
 """
-    expected_error_output = """\
-  UploadError
-
-  HTTP Error 400: Bad Request
+    expected_error_output = """
+HTTP Error 400: Bad Request
 """
 
     assert expected_output in app_tester.io.fetch_output()


### PR DESCRIPTION
# Pull Request Check List

Replaces: #2915
Resolves: #2854, #3273, #4014, #5229

<img width="700" alt="image" src="https://user-images.githubusercontent.com/36469655/167277202-79f3f2c0-3617-42c7-850b-aa7b999420d4.png">


<details>
  <summary>Verbose output</summary>

  ```py
  ~/dev/contrib/poetry reduce-default-errors-verbosity.
(.venv) $ poetry add something_usefull -v
Using virtualenv: /Users/bobronium/dev/contrib/poetry/.venv

  Stack trace:

  21  .venv/lib/python3.10/site-packages/cleo/application.py:330 in run
        exit_code = self._run(io)

  20  src/poetry/console/application.py:184 in _run
        return super()._run(io)

  19  .venv/lib/python3.10/site-packages/cleo/application.py:425 in _run
        exit_code = self._run_command(command, io)

  18  .venv/lib/python3.10/site-packages/cleo/application.py:467 in _run_command
        raise error

  17  .venv/lib/python3.10/site-packages/cleo/application.py:451 in _run_command
        exit_code = command.run(io)

  16  .venv/lib/python3.10/site-packages/cleo/commands/base_command.py:118 in run
        status_code = self.execute(io)

  15  .venv/lib/python3.10/site-packages/cleo/commands/command.py:85 in execute
        return self.handle()

  14  src/poetry/console/commands/add.py:159 in handle
        requirements = self._determine_requirements(

  13  src/poetry/console/commands/init.py:355 in _determine_requirements
        name, version = self._find_best_version_for_package(

  12  src/poetry/console/commands/init.py:390 in _find_best_version_for_package
        package = selector.find_best_candidate(

  11  src/poetry/version/version_selector.py:39 in find_best_candidate
        candidates = self._pool.find_packages(dependency)

  10  src/poetry/repositories/pool.py:167 in find_packages
        packages += repo.find_packages(dependency)

   9  src/poetry/repositories/pypi_repository.py:53 in find_packages
        info = self.get_package_info(dependency.name)

   8  src/poetry/repositories/pypi_repository.py:141 in get_package_info
        return self._cache.store("packages").remember_forever(

   7  .venv/lib/python3.10/site-packages/cachy/repository.py:174 in remember_forever
        val = value(callback)

   6  .venv/lib/python3.10/site-packages/cachy/helpers.py:6 in value
        return val()

   5  src/poetry/repositories/pypi_repository.py:142 in <lambda>
        name, lambda: self._get_package_info(name)

   4  src/poetry/repositories/pypi_repository.py:146 in _get_package_info
        data = self._get(f"pypi/{name}/json")

   3  src/poetry/repositories/pypi_repository.py:231 in _get
        json_response = self.session.get(self._base_url + endpoint)

   2  src/poetry/utils/authenticator.py:229 in get
        return self.request("get", url, **kwargs)

   1  src/poetry/utils/authenticator.py:215 in request
        resp.raise_for_status()

  HTTPError

  404 Client Error: Not Found for url: https://pypi.org/pypi/something-usefull/json/

  at .venv/lib/python3.10/site-packages/requests/models.py:960 in raise_for_status
      956│         elif 500 <= self.status_code < 600:
      957│             http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
      958│ 
      959│         if http_error_msg:
    → 960│             raise HTTPError(http_error_msg, response=self)
      961│ 
      962│     def close(self):
      963│         """Releases the connection back to the pool. Once this method has been
      964│         called the underlying ``raw`` object must not be accessed again.
  ```
</details>

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
