### PR TITLE
partially restore temporary_directory()

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -8,7 +8,6 @@ import tarfile
 import zipfile
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -23,6 +22,7 @@ from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.core.utils.helpers import parse_requires
+from poetry.core.utils.helpers import temporary_directory
 from poetry.core.version.markers import InvalidMarker
 
 from poetry.utils.env import EnvCommandError
@@ -293,7 +293,7 @@ class PackageInfo:
 
             context = tarfile.open
 
-        with TemporaryDirectory() as tmp_str:
+        with temporary_directory() as tmp_str:
             tmp = Path(tmp_str)
             with context(path.as_posix()) as archive:
                 archive.extractall(tmp.as_posix())

--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -8,7 +8,6 @@ import urllib.parse
 from abc import ABC
 from collections import defaultdict
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -17,6 +16,7 @@ import requests
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.utils.link import Link
 from poetry.core.semver.helpers import parse_constraint
+from poetry.core.utils.helpers import temporary_directory
 from poetry.core.version.markers import parse_marker
 
 from poetry.repositories.cached import CachedRepository
@@ -87,7 +87,7 @@ class HTTPRepository(CachedRepository, ABC):
 
         filename = os.path.basename(wheel_name)
 
-        with TemporaryDirectory() as temp_dir:
+        with temporary_directory() as temp_dir:
             filepath = Path(temp_dir) / filename
             self._download(url, str(filepath))
 
@@ -103,7 +103,7 @@ class HTTPRepository(CachedRepository, ABC):
 
         filename = os.path.basename(sdist_name)
 
-        with TemporaryDirectory() as temp_dir:
+        with temporary_directory() as temp_dir:
             filepath = Path(temp_dir) / filename
             self._download(url, str(filepath))
 
@@ -232,7 +232,7 @@ class HTTPRepository(CachedRepository, ABC):
                 and link.hash_name not in ("sha256", "sha384", "sha512")
                 and hasattr(hashlib, link.hash_name)
             ):
-                with TemporaryDirectory() as temp_dir:
+                with temporary_directory() as temp_dir:
                     filepath = Path(temp_dir) / link.filename
                     self._download(link.url, str(filepath))
 

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -16,7 +16,6 @@ from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
 from subprocess import CalledProcessError
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterable
@@ -36,6 +35,7 @@ from poetry.core.poetry import Poetry
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
+from poetry.core.utils.helpers import temporary_directory
 from virtualenv.seed.wheels.embed import get_embed_wheel
 
 from poetry.locations import CACHE_DIR
@@ -1833,7 +1833,7 @@ def ephemeral_environment(
     executable: str | Path | None = None,
     flags: dict[str, bool] = None,
 ) -> Iterator[VirtualEnv]:
-    with TemporaryDirectory() as tmp_dir:
+    with temporary_directory() as tmp_dir:
         # TODO: cache PEP 517 build environment corresponding to each project venv
         venv_dir = Path(tmp_dir) / ".venv"
         EnvManager.build_venv(


### PR DESCRIPTION
Per https://github.com/python-poetry/poetry/pull/5522#issuecomment-1129681924, I think that MR was merged prematurely.

No need to restore it completely though: one implementation of `temporary_directory()` is enough - so let's use the one from poetry-core