### PR TITLE
tests: Update generated PKG-INFO fixture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,3 +111,8 @@ jobs:
 
       - name: Run pytest (poetry-plugin-export)
         run: poetry run python -m pytest -p no:sugar -q poetry-plugin-export/tests/
+
+      - name: Check for clean working tree
+        run: |
+          git diff --exit-code --stat HEAD
+          git -C poetry-plugin-export diff --exit-code --stat HEAD

--- a/tests/fixtures/git/github.com/demo/demo/demo.egg-info/PKG-INFO
+++ b/tests/fixtures/git/github.com/demo/demo/demo.egg-info/PKG-INFO
@@ -6,9 +6,5 @@ Home-page: https://github.com/demo/demo
 Author: Sébastien Eustace
 Author-email: sebastien@eustace.io
 License: MIT
-Platform: UNKNOWN
 Provides-Extra: foo
 Provides-Extra: bar
-
-UNKNOWN
-


### PR DESCRIPTION
Since commit f5cbba2bca2293b6e7b0fed6fd8b506203c969f4 (#4766), `test_executor_should_write_pep610_url_references_for_git` has been writing a different version of this file than the one checked into the repository, leaving a dirty working tree. Fix it and add a CI test.

(Here’s how the new CI test [fails](https://github.com/andersk/poetry/runs/6540382659) without the fix.)

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
