### PR TITLE
config: allow bool values for repo cert

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,11 +315,14 @@ for more information.
 
 ### `certificates.<name>.cert`:
 
-**Type**: string
+**Type**: string | bool
 
 Set custom certificate authority for repository `<name>`.
 See [Repositories - Configuring credentials - Custom certificate authority]({{< relref "repositories#custom-certificate-authority-and-mutual-tls-authentication" >}})
 for more information.
+
+This configuration can be set to `false`, if TLS certificate verification should be skipped for this
+repository.
 
 ### `certificates.<name>.client-cert`:
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -384,6 +384,21 @@ poetry config certificates.foo.cert /path/to/ca.pem
 poetry config certificates.foo.client-cert /path/to/client.pem
 ```
 
+{{% note %}}
+The value of `certificates.<repository>.cert` can be set to `false` if certificate verification is
+required to be skipped. This is useful for cases where a package source with self-signed certificates
+are used.
+
+```bash
+poetry config certificates.foo.cert false
+```
+
+{{% warning %}}
+Disabling certificate verification is not recommended as it is does not conform to security
+best practices.
+{{% /warning %}}
+{{% /note %}}
+
 ## Caches
 
 Poetry employs multiple caches for package sources in order to improve user experience and avoid duplicate network

--- a/src/poetry/installation/pip_installer.py
+++ b/src/poetry/installation/pip_installer.py
@@ -63,11 +63,17 @@ class PipInstaller(BaseInstaller):
                 args += ["--trusted-host", parsed.hostname]
 
             if isinstance(repository, HTTPRepository):
-                if repository.cert:
-                    args += ["--cert", str(repository.cert)]
+                certificates = repository.certificates
 
-                if repository.client_cert:
-                    args += ["--client-cert", str(repository.client_cert)]
+                if certificates.cert:
+                    args += ["--cert", str(certificates.cert)]
+
+                if parsed.scheme == "https" and not certificates.verify:
+                    assert parsed.hostname is not None
+                    args += ["--trusted-host", parsed.hostname]
+
+                if certificates.client_cert:
+                    args += ["--client-cert", str(certificates.client_cert)]
 
                 index_url = repository.authenticated_url
 

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 
 from poetry.publishing.uploader import Uploader
 from poetry.utils.authenticator import Authenticator
-from poetry.utils.helpers import get_cert
-from poetry.utils.helpers import get_client_cert
 
 
 if TYPE_CHECKING:
@@ -72,9 +70,10 @@ class Publisher:
                     username = auth.username
                     password = auth.password
 
-        resolved_client_cert = client_cert or get_client_cert(
-            self._poetry.config, repository_name
-        )
+        certificates = self._authenticator.get_certs_for_repository(repository_name)
+        resolved_cert = cert or certificates.cert or certificates.verify
+        resolved_client_cert = client_cert or certificates.client_cert
+
         # Requesting missing credentials but only if there is not a client cert defined.
         if not resolved_client_cert and hasattr(self._io, "ask"):
             if username is None:
@@ -96,7 +95,7 @@ class Publisher:
 
         self._uploader.upload(
             url,
-            cert=cert or get_cert(self._poetry.config, repository_name),
+            cert=resolved_cert,
             client_cert=resolved_client_cert,
             dry_run=dry_run,
             skip_existing=skip_existing,

--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import io
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -25,8 +26,6 @@ from poetry.utils.patterns import wheel_file_re
 
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from cleo.io.null_io import NullIO
 
     from poetry.poetry import Poetry
@@ -114,15 +113,14 @@ class Uploader:
     def upload(
         self,
         url: str,
-        cert: Path | None = None,
+        cert: Path | bool = True,
         client_cert: Path | None = None,
         dry_run: bool = False,
         skip_existing: bool = False,
     ) -> None:
         session = self.make_session()
 
-        if cert:
-            session.verify = str(cert)
+        session.verify = str(cert) if isinstance(cert, Path) else cert
 
         if client_cert:
             session.cert = str(client_cert)

--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -31,6 +31,7 @@ from poetry.utils.patterns import wheel_file_re
 if TYPE_CHECKING:
     from poetry.config.config import Config
     from poetry.inspection.info import PackageInfo
+    from poetry.utils.authenticator import RepositoryCertificateConfig
 
 
 class HTTPRepository(CachedRepository, ABC):
@@ -59,18 +60,8 @@ class HTTPRepository(CachedRepository, ABC):
         return self._url
 
     @property
-    def cert(self) -> Path | None:
-        cert = self._authenticator.get_certs_for_url(self.url).get("verify")
-        if cert:
-            return Path(cert)
-        return None
-
-    @property
-    def client_cert(self) -> Path | None:
-        cert = self._authenticator.get_certs_for_url(self.url).get("cert")
-        if cert:
-            return Path(cert)
-        return None
+    def certificates(self) -> RepositoryCertificateConfig:
+        return self._authenticator.get_certs_for_url(self.url)
 
     @property
     def authenticated_url(self) -> str:

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from requests import Session
 
-    from poetry.config.config import Config
     from poetry.utils.authenticator import Authenticator
 
 
@@ -31,22 +30,6 @@ def canonicalize_name(name: str) -> str:
 
 def module_name(name: str) -> str:
     return canonicalize_name(name).replace(".", "_").replace("-", "_")
-
-
-def get_cert(config: Config, repository_name: str) -> Path | None:
-    cert = config.get(f"certificates.{repository_name}.cert")
-    if cert:
-        return Path(cert)
-    else:
-        return None
-
-
-def get_client_cert(config: Config, repository_name: str) -> Path | None:
-    client_cert = config.get(f"certificates.{repository_name}.client-cert")
-    if client_cert:
-        return Path(client_cert)
-    else:
-        return None
 
 
 def _on_rm_error(func: Callable[[str], None], path: str, exc_info: Exception) -> None:

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -175,16 +175,26 @@ def test_set_client_cert(
     )
 
 
+@pytest.mark.parametrize(
+    ("value", "result"),
+    [
+        ("path/to/ca.pem", "path/to/ca.pem"),
+        ("true", True),
+        ("false", False),
+    ],
+)
 def test_set_cert(
     tester: CommandTester,
     auth_config_source: DictConfigSource,
     mocker: MockerFixture,
+    value: str,
+    result: str | bool,
 ):
     mocker.spy(ConfigSource, "__init__")
 
-    tester.execute("certificates.foo.cert path/to/ca.pem")
+    tester.execute(f"certificates.foo.cert {value}")
 
-    assert auth_config_source.config["certificates"]["foo"]["cert"] == "path/to/ca.pem"
+    assert auth_config_source.config["certificates"]["foo"]["cert"] == result
 
 
 def test_config_installer_parallel(

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -14,6 +14,7 @@ from poetry.core.packages.package import Package
 from poetry.installation.pip_installer import PipInstaller
 from poetry.repositories.legacy_repository import LegacyRepository
 from poetry.repositories.pool import Pool
+from poetry.utils.authenticator import RepositoryCertificateConfig
 from poetry.utils.env import NullEnv
 
 
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from poetry.utils.env import VirtualEnv
+    from tests.conftest import Config
 
 
 @pytest.fixture
@@ -120,15 +122,15 @@ def test_install_with_non_pypi_default_repository(pool: Pool, installer: PipInst
 @pytest.mark.parametrize(
     ("key", "option"),
     [
-        ("cert", "client-cert"),
-        ("verify", "cert"),
+        ("client_cert", "client-cert"),
+        ("cert", "cert"),
     ],
 )
 def test_install_with_certs(mocker: MockerFixture, key: str, option: str):
     client_path = "path/to/client.pem"
     mocker.patch(
         "poetry.utils.authenticator.Authenticator.get_certs_for_url",
-        return_value={key: client_path},
+        return_value=RepositoryCertificateConfig(**{key: Path(client_path)}),
     )
 
     default = LegacyRepository("default", "https://foo.bar")
@@ -204,3 +206,31 @@ def test_uninstall_git_package_nspkg_pth_cleanup(
     # any command in the virtual environment should trigger the error message
     output = tmp_venv.run("python", "-m", "site")
     assert not re.match(rf"Error processing line 1 of .*{pth_file}", output)
+
+
+def test_install_with_trusted_host(config: Config):
+    config.merge({"certificates": {"default": {"cert": False}}})
+
+    default = LegacyRepository("default", "https://foo.bar")
+    pool = Pool()
+    pool.add_repository(default, default=True)
+
+    null_env = NullEnv()
+
+    installer = PipInstaller(null_env, NullIO(), pool)
+
+    foo = Package(
+        "foo",
+        "0.0.0",
+        source_type="legacy",
+        source_reference=default.name,
+        source_url=default.url,
+    )
+
+    installer.install(foo)
+
+    assert len(null_env.executed) == 1
+    cmd = null_env.executed[0]
+    assert "--trusted-host" in cmd
+    cert_index = cmd.index("--trusted-host")
+    assert cmd[cert_index + 1] == "foo.bar"

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -38,7 +38,7 @@ def test_publish_publishes_to_pypi_by_default(
     assert [("foo", "bar")] == uploader_auth.call_args
     assert [
         ("https://upload.pypi.org/legacy/",),
-        {"cert": None, "client_cert": None, "dry_run": False, "skip_existing": False},
+        {"cert": True, "client_cert": None, "dry_run": False, "skip_existing": False},
     ] == uploader_upload.call_args
 
 
@@ -70,7 +70,7 @@ def test_publish_can_publish_to_given_repository(
     assert [("foo", "bar")] == uploader_auth.call_args
     assert [
         ("http://foo.bar",),
-        {"cert": None, "client_cert": None, "dry_run": False, "skip_existing": False},
+        {"cert": True, "client_cert": None, "dry_run": False, "skip_existing": False},
     ] == uploader_upload.call_args
     assert "Publishing my-package (1.2.3) to foo" in io.fetch_output()
 
@@ -104,7 +104,7 @@ def test_publish_uses_token_if_it_exists(
     assert [("__token__", "my-token")] == uploader_auth.call_args
     assert [
         ("https://upload.pypi.org/legacy/",),
-        {"cert": None, "client_cert": None, "dry_run": False, "skip_existing": False},
+        {"cert": True, "client_cert": None, "dry_run": False, "skip_existing": False},
     ] == uploader_upload.call_args
 
 
@@ -159,7 +159,7 @@ def test_publish_uses_client_cert(
     assert [
         ("https://foo.bar",),
         {
-            "cert": None,
+            "cert": True,
             "client_cert": Path(client_cert),
             "dry_run": False,
             "skip_existing": False,
@@ -186,5 +186,5 @@ def test_publish_read_from_environment_variable(
     assert [("bar", "baz")] == uploader_auth.call_args
     assert [
         ("https://foo.bar",),
-        {"cert": None, "client_cert": None, "dry_run": False, "skip_existing": False},
+        {"cert": True, "client_cert": None, "dry_run": False, "skip_existing": False},
     ] == uploader_upload.call_args

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,19 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import TYPE_CHECKING
-
 import pytest
 
 from poetry.core.utils.helpers import parse_requires
 
 from poetry.utils.helpers import canonicalize_name
-from poetry.utils.helpers import get_cert
-from poetry.utils.helpers import get_client_cert
-
-
-if TYPE_CHECKING:
-    from tests.conftest import Config
 
 
 def test_parse_requires():
@@ -70,20 +61,6 @@ isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e5283576
     ]
     # fmt: on
     assert result == expected
-
-
-def test_get_cert(config: Config):
-    ca_cert = "path/to/ca.pem"
-    config.merge({"certificates": {"foo": {"cert": ca_cert}}})
-
-    assert get_cert(config, "foo") == Path(ca_cert)
-
-
-def test_get_client_cert(config: Config):
-    client_cert = "path/to/client.pem"
-    config.merge({"certificates": {"foo": {"client-cert": client_cert}}})
-
-    assert get_client_cert(config, "foo") == Path(client_cert)
 
 
 test_canonicalize_name_cases = [


### PR DESCRIPTION
boolean values in addition to certificate paths. This allows for repositories to skip TLS certificate validation for cases where self-signed certificats are used by package sources.

In addition to the above, the certificate configuration handling has now been delegated to a dedicated dataclass.

Closes: #3676
Resolves: #1556
