### PR TITLE
Refactor `show` command a bit

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -165,9 +165,7 @@ lists all packages available."""
             ["<info>description</>", f" : {pkg.description}"],
         ]
 
-        table = self.table(style="compact")
-        table.add_rows(rows)
-        table.render()
+        self.table(rows=rows, style="compact").render()
 
         if pkg.requires:
             self.line("")

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -115,15 +115,7 @@ lists all packages available."""
 
         # Show tree view if requested
         if self.option("tree") and package is None:
-            requires = root.all_requires
-            packages = locked_repo.packages
-            for p in packages:
-                for require in requires:
-                    if p.name == require.name:
-                        self.display_package_tree(self.io, p, packages)
-                        break
-
-            return 0
+            return self._display_packages_tree_information(locked_repo, root)
 
         locked_packages = locked_repo.packages
         pool = Pool(ignore_repository_names=True)
@@ -375,6 +367,19 @@ lists all packages available."""
             self.line("<info>required by</info>")
             for parent, requires_version in required_by.items():
                 self.line(f" - <c1>{parent}</c1> <b>{requires_version}</b>")
+
+        return 0
+
+    def _display_packages_tree_information(
+        self, locked_repository: Repository, root: ProjectPackage
+    ) -> int:
+        packages = locked_repository.packages
+
+        for p in packages:
+            for require in root.all_requires:
+                if p.name == require.name:
+                    self.display_package_tree(self.io, p, packages)
+                    break
 
         return 0
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -118,10 +118,11 @@ lists all packages available."""
         self, package: str, locked_repository: Repository
     ) -> int:
         locked_packages = locked_repository.packages
+        canonicalized_package = canonicalize_name(package)
         pkg = None
 
         for locked in locked_packages:
-            if canonicalize_name(package) == locked.name:
+            if locked.name == canonicalized_package:
                 pkg = locked
                 break
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -102,14 +102,15 @@ lists all packages available."""
             return 1
 
         locked_repo = self.poetry.locker.locked_repository()
-        root = self.project_with_activated_groups_only()
-
-        # Show tree view if requested
-        if self.option("tree") and package is None:
-            return self._display_packages_tree_information(locked_repo, root)
 
         if package:
             return self._display_single_package_information(package, locked_repo)
+
+        root = self.project_with_activated_groups_only()
+
+        # Show tree view if requested
+        if self.option("tree"):
+            return self._display_packages_tree_information(locked_repo, root)
 
         return self._display_packages_information(locked_repo, root)
 


### PR DESCRIPTION
# Pull Request Check List

- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Refactor `show` command a tiny bit to separate the different cases into dedicated functions, since right now `handle` method is 300 lines long.
This also has the advantage of making some imports necessary only on a specific variant of the command.