### PR TITLE
Bump `flake8` additional dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,17 +31,17 @@ repos:
     hooks:
       - id: yesqa
         additional_dependencies: &flake8_deps
-          - flake8-annotations==2.7.0
+          - flake8-annotations==2.9.0
           - flake8-broken-line==0.4.0
-          - flake8-bugbear==21.9.2
-          - flake8-comprehensions==3.7.0
-          - flake8-eradicate==1.2.0
-          - flake8-no-pep420==1.2.0
+          - flake8-bugbear==22.4.25
+          - flake8-comprehensions==3.10.0
+          - flake8-eradicate==1.2.1
+          - flake8-no-pep420==2.3.0
           - flake8-quotes==3.3.1
-          - flake8-simplify==0.14.2
-          - flake8-tidy-imports==4.5.0
-          - flake8-type-checking==1.1.0
-          - flake8-typing-imports==1.11.0
+          - flake8-simplify==0.19.2
+          - flake8-tidy-imports==4.8.0
+          - flake8-type-checking==1.5.0
+          - flake8-typing-imports==1.12.0
           - flake8-use-fstring==1.3
           - pep8-naming==0.12.1
 

--- a/src/poetry/console/commands/source/show.py
+++ b/src/poetry/console/commands/source/show.py
@@ -26,7 +26,7 @@ class SourceShowCommand(Command):
             self.line("No sources configured for this project.")
             return 0
 
-        if names and not any(map(lambda s: s.name in names, sources)):
+        if names and not any(s.name in names for s in sources):
             self.line_error(f"No source found with name(s): {', '.join(names)}")
             return 1
 

--- a/src/poetry/mixology/term.py
+++ b/src/poetry/mixology/term.py
@@ -23,6 +23,8 @@ class Term:
     def __init__(self, dependency: Dependency, is_positive: bool) -> None:
         self._dependency = dependency
         self._positive = is_positive
+        self.relation = functools.lru_cache(maxsize=None)(self._relation)
+        self.intersect = functools.lru_cache(maxsize=None)(self._intersect)
 
     @property
     def inverse(self) -> Term:
@@ -48,8 +50,7 @@ class Term:
             and self.relation(other) == SetRelation.SUBSET
         )
 
-    @functools.lru_cache(maxsize=None)
-    def relation(self, other: Term) -> str:
+    def _relation(self, other: Term) -> str:
         """
         Returns the relationship between the package versions
         allowed by this term and another.
@@ -111,8 +112,7 @@ class Term:
                 # not foo ^1.5.0 is a superset of not foo ^1.0.0
                 return SetRelation.OVERLAPPING
 
-    @functools.lru_cache(maxsize=None)
-    def intersect(self, other: Term) -> Term | None:
+    def _intersect(self, other: Term) -> Term | None:
         """
         Returns a Term that represents the packages
         allowed by both this term and another

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -384,7 +384,7 @@ class Authenticator:
             logger.debug(
                 "Multiple source configurations found for %s - %s",
                 parsed_url.netloc,
-                ", ".join(map(lambda c: c.name, candidates)),
+                ", ".join(c.name for c in candidates),
             )
             # prefer the more specific path
             candidates.sort(

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -104,6 +104,9 @@ class Authenticator:
             if not disable_cache
             else None
         )
+        self.get_repository_config_for_url = functools.lru_cache(maxsize=None)(
+            self._get_repository_config_for_url
+        )
 
     @property
     def cache(self) -> FileCache | None:
@@ -351,8 +354,7 @@ class Authenticator:
             self._certs[url] = self._get_certs_for_url(url)
         return self._certs[url]
 
-    @functools.lru_cache(maxsize=None)
-    def get_repository_config_for_url(
+    def _get_repository_config_for_url(
         self, url: str, exact_match: bool = False
     ) -> AuthenticatorRepositoryConfig | None:
         parsed_url = urllib.parse.urlsplit(url)

--- a/tests/console/commands/source/test_show.py
+++ b/tests/console/commands/source/test_show.py
@@ -41,10 +41,9 @@ url        : https://two.com
 default    : no
 secondary  : no
 """.splitlines()
-    assert (
-        list(map(lambda l: l.strip(), tester.io.fetch_output().strip().splitlines()))
-        == expected
-    )
+    assert [
+        line.strip() for line in tester.io.fetch_output().strip().splitlines()
+    ] == expected
     assert tester.status_code == 0
 
 
@@ -57,10 +56,9 @@ url        : https://one.com
 default    : no
 secondary  : no
 """.splitlines()
-    assert (
-        list(map(lambda l: l.strip(), tester.io.fetch_output().strip().splitlines()))
-        == expected
-    )
+    assert [
+        line.strip() for line in tester.io.fetch_output().strip().splitlines()
+    ] == expected
     assert tester.status_code == 0
 
 
@@ -78,10 +76,9 @@ url        : https://two.com
 default    : no
 secondary  : no
 """.splitlines()
-    assert (
-        list(map(lambda l: l.strip(), tester.io.fetch_output().strip().splitlines()))
-        == expected
-    )
+    assert [
+        line.strip() for line in tester.io.fetch_output().strip().splitlines()
+    ] == expected
     assert tester.status_code == 0
 
 


### PR DESCRIPTION
# Pull Request Check List
- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Similarly to https://github.com/python-poetry/poetry-core/pull/362, update flake8 dependencies.

https://github.com/python-poetry/poetry/commit/b1a6ef5b63f36d17f69e2487085d6d33f860601a updates some assignments to avoid unnecessary `map`, according to the new [C417 rule from flake8-comprehensions](https://github.com/adamchainz/flake8-comprehensions/blob/6e319a14ca056bf38e3fad16862033d1c3a1d0a5/README.rst#c417-unnecessary-map-usage---rewrite-using-a-generator-expressionlistsetdict-comprehension).

https://github.com/python-poetry/poetry/commit/356766efaca264ddba3484dc2b00ee811079326d is a bit more tricky. It updates misuses of `lru_cache` that prevent class instances from being garbage collected when it is applied on class instances methods.
This is reported by the new [B019 rule of flake8-bugbear](https://github.com/PyCQA/flake8-bugbear/pull/218).
Some resources about this:
- https://rednafi.github.io/reflections/dont-wrap-instance-methods-with-functoolslru_cache-decorator-in-python.html
- https://www.youtube.com/watch?v=sVjtp6tGo0g

Changelogs:
- [flake8-annotations](https://github.com/sco1/flake8-annotations/blob/ea1e59eb02b0ddc1eb854aea23ea9e74a84deed3/CHANGELOG.md)
- [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear/blob/0d54ee6d14367e444664fa38b8522776aaaee5df/README.rst#change-log)
- [flake8-comprehensions](https://github.com/adamchainz/flake8-comprehensions/blob/05067c706835799ec2fdce403efc2ce115bd8466/HISTORY.rst)
- [flake8-eradicate](https://github.com/wemake-services/flake8-eradicate/blob/275c8963543fbc805fd6d59bbc0d51aecdf65dfc/CHANGELOG.md)
- [flake8-no-pep420](https://github.com/adamchainz/flake8-no-pep420/blob/da3808adca131a8135857a63d83b106d27a4af75/HISTORY.rst)
- [flake8-simplify](https://github.com/MartinThoma/flake8-simplify/blob/f1b6c6d003503f71834345f443a13b9ff06d96cd/CHANGELOG.md)
- [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports/blob/67a1ef5ddddce27fb802fac652632b6466a489ff/HISTORY.rst)
- [flake8-type-checking](https://github.com/snok/flake8-type-checking/releases)
- [flake8-typing-imports](https://github.com/asottile/flake8-typing-imports/compare/v1.11.0...v1.12.0)