### PR TITLE
Change typing.Callable to collections.abc.Callable

### DIFF
--- a/src/poetry/__version__.py
+++ b/src/poetry/__version__.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING
 
 from poetry.utils._compat import metadata
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 # The metadata.version that we import for Python 3.7 is untyped, work around

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -9,7 +9,6 @@ from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 
 from poetry.core.toml import TOMLFile
 from poetry.core.utils.helpers import canonicalize_name
@@ -21,6 +20,8 @@ from poetry.locations import CONFIG_DIR
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from poetry.config.config_source import ConfigSource
 
 

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -7,7 +7,6 @@ from contextlib import suppress
 from importlib import import_module
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import cast
 
 from cleo.application import Application as BaseApplication
@@ -24,6 +23,8 @@ from poetry.console.commands.command import Command
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from cleo.events.console_command_event import ConsoleCommandEvent
     from cleo.io.inputs.definition import Definition
     from cleo.io.inputs.input import Input

--- a/src/poetry/console/command_loader.py
+++ b/src/poetry/console/command_loader.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Callable
 
 from cleo.exceptions import LogicException
 from cleo.loaders.factory_command_loader import FactoryCommandLoader
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from poetry.console.commands.command import Command
 
 

--- a/src/poetry/console/commands/about.py
+++ b/src/poetry/console/commands/about.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING
 
 from poetry.console.commands.command import Command
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class AboutCommand(Command):

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -10,7 +10,6 @@ import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import ContextManager
 from typing import Iterator
 from typing import cast
@@ -31,6 +30,8 @@ from poetry.utils.setup_reader import SetupReader
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from poetry.core.packages.project_package import ProjectPackage
 
 

--- a/src/poetry/mixology/incompatibility.py
+++ b/src/poetry/mixology/incompatibility.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Callable
 from typing import Iterator
 
 from poetry.mixology.incompatibility_cause import ConflictCause
@@ -14,6 +13,8 @@ from poetry.mixology.incompatibility_cause import RootCause
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from poetry.mixology.incompatibility_cause import IncompatibilityCause
     from poetry.mixology.term import Term
 

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -13,7 +13,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import Iterable
 from typing import Iterator
 from typing import cast
@@ -43,6 +42,8 @@ from poetry.vcs.git import Git
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
     from poetry.core.semver.version_constraint import VersionConstraint

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -10,10 +10,11 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from poetry.core.packages.package import Package
     from requests import Session
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -4,7 +4,6 @@ import os
 import re
 
 from typing import TYPE_CHECKING
-from typing import Callable
 from typing import Iterator
 
 import pytest
@@ -17,6 +16,7 @@ from poetry.config.config import int_normalizer
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 
 from poetry.core.semver.version import Version
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from poetry.core.version.pep440.version import PEP440Version
 
 VERSION_3_7_1 = Version.parse("3.7.1")

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -7,7 +7,6 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import Iterator
 
 import pytest
@@ -34,6 +33,8 @@ from poetry.utils.helpers import remove_directory
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
     from poetry.poetry import Poetry

--- a/tests/utils/test_setup_reader.py
+++ b/tests/utils/test_setup_reader.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import os
 
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import pytest
 
 from poetry.core.version.exceptions import InvalidVersion
 
 from poetry.utils.setup_reader import SetupReader
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

According to the [`typing.Callable`](https://docs.python.org/3/library/typing.html#typing.Callable) docs:

> Deprecated since version 3.9: [collections.abc.Callable](https://docs.python.org/3/library/collections.abc.html#collections.abc.Callable) now supports []. See [PEP 585](https://www.python.org/dev/peps/pep-0585) and [Generic Alias Type](https://docs.python.org/3/library/stdtypes.html#types-genericalias).

This PR changes `from typing import Callable` to `from collections.abc import Callable`