### PR TITLE
plugins: hide deprecated command

### DIFF
--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -43,6 +43,7 @@ It works similarly to the <c1>add</c1> command:
 
 {deprecation}
 """
+    hidden = True
 
     def handle(self) -> int:
         self.line_error(self.deprecation)

--- a/src/poetry/console/commands/plugin/remove.py
+++ b/src/poetry/console/commands/plugin/remove.py
@@ -36,6 +36,8 @@ class PluginRemoveCommand(Command):
         "</warning>"
     )
 
+    hidden = True
+
     def handle(self) -> int:
         self.line_error(self.help)
 

--- a/src/poetry/console/commands/plugin/show.py
+++ b/src/poetry/console/commands/plugin/show.py
@@ -19,6 +19,7 @@ class PluginShowCommand(Command):
         "<warning>This command is deprecated. Use <c2>self show plugins</> "
         "command instead.</warning>"
     )
+    hidden = True
 
     def handle(self) -> int:
         self.line_error(self.help)


### PR DESCRIPTION
Quick follow up to #5450 in order to hide `poetry plugin` from the top-level help output
