### PR TITLE
clarify documentation for `--why` command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -444,7 +444,7 @@ required by
 ### Options
 
 * `--without`: The dependency groups to ignore.
-* `--why`: Include reverse dependencies where applicable.
+* `--why`: When showing the full list, or a `--tree` for a single package, display why a package is included.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
 * `--default`: Only include the main dependencies. (**Deprecated**)
@@ -456,6 +456,7 @@ required by
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.
 {{% /note %}}
+
 
 ## build
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -50,7 +50,8 @@ class ShowCommand(GroupCommand):
         option(
             "why",
             None,
-            "When listing the tree for a single package, start from parents.",
+            "When showing the full list, or a `--tree` for a single package, start from"
+            " parents.",
         ),
         option("latest", "l", "Show the latest version."),
         option(

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -50,8 +50,8 @@ class ShowCommand(GroupCommand):
         option(
             "why",
             None,
-            "When showing the full list, or a `--tree` for a single package, start from"
-            " parents.",
+            "When showing the full list, or a <info>--tree</info> for a single package,"
+            " also display why it's included.",
         ),
         option("latest", "l", "Show the latest version."),
         option(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5625 

I didn't find a way to highlight `--tree` in a better way in the help command.

<img width="669" alt="image" src="https://user-images.githubusercontent.com/8234817/169529924-154e8bf5-ccac-4de6-8f8f-f27ebb8d03ae.png">


cc @Secrus