### PR TITLE
poc: isolated project plugins & tools

### DIFF
--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -42,6 +42,10 @@ class PluginManager:
     def get_plugin_entry_points(
         self, env: Env | None = None
     ) -> list[entrypoints.EntryPoint]:
+        from poetry.utils.env import EnvManager
+
+        EnvManager.load_project_plugins()
+
         entry_points: list[entrypoints.EntryPoint] = entrypoints.get_group_all(
             self._group, path=env.sys_path if env else sys.path
         )


### PR DESCRIPTION
This is a proof of concept for discussions and feedback only.

## Project Level Plugins
### Rationale
In a lot of case, a project might require a plugin that is otherwise not required anywhere else for a user. This can in theory be defined within the `pyproject.toml` as opposed to being manual instructions for the user.

## Project Tools
### Rationale
Projects usually require additional tools like `pre-commit` and `tox`. Today, these tools are part of the project's dependency graph. While this is useful for cases like `pytest`, it is not so much the case for `tox` and/or `pre-commit` that are used as cli tools and not used within the project code.

## Implementation Details
In this poc, when `poetry install` is run, we 

1. create a `.poetry` directory if either `tools` or `plugins` are defined.
2. create a plugins directory (`.poetry/plugins`) to which plugin wheels will be installed (without polluting the project venv or the global system site)
3. create a `tools/<name>` virtual environment with only the tool and any additional dependencies specified.
4. create a `.poetry/config.toml` to store hashes, sytem python version and poetry version to detect changes.

## Example Configuration
In this poc we use `overlay` section to avoid validation errors.

```toml
[overlay]
plugins = [
    "poethepoet"
]

[overlay.tools]
tox = [
    "tox",
    "tox-venv",
]
pre-commit = [
    "pre-commit"
]
```

This can use used as follows.

```sh
poetry install
poetry poe --help
poetry run tox --version
poetry run pre-commit --version
```

## Limitations
1. We use `pip install` to demonstrate capability. This can be replaced with Poetry's internals.
2. Plugins are all installed to a single directory (this can be changed)
