### PR TITLE
repos: configure source for credential lookup

### DIFF
--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -47,6 +47,7 @@ class HTTPRepository(CachedRepository, ABC):
             cache_id=name,
             disable_cache=disable_cache,
         )
+        self._authenticator.add_repository(name, url)
 
     @property
     def session(self) -> Authenticator:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -323,6 +323,14 @@ class Authenticator:
 
         return self._configured_repositories
 
+    def reset_credentials_cache(self) -> None:
+        self.get_repository_config_for_url.cache_clear()
+        self._credentials = {}
+
+    def add_repository(self, name: str, url: str) -> None:
+        self.configured_repositories[name] = AuthenticatorRepositoryConfig(name, url)
+        self.reset_credentials_cache()
+
     def get_certs_for_url(self, url: str) -> dict[str, Path | None]:
         if url not in self._certs:
             self._certs[url] = self._get_certs_for_url(url)

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import re
 import shutil
 
 from pathlib import Path
@@ -26,6 +28,8 @@ if TYPE_CHECKING:
     import httpretty
 
     from _pytest.monkeypatch import MonkeyPatch
+
+    from poetry.config.config import Config
 
 
 @pytest.fixture(autouse=True)
@@ -418,3 +422,42 @@ def test_get_redirected_response_url(
 
     monkeypatch.setattr(repo.session, "get", get_mock)
     assert repo._get_page("/foo")._url == "http://legacy.redirect.bar/foo/"
+
+
+@pytest.mark.parametrize(
+    ("repositories",),
+    [
+        ({},),
+        # ensure path is respected
+        ({"publish": {"url": "https://foo.bar/legacy"}},),
+        # ensure path length does not give incorrect results
+        ({"publish": {"url": "https://foo.bar/upload/legacy"}},),
+    ],
+)
+def test_authenticator_with_implicit_repository_configuration(
+    http: type[httpretty.httpretty],
+    config: Config,
+    repositories: dict[str, dict[str, str]],
+) -> None:
+    http.register_uri(
+        http.GET,
+        re.compile("^https?://foo.bar/(.+?)$"),
+    )
+
+    config.merge(
+        {
+            "repositories": repositories,
+            "http-basic": {
+                "source": {"username": "foo", "password": "bar"},
+                "publish": {"username": "baz", "password": "qux"},
+            },
+        }
+    )
+
+    repo = LegacyRepository(name="source", url="https://foo.bar/simple", config=config)
+    repo._get_page("/foo")
+
+    request = http.last_request()
+
+    basic_auth = base64.b64encode(b"foo:bar").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"


### PR DESCRIPTION
With this change users no longer need to configure source url explicitly via `repositories` configuration values when credentials are required.

In practice this means private repositories can now be configured as follows.

```bash
poetry source add name url
poetry config http-basic.name username password
```

This used to be as follows.

```bash
poetry source add name url
poetry config repositories.name url
poetry config http-basic.name username password
```