### PR TITLE
Ensure `--dry-run` option doesn't update `poetry.lock` for `add`, `update` and `remove`

### DIFF
--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -337,7 +337,7 @@ class Installer:
         # Execute operations
         return self._execute(ops)
 
-    def _write_lock_file(self, repo: Repository, force: bool = True) -> None:
+    def _write_lock_file(self, repo: Repository, force: bool = False) -> None:
         if force or (self._update and self._write_lock):
             updated_lock = self._locker.set_lock_data(self._package, repo.packages)
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -338,7 +338,7 @@ class Installer:
         return self._execute(ops)
 
     def _write_lock_file(self, repo: Repository, force: bool = False) -> None:
-        if force or (self._update and self._write_lock):
+        if self._write_lock and (force or self._update):
             updated_lock = self._locker.set_lock_data(self._package, repo.packages)
 
             if updated_lock:

--- a/tests/console/commands/plugin/test_remove.py
+++ b/tests/console/commands/plugin/test_remove.py
@@ -122,8 +122,6 @@ def test_remove_installed_package_dry_run(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 0 installs, 0 updates, 1 removal
 
   • Removing poetry-plugin (1.2.3)

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers import get_package
+
+
+if TYPE_CHECKING:
+    from poetry.poetry import Poetry
+    from tests.helpers import TestRepository
+    from tests.types import CommandTesterFactory
+    from tests.types import FixtureDirGetter
+    from tests.types import ProjectFactory
+
+
+@pytest.fixture
+def poetry_with_up_to_date_lockfile(
+    project_factory: ProjectFactory, fixture_dir: FixtureDirGetter
+) -> Poetry:
+    source = fixture_dir("outdated_lock")
+
+    return project_factory(
+        name="foobar",
+        pyproject_content=(source / "pyproject.toml").read_text(encoding="utf-8"),
+        poetry_lock_content=(source / "poetry.lock").read_text(encoding="utf-8"),
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "--dry-run",
+        "docker --dry-run",
+    ],
+)
+def test_update_with_dry_run_keep_files_intact(
+    command: str,
+    poetry_with_up_to_date_lockfile: Poetry,
+    repo: TestRepository,
+    command_tester_factory: CommandTesterFactory,
+):
+    tester = command_tester_factory("update", poetry=poetry_with_up_to_date_lockfile)
+
+    original_pyproject_content = poetry_with_up_to_date_lockfile.file.read()
+    original_lockfile_content = poetry_with_up_to_date_lockfile._locker.lock_data
+
+    repo.add_package(get_package("docker", "4.3.0"))
+    repo.add_package(get_package("docker", "4.3.1"))
+
+    tester.execute(command)
+
+    assert poetry_with_up_to_date_lockfile.file.read() == original_pyproject_content
+    assert (
+        poetry_with_up_to_date_lockfile._locker.lock_data == original_lockfile_content
+    )


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3666
Resolves: #3766

- [x] Added **tests** for changed code.
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Update logic of `_write_lock_file` to ensure that `--dry-run` option of `add`, `update` and `remove` commands leave `poetry.lock` intact.

This supersedes #3767, since it has become stale, while adding missing tests for `--dry-run` arguments on the commands.

- https://github.com/python-poetry/poetry/commit/a0c605a5824a0ec4538056c64f40a78313e628b7 adds tests to show that [they currently fail](https://github.com/python-poetry/poetry/runs/6644967841?check_suite_focus=true)
- other commits fix the issue to make them pass