### PR TITLE
Canonicalize package name for `show`, `add` and `remove`

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -9,6 +9,8 @@ from cleo.helpers import argument
 from cleo.helpers import option
 from tomlkit.toml_document import TOMLDocument
 
+from poetry.utils.helpers import canonicalize_name
+
 
 try:
     from poetry.core.packages.dependency_group import MAIN_GROUP
@@ -268,7 +270,7 @@ You can specify a package in the following forms:
 
         for name in packages:
             for key in section:
-                if key.lower() == name.lower():
+                if canonicalize_name(key) == canonicalize_name(name):
                     existing_packages.append(name)
 
         return existing_packages

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -6,6 +6,8 @@ from cleo.helpers import argument
 from cleo.helpers import option
 from tomlkit.toml_document import TOMLDocument
 
+from poetry.utils.helpers import canonicalize_name
+
 
 try:
     from poetry.core.packages.dependency_group import MAIN_GROUP
@@ -129,7 +131,7 @@ list of installed packages
 
         for package in packages:
             for existing_package in section_keys:
-                if existing_package.lower() == package.lower():
+                if canonicalize_name(existing_package) == canonicalize_name(package):
                     del section[existing_package]
                     removed.append(package)
                     group.remove_dependency(package)

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -10,6 +10,7 @@ from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.vcs_dependency import VCSDependency
 
 from poetry.console.commands.group_command import GroupCommand
+from poetry.utils.helpers import canonicalize_name
 
 
 if TYPE_CHECKING:
@@ -148,7 +149,7 @@ lists all packages available."""
         if package:
             pkg = None
             for locked in locked_packages:
-                if package.lower() == locked.name:
+                if canonicalize_name(package) == locked.name:
                     pkg = locked
                     break
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -940,6 +940,30 @@ If you prefer to upgrade it to the latest available version,\
     assert expected in tester.io.fetch_output()
 
 
+def test_add_should_skip_when_adding_canonicalized_existing_package_with_no_constraint(
+    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
+):
+    content = app.poetry.file.read()
+    content["tool"]["poetry"]["dependencies"]["foo-bar"] = "^1.0"
+    app.poetry.file.write(content)
+
+    repo.add_package(get_package("foo-bar", "1.1.2"))
+    tester.execute("Foo_Bar")
+
+    expected = """\
+The following packages are already present in the pyproject.toml and will be skipped:
+
+  • Foo_Bar
+
+If you want to update it to the latest compatible version,\
+ you can use `poetry update package`.
+If you prefer to upgrade it to the latest available version,\
+ you can use `poetry add package@latest`.
+"""
+
+    assert expected in tester.io.fetch_output()
+
+
 def test_add_should_work_when_adding_existing_package_with_latest_constraint(
     app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
 ):

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -317,6 +317,48 @@ def test_show_basic_with_installed_packages_single(
     ] == [line.strip() for line in tester.io.fetch_output().splitlines()]
 
 
+def test_show_basic_with_installed_packages_single_canonicalized(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+):
+    poetry.package.add_dependency(Factory.create_dependency("foo-bar", "^0.1.0"))
+
+    foo_bar = get_package("foo-bar", "0.1.0")
+    foo_bar.description = "Foobar package"
+
+    installed.add_package(foo_bar)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "foo-bar",
+                    "version": "0.1.0",
+                    "description": "Foobar package",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "hashes": {"foo-bar": []},
+            },
+        }
+    )
+
+    tester.execute("Foo_Bar")
+
+    assert [
+        "name         : foo-bar",
+        "version      : 0.1.0",
+        "description  : Foobar package",
+    ] == [line.strip() for line in tester.io.fetch_output().splitlines()]
+
+
 def test_show_basic_with_not_installed_packages_non_decorated(
     tester: CommandTester, poetry: Poetry, installed: Repository
 ):


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5699

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Make the commands behavior a bit more consistent by canonicalizing package name for `show`, `add` and `remove`, similarly to what we already do for `update`.