### PR TITLE
Handle a deprecation warning in a test

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -57,7 +57,7 @@ Note that the installer does not support Python < 3.7.
 {{% /note %}}
 
 {{% warning %}}
-The previous `get-poetry.py` and `install-poetry.py` installers are now deprecated. if you are currently using them
+The previous `get-poetry.py` and `install-poetry.py` installers are now deprecated. If you are currently using them
 you should migrate to the new, supported, installer through `https://install.python-poetry.org`.
 {{% /warning %}}
 {{< /step >}}

--- a/tests/console/commands/self/test_show_plugins.py
+++ b/tests/console/commands/self/test_show_plugins.py
@@ -43,7 +43,7 @@ def plugin_package() -> Package:
 
 @pytest.fixture()
 def plugin_distro(plugin_package: Package) -> Distribution:
-    return Distribution(plugin_package.name, plugin_package.version.to_string(True))
+    return Distribution(plugin_package.name, plugin_package.version.to_string())
 
 
 @pytest.mark.parametrize("entrypoint_name", ["poetry-plugin", "not-package-name"])


### PR DESCRIPTION
# Pull Request Check List

- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Handle a deprecation warning [reported](https://github.com/python-poetry/poetry/runs/6694707414?check_suite_focus=true#step:14:26) by the test suite.
This comes from [this change](https://github.com/python-poetry/poetry-core/pull/344/files#diff-41bd7e9d451c4496d3b88133b2c0449a81edb6247df8c8150dc3380677b61f85R146-R156) which makes it unnecessary to pass `short` parameter to `to_string` since it's not taken into account anymore.

https://github.com/python-poetry/poetry/commit/d3a88bcc7a023d1583745d3706acad7823f2553e bonus commit fixes a tiny mistake I made in the docs in https://github.com/python-poetry/poetry/pull/5739 :see_no_evil: 