### PR TITLE
pipeline fix: handle importlib typing at python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,18 @@ module = [
 ]
 ignore_errors = true
 
+# use of importlib-metadata backport at python3.7 makes it impossible to
+# satisfy mypy without some ignores: but we get a different set of ignores at
+# different python versions.
+#
+# <https://github.com/python/mypy/issues/8823>, meanwhile suppress that
+# warning.
+[[tool.mypy.overrides]]
+module = [
+  'poetry.repositories.installed_repository',
+]
+warn_unused_ignores = false
+
 [[tool.mypy.overrides]]
 module = [
   'cachecontrol.*',

--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -163,7 +163,11 @@ class InstalledRepository(Repository):
             source_reference=source_reference,
             source_resolved_reference=source_resolved_reference,
         )
-        package.description = distribution.metadata.get("summary", "")
+
+        package.description = distribution.metadata.get(  # type: ignore[attr-defined]
+            "summary",
+            "",
+        )
 
         return package
 
@@ -213,7 +217,10 @@ class InstalledRepository(Repository):
             develop=develop,
         )
 
-        package.description = distribution.metadata.get("summary", "")
+        package.description = distribution.metadata.get(  # type: ignore[attr-defined]
+            "summary",
+            "",
+        )
 
         return package
 
@@ -229,7 +236,9 @@ class InstalledRepository(Repository):
 
         for entry in reversed(env.sys_path):
             for distribution in sorted(
-                metadata.distributions(path=[entry]),
+                metadata.distributions(  # type: ignore[no-untyped-call]
+                    path=[entry],
+                ),
                 key=lambda d: str(d._path),  # type: ignore[attr-defined]
             ):
                 name = canonicalize_name(distribution.metadata["name"])


### PR DESCRIPTION
Kinda ridiculous, but happens in few enough places that it's just about tolerable.

Looks like the types on the backported importlib metadata aren't quite the same as the types on the 3.8-and-onwards version.  So I've written the same code twice but ignoring different errors...