### PR TITLE
cleo-typechecking

### DIFF
--- a/src/poetry/console/commands/about.py
+++ b/src/poetry/console/commands/about.py
@@ -15,7 +15,7 @@ class AboutCommand(Command):
 
     description = "Shows information about Poetry."
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         from poetry.utils._compat import metadata
 
         # The metadata.version that we import for Python 3.7 is untyped, work around
@@ -34,3 +34,5 @@ Poetry-Core Version: {version('poetry-core')}</info>
 See <fg=blue>https://github.com/python-poetry/poetry</> for more information.</comment>\
 """
         )
+
+        return 0

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -245,7 +245,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
 
         self._installer.set_package(self.poetry.package)
         self._installer.dry_run(self.option("dry-run"))
-        self._installer.verbose(self._io.is_verbose())
+        self._installer.verbose(self.io.is_verbose())
         self._installer.update(True)
         if self.option("lock"):
             self._installer.lock()

--- a/src/poetry/console/commands/build.py
+++ b/src/poetry/console/commands/build.py
@@ -21,7 +21,7 @@ class BuildCommand(EnvCommand):
         "poetry.core.masonry.builders.wheel",
     ]
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         from poetry.core.masonry.builder import Builder
 
         with build_environment(poetry=self.poetry, env=self.env, io=self.io) as env:
@@ -33,3 +33,5 @@ class BuildCommand(EnvCommand):
 
             builder = Builder(self.poetry)
             builder.build(fmt, executable=env.python)
+
+        return 0

--- a/src/poetry/console/commands/cache/list.py
+++ b/src/poetry/console/commands/cache/list.py
@@ -9,7 +9,7 @@ class CacheListCommand(Command):
     name = "cache list"
     description = "List Poetry's caches."
 
-    def handle(self) -> int | None:
+    def handle(self) -> int:
         config = Config.create()
         if config.repository_cache_directory.exists():
             caches = sorted(config.repository_cache_directory.iterdir())
@@ -19,4 +19,4 @@ class CacheListCommand(Command):
                 return 0
 
         self.line_error("<warning>No caches found</>")
-        return None
+        return 0

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -120,7 +120,7 @@ To remove a repository (repo is a short alias for repositories):
 
         return unique_config_values
 
-    def handle(self) -> int | None:
+    def handle(self) -> int:
         from pathlib import Path
 
         from poetry.core.pyproject.exceptions import PyProjectException
@@ -195,7 +195,7 @@ To remove a repository (repo is a short alias for repositories):
         if setting_key in unique_config_values:
             if self.option("unset"):
                 config.config_source.remove_property(setting_key)
-                return None
+                return 0
 
             return self._handle_single_value(
                 config.config_source,

--- a/src/poetry/console/commands/debug/info.py
+++ b/src/poetry/console/commands/debug/info.py
@@ -25,5 +25,5 @@ class DebugInfoCommand(Command):
         )
         command = self.application.get("env info")
 
-        exit_code: int = command.run(self._io)
+        exit_code: int = command.run(self.io)
         return exit_code

--- a/src/poetry/console/commands/debug/resolve.py
+++ b/src/poetry/console/commands/debug/resolve.py
@@ -86,7 +86,7 @@ class DebugResolveCommand(InitCommand):
 
         pool = self.poetry.pool
 
-        solver = Solver(package, pool, Repository(), Repository(), self._io)
+        solver = Solver(package, pool, Repository(), Repository(), self.io)
 
         ops = solver.solve().calculate_operations()
 

--- a/src/poetry/console/commands/env/info.py
+++ b/src/poetry/console/commands/env/info.py
@@ -18,7 +18,7 @@ class EnvInfoCommand(Command):
 
     options = [option("path", "p", "Only display the environment's path.")]
 
-    def handle(self) -> int | None:
+    def handle(self) -> int:
         from poetry.utils.env import EnvManager
 
         env = EnvManager(self.poetry).get()
@@ -29,10 +29,10 @@ class EnvInfoCommand(Command):
 
             self.line(str(env.path))
 
-            return None
+            return 0
 
         self._display_complete_info(env)
-        return None
+        return 0
 
     def _display_complete_info(self, env: Env) -> None:
         env_python_version = ".".join(str(s) for s in env.version_info[:3])

--- a/src/poetry/console/commands/env/list.py
+++ b/src/poetry/console/commands/env/list.py
@@ -12,7 +12,7 @@ class EnvListCommand(Command):
 
     options = [option("full-path", None, "Output the full paths of the virtualenvs.")]
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         from poetry.utils.env import EnvManager
 
         manager = EnvManager(self.poetry)
@@ -29,3 +29,5 @@ class EnvListCommand(Command):
                 continue
 
             self.line(name)
+
+        return 0

--- a/src/poetry/console/commands/env/remove.py
+++ b/src/poetry/console/commands/env/remove.py
@@ -29,7 +29,7 @@ class EnvRemoveCommand(Command):
         ),
     ]
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         from poetry.utils.env import EnvManager
 
         pythons = self.argument("python")
@@ -46,3 +46,5 @@ class EnvRemoveCommand(Command):
             for venv in manager.list():
                 manager.remove_venv(venv.path)
                 self.line(f"Deleted virtualenv: <comment>{venv.path}</comment>")
+
+        return 0

--- a/src/poetry/console/commands/env/use.py
+++ b/src/poetry/console/commands/env/use.py
@@ -12,16 +12,18 @@ class EnvUseCommand(Command):
 
     arguments = [argument("python", "The python executable to use.")]
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         from poetry.utils.env import EnvManager
 
         manager = EnvManager(self.poetry)
 
         if self.argument("python") == "system":
-            manager.deactivate(self._io)
+            manager.deactivate(self.io)
 
-            return
+            return 0
 
-        env = manager.activate(self.argument("python"), self._io)
+        env = manager.activate(self.argument("python"), self.io)
 
         self.line(f"Using virtualenv: <comment>{env.path}</>")
+
+        return 0

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -101,7 +101,7 @@ dependencies and not including the current project, run the command with the
         self._installer.only_groups(self.activated_groups)
         self._installer.dry_run(self.option("dry-run"))
         self._installer.requires_synchronization(with_synchronization)
-        self._installer.verbose(self._io.is_verbose())
+        self._installer.verbose(self.io.is_verbose())
 
         return_code = self._installer.run()
 
@@ -112,7 +112,7 @@ dependencies and not including the current project, run the command with the
             return 0
 
         try:
-            builder = EditableBuilder(self.poetry, self._env, self._io)
+            builder = EditableBuilder(self.poetry, self._env, self.io)
         except ModuleOrPackageNotFound:
             # This is likely due to the fact that the project is an application
             # not following the structure expected by Poetry
@@ -124,7 +124,7 @@ dependencies and not including the current project, run the command with the
             f" <c1>{self.poetry.package.pretty_name}</c1>"
             f" (<{{tag}}>{self.poetry.package.pretty_version}</>)"
         )
-        overwrite = self._io.output.is_decorated() and not self.io.is_debug()
+        overwrite = self.io.output.is_decorated() and not self.io.is_debug()
         self.line("")
         self.write(log_install.format(tag="c2"))
         if not overwrite:

--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -27,7 +27,7 @@ class NewCommand(Command):
         ),
     ]
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         from pathlib import Path
 
         from poetry.core.vcs.git import GitConfig
@@ -87,3 +87,5 @@ class NewCommand(Command):
             f"Created package <info>{layout_._package_name}</> in"
             f" <fg=blue>{path.as_posix()}</>"
         )
+
+        return 0

--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -60,8 +60,8 @@ It works similarly to the <c1>add</c1> command:
         exit_code: int = command.run(
             IO(
                 StringInput(" ".join(argv)),
-                self._io.output,
-                self._io.error_output,
+                self.io.output,
+                self.io.error_output,
             )
         )
         return exit_code

--- a/src/poetry/console/commands/plugin/remove.py
+++ b/src/poetry/console/commands/plugin/remove.py
@@ -55,8 +55,8 @@ class PluginRemoveCommand(Command):
         exit_code: int = command.run(
             IO(
                 StringInput(" ".join(argv)),
-                self._io.output,
-                self._io.error_output,
+                self.io.output,
+                self.io.error_output,
             )
         )
         return exit_code

--- a/src/poetry/console/commands/plugin/show.py
+++ b/src/poetry/console/commands/plugin/show.py
@@ -32,8 +32,8 @@ class PluginShowCommand(Command):
         exit_code: int = command.run(
             IO(
                 StringInput(""),
-                self._io.output,
-                self._io.error_output,
+                self.io.output,
+                self.io.error_output,
             )
         )
         return exit_code

--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -47,7 +47,7 @@ the config command.
 
     loggers = ["poetry.masonry.publishing.publisher"]
 
-    def handle(self) -> int | None:
+    def handle(self) -> int:
         from poetry.publishing.publisher import Publisher
 
         publisher = Publisher(self.poetry, self.io)
@@ -90,4 +90,4 @@ the config command.
             self.option("skip-existing"),
         )
 
-        return None
+        return 0

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -105,7 +105,7 @@ list of installed packages
 
         self._installer.set_package(self.poetry.package)
         self._installer.dry_run(self.option("dry-run", False))
-        self._installer.verbose(self._io.is_verbose())
+        self._installer.verbose(self.io.is_verbose())
         self._installer.update(True)
         self._installer.whitelist(removed_set)
 

--- a/src/poetry/console/commands/run.py
+++ b/src/poetry/console/commands/run.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Any
 
 from cleo.helpers import argument
 
@@ -21,7 +20,7 @@ class RunCommand(EnvCommand):
         argument("args", "The command and arguments/options to run.", multiple=True)
     ]
 
-    def handle(self) -> Any:
+    def handle(self) -> int:
         args = self.argument("args")
         script = args[0]
         scripts = self.poetry.local_config.get("scripts")
@@ -46,7 +45,7 @@ class RunCommand(EnvCommand):
 
         return module
 
-    def run_script(self, script: str | dict[str, str], args: str) -> Any:
+    def run_script(self, script: str | dict[str, str], args: str) -> int:
         if isinstance(script, dict):
             script = script["callable"]
 

--- a/src/poetry/console/commands/search.py
+++ b/src/poetry/console/commands/search.py
@@ -12,7 +12,7 @@ class SearchCommand(Command):
 
     arguments = [argument("tokens", "The tokens to search for.", multiple=True)]
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         from poetry.repositories.pypi_repository import PyPiRepository
 
         results = PyPiRepository().search(self.argument("tokens"))
@@ -27,3 +27,5 @@ class SearchCommand(Command):
 
             if result.description:
                 self.line(f" {result.description}")
+
+        return 0

--- a/src/poetry/console/commands/self/self_command.py
+++ b/src/poetry/console/commands/self/self_command.py
@@ -83,7 +83,7 @@ class SelfCommand(InstallerCommand):
         with directory(self.system_pyproject.parent):
             self.generate_system_pyproject()
             self._poetry = Factory().create_poetry(
-                self.system_pyproject.parent, io=self._io, disable_plugins=True
+                self.system_pyproject.parent, io=self.io, disable_plugins=True
             )
 
     @property

--- a/src/poetry/console/commands/self/update.py
+++ b/src/poetry/console/commands/self/update.py
@@ -40,7 +40,7 @@ environment.
         application = cast(Application, self.application)
         add_command: AddCommand = cast(AddCommand, application.find("add"))
         add_command.set_env(self.env)
-        application.configure_installer_for_command(add_command, self._io)
+        application.configure_installer_for_command(add_command, self.io)
 
         argv = ["add", f"poetry@{self.argument('version')}"]
 
@@ -53,8 +53,8 @@ environment.
         exit_code: int = add_command.run(
             IO(
                 StringInput(" ".join(argv)),
-                self._io.output,
-                self._io.error_output,
+                self.io.output,
+                self.io.error_output,
             )
         )
         return exit_code

--- a/src/poetry/console/commands/shell.py
+++ b/src/poetry/console/commands/shell.py
@@ -18,7 +18,7 @@ class ShellCommand(EnvCommand):
 If one doesn't exist yet, it will be created.
 """
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         from poetry.utils.shell import Shell
 
         # Check if it's already activated or doesn't exist and won't be created
@@ -30,7 +30,7 @@ If one doesn't exist yet, it will be created.
                 f"Virtual environment already activated: <info>{self.env.path}</>"
             )
 
-            return
+            return 0
 
         self.line(f"Spawning shell within <info>{self.env.path}</>")
 
@@ -39,3 +39,5 @@ If one doesn't exist yet, it will be created.
         shell = Shell.get()
         shell.activate(self.env)  # type: ignore[arg-type]
         environ.pop("POETRY_ACTIVE")
+
+        return 0

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -72,7 +72,7 @@ lists all packages available."""
 
     colors = ["cyan", "yellow", "green", "magenta", "blue"]
 
-    def handle(self) -> int | None:
+    def handle(self) -> int:
         from cleo.io.null_io import NullIO
         from cleo.terminal import Terminal
 
@@ -105,7 +105,7 @@ lists all packages available."""
                 return 1
 
         if self.option("outdated"):
-            self._io.input.set_option("latest", True)
+            self.io.input.set_option("latest", True)
 
         if not self.poetry.locker.is_locked():
             self.line_error(
@@ -124,7 +124,7 @@ lists all packages available."""
             for p in packages:
                 for require in requires:
                     if p.name == require.name:
-                        self.display_package_tree(self._io, p, locked_repo)
+                        self.display_package_tree(self.io, p, locked_repo)
                         break
 
             return 0
@@ -175,17 +175,15 @@ lists all packages available."""
                         # if no rev-deps exist we'll make this clear as it can otherwise
                         # look very odd for packages that also have no or few direct
                         # dependencies
-                        self._io.write_line(
-                            f"Package {package} is a direct dependency."
-                        )
+                        self.io.write_line(f"Package {package} is a direct dependency.")
 
                     for p in packages:
                         self.display_package_tree(
-                            self._io, p, locked_repo, why_package=pkg
+                            self.io, p, locked_repo, why_package=pkg
                         )
 
                 else:
-                    self.display_package_tree(self._io, pkg, locked_repo)
+                    self.display_package_tree(self.io, pkg, locked_repo)
 
                 return 0
 
@@ -230,7 +228,7 @@ lists all packages available."""
                 continue
 
             current_length = len(locked.pretty_name)
-            if not self._io.output.is_decorated():
+            if not self.io.output.is_decorated():
                 installed_status = self.get_installed_status(locked, installed_repo)
 
                 if installed_status == "not-installed":
@@ -311,7 +309,7 @@ lists all packages available."""
                 if installed_status == "not-installed":
                     color = "red"
 
-                    if not self._io.output.is_decorated():
+                    if not self.io.output.is_decorated():
                         # Non installed in non decorated mode
                         install_marker = " (!)"
 
@@ -372,7 +370,7 @@ lists all packages available."""
 
             self.line(line)
 
-        return None
+        return 0
 
     def display_package_tree(
         self,

--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -49,7 +49,7 @@ class SourceAddCommand(Command):
         source_table.add(nl())
         return source_table
 
-    def handle(self) -> int | None:
+    def handle(self) -> int:
         from poetry.factory import Factory
         from poetry.repositories import Pool
 

--- a/src/poetry/console/commands/source/remove.py
+++ b/src/poetry/console/commands/source/remove.py
@@ -36,7 +36,7 @@ class SourceRemoveCommand(Command):
         source_table.add(nl())
         return source_table
 
-    def handle(self) -> int | None:
+    def handle(self) -> int:
         name = self.argument("name")
 
         sources = AoT([])

--- a/src/poetry/console/commands/source/show.py
+++ b/src/poetry/console/commands/source/show.py
@@ -18,7 +18,7 @@ class SourceShowCommand(Command):
         ),
     ]
 
-    def handle(self) -> int | None:
+    def handle(self) -> int:
         sources = self.poetry.get_sources()
         names = self.argument("source")
 

--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -57,7 +57,7 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
         "prerelease",
     }
 
-    def handle(self) -> None:
+    def handle(self) -> int:
         version = self.argument("version")
 
         if version:
@@ -88,6 +88,8 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
                     f"<comment>{self.poetry.package.name}</>"
                     f" <info>{self.poetry.package.pretty_version}</>"
                 )
+
+        return 0
 
     def increment_version(self, version: str, rule: str) -> Version:
         from poetry.core.semver.version import Version

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1484,7 +1484,7 @@ class Env:
 
         return decode(output)
 
-    def execute(self, bin: str, *args: str, **kwargs: Any) -> int | None:
+    def execute(self, bin: str, *args: str, **kwargs: Any) -> int:
         command = self.get_command_from_bin(bin) + list(args)
         env = kwargs.pop("env", dict(os.environ))
 
@@ -1753,7 +1753,7 @@ class VirtualEnv(Env):
 
         return environ
 
-    def execute(self, bin: str, *args: str, **kwargs: Any) -> int | None:
+    def execute(self, bin: str, *args: str, **kwargs: Any) -> int:
         kwargs["env"] = self.get_temp_environ(environ=kwargs.get("env"))
         return super().execute(bin, *args, **kwargs)
 
@@ -1836,7 +1836,7 @@ class GenericEnv(VirtualEnv):
         paths: dict[str, str] = json.loads(output)
         return paths
 
-    def execute(self, bin: str, *args: str, **kwargs: Any) -> int | None:
+    def execute(self, bin: str, *args: str, **kwargs: Any) -> int:
         command = self.get_command_from_bin(bin) + list(args)
         env = kwargs.pop("env", dict(os.environ))
 
@@ -1880,12 +1880,12 @@ class NullEnv(SystemEnv):
             return super()._run(cmd, **kwargs)
         return 0
 
-    def execute(self, bin: str, *args: str, **kwargs: Any) -> int | None:
+    def execute(self, bin: str, *args: str, **kwargs: Any) -> int:
         self.executed.append([bin] + list(args))
 
         if self._execute:
             return super().execute(bin, *args, **kwargs)
-        return None
+        return 0
 
     def _bin(self, bin: str) -> str:
         return bin


### PR DESCRIPTION
fixing some - but by no means all - of the errors that would be exposed if cleo revealed its types.  On a `Command`

- `self._io` may be None, there's a property that gives the guaranteed-not-None thing
- `self.handle()` is supposed to return an `int`