### PR TITLE
Add --dry-run option to version command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -622,7 +622,7 @@ The table below illustrates the effect of these rules with concrete examples.
 ### Options
 
 * `--short (-s)`: Output the version number only.
-* `--dry-run`: Output the operations but do not execute anything.
+* `--dry-run`: Do not update pyproject.toml file.
 
 ## export
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -622,7 +622,7 @@ The table below illustrates the effect of these rules with concrete examples.
 ### Options
 
 * `--short (-s)`: Output the version number only.
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
+* `--dry-run`: Output the operations but do not execute anything.
 
 ## export
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -622,6 +622,7 @@ The table below illustrates the effect of these rules with concrete examples.
 ### Options
 
 * `--short (-s)`: Output the version number only.
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
 
 ## export
 

--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -31,7 +31,11 @@ class VersionCommand(Command):
     ]
     options = [
         option("short", "s", "Output the version number only"),
-        option("dry-run", None, "Outputs the operations but will not execute anything"),
+        option(
+            "dry-run",
+            None,
+            "Outputs the version without updating the pyproject.toml file",
+        ),
     ]
 
     help = """\

--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -31,7 +31,7 @@ class VersionCommand(Command):
     ]
     options = [
         option("short", "s", "Output the version number only"),
-        option("dry-run", None, "Perform all actions except upload the package."),
+        option("dry-run", None, "Outputs the operations but will not execute anything"),
     ]
 
     help = """\

--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -34,7 +34,7 @@ class VersionCommand(Command):
         option(
             "dry-run",
             None,
-            "Outputs the version without updating the pyproject.toml file",
+            "Do not update pyproject.toml file",
         ),
     ]
 

--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -29,7 +29,10 @@ class VersionCommand(Command):
             optional=True,
         )
     ]
-    options = [option("short", "s", "Output the version number only")]
+    options = [
+        option("short", "s", "Output the version number only"),
+        option("dry-run", None, "Perform all actions except upload the package."),
+    ]
 
     help = """\
 The version command shows the current version of the project or bumps the version of
@@ -66,12 +69,13 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
                     f" to <fg=green>{version}</>"
                 )
 
-            content: dict[str, Any] = self.poetry.file.read()
-            poetry_content = content["tool"]["poetry"]
-            poetry_content["version"] = version.text
+            if not self.option("dry-run"):
+                content: dict[str, Any] = self.poetry.file.read()
+                poetry_content = content["tool"]["poetry"]
+                poetry_content["version"] = version.text
 
-            assert isinstance(content, TOMLDocument)
-            self.poetry.file.write(content)
+                assert isinstance(content, TOMLDocument)
+                self.poetry.file.write(content)
         else:
             if self.option("short"):
                 self.line(self.poetry.package.pretty_version)

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -81,6 +81,7 @@ def test_short_version_update(tester: CommandTester):
 def test_dry_run(tester: CommandTester):
     old_pyproject = tester.command.poetry.file.path.read_text()
     tester.execute("--dry-run major")
-    assert tester.io.fetch_output() == "Bumping version from 1.2.3 to 2.0.0\n"
+
     new_pyproject = tester.command.poetry.file.path.read_text()
+    assert tester.io.fetch_output() == "Bumping version from 1.2.3 to 2.0.0\n"
     assert old_pyproject == new_pyproject

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -79,6 +79,8 @@ def test_short_version_update(tester: CommandTester):
 
 
 def test_dry_run(tester: CommandTester):
-    content = tester.command.poetry.file.path.read_text()
+    old_pyproject = tester.command.poetry.file.path.read_text()
     tester.execute("--dry-run major")
-    assert content == tester.command.poetry.file.path.read_text()
+    assert tester.io.fetch_output() == "Bumping version from 1.2.3 to 2.0.0\n"
+    new_pyproject = tester.command.poetry.file.path.read_text()
+    assert old_pyproject == new_pyproject

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -76,3 +76,9 @@ def test_version_update(tester: CommandTester):
 def test_short_version_update(tester: CommandTester):
     tester.execute("--short 2.0.0")
     assert tester.io.fetch_output() == "2.0.0\n"
+
+
+def test_dry_run(tester: CommandTester):
+    content = tester.command.poetry.file.path.read_text()
+    tester.execute("--dry-run major")
+    assert content == tester.command.poetry.file.path.read_text()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5074

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->
This PR add the `--dry-run` option to the `version` command, so it will not update the `pyproject.toml` file but only print the output on the terminal. 

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
