### PR TITLE
source show: include pypi and additional information about order

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -797,7 +797,9 @@ poetry source show pypi-test
 ```
 
 {{% note %}}
-This command will only show sources configured via the `pyproject.toml` and does not include PyPI.
+When used with the `-v` (verbose) global option, this command will provide additional
+information about the sources configured for your project, if more than one is
+available.
 {{% /note %}}
 
 ### `source remove`

--- a/src/poetry/console/commands/source/show.py
+++ b/src/poetry/console/commands/source/show.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from cleo.helpers import argument
 
+from poetry.config.source import Source
 from poetry.console.commands.command import Command
 
 
@@ -18,42 +19,87 @@ class SourceShowCommand(Command):
         ),
     ]
 
-    def handle(self) -> int | None:
-        sources = self.poetry.get_sources()
-        names = self.argument("source")
-
-        if not sources:
-            self.line("No sources configured for this project.")
-            return 0
-
-        if names and not any(s.name in names for s in sources):
-            self.line_error(f"No source found with name(s): {', '.join(names)}")
-            return 1
-
+    def render_source(self, source: Source) -> None:
         bool_string = {
             True: "yes",
             False: "no",
         }
 
-        for source in sources:
-            if names and source.name not in names:
-                continue
+        table = self.table(style="compact")
+        rows = [
+            ["<info>name</>", f" : <c1>{source.name}</>"],
+            ["<info>url</>", f" : {source.url}"],
+            [
+                "<info>default</>",
+                f" : {bool_string.get(source.default, False)}",
+            ],
+            [
+                "<info>secondary</>",
+                f" : {bool_string.get(source.secondary, False)}",
+            ],
+        ]
+        table.add_rows(rows)
+        table.render()
+        self.line("")
 
-            table = self.table(style="compact")
-            rows = [
-                ["<info>name</>", f" : <c1>{source.name}</>"],
-                ["<info>url</>", f" : {source.url}"],
-                [
-                    "<info>default</>",
-                    f" : {bool_string.get(source.default, False)}",
-                ],
-                [
-                    "<info>secondary</>",
-                    f" : {bool_string.get(source.secondary, False)}",
-                ],
-            ]
-            table.add_rows(rows)
-            table.render()
+    def handle(self) -> int | None:
+        sources = self.poetry.get_sources()
+        names = self.argument("source")
+
+        if names and "pypi" not in names and not any(s.name in names for s in sources):
+            self.line_error(f"No source found with name(s): {', '.join(names)}")
+            return 1
+
+        for repositories, secondary in [
+            (self.poetry.pool.primary_repositories, False),
+            (self.poetry.pool.secondary_repositories, True),
+        ]:
+            for repository in repositories:
+                if names and repository.name not in names:
+                    continue
+
+                self.render_source(
+                    Source(
+                        name=repository.name or "-",
+                        url=getattr(repository, "url", "-"),
+                        default=repository is self.poetry.pool.default_repository,
+                        secondary=secondary,
+                    )
+                )
+
+        if names or not self.io.is_verbose():
+            return 0
+
+        self.write(
+            "<c2>Poetry will search <warning>all</> of the above package sources when "
+            "searching for packages.</>\n"
+        )
+
+        if len(self.poetry.pool.repositories) <= 1:
+            return 0
+
+        self.line("")
+
+        first = self.poetry.pool.repositories[0].name or ""
+        last = self.poetry.pool.repositories[-1].name or ""
+
+        if first and last:
+            self.write(
+                "<c2>All other things equal, for a give package that is available from"
+                " multiple sources, it will be preferred in the order listed"
+                " above.</>\n\n<warning>For example, if a package <c2>foo</> is"
+                f" available in both <c1>{first}</> and <c1>{last}</>, Poetry will"
+                f" select <c1>{first}</>.\n\nYou can override this, by explicitly"
+                " specify the source when adding the package.\n\n    $ <c2>poetry add"
+                f" --source {last} foo</>\n\n</>"
+            )
+
+            if first.lower() != "pypi":
+                self.write(
+                    "<warning>Alternatively, you can set <c2>all</> your custom sources"
+                    " as <c2>secondary</>.</>\n"
+                )
+
             self.line("")
 
         return 0

--- a/src/poetry/repositories/pool.py
+++ b/src/poetry/repositories/pool.py
@@ -57,6 +57,26 @@ class Pool(Repository):
 
         raise ValueError(f'Repository "{name}" does not exist.')
 
+    @property
+    def default_repository(self) -> Repository | None:
+        if self.has_default() and self._repositories:
+            return self._repositories[0]
+        return None
+
+    @property
+    def primary_repositories(self) -> list[Repository]:
+        if self._secondary_start_idx is None:
+            return self.repositories
+
+        return self._repositories[: self._secondary_start_idx]
+
+    @property
+    def secondary_repositories(self) -> list[Repository]:
+        if self._secondary_start_idx is None:
+            return []
+
+        return self._repositories[self._secondary_start_idx :]
+
     def add_repository(
         self, repository: Repository, default: bool = False, secondary: bool = False
     ) -> Pool:

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -36,7 +36,7 @@ class PyPiRepository(HTTPRepository):
         fallback: bool = True,
     ) -> None:
         super().__init__(
-            "PyPI", url.rstrip("/") + "/simple/", disable_cache=disable_cache
+            "pypi", url.rstrip("/") + "/simple/", disable_cache=disable_cache
         )
 
         self._base_url = url

--- a/tests/console/commands/source/test_show.py
+++ b/tests/console/commands/source/test_show.py
@@ -40,6 +40,11 @@ name       : two
 url        : https://two.com
 default    : no
 secondary  : no
+
+name       : pypi
+url        : https://pypi.org/simple/
+default    : no
+secondary  : yes
 """.splitlines()
     assert [
         line.strip() for line in tester.io.fetch_output().strip().splitlines()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -211,7 +211,7 @@ def test_poetry_with_non_default_source(with_simple_keyring: None):
     assert poetry.pool.repositories[0].name == "foo"
     assert isinstance(poetry.pool.repositories[0], LegacyRepository)
 
-    assert poetry.pool.repositories[1].name == "PyPI"
+    assert poetry.pool.repositories[1].name == "pypi"
     assert isinstance(poetry.pool.repositories[1], PyPiRepository)
 
 
@@ -223,7 +223,7 @@ def test_poetry_with_non_default_secondary_source(with_simple_keyring: None):
     assert poetry.pool.has_default()
 
     repository = poetry.pool.repositories[0]
-    assert repository.name == "PyPI"
+    assert repository.name == "pypi"
     assert isinstance(repository, PyPiRepository)
 
     repository = poetry.pool.repositories[1]
@@ -241,7 +241,7 @@ def test_poetry_with_non_default_multiple_secondary_sources(with_simple_keyring:
     assert poetry.pool.has_default()
 
     repository = poetry.pool.repositories[0]
-    assert repository.name == "PyPI"
+    assert repository.name == "pypi"
     assert isinstance(repository, PyPiRepository)
 
     repository = poetry.pool.repositories[1]
@@ -269,7 +269,7 @@ def test_poetry_with_non_default_multiple_sources(with_simple_keyring: None):
     assert isinstance(repository, LegacyRepository)
 
     repository = poetry.pool.repositories[2]
-    assert repository.name == "PyPI"
+    assert repository.name == "pypi"
     assert isinstance(repository, PyPiRepository)
 
 
@@ -280,7 +280,7 @@ def test_poetry_with_no_default_source():
 
     assert poetry.pool.has_default()
 
-    assert poetry.pool.repositories[0].name == "PyPI"
+    assert poetry.pool.repositories[0].name == "pypi"
     assert isinstance(poetry.pool.repositories[0], PyPiRepository)
 
 


### PR DESCRIPTION
```console
$ poetry source show -v
 name       : pypi-simple             
 url        : https://pypi.org/simple 
 default    : no                      
 secondary  : no                      

 name       : pypi                     
 url        : https://pypi.org/simple/ 
 default    : no                       
 secondary  : yes                      

Poetry will search all of the above package sources when searching for packages.

All other things equal, for a give package that is available from multiple sources, it will be preferred in the order listed above.

For example, if a package foo is available in both pypi-simple and pypi, Poetry will select pypi-simple.

You can override this, by explicitly specify the source when adding the package.

    $ poetry add --source pypi foo

Alternatively, you can set all your custom sources as secondary.

```