### PR TITLE
Add example for each section of `pyproject.toml`

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -74,7 +74,7 @@ If your project is proprietary and does not use a specific licence, you can set 
 {{% /note %}}
 
 ```toml
-authors = "MIT"
+license = "MIT"
 ```
 
 ## authors
@@ -97,7 +97,7 @@ This is a list of maintainers and should be distinct from authors. Maintainers m
 
 ```toml
 maintainers = [
-    Richard Brave <email@example.org>
+    "Richard Brave <email@example.org>"
 ]
 ```
 
@@ -108,7 +108,7 @@ The readme file of the package. **Optional**
 The file can be either `README.rst` or `README.md`.
 
 ```toml
-readme = README.md # or README.rst
+readme = "README.md" # or "README.rst"
 ```
 
 ## homepage

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -17,11 +17,19 @@ The `tool.poetry` section of the `pyproject.toml` file is composed of multiple s
 
 The name of the package. **Required**
 
+```toml
+name = "my-package"
+```
+
 ## version
 
 The version of the package. **Required**
 
 This should be a valid [PEP 440](https://peps.python.org/pep-0440/) string.
+
+```toml
+version = "0.1.0"
+```
 
 {{% note %}}
 
@@ -33,6 +41,10 @@ If you would like to use semantic versioning for your project, please see
 ## description
 
 A short description of the package. **Required**
+
+```toml
+description = "The description of the package"
+```
 
 ## license
 
@@ -61,11 +73,21 @@ More identifiers are listed at the [SPDX Open Source License Registry](https://s
 If your project is proprietary and does not use a specific licence, you can set this value as `Proprietary`.
 {{% /note %}}
 
+```toml
+authors = "MIT"
+```
+
 ## authors
 
 The authors of the package. **Required**
 
 This is a list of authors and should contain at least one author. Authors must be in the form `name <email>`.
+
+```toml
+license = [
+    "Sébastien Eustace <sebastien@eustace.io>"
+]
+```
 
 ## maintainers
 
@@ -73,27 +95,53 @@ The maintainers of the package. **Optional**
 
 This is a list of maintainers and should be distinct from authors. Maintainers may contain an email and be in the form `name <email>`.
 
+```toml
+maintainers = [
+    Richard Brave <email@example.org>
+]
+```
+
 ## readme
 
 The readme file of the package. **Optional**
 
 The file can be either `README.rst` or `README.md`.
 
+```toml
+readme = README.md # or README.rst
+```
+
 ## homepage
 
 An URL to the website of the project. **Optional**
+
+```toml
+homepage = "https://python-poetry.org/"
+```
 
 ## repository
 
 An URL to the repository of the project. **Optional**
 
+```toml
+repository = "https://github.com/python-poetry/poetry"
+```
+
 ## documentation
 
 An URL to the documentation of the project. **Optional**
 
+```toml
+documentation = "https://python-poetry.org/docs/"
+```
+
 ## keywords
 
 A list of keywords that the package is related to. **Optional**
+
+```toml
+keywords = ["packaging", "poetry"]
+```
 
 ## classifiers
 

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -43,7 +43,7 @@ If you would like to use semantic versioning for your project, please see
 A short description of the package. **Required**
 
 ```toml
-description = "The description of the package"
+description = "A short description of the package."
 ```
 
 ## license

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -84,7 +84,7 @@ The authors of the package. **Required**
 This is a list of authors and should contain at least one author. Authors must be in the form `name <email>`.
 
 ```toml
-license = [
+authors = [
     "Sébastien Eustace <sebastien@eustace.io>"
 ]
 ```

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -85,7 +85,7 @@ This is a list of authors and should contain at least one author. Authors must b
 
 ```toml
 authors = [
-    "Sébastien Eustace <sebastien@eustace.io>"
+    "Sébastien Eustace <sebastien@eustace.io>",
 ]
 ```
 
@@ -97,7 +97,7 @@ This is a list of maintainers and should be distinct from authors. Maintainers m
 
 ```toml
 maintainers = [
-    "Richard Brave <email@example.org>"
+    "Richard Brave <email@example.org>",
 ]
 ```
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here -> not found maybe I use wrong keyword :)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code. -> None
- [x] Updated **documentation** for changed code. -> None

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Hello, thank you for Poetry project. One of papercut in poetry docs was examples for simple section in `pyproject.toml` like `authors`, `maintainers` need to use `list` and `<>` to point email. For beginner like me, this example will help them to more understand how to fill the `pyproject.toml`.
Also another questions how to write multiple maintainer?

```toml
maintainer = [
    "Apple Juice <apple@juice.org>",
    "Orange Juice <orange@juice.org>",
]
```
Did example right, do I need use trailing comma, how about whitespace do toml use `space` or `tabs`. Maybe  I need to read toml spec ;)


