### PR TITLE
install: add --no-binary option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -223,6 +223,7 @@ option is used.
 * `--default`: Only include the main dependencies. (**Deprecated**)
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
 * `--no-root`: Do not install the root package (your project).
+* `--no-binary`: Do not use binary distributions for packages matching given policy. Use package name to disallow a specific package; or `:all:` to disallow and `:none:` to force binary for all packages.
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
 * `--extras (-E)`: Features to install (multiple values allowed).
 * `--no-dev`: Do not install dev dependencies. (**Deprecated**)
@@ -232,6 +233,12 @@ option is used.
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.
 {{% /note %}}
+
+{{% note %}}
+The `--no-binary` option will only work with the new installer. For the old installer,
+this is ignored.
+{{% /note %}}
+
 
 ## update
 

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -34,6 +34,16 @@ class InstallCommand(InstallerCommand):
             "no-root", None, "Do not install the root package (the current project)."
         ),
         option(
+            "no-binary",
+            None,
+            "Do not use binary distributions for packages matching given policy.\n"
+            "Use package name to disallow a specific package; or <b>:all:</b> to\n"
+            "disallow and <b>:none:</b> to force binary for all packages. Multiple\n"
+            "packages can be specified separated by commas.",
+            flag=False,
+            multiple=True,
+        ),
+        option(
             "dry-run",
             None,
             "Output the operations but do not execute anything "
@@ -97,6 +107,17 @@ dependencies and not including the current project, run the command with the
             )
 
             with_synchronization = True
+
+        if self.option("no-binary"):
+            policy = ",".join(self.option("no-binary", []))
+            try:
+                self._installer.no_binary(policy=policy)
+            except ValueError as e:
+                self.line_error(
+                    f"<warning>Invalid value (<c1>{policy}</>) for"
+                    f" `<b>--no-binary</b>`</>.\n\n<error>{e}</>"
+                )
+                return 1
 
         self._installer.only_groups(self.activated_groups)
         self._installer.dry_run(self.option("dry-run"))

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -92,6 +92,9 @@ class Executor:
     def removals_count(self) -> int:
         return self._executed["uninstall"]
 
+    def set_no_binary_policy(self, policy: str) -> None:
+        self._chooser.set_no_binary_policy(policy)
+
     def supports_fancy_output(self) -> bool:
         return self._io.output.is_decorated() and not self._dry_run
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -135,6 +135,11 @@ class Installer:
     def is_verbose(self) -> bool:
         return self._verbose
 
+    def no_binary(self, policy: str) -> Installer:
+        if self._executor:
+            self._executor.set_no_binary_policy(policy=policy)
+        return self
+
     def only_groups(self, groups: Iterable[str]) -> Installer:
         self._groups = groups
 

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -136,3 +136,29 @@ def test_sync_option_is_passed_to_the_installer(
     tester.execute("--sync")
 
     assert tester.command.installer._requires_synchronization
+
+
+@pytest.mark.parametrize(
+    ("options", "policy"),
+    [
+        (
+            "--no-binary :all:",
+            {":all:"},
+        ),
+        ("--no-binary :none:", {":none:"}),
+        ("--no-binary pytest", {"pytest"}),
+        ("--no-binary pytest,black", {"black", "pytest"}),
+        ("--no-binary pytest --no-binary black", {"black", "pytest"}),
+    ],
+)
+def test_no_binary_option_is_passed_to_the_installer(
+    tester: CommandTester, mocker: MockerFixture, options: str, policy: set[str]
+) -> None:
+    """
+    The --no-binary option is passed properly to the installer.
+    """
+    mocker.patch.object(tester.command.installer, "run", return_value=1)
+
+    tester.execute(options)
+
+    assert tester.command.installer.executor._chooser._no_binary_policy == policy

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -121,6 +121,44 @@ def test_chooser_chooses_universal_wheel_link_if_available(
     assert link.filename == "pytest-3.5.0-py2.py3-none-any.whl"
 
 
+@pytest.mark.parametrize(
+    ("policy", "filename"),
+    [
+        (":all:", "pytest-3.5.0.tar.gz"),
+        (":none:", "pytest-3.5.0-py2.py3-none-any.whl"),
+        ("black", "pytest-3.5.0-py2.py3-none-any.whl"),
+        ("pytest", "pytest-3.5.0.tar.gz"),
+        ("pytest,black", "pytest-3.5.0.tar.gz"),
+    ],
+)
+@pytest.mark.parametrize("source_type", ["", "legacy"])
+def test_chooser_no_binary_policy(
+    env: MockEnv,
+    mock_pypi: None,
+    mock_legacy: None,
+    source_type: str,
+    pool: Pool,
+    policy: str,
+    filename: str,
+):
+    chooser = Chooser(pool, env)
+    chooser.set_no_binary_policy(policy)
+
+    package = Package("pytest", "3.5.0")
+    if source_type == "legacy":
+        package = Package(
+            package.name,
+            package.version.text,
+            source_type="legacy",
+            source_reference="foo",
+            source_url="https://foo.bar/simple/",
+        )
+
+    link = chooser.choose_for(package)
+
+    assert link.filename == filename
+
+
 @pytest.mark.parametrize("source_type", ["", "legacy"])
 def test_chooser_chooses_specific_python_universal_wheel_link_if_available(
     env: MockEnv, mock_pypi: None, mock_legacy: None, source_type: str, pool: Pool


### PR DESCRIPTION
This changeset introduces a familiar option from `pip` for Poetry's install command. Users can now use `--no-binary :all:|:none:|package` to indicate they do not want to instal lthe binary distribution of packages.

Resolves: #1316
Resolves: #5599
Resolves: #365 