### PR TITLE
tolerate `poetry init` in `/`

### DIFF
--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -90,6 +90,9 @@ class Layout:
     def get_package_include(self) -> InlineTable | None:
         package = inline_table()
 
+        # If a project is created in the root directory (this is reasonable inside a
+        # docker container, eg <https://github.com/python-poetry/poetry/issues/5103>)
+        # then parts will be empty.
         parts = self._package_path_relative.parts
         if not parts:
             return None

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -90,7 +90,11 @@ class Layout:
     def get_package_include(self) -> InlineTable | None:
         package = inline_table()
 
-        include = self._package_path_relative.parts[0]
+        parts = self._package_path_relative.parts
+        if not parts:
+            return None
+
+        include = parts[0]
         package.append("include", include)  # type: ignore[no-untyped-call]
 
         if self.basedir != Path():


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5103

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Not so easy to add a testcase for this one: I can arrange that we go through the fixed code branch, but then the unit test actually tries to create a project in `/`, which it usually doesn't have permission to do (and would be undesirable even if it did)