### PR TITLE
tests: make tests compatible with core > 1.1.0a7

### DIFF
--- a/tests/compat.py
+++ b/tests/compat.py
@@ -10,3 +10,13 @@ try:
     from typing import Protocol
 except ImportError:
     from typing_extensions import Protocol  # noqa: F401, TC002
+
+from poetry.core.semver.helpers import parse_constraint
+from poetry.core.semver.version import Version
+
+from poetry.utils._compat import metadata
+
+
+is_poetry_core_1_1_0a7_compat = not parse_constraint(">1.1.0a7").allows(
+    Version.parse(metadata.version("poetry-core"))
+)

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -10,6 +10,7 @@ import pytest
 from poetry.core.semver.version import Version
 
 from poetry.repositories.legacy_repository import LegacyRepository
+from tests.compat import is_poetry_core_1_1_0a7_compat
 from tests.helpers import get_dependency
 from tests.helpers import get_package
 
@@ -981,7 +982,7 @@ def test_add_chooses_prerelease_if_only_prereleases_are_available(
     tester.execute("foo")
 
     expected = """\
-Using version ^1.2.3-beta.1 for foo
+Using version ^1.2.3b1 for foo
 
 Updating dependencies
 Resolving dependencies...
@@ -992,6 +993,8 @@ Package operations: 1 install, 0 updates, 0 removals
 
   • Installing foo (1.2.3b1)
 """
+    if is_poetry_core_1_1_0a7_compat:
+        expected = expected.replace("^1.2.3b1", "^1.2.3-beta.1")
 
     assert expected in tester.io.fetch_output()
 
@@ -1912,7 +1915,7 @@ def test_add_chooses_prerelease_if_only_prereleases_are_available_old_installer(
     old_tester.execute("foo")
 
     expected = """\
-Using version ^1.2.3-beta.1 for foo
+Using version ^1.2.3b1 for foo
 
 Updating dependencies
 Resolving dependencies...
@@ -1923,6 +1926,8 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing foo (1.2.3b1)
 """
+    if is_poetry_core_1_1_0a7_compat:
+        expected = expected.replace("^1.2.3b1", "^1.2.3-beta.1")
 
     assert expected in old_tester.io.fetch_output()
 

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from poetry.console.commands.version import VersionCommand
+from tests.compat import is_poetry_core_1_1_0a7_compat
 
 
 if TYPE_CHECKING:
@@ -35,23 +36,25 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
         ("1.2.3", "patch", "1.2.4"),
         ("1.2.3", "minor", "1.3.0"),
         ("1.2.3", "major", "2.0.0"),
-        ("1.2.3", "prepatch", "1.2.4-alpha.0"),
-        ("1.2.3", "preminor", "1.3.0-alpha.0"),
-        ("1.2.3", "premajor", "2.0.0-alpha.0"),
+        ("1.2.3", "prepatch", "1.2.4a0"),
+        ("1.2.3", "preminor", "1.3.0a0"),
+        ("1.2.3", "premajor", "2.0.0a0"),
         ("1.2.3-beta.1", "patch", "1.2.3"),
         ("1.2.3-beta.1", "minor", "1.3.0"),
         ("1.2.3-beta.1", "major", "2.0.0"),
-        ("1.2.3-beta.1", "prerelease", "1.2.3-beta.2"),
-        ("1.2.3-beta1", "prerelease", "1.2.3-beta.2"),
-        ("1.2.3beta1", "prerelease", "1.2.3-beta.2"),
-        ("1.2.3b1", "prerelease", "1.2.3-beta.2"),
-        ("1.2.3", "prerelease", "1.2.4-alpha.0"),
+        ("1.2.3-beta.1", "prerelease", "1.2.3b2"),
+        ("1.2.3-beta1", "prerelease", "1.2.3b2"),
+        ("1.2.3beta1", "prerelease", "1.2.3b2"),
+        ("1.2.3b1", "prerelease", "1.2.3b2"),
+        ("1.2.3", "prerelease", "1.2.4a0"),
         ("0.0.0", "1.2.3", "1.2.3"),
     ],
 )
 def test_increment_version(
     version: str, rule: str, expected: str, command: VersionCommand
 ):
+    if is_poetry_core_1_1_0a7_compat:
+        expected = expected.replace("a", "-alpha.").replace("b", "-beta.")
     assert command.increment_version(version, rule).text == expected
 
 

--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -6,11 +6,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from deepdiff import DeepDiff
-from poetry.core.semver.helpers import parse_constraint
-from poetry.core.semver.version import Version
 
-from poetry.utils._compat import metadata
 from poetry.utils.dependency_specification import parse_dependency_specification
+from tests.compat import is_poetry_core_1_1_0a7_compat
 
 
 if TYPE_CHECKING:
@@ -78,11 +76,7 @@ if TYPE_CHECKING:
                 "markers": 'python_version == "2.7"',
                 "url": "http://foo.com",
                 **(
-                    {"extras": ["fred", "bar"]}
-                    if parse_constraint(">1.1.0a7").allows(
-                        Version.parse(metadata.version("poetry-core"))
-                    )
-                    else {}
+                    {} if is_poetry_core_1_1_0a7_compat else {"extras": ["fred", "bar"]}
                 ),
             },
         ),


### PR DESCRIPTION
Downstream tests in poetry-core did not fail in python-poetry/poetry-core#344 and in master after merging, but are failing in new PRs!?