### PR TITLE
Enable more `mypy` optional error codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,10 @@ force-exclude = '''
 files = "src"
 show_error_codes = true
 strict = true
-enable_error_code = ["ignore-without-code"]
+enable_error_code = [
+    "ignore-without-code",
+    "truthy-bool",
+]
 
 # The following whitelist is used to allow for incremental adoption
 # of Mypy. Modules should be removed from this whitelist as and when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ show_error_codes = true
 strict = true
 enable_error_code = [
     "ignore-without-code",
+    "redundant-expr",
     "truthy-bool",
 ]
 

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -418,7 +418,7 @@ You can specify a package in the following forms:
         return [
             parse_dependency_specification(
                 requirement=requirement,
-                env=self.env if isinstance(self, EnvCommand) and self.env else None,
+                env=self.env if isinstance(self, EnvCommand) else None,
                 cwd=cwd,
             )
             for requirement in requirements

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -424,10 +424,7 @@ class PackageInfo:
             except ValueError:
                 return None
 
-        info = cls._from_distribution(dist=dist)
-        if info:
-            return info
-        return None
+        return cls._from_distribution(dist=dist)
 
     @classmethod
     def from_package(cls, package: Package) -> PackageInfo:
@@ -491,7 +488,6 @@ class PackageInfo:
 
                     # we discovered PkgInfo but no requirements were listed
 
-        assert info
         info._source_type = "directory"
         info._source_url = path.as_posix()
 

--- a/src/poetry/repositories/pool.py
+++ b/src/poetry/repositories/pool.py
@@ -46,9 +46,7 @@ class Pool(Repository):
         return self._has_primary_repositories
 
     def has_repository(self, name: str) -> bool:
-        name = name.lower() if name is not None else None
-
-        return name in self._lookup
+        return name.lower() in self._lookup
 
     def repository(self, name: str) -> Repository:
         if name is not None:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -211,7 +211,7 @@ class Authenticator:
                     raise e
             else:
                 if resp.status_code not in [502, 503, 504] or is_last_attempt:
-                    if resp.status_code is not None and raise_for_status:
+                    if raise_for_status:
                         resp.raise_for_status()
                     return resp
 


### PR DESCRIPTION
# Pull Request Check List
- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Enable 2 new optional `mypy` error codes:
- [truthy-bool](https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-expression-is-not-implicitly-true-in-boolean-context-truthy-bool) checks for unneeded conditions that will always be true.
- [redudant-expr](https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-expression-is-redundant-redundant-expr) checks for expressions that are redundant.

Also update the code a bit to comply with those 2 new options.