### PR TITLE
docs: list `--why` as a suboption of `--tree` in `poetry show`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -444,12 +444,12 @@ required by
 ### Options
 
 * `--without`: The dependency groups to ignore.
-* `--why`: Include reverse dependencies where applicable.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
 * `--default`: Only include the main dependencies. (**Deprecated**)
 * `--no-dev`: Do not list the dev dependencies. (**Deprecated**)
 * `--tree`: List the dependencies as a tree.
+    * `--why`: When listing the tree for a single package, start from parents.
 * `--latest (-l)`: Show the latest version.
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.
 


### PR DESCRIPTION
Hi!
Here's my attempt for #5625