### PR TITLE
perf(solver): reduce the number of overrides …

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -631,7 +631,9 @@ class Provider:
                         dep_other.set_constraint(
                             dep_other.constraint.intersect(dep_any.constraint)
                         )
-            elif not inverted_marker.is_empty():
+            elif not inverted_marker.is_empty() and self._python_constraint.allows_any(
+                get_python_constraint_from_marker(inverted_marker)
+            ):
                 # if there is no any marker dependency
                 # and the inverted marker is not empty,
                 # a dependency with the inverted union of all markers is required


### PR DESCRIPTION
… by avoiding adding dummy dependencies if the project's python constraint does not allow any version compatible with the marker of the dependency

follow-up of #4695

Requires: python-poetry/poetry-core#347 (poetry-core > 1.1.0a7)

I did some measurements from issues solved by #4695 with and without this PR. I always measured the second resolution so that a complete cache before each measurement can be assumed. The differences in resolution time may be greater without a filled cache. (The resulting lock file is the same with/without this PR.)

|`pyproject.toml` from ...| without PR | with PR |
|---|---|---|
|#3367|Complete version solving took 0.401 seconds with 6 overrides|Complete version solving took 0.370 seconds with 4 overrides|
|#4670|Complete version solving took 0.733 seconds with 24 overrides|Complete version solving took 0.590 seconds with 16 overrides|
|#4870|Complete version solving took 31.120 seconds with 57 overrides|Complete version solving took 27.163 seconds with 52 overrides|