### PR TITLE
Test against Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-beta.3"]
         include:
           - os: Ubuntu
             image: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-beta.3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         include:
           - os: Ubuntu
             image: ubuntu-22.04

--- a/.github/workflows/skip.yml
+++ b/.github/workflows/skip.yml
@@ -28,6 +28,6 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-beta.3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
     steps:
       - run: exit 0

--- a/.github/workflows/skip.yml
+++ b/.github/workflows/skip.yml
@@ -28,6 +28,6 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-beta.3"]
     steps:
       - run: exit 0


### PR DESCRIPTION
# Pull Request Check List

- ~[ ] Added **tests** for changed code.~ Not applicable
- ~[ ] Updated **documentation** for changed code.~ Not applicable

Since Python 3.11 reached a beta state, it would be nice to start running the test suite against it, to ensure that Poetry works as expected on this version when the final version is out.

It was not really feasible to do that earlier with `3.11.0b1` because of https://github.com/python-poetry/poetry/issues/5597 (and the associated upstream issue), and would have required a workaround with `3.11.0b2` because of https://github.com/pytest-dev/pytest/issues/10008.

`3.11.0b3` was [released](https://www.python.org/downloads/release/python-3110b3/) quickly after `3.11.0b2`, which fixes the problem in `3.11.0b2`, so we can now test against Python 3.11.

The good news is that the tests [all pass](https://github.com/python-poetry/poetry/runs/6715337505?check_suite_focus=true#step:14:1) on Python 3.11 :tada: (though there are some deprecation warnings).