### PR TITLE
Use env vars if either `--username` or `--password` (or both) is missing

### DIFF
--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -54,9 +54,9 @@ class Publisher:
                 raise RuntimeError(f"Repository {repository_name} is not defined")
 
         if not (username and password):
-            # Check if we have a token first
             token = None
             if not (username or password):
+                # If both are missing, check if we have a token first
                 token = self._authenticator.get_pypi_token(repository_name)
 
             if token:

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -55,7 +55,10 @@ class Publisher:
 
         if not (username and password):
             # Check if we have a token first
-            token = self._authenticator.get_pypi_token(repository_name)
+            token = None
+            if not (username or password):
+                token = self._authenticator.get_pypi_token(repository_name)
+
             if token:
                 logger.debug("Found an API token for %s.", repository_name)
                 username = "__token__"
@@ -66,8 +69,8 @@ class Publisher:
                     logger.debug(
                         "Found authentication information for %s.", repository_name
                     )
-                    username = auth.username
-                    password = auth.password
+                    username = auth.username or username
+                    password = auth.password or password
 
         certificates = self._authenticator.get_certs_for_repository(repository_name)
         resolved_cert = cert or certificates.cert or certificates.verify

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -69,8 +69,8 @@ class Publisher:
                     logger.debug(
                         "Found authentication information for %s.", repository_name
                     )
-                    username = auth.username or username
-                    password = auth.password or password
+                    username = username or auth.username
+                    password = password or auth.password
 
         certificates = self._authenticator.get_certs_for_repository(repository_name)
         resolved_cert = cert or certificates.cert or certificates.verify


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5526 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This PR changes authentication logic for publishing:
- If both `username` and `password` is missing, consider PyPI token env var.
- If no PyPI token and either `username` or `password` is missing, consider http basic env var for the missing field.

Previously, env vars were only considered if both CLI options where missing. This PR effectively makes it possible to mix the CLI options with the env vars.

This way both
```
poetry config repositories.myrepo $REPO_URL \
  && POETRY_HTTP_BASIC_MYREPO_PASSWORD=$PASSWORD \
     poetry publish -r myrepo -u $USERNAME

poetry config repositories.myrepo $REPO_URL \
  && POETRY_HTTP_BASIC_MYREPO_USERNAME=$USERNAME \
     poetry publish -r myrepo -p $PASSWORD
```
will work. I am doubtful about whether it is worth supporting the second use case.