### PR TITLE
chore(inspection): remove type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ enable_error_code = ["ignore-without-code"]
 
 [[tool.mypy.overrides]]
 module = [
-  'poetry.inspection.info',
   'poetry.installation.chef',
   'poetry.installation.chooser',
   'poetry.installation.executor',
@@ -148,6 +147,7 @@ module = [
   'html5lib.*',
   'jsonschema.*',
   'pexpect.*',
+  'pkginfo.*',
   'poetry.core.*',
   'requests_toolbelt.*',
   'shellingham.*',

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -18,7 +18,6 @@ from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import ContextManager
 from typing import Iterable
 from typing import Iterator
 from typing import TypeVar
@@ -1830,7 +1829,7 @@ class NullEnv(SystemEnv):
 def ephemeral_environment(
     executable: str | Path | None = None,
     flags: dict[str, bool] = None,
-) -> ContextManager[VirtualEnv]:
+) -> Iterator[VirtualEnv]:
     with TemporaryDirectory() as tmp_dir:
         # TODO: cache PEP 517 build environment corresponding to each project venv
         venv_dir = Path(tmp_dir) / ".venv"


### PR DESCRIPTION
Removes `poetry.inspection.*` from mypy's ignored list

Relates-to: https://github.com/python-poetry/poetry/issues/5017
