### PR TITLE
git: allow http auth via dulwich

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,9 @@ jobs:
         run: poetry run mypy
 
       - name: Run pytest (integration suite)
+        env:
+          POETRY_TEST_INTEGRATION_GIT_USERNAME: ${GITHUB_ACTOR}
+          POETRY_TEST_INTEGRATION_GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: poetry run python -m pytest -p no:sugar -q --integration tests/integration
 
       - name: Get Plugin Version (poetry-plugin-export)

--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -17,7 +17,6 @@ from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.utils.link import Link
 from poetry.core.version.markers import parse_marker
 
-from poetry.config.config import Config
 from poetry.repositories.cached import CachedRepository
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.exceptions import RepositoryError
@@ -29,6 +28,7 @@ from poetry.utils.patterns import wheel_file_re
 
 
 if TYPE_CHECKING:
+    from poetry.config.config import Config
     from poetry.inspection.info import PackageInfo
 
 
@@ -43,7 +43,7 @@ class HTTPRepository(CachedRepository, ABC):
         super().__init__(name, disable_cache)
         self._url = url
         self._authenticator = Authenticator(
-            config=config or Config(use_environment=True),
+            config=config,
             cache_id=name,
             disable_cache=disable_cache,
         )

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -18,6 +18,7 @@ import requests.exceptions
 from cachecontrol import CacheControl
 from cachecontrol.caches import FileCache
 
+from poetry.config.config import Config
 from poetry.exceptions import PoetryException
 from poetry.locations import REPOSITORY_CACHE_DIR
 from poetry.utils.helpers import get_cert
@@ -30,8 +31,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from cleo.io.io import IO
-
-    from poetry.config.config import Config
 
 
 logger = logging.getLogger(__name__)
@@ -84,12 +83,12 @@ class AuthenticatorRepositoryConfig:
 class Authenticator:
     def __init__(
         self,
-        config: Config,
+        config: Config | None = None,
         io: IO | None = None,
         cache_id: str | None = None,
         disable_cache: bool = False,
     ) -> None:
-        self._config = config
+        self._config = config or Config(use_environment=True)
         self._io = io
         self._sessions_for_netloc: dict[str, requests.Session] = {}
         self._credentials: dict[str, HTTPAuthCredential] = {}
@@ -371,3 +370,15 @@ class Authenticator:
         if selected:
             return selected.certs(config=self._config)
         return {"cert": None, "verify": None}
+
+
+_authenticator: Authenticator | None = None
+
+
+def get_default_authenticator() -> Authenticator:
+    global _authenticator
+
+    if _authenticator is None:
+        _authenticator = Authenticator()
+
+    return _authenticator

--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -18,6 +18,7 @@ from dulwich.refs import ANNOTATED_TAG_SUFFIX
 from dulwich.repo import Repo
 
 from poetry.console.exceptions import PoetrySimpleConsoleException
+from poetry.utils.authenticator import get_default_authenticator
 from poetry.utils.helpers import remove_directory
 
 
@@ -181,7 +182,11 @@ class Git:
         """
         client: GitClient
         path: str
-        client, path = get_transport_and_path(url)
+
+        credentials = get_default_authenticator().get_credentials_for_url(url=url)
+        client, path = get_transport_and_path(
+            url, username=credentials.username, password=credentials.password
+        )
 
         with local:
             return client.fetch(


### PR DESCRIPTION
This change makes use of existing repository authentication mechanisms to enable http authentication for git dependencies.

HTTP basic authentication for git repositories can now be enabled using these commands.

```sh
poetry config repositories.git-repo https://gitlhub.com/org/project.git
poetry config http-basic.git-repo username token
poetry add git+https://github.com/org/project.git
```

Thanks to the improvements in #5518, You can also add organisation or host level tokens by using a shorter url for the repository in config like, `https://github.com` or `https://github.com/org`. But do remember that this would apply to all clones - so project specific tokens are better. Alternatively, use `poetry config --local`.

This builds on top of #5428 and #5518 to enable http basic auth for vcs sources without issues like leaking credentials into the lockfile or pyproject.toml files as with previous attempts in #2169 and https://github.com/python-poetry/poetry-core/pull/115.

Resolves: #2062 
Closes: https://github.com/python-poetry/poetry-core/pull/115