### PR TITLE
repo: handle invalid distributions gracefully

### DIFF
--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -56,8 +56,8 @@ class MockEnv(BaseMockEnv):
         }
 
     @property
-    def sys_path(self) -> list[Path]:
-        return [ENV_DIR, SITE_PLATLIB, SITE_PURELIB]
+    def sys_path(self) -> list[str]:
+        return [str(path) for path in [ENV_DIR, SITE_PLATLIB, SITE_PURELIB]]
 
 
 @pytest.fixture

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -65,12 +65,8 @@ def env() -> MockEnv:
     return MockEnv(path=ENV_DIR)
 
 
-@pytest.fixture
-def repository(mocker: MockerFixture, env: MockEnv) -> InstalledRepository:
-    mocker.patch(
-        "poetry.utils._compat.metadata.Distribution.discover",
-        return_value=INSTALLED_RESULTS,
-    )
+@pytest.fixture(autouse=True)
+def mock_git_info(mocker: MockerFixture) -> None:
     mocker.patch(
         "poetry.vcs.git.Git.info",
         return_value=namedtuple("GitRepoLocalInfo", "origin revision")(
@@ -78,7 +74,19 @@ def repository(mocker: MockerFixture, env: MockEnv) -> InstalledRepository:
             revision="bb058f6b78b2d28ef5d9a5e759cfa179a1a713d6",
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_installed_repository_vendors(mocker: MockerFixture) -> None:
     mocker.patch("poetry.repositories.installed_repository._VENDORS", str(VENDOR_DIR))
+
+
+@pytest.fixture
+def repository(mocker: MockerFixture, env: MockEnv) -> InstalledRepository:
+    mocker.patch(
+        "poetry.utils._compat.metadata.Distribution.discover",
+        return_value=INSTALLED_RESULTS,
+    )
     return InstalledRepository.load(env)
 
 


### PR DESCRIPTION
This change ensures that poetry does not bail out when encountering a  bad distributions in `sys_path`. This behaviour is similar to how `pip` handles this today. In addition to ignoring these distributions, we also issue a warning log so users can choose to act on this.

Further, this change also handles a scenario where an empty path is present in the `sys_path`.

Additional commits exists in this PR to clean up related tests.

Resolves: #3628 
Closes: #4702