### PR TITLE
Poetry core updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ module = [
   'crashtest.*',
   'pexpect.*',
   'pkginfo.*',
-  'poetry.core.*',
   'requests_toolbelt.*',
   'shellingham.*',
   'virtualenv.*',

--- a/tests/console/commands/test_search.py
+++ b/tests/console/commands/test_search.py
@@ -96,9 +96,6 @@ sqlalchemy-sqlany (1.0.3)
  SAP Sybase SQL Anywhere dialect for SQLAlchemy
 """
 
-    # TODO remove this when https://github.com/python-poetry/poetry-core/pull/328
-    # reaches a published version of poetry-core.
     output = tester.io.fetch_output()
-    output = output.replace("transmogrify.sqlalchemy", "transmogrify-sqlalchemy")
 
     assert output == expected

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1169,13 +1169,6 @@ def test_installer_with_pypi_repository(
 
     expected = fixture("with-pypi-repository")
 
-    # TODO remove this when https://github.com/python-poetry/poetry-core/pull/328
-    # reaches a published version of poetry-core.
-    extras = locker.written_data["package"][0]["extras"]
-    for key, values in list(extras.items()):
-        extras[key] = [
-            value.replace("zope.interface", "zope-interface") for value in values
-        ]
     assert not DeepDiff(expected, locker.written_data, ignore_order=True)
 
 

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -833,13 +833,6 @@ def test_installer_with_pypi_repository(
 
     expected = fixture("with-pypi-repository")
 
-    # TODO remove this when https://github.com/python-poetry/poetry-core/pull/328
-    # reaches a published version of poetry-core.
-    extras = locker.written_data["package"][0]["extras"]
-    for key, values in list(extras.items()):
-        extras[key] = [
-            value.replace("zope.interface", "zope-interface") for value in values
-        ]
     assert not DeepDiff(expected, locker.written_data, ignore_order=True)
 
 


### PR DESCRIPTION
A couple of bits of tidying following the recent publication of poetry-core

- we don't need to ignore missing imports from poetry-core any more
- some test scripts that don't need to be compatible with 1.1.0a7