### PR TITLE
improve git http authentication via repository configuration

### DIFF
--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -117,11 +117,11 @@ To remove a repository (repo is a short alias for repositories):
         from poetry.core.pyproject.exceptions import PyProjectException
         from poetry.core.toml.file import TOMLFile
 
+        from poetry.config.config import Config
         from poetry.config.file_config_source import FileConfigSource
-        from poetry.factory import Factory
         from poetry.locations import CONFIG_DIR
 
-        config = Factory.create_config(self.io)
+        config = Config.create()
         config_file = TOMLFile(CONFIG_DIR / "config.toml")
 
         try:

--- a/src/poetry/console/commands/self/update.py
+++ b/src/poetry/console/commands/self/update.py
@@ -191,7 +191,7 @@ class SelfUpdateCommand(Command):
             root,
             NullLocker(self.data_dir.joinpath("poetry.lock"), {}),
             self.pool,
-            Config(),
+            config=Config.create(),
             installed=installed,
         )
         installer.update(True)

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -270,6 +270,11 @@ class Authenticator:
         return credential
 
     def get_credentials_for_git_url(self, url: str) -> HTTPAuthCredential:
+        parsed_url = urllib.parse.urlsplit(url)
+
+        if parsed_url.scheme not in {"http", "https"}:
+            return HTTPAuthCredential()
+
         key = f"git+{url}"
 
         if key not in self._credentials:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -88,7 +88,7 @@ class Authenticator:
         cache_id: str | None = None,
         disable_cache: bool = False,
     ) -> None:
-        self._config = config or Config(use_environment=True)
+        self._config = config or Config.create()
         self._io = io
         self._sessions_for_netloc: dict[str, requests.Session] = {}
         self._credentials: dict[str, HTTPAuthCredential] = {}

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -245,8 +245,10 @@ class Authenticator:
 
         return self._credentials[key]
 
-    def _get_credentials_for_url(self, url: str) -> HTTPAuthCredential:
-        repository = self.get_repository_config_for_url(url)
+    def _get_credentials_for_url(
+        self, url: str, exact_match: bool = False
+    ) -> HTTPAuthCredential:
+        repository = self.get_repository_config_for_url(url, exact_match)
 
         credential = (
             self._get_credentials_for_repository(repository=repository)
@@ -266,6 +268,14 @@ class Authenticator:
             )
 
         return credential
+
+    def get_credentials_for_git_url(self, url: str) -> HTTPAuthCredential:
+        key = f"git+{url}"
+
+        if key not in self._credentials:
+            self._credentials[key] = self._get_credentials_for_url(url, True)
+
+        return self._credentials[key]
 
     def get_credentials_for_url(self, url: str) -> HTTPAuthCredential:
         parsed_url = urllib.parse.urlsplit(url)
@@ -338,13 +348,17 @@ class Authenticator:
 
     @functools.lru_cache(maxsize=None)
     def get_repository_config_for_url(
-        self, url: str
+        self, url: str, exact_match: bool = False
     ) -> AuthenticatorRepositoryConfig | None:
         parsed_url = urllib.parse.urlsplit(url)
         candidates_netloc_only = []
         candidates_path_match = []
 
         for repository in self.configured_repositories.values():
+            if exact_match:
+                if parsed_url.path == repository.path:
+                    return repository
+                continue
 
             if repository.netloc == parsed_url.netloc:
                 if parsed_url.path.startswith(repository.path) or commonprefix(

--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -186,9 +186,17 @@ class Git:
         client: GitClient
         path: str
 
+        kwargs: dict[str, str] = {}
         credentials = get_default_authenticator().get_credentials_for_git_url(url=url)
+
+        if credentials.password and credentials.username:
+            # we do this conditionally as otherwise, dulwich might complain if these
+            # parameters are passed in for an ssh url
+            kwargs["username"] = credentials.username
+            kwargs["password"] = credentials.password
+
         client, path = get_transport_and_path(  # type: ignore[no-untyped-call]
-            url, username=credentials.username, password=credentials.password
+            url, **kwargs
         )
 
         with local:

--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -349,20 +349,18 @@ class Git:
 
     @staticmethod
     def is_using_legacy_client() -> bool:
-        from poetry.factory import Factory
+        from poetry.config.config import Config
 
         legacy_client: bool = (
-            Factory.create_config()
-            .get("experimental", {})
-            .get("system-git-client", False)
+            Config.create().get("experimental", {}).get("system-git-client", False)
         )
         return legacy_client
 
     @staticmethod
     def get_default_source_root() -> Path:
-        from poetry.factory import Factory
+        from poetry.config.config import Config
 
-        return Path(Factory.create_config().get("cache-dir")) / "src"
+        return Path(Config.create().get("cache-dir")) / "src"
 
     @classmethod
     def clone(

--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -186,7 +186,7 @@ class Git:
         client: GitClient
         path: str
 
-        credentials = get_default_authenticator().get_credentials_for_url(url=url)
+        credentials = get_default_authenticator().get_credentials_for_git_url(url=url)
         client, path = get_transport_and_path(  # type: ignore[no-untyped-call]
             url, username=credentials.username, password=credentials.password
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,7 @@ def config(
     c.set_config_source(config_source)
     c.set_auth_config_source(auth_config_source)
 
-    mocker.patch("poetry.factory.Factory.create_config", return_value=c)
+    mocker.patch("poetry.config.config.Config.create", return_value=c)
     mocker.patch("poetry.config.config.Config.set_config_source")
 
     return c
@@ -219,7 +219,7 @@ def config_dir(tmp_dir: str) -> Path:
 @pytest.fixture(autouse=True)
 def mock_user_config_dir(mocker: MockerFixture, config_dir: Path) -> None:
     mocker.patch("poetry.locations.CONFIG_DIR", new=config_dir)
-    mocker.patch("poetry.factory.CONFIG_DIR", new=config_dir)
+    mocker.patch("poetry.config.config.CONFIG_DIR", new=config_dir)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,6 +17,7 @@ from poetry.core.packages.utils.link import Link
 from poetry.core.toml.file import TOMLFile
 from poetry.core.vcs.git import ParsedUrl
 
+from poetry.config.config import Config
 from poetry.console.application import Application
 from poetry.factory import Factory
 from poetry.installation.executor import Executor
@@ -107,7 +108,7 @@ def mock_clone(
     folder = Path(__file__).parent / "fixtures" / "git" / parsed.resource / path
 
     if not source_root:
-        source_root = Path(Factory.create_config().get("cache-dir")) / "src"
+        source_root = Path(Config.create().get("cache-dir")) / "src"
 
     dest = source_root / path
     dest.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/test_utils_vcs_git.py
+++ b/tests/integration/test_utils_vcs_git.py
@@ -298,6 +298,25 @@ def test_configured_repository_http_auth(
     spy_get_transport_and_path.assert_called_once()
 
 
+def test_username_password_parameter_is_not_passed_to_dulwich(
+    mocker: MockerFixture, source_url: str, config: Config
+) -> None:
+    from poetry.vcs.git import backend
+
+    spy_clone = mocker.spy(Git, "_clone")
+    spy_get_transport_and_path = mocker.spy(backend, "get_transport_and_path")
+
+    with Git.clone(url=source_url, branch="0.1") as repo:
+        assert_version(repo, BRANCH_TO_REVISION_MAP["0.1"])
+
+    spy_clone.assert_called_once()
+
+    spy_get_transport_and_path.assert_called_with(
+        location=source_url,
+    )
+    spy_get_transport_and_path.assert_called_once()
+
+
 def test_system_git_called_when_configured(
     mocker: MockerFixture, source_url: str, use_system_git_client: None
 ) -> None:

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -59,7 +59,7 @@ def test_publish_can_publish_to_given_repository(
         }
     )
 
-    mocker.patch("poetry.factory.Factory.create_config", return_value=config)
+    mocker.patch("poetry.config.config.Config.create", return_value=config)
     poetry = Factory().create_poetry(fixture_dir(fixture_name))
 
     io = BufferedIO()

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -592,6 +592,10 @@ def test_authenticator_git_repositories(
     assert two.username == "baz"
     assert two.password == "qux"
 
+    two_ssh = authenticator.get_credentials_for_git_url("ssh://git@foo.bar/org/two.git")
+    assert not two_ssh.username
+    assert not two_ssh.password
+
     three = authenticator.get_credentials_for_git_url("https://foo.bar/org/three.git")
     assert not three.username
     assert not three.password


### PR DESCRIPTION
**replace Factory.create_config() w/ Config.create()**

Prior to this change when `Config` was initialised for non-command use, user `config.toml` and `auth.toml` files were not loaded. This caused unintended side effects when configuration look up were performed from the `Authenticator` and other parts of the code.

**ensure git repository authn uses exact urls**

Since git repository authentication is a special case of repository configuration, the existing assumptions around path matching do not apply. In order to prevent unexpected behaviour due to similar path matching, git authentication will use exact url matching.

**git: ignore http auth for ssh url**

This change ensures that http-basic auth credentials are only passed to dulwich when the remote url uses http/https schemes.

In addition to the above, it is now ensured that username/password  parameters are not passed through to dulwich unless both username and password are configured explicitly. This is to ensure that dulwich does not bail out if it detects a username in the url (eg: `ssh://git@github.com`).

Relates-to: #5567 (this feature relies on config being available)