### PR TITLE
Update documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Provide more context by answering these questions:
 Include details about your configuration and environment:
 
 * **Which version of Poetry are you using?** You can get the exact version by running `poetry -V` in your terminal.
-* **Which Python version Poetry has been installed for?** Execute the `debug:info` to get the information.
+* **Which Python version Poetry has been installed for?** Execute the `poetry debug info` to get the information.
 * **What's the name and version of the OS you're using**?
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ If you are helping with the triage of reported issues, this section provides som
 
 #### Multiple versions
 
-Often times you would want to attempt to reproduce issues with multiple versions of `poetry` at the same time. For these use cases, the [pipx project](https://pipxproject.github.io/pipx/) is useful.
+Often times you would want to attempt to reproduce issues with multiple versions of `poetry` at the same time. For these use cases, the [pipx project](https://pypa.github.io/pipx/) is useful.
 
 You can set your environment up like so.
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -155,7 +155,7 @@ curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python3 -
 
 {{< tab tabID="installing-with-pipx" >}}
 
-Using [`pipx`](https://github.com/pipxproject/pipx) to install Poetry is also possible.
+Using [`pipx`](https://github.com/pypa/pipx) to install Poetry is also possible.
 
 `pipx` is used to install Python CLI applications globally while still isolating them in virtual environments.
 This allows for clean upgrades and uninstalls.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -205,7 +205,7 @@ If you are helping with the triage of reported issues, this section provides som
 
 #### Multiple versions
 
-Often times you would want to attempt to reproduce issues with multiple versions of `poetry` at the same time. For these use cases, the [pipx project](https://pipxproject.github.io/pipx/) is useful.
+Often times you would want to attempt to reproduce issues with multiple versions of `poetry` at the same time. For these use cases, the [pipx project](https://pypa.github.io/pipx/) is useful.
 
 You can set your environment up like so.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,7 +66,7 @@ Provide more context by answering these questions:
 Include details about your configuration and environment:
 
 * **Which version of Poetry are you using?** You can get the exact version by running `poetry -V` in your terminal.
-* **Which Python version Poetry has been installed for?** Execute the `debug:info` to get the information.
+* **Which Python version Poetry has been installed for?** Execute the `poetry debug info` to get the information.
 * **What's the name and version of the OS you're using**?
 
 


### PR DESCRIPTION
1. Fix outdated references to the `debug:info` command in docs.
2. Update `pipx` related links to the latest.