### PR TITLE
chore(console): remove type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ enable_error_code = ["ignore-without-code"]
 
 [[tool.mypy.overrides]]
 module = [
-  'poetry.console.commands.init',
   'poetry.inspection.info',
   'poetry.installation.chef',
   'poetry.installation.chooser',

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Mapping
 
 from tomlkit import dumps
 from tomlkit import inline_table
@@ -50,8 +51,8 @@ class Layout:
         author: str | None = None,
         license: str | None = None,
         python: str = "*",
-        dependencies: dict[str, str] | None = None,
-        dev_dependencies: dict[str, str] | None = None,
+        dependencies: dict[str, str | Mapping[str, Any]] | None = None,
+        dev_dependencies: dict[str, str | Mapping[str, Any]] | None = None,
     ) -> None:
         self._project = canonicalize_name(project).replace(".", "-")
         self._package_path_relative = Path(


### PR DESCRIPTION
Removes `poetry.console.commands.init` from mypy's ignored list

Relates-to: https://github.com/python-poetry/poetry/issues/5017
