### PR TITLE
remove unused Link parameters

### DIFF
--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import urllib.parse
 import warnings
 
-from html import unescape
 from typing import TYPE_CHECKING
 
 from poetry.core.packages.utils.link import Link
@@ -31,9 +30,7 @@ class HTMLPage(LinkSource):
             if anchor.get("href"):
                 href = anchor.get("href")
                 url = self.clean_link(urllib.parse.urljoin(self._url, href))
-                pyrequire = anchor.get("data-requires-python")
-                pyrequire = unescape(pyrequire) if pyrequire else None
-                link = Link(url, self, requires_python=pyrequire)
+                link = Link(url)
 
                 if link.ext not in self.SUPPORTED_FORMATS:
                     continue


### PR DESCRIPTION
Per https://github.com/python-poetry/poetry-core/pull/386, there's a whole pile of code in the `Link` that is unused.

This is the one place in the codebase that provides the unused information.