### PR TITLE
fix: only consider package links for sdist and bdist_wheels

### DIFF
--- a/tests/repositories/fixtures/pypi.org/json/hbmqtt.json
+++ b/tests/repositories/fixtures/pypi.org/json/hbmqtt.json
@@ -1,0 +1,919 @@
+{
+  "info": {
+    "author": "Nicolas Jouanin",
+    "author_email": "nico@beerfactory.org",
+    "bugtrack_url": null,
+    "classifiers": [
+      "Development Status :: 3 - Alpha",
+      "Intended Audience :: Developers",
+      "License :: OSI Approved :: MIT License",
+      "Operating System :: MacOS",
+      "Operating System :: Microsoft :: Windows",
+      "Operating System :: POSIX",
+      "Programming Language :: Python :: 3.4",
+      "Programming Language :: Python :: 3.5",
+      "Programming Language :: Python :: 3.6",
+      "Topic :: Communications",
+      "Topic :: Internet"
+    ],
+    "description": "",
+    "description_content_type": "",
+    "docs_url": null,
+    "download_url": "",
+    "downloads": {
+      "last_day": -1,
+      "last_month": -1,
+      "last_week": -1
+    },
+    "home_page": "https://github.com/beerfactory/hbmqtt",
+    "keywords": "",
+    "license": "MIT",
+    "maintainer": "",
+    "maintainer_email": "",
+    "name": "hbmqtt",
+    "package_url": "https://pypi.org/project/hbmqtt/",
+    "platform": "all",
+    "project_url": "https://pypi.org/project/hbmqtt/",
+    "project_urls": {
+      "Homepage": "https://github.com/beerfactory/hbmqtt"
+    },
+    "release_url": "https://pypi.org/project/hbmqtt/0.9.6/",
+    "requires_dist": null,
+    "requires_python": "",
+    "summary": "MQTT client/broker using Python 3.4 asyncio library",
+    "version": "0.9.6",
+    "yanked": false,
+    "yanked_reason": null
+  },
+  "last_serial": 6518769,
+  "releases": {
+    "0.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "6b1ad8c282f639312faaadb08b35fa1b",
+          "sha256": "9f8b970df1d2ae066232398ef25f0f0e78ca056bb94546cf4a5abdbca11264f0"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.1-py3.4.egg",
+        "has_sig": false,
+        "md5_digest": "6b1ad8c282f639312faaadb08b35fa1b",
+        "packagetype": "bdist_egg",
+        "python_version": "3.4",
+        "requires_python": null,
+        "size": 94163,
+        "upload_time": "2015-06-30T11:19:50",
+        "upload_time_iso_8601": "2015-06-30T11:19:50.495198Z",
+        "url": "https://files.pythonhosted.org/packages/55/77/254c0c8fd2f76b675b4bf86a1e311ced1275ecc31f4d023721fe4176d5bd/hbmqtt-0.1-py3.4.egg",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "4ef46f395f58a593d6f5ab3a59736d41",
+          "sha256": "dbc1ac9a7d176f238a2426ea83f37035b8e9362ccfc21b00d56304b9611fb2e1"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "4ef46f395f58a593d6f5ab3a59736d41",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 19158,
+        "upload_time": "2015-06-30T11:19:46",
+        "upload_time_iso_8601": "2015-06-30T11:19:46.162531Z",
+        "url": "https://files.pythonhosted.org/packages/fc/48/25d1fc267ccf01c02a677d4d18ec1ced1792e22f96e8e0f822c372c54ced/hbmqtt-0.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "cc28398754bc8edca3beb39711f3b96a",
+          "sha256": "3122a884d0dda0bb1ca77245c37a6b4c0dce1be01886a629fd7521ee12728940"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.2-py3.4.egg",
+        "has_sig": false,
+        "md5_digest": "cc28398754bc8edca3beb39711f3b96a",
+        "packagetype": "bdist_egg",
+        "python_version": "3.4",
+        "requires_python": null,
+        "size": 92388,
+        "upload_time": "2015-07-06T20:40:55",
+        "upload_time_iso_8601": "2015-07-06T20:40:55.799596Z",
+        "url": "https://files.pythonhosted.org/packages/d2/f6/2c5b5d4a00520b0d414766303d3c34005957e8eeab075a4e85198f51d8d5/hbmqtt-0.2-py3.4.egg",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "8e46bdf504e2aa1976a3d532fd92ec5f",
+          "sha256": "74bce279020646a7d0057df62dd6b9c3cdf800be28334297f1d0a675a3135d34"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "8e46bdf504e2aa1976a3d532fd92ec5f",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 18373,
+        "upload_time": "2015-07-06T20:40:49",
+        "upload_time_iso_8601": "2015-07-06T20:40:49.518118Z",
+        "url": "https://files.pythonhosted.org/packages/8a/2c/f810278f1747f5065a3e02d1c1fb50ec24795e5fdd8817636ee86cb0e3db/hbmqtt-0.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.3": [
+      {
+        "comment_text": "built for Darwin-14.4.0",
+        "digests": {
+          "md5": "311d02c8dd9319bf270221aeb350a80f",
+          "sha256": "73a2bd9fe49bb34cf0e62bb891ff6212c6eaadc87d6f613481f048329b7fd5a4"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.3.macosx-10.6-intel.tar.gz",
+        "has_sig": false,
+        "md5_digest": "311d02c8dd9319bf270221aeb350a80f",
+        "packagetype": "bdist_dumb",
+        "python_version": "any",
+        "requires_python": null,
+        "size": 61423,
+        "upload_time": "2015-07-21T19:47:54",
+        "upload_time_iso_8601": "2015-07-21T19:47:54.096949Z",
+        "url": "https://files.pythonhosted.org/packages/d5/0f/1519d8109bbc1475dcd47199b9ba4add6548b78b63c5c1732c24b895e8ad/hbmqtt-0.3.macosx-10.6-intel.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "eb78c2f10b16a8f32a6aab747b39996e",
+          "sha256": "a8b9d3e3ebb9320de53d18d843855153ac983fdedc656aa7ac71e4223182a56d"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "eb78c2f10b16a8f32a6aab747b39996e",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 21489,
+        "upload_time": "2015-07-21T19:47:44",
+        "upload_time_iso_8601": "2015-07-21T19:47:44.050233Z",
+        "url": "https://files.pythonhosted.org/packages/a7/a2/0973f49c64ef86dab91d42aa68f002948dd2d3ef427383c19cd6fb5c1e37/hbmqtt-0.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.4": [
+      {
+        "comment_text": "built for Darwin-14.4.0",
+        "digests": {
+          "md5": "d9c6465a5ab36fc0b026c132094ebc9c",
+          "sha256": "c00c34a7318fb395053c41627f826615c1e4fe6166a162b1e6b4dd863ac6e5c4"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.4.macosx-10.6-intel.tar.gz",
+        "has_sig": false,
+        "md5_digest": "d9c6465a5ab36fc0b026c132094ebc9c",
+        "packagetype": "bdist_dumb",
+        "python_version": "any",
+        "requires_python": null,
+        "size": 66614,
+        "upload_time": "2015-07-27T20:01:32",
+        "upload_time_iso_8601": "2015-07-27T20:01:32.763351Z",
+        "url": "https://files.pythonhosted.org/packages/6c/94/926d102eab2e399842f1871858bb45f59c60b2cb561e6bba2e1b2f544bcf/hbmqtt-0.4.macosx-10.6-intel.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "ec0993335b631e0d536a300b4cac5fb3",
+          "sha256": "3e3b34af8e5ad73be32499aa4992ba94582c1cdbcaba3a691e5825a25b27e1ee"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.4.tar.gz",
+        "has_sig": false,
+        "md5_digest": "ec0993335b631e0d536a300b4cac5fb3",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 23133,
+        "upload_time": "2015-07-27T20:01:23",
+        "upload_time_iso_8601": "2015-07-27T20:01:23.980254Z",
+        "url": "https://files.pythonhosted.org/packages/41/9c/c2d51d88e87cbeb61dba3812caa3a3b725ebf1f6ae1b413359707539313a/hbmqtt-0.4.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.5": [
+      {
+        "comment_text": "built for Darwin-14.4.0",
+        "digests": {
+          "md5": "86604a5979f7a8444255e687f329cf67",
+          "sha256": "d81b84811bc82b919f91454592e302bb810bef7bd82a34bd1b57a2dc954f79d4"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.5.macosx-10.6-intel.tar.gz",
+        "has_sig": false,
+        "md5_digest": "86604a5979f7a8444255e687f329cf67",
+        "packagetype": "bdist_dumb",
+        "python_version": "any",
+        "requires_python": null,
+        "size": 78085,
+        "upload_time": "2015-08-12T17:01:45",
+        "upload_time_iso_8601": "2015-08-12T17:01:45.090856Z",
+        "url": "https://files.pythonhosted.org/packages/91/e7/e23871fb0622e3ed4f2e2637b2ef8fd40d521912a78efb829c3f78711b6d/hbmqtt-0.5.macosx-10.6-intel.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "52a2bc67e0a01ca58fea823c12711916",
+          "sha256": "bfe38e2b13181fab352512a8bf61e6e7b8167be46937b87117fd70c3ef863937"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.5.tar.gz",
+        "has_sig": false,
+        "md5_digest": "52a2bc67e0a01ca58fea823c12711916",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 27698,
+        "upload_time": "2015-08-12T17:01:36",
+        "upload_time_iso_8601": "2015-08-12T17:01:36.473665Z",
+        "url": "https://files.pythonhosted.org/packages/bf/8f/948baa9fe730b79cc0bbc69fab0a15b53e5cd91935cd8afd507cadf1553e/hbmqtt-0.5.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.5.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "9ce497551d76e635f341d0e1457e1337",
+          "sha256": "699fe6917cadf6fe535d331e282eee45423275b56ce6bb6b225d789bd742db53"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.5.1-py34-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "9ce497551d76e635f341d0e1457e1337",
+        "packagetype": "bdist_wheel",
+        "python_version": "py34",
+        "requires_python": null,
+        "size": 49299,
+        "upload_time": "2015-08-13T20:15:53",
+        "upload_time_iso_8601": "2015-08-13T20:15:53.106623Z",
+        "url": "https://files.pythonhosted.org/packages/75/f2/3ec5faf3be0b6407fdfe504e0d3af7568e821286b602b6744b8743722e19/hbmqtt-0.5.1-py34-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.6": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "bef92abacdacdaf83f751e8c33c2ce9d",
+          "sha256": "dd95125c7132ee753ceb5a15a5a0ce04bd86f9983b4a2dae3a9c1fc46dafa942"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.6-py34-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "bef92abacdacdaf83f751e8c33c2ce9d",
+        "packagetype": "bdist_wheel",
+        "python_version": "py34",
+        "requires_python": null,
+        "size": 73301,
+        "upload_time": "2015-11-13T21:16:12",
+        "upload_time_iso_8601": "2015-11-13T21:16:12.865979Z",
+        "url": "https://files.pythonhosted.org/packages/fa/d7/c4c71b8388cf20dfc8705d6c635e15c3ef268cf0ab23ad1ef25a1e9be86d/hbmqtt-0.6-py34-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "0d0587cf4829ee5de28632af296cdf58",
+          "sha256": "8caeb4d7d091d3dd2cad78981f5242fa20f625458d0f114637adcbef3839abd4"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.6.tar.gz",
+        "has_sig": false,
+        "md5_digest": "0d0587cf4829ee5de28632af296cdf58",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 43585,
+        "upload_time": "2015-11-13T21:16:38",
+        "upload_time_iso_8601": "2015-11-13T21:16:38.808098Z",
+        "url": "https://files.pythonhosted.org/packages/ba/3f/af82c3d1a67d7f0b7e3d4446b3c0dd4913e7e00edb3c43a3b44b868adc44/hbmqtt-0.6.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.6.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "3356d1b94626f542ca1bba3870d26913",
+          "sha256": "3f6ca2d0e9fd239c658e6024c03d7156a3d41299e5aec246ec41dc76fa04db84"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.6.1-py34-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "3356d1b94626f542ca1bba3870d26913",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.5",
+        "requires_python": null,
+        "size": 73346,
+        "upload_time": "2016-02-05T20:14:33",
+        "upload_time_iso_8601": "2016-02-05T20:14:33.558316Z",
+        "url": "https://files.pythonhosted.org/packages/4f/f8/846766e3bee221457cd4332001d92e1d95a02b66f3dfdbb66f4677bbd3ba/hbmqtt-0.6.1-py34-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.6.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "ea715d369a9acd6207665ab6dd92c5cf",
+          "sha256": "8ef4587daabc651aaf9dd358b01d3deb5ff384e2d2412650f01b136b8de3dcc2"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.6.2-py34-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "ea715d369a9acd6207665ab6dd92c5cf",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.5",
+        "requires_python": null,
+        "size": 73398,
+        "upload_time": "2016-03-06T21:00:55",
+        "upload_time_iso_8601": "2016-03-06T21:00:55.260927Z",
+        "url": "https://files.pythonhosted.org/packages/3c/85/1618dc19ec571cb2251269107f42bd8b1b67007ea076ef9f31c437ec41d2/hbmqtt-0.6.2-py34-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.6.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "7a5bfb63f5ddc239c734c1ffc430466b",
+          "sha256": "8c3290a6d8afbdd74bd5b7f31d3e85f9a1b274a0e26367b0b52eda38323d3f03"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.6.3-py34-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "7a5bfb63f5ddc239c734c1ffc430466b",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.5",
+        "requires_python": null,
+        "size": 73460,
+        "upload_time": "2016-03-12T20:57:03",
+        "upload_time_iso_8601": "2016-03-12T20:57:03.214700Z",
+        "url": "https://files.pythonhosted.org/packages/10/9c/3bda698c0be0e112d4295f726496b7e3e4518818d08d5a035f7832e40114/hbmqtt-0.6.3-py34-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.7": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "7001a8bd4cb8331b28891cdb364d0edd",
+          "sha256": "7b01ca7b9874f12ae2333ef27a33b8480611be50aeb62587882bcfb521f99203"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.7-py34.py35-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "7001a8bd4cb8331b28891cdb364d0edd",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.5",
+        "requires_python": null,
+        "size": 73919,
+        "upload_time": "2016-05-04T21:04:51",
+        "upload_time_iso_8601": "2016-05-04T21:04:51.903959Z",
+        "url": "https://files.pythonhosted.org/packages/89/e2/ee7c6fa7468954d67b90819710a4582bfa3f4565cef1f510332d1c9612ba/hbmqtt-0.7-py34.py35-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.7.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "b93d4511379298136c0ad5bdf69e65d8",
+          "sha256": "d6ee222bc182615fa99e5c9e71aa6b4e23d266b1d284dda8e3cc93fc3478d311"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.7.1-py34.py35-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "b93d4511379298136c0ad5bdf69e65d8",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.5",
+        "requires_python": null,
+        "size": 73958,
+        "upload_time": "2016-05-07T05:29:06",
+        "upload_time_iso_8601": "2016-05-07T05:29:06.491041Z",
+        "url": "https://files.pythonhosted.org/packages/fd/75/7c2ee26f2c2ff3c796d1c4d577c26b559eb82e57fffb221304c16fd8a134/hbmqtt-0.7.1-py34.py35-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.7.2": [],
+    "0.7.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "10c7d3910e39baff2b81e80dcdcf2d4d",
+          "sha256": "21a4482c74511061a24a678c74785677e7c26601fa516298a6aaa80527b4ba2f"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.7.3-py34.py35-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "10c7d3910e39baff2b81e80dcdcf2d4d",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.5",
+        "requires_python": null,
+        "size": 74024,
+        "upload_time": "2016-05-31T20:22:48",
+        "upload_time_iso_8601": "2016-05-31T20:22:48.283221Z",
+        "url": "https://files.pythonhosted.org/packages/03/8f/473d217c22d174dbbd47de3c6ed2bc5424a30cd08f0b5c8c4440ac514dd4/hbmqtt-0.7.3-py34.py35-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.8": [
+      {
+        "comment_text": "built for Darwin-16.1.0",
+        "digests": {
+          "md5": "af92296969662172a5a239ff62e306f1",
+          "sha256": "c046161359f4b6ee8874da9a05f06db9ebc9bd494e478f7c735f0c54e0aa7eb4"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.8.macosx-10.6-intel.tar.gz",
+        "has_sig": false,
+        "md5_digest": "af92296969662172a5a239ff62e306f1",
+        "packagetype": "bdist_dumb",
+        "python_version": "any",
+        "requires_python": null,
+        "size": 121302,
+        "upload_time": "2016-11-27T19:54:34",
+        "upload_time_iso_8601": "2016-11-27T19:54:34.839202Z",
+        "url": "https://files.pythonhosted.org/packages/1c/d7/7949b2a5ce4fd6fdc2e2af92a5843417689fdccf84382814f14c82b2ff0f/hbmqtt-0.8.macosx-10.6-intel.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "8536de4bffcfc49492c19b4f9701592d",
+          "sha256": "ef341b64c653b62fe5a93747363a97b90e1b97dd9a8968f80349fb40971fe8d4"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.8.tar.gz",
+        "has_sig": false,
+        "md5_digest": "8536de4bffcfc49492c19b4f9701592d",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 44131,
+        "upload_time": "2016-11-27T19:54:23",
+        "upload_time_iso_8601": "2016-11-27T19:54:23.065804Z",
+        "url": "https://files.pythonhosted.org/packages/4f/bf/e8b686f9cc98396de0e7258d95ebb8914b44fd63e5e0117eb6f443c7f2cf/hbmqtt-0.8.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.8.dev20160507052755": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "9a90c636c403efb6dbfff9187d01903d",
+          "sha256": "c284329b0037d79648c5828f18c0f09ce62764df1d31f53aebb221561903adcb"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.8.dev20160507052755-py34.py35-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "9a90c636c403efb6dbfff9187d01903d",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.5",
+        "requires_python": null,
+        "size": 74263,
+        "upload_time": "2016-05-07T05:28:47",
+        "upload_time_iso_8601": "2016-05-07T05:28:47.016869Z",
+        "url": "https://files.pythonhosted.org/packages/8e/f2/bd6306a45035c7d7a89727e3378035cd0f530b3a59af9c2308618f314357/hbmqtt-0.8.dev20160507052755-py34.py35-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.9": [
+      {
+        "comment_text": "built for Darwin-16.6.0",
+        "digests": {
+          "md5": "bcc20dc1d12d40bf55544823baa7a6a2",
+          "sha256": "a682dbdea33b95bb18122ba3e2d2606b6dc95f0d955f997a981b73a476da6452"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.macosx-10.6-intel.tar.gz",
+        "has_sig": false,
+        "md5_digest": "bcc20dc1d12d40bf55544823baa7a6a2",
+        "packagetype": "bdist_dumb",
+        "python_version": "any",
+        "requires_python": null,
+        "size": 120891,
+        "upload_time": "2017-06-02T19:51:59",
+        "upload_time_iso_8601": "2017-06-02T19:51:59.982524Z",
+        "url": "https://files.pythonhosted.org/packages/d7/56/0899ca18cc204fbb8d01f466b64bbec4b7938ed5f95c4e1c7a97a1131f87/hbmqtt-0.9.macosx-10.6-intel.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "dfb8ee2295e9c716e1e9fe9c0863e3b1",
+          "sha256": "9e290992f66424f0ab67c790c839d76dc1c477329a8fab6a6c466362180ff07f"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.tar.gz",
+        "has_sig": false,
+        "md5_digest": "dfb8ee2295e9c716e1e9fe9c0863e3b1",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 45078,
+        "upload_time": "2017-06-02T19:51:50",
+        "upload_time_iso_8601": "2017-06-02T19:51:50.136435Z",
+        "url": "https://files.pythonhosted.org/packages/e0/cc/4428dc925d9119d9242a2af10c8185de621c7e3758d2ed9c4fa5a2bf9b18/hbmqtt-0.9.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.9.1": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "255f57ca5096f9a0f3900f0ad774e377",
+          "sha256": "b3b786ea3c50a2b1da6a05d56bccc910626cf607071eeaf1360648e2e0bf4b0b"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.1-py34.py35-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "255f57ca5096f9a0f3900f0ad774e377",
+        "packagetype": "bdist_wheel",
+        "python_version": "py34.py35",
+        "requires_python": null,
+        "size": 74581,
+        "upload_time": "2017-10-14T07:05:10",
+        "upload_time_iso_8601": "2017-10-14T07:05:10.669305Z",
+        "url": "https://files.pythonhosted.org/packages/af/94/1593797f833c490f029b9a7cfbc8e3c38d9f05c7fe841d768e92decbee7c/hbmqtt-0.9.1-py34.py35-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "820b3c3d2642f1db0cdd486e5191d7cd",
+          "sha256": "3d730429f1d6f9fc10ffceea1b516bb38e9c90b97fd30c31672f39823cc39812"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "820b3c3d2642f1db0cdd486e5191d7cd",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 67895,
+        "upload_time": "2017-10-14T07:06:39",
+        "upload_time_iso_8601": "2017-10-14T07:06:39.997286Z",
+        "url": "https://files.pythonhosted.org/packages/a1/e2/594b1c63d970eb5bcbe88c30cb41ca046c722ce17181045e54b7a894a9fc/hbmqtt-0.9.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.9.2": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "bea7436dae89d638747aa3748f2688f7",
+          "sha256": "380a42018df78c480488659183341c369ae3cd0375914f77f979250bcacb21ae"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.2-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "bea7436dae89d638747aa3748f2688f7",
+        "packagetype": "bdist_wheel",
+        "python_version": "py2.py3",
+        "requires_python": null,
+        "size": 74865,
+        "upload_time": "2018-03-07T11:08:44",
+        "upload_time_iso_8601": "2018-03-07T11:08:44.381985Z",
+        "url": "https://files.pythonhosted.org/packages/64/2d/128401e6b45f71e51e5705a95cbfd327f83ad9220d5e8212756825ec8f25/hbmqtt-0.9.2-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "83cef82949d772178274d3d6e7d33c8d",
+          "sha256": "6f61e05007648a4f33e300fafcf42776ca95508ba1141799f94169427ce5018c"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.2.tar.gz",
+        "has_sig": false,
+        "md5_digest": "83cef82949d772178274d3d6e7d33c8d",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 69567,
+        "upload_time": "2018-03-14T20:52:00",
+        "upload_time_iso_8601": "2018-03-14T20:52:00.320592Z",
+        "url": "https://files.pythonhosted.org/packages/42/e4/74d299d9cca3aae4be607ea8f3de1a76a3d63cf397da5c0ea0fb128dce79/hbmqtt-0.9.2.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.9.3": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "106540f1accc6b943d230f85a38ff429",
+          "sha256": "957b946b9ccd89d71401a6240160f30363ecfe813703d53083156c6ded07a8ba"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.3-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "106540f1accc6b943d230f85a38ff429",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.6",
+        "requires_python": null,
+        "size": 69733,
+        "upload_time": "2018-07-16T19:15:27",
+        "upload_time_iso_8601": "2018-07-16T19:15:27.812199Z",
+        "url": "https://files.pythonhosted.org/packages/8f/ff/cdd3c040dd4a0c3994b7bc88d02f38b5fa50300e5f6416cf748783f2a2ea/hbmqtt-0.9.3-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "9e0e1b66073aff0d11df424e1f05ebae",
+          "sha256": "ba437eedae43496bb9b7e006f096758adfb854df95bd1d711cfec053d23fe207"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.3.tar.gz",
+        "has_sig": false,
+        "md5_digest": "9e0e1b66073aff0d11df424e1f05ebae",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 70277,
+        "upload_time": "2018-07-16T19:15:12",
+        "upload_time_iso_8601": "2018-07-16T19:15:12.261896Z",
+        "url": "https://files.pythonhosted.org/packages/fe/0e/1470eb7ff7bef15e11c81674fe34c47ae05f5e334c500f2184bb08767222/hbmqtt-0.9.3.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.9.4": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "4eb938b60361cb838a33d851002c9d60",
+          "sha256": "1592d7b74fba12361808c9f687fc7a38b4da386a599dfab175f3d292a73c8f60"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.4-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "4eb938b60361cb838a33d851002c9d60",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.6",
+        "requires_python": null,
+        "size": 75626,
+        "upload_time": "2018-07-21T19:44:56",
+        "upload_time_iso_8601": "2018-07-21T19:44:56.616760Z",
+        "url": "https://files.pythonhosted.org/packages/39/03/2c3042967200e995587a869b5974b9e28e53cae6bbd5e7256ef8a405c4f4/hbmqtt-0.9.4-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "e9df53f45b16866cef96c065f15e87af",
+          "sha256": "719bdff59055256e2933567bd329f2fb3a8a70f6fa03f68183ac6c6305bdfca5"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.4-py34.py35-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "e9df53f45b16866cef96c065f15e87af",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.6",
+        "requires_python": null,
+        "size": 75626,
+        "upload_time": "2018-07-21T19:49:23",
+        "upload_time_iso_8601": "2018-07-21T19:49:23.894651Z",
+        "url": "https://files.pythonhosted.org/packages/7c/55/fbc09e1321419b1d67e3723ba58770c42c8f78c14d219a97f53893c53f9a/hbmqtt-0.9.4-py34.py35-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "1b28e2cb30de318799813f1ba2bfcd98",
+          "sha256": "48f2f3ef2beb9924a4c2c10263630e65cf8d11f72c812748a0b2c1b09499602b"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.4.tar.gz",
+        "has_sig": false,
+        "md5_digest": "1b28e2cb30de318799813f1ba2bfcd98",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 70321,
+        "upload_time": "2018-07-21T19:44:16",
+        "upload_time_iso_8601": "2018-07-21T19:44:16.993953Z",
+        "url": "https://files.pythonhosted.org/packages/8c/91/52b70dcff86befc43c9755594c6322965fc755ba6c4ed25ff737950974e5/hbmqtt-0.9.4.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.9.5": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "e12222ac1b291c6069c63b3dc7ca5679",
+          "sha256": "235fffa4645005536fefb9945084165d9e26cbf889b767f7d896aa929b99d49e"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.5-py2.py3-none-any.whl",
+        "has_sig": false,
+        "md5_digest": "e12222ac1b291c6069c63b3dc7ca5679",
+        "packagetype": "bdist_wheel",
+        "python_version": "3.7",
+        "requires_python": null,
+        "size": 74473,
+        "upload_time": "2018-11-11T11:02:36",
+        "upload_time_iso_8601": "2018-11-11T11:02:36.596666Z",
+        "url": "https://files.pythonhosted.org/packages/e6/3c/de08eeef75dc4bd86673f48ca4a97b51c9524cf2a32f1ef8ce0bfae81270/hbmqtt-0.9.5-py2.py3-none-any.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "2916f6094808aa8d586e45d8f88c1c8b",
+          "sha256": "9886b1c8321d16e971376dc609b902e0c84118846642b5e09f08a4ca876a7f2a"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.5.tar.gz",
+        "has_sig": false,
+        "md5_digest": "2916f6094808aa8d586e45d8f88c1c8b",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 69338,
+        "upload_time": "2018-11-11T11:00:18",
+        "upload_time_iso_8601": "2018-11-11T11:00:18.116766Z",
+        "url": "https://files.pythonhosted.org/packages/88/93/fae9bc11ce60ad0b76639eebb3f9bb9c5c8deb52864349a7f6bb487d2b0c/hbmqtt-0.9.5.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "0.9.6": [
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "e7ecbb2bf3aa2b3b5b2a47dc5289039a",
+          "sha256": "c83ba91dc5cf9a01f83afb5380701504f69bdf9ea1c071f4dfdc1cba412fcd63"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.6.linux-x86_64.tar.gz",
+        "has_sig": false,
+        "md5_digest": "e7ecbb2bf3aa2b3b5b2a47dc5289039a",
+        "packagetype": "bdist_dumb",
+        "python_version": "any",
+        "requires_python": null,
+        "size": 126180,
+        "upload_time": "2020-01-25T14:12:53",
+        "upload_time_iso_8601": "2020-01-25T14:12:53.948778Z",
+        "url": "https://files.pythonhosted.org/packages/ee/27/912d1d8c307a72985edf0b6ad9fc1c32e22bfc42efbd0244902c43bd9307/hbmqtt-0.9.6.linux-x86_64.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "d7896681b8d7d27b53302350b5b3c9c2",
+          "sha256": "57799a933500caadb472000ba0c1e043d4768608cd8142104f89c53930d8613c"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.6-py3.8.egg",
+        "has_sig": false,
+        "md5_digest": "d7896681b8d7d27b53302350b5b3c9c2",
+        "packagetype": "bdist_egg",
+        "python_version": "3.8",
+        "requires_python": null,
+        "size": 186560,
+        "upload_time": "2020-01-25T14:13:44",
+        "upload_time_iso_8601": "2020-01-25T14:13:44.484402Z",
+        "url": "https://files.pythonhosted.org/packages/4f/4b/69014d0fd585b45bfdb77ef0e70bcf035fc8fc798c2a0610fd7cfae56cfd/hbmqtt-0.9.6-py3.8.egg",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "digests": {
+          "md5": "cc1f010f129465cc396339640fcffed9",
+          "sha256": "6764d3c7cf6d056238c04709c23dbb72e2b0227495efd871c2f1da10a4472cd9"
+        },
+        "downloads": -1,
+        "filename": "hbmqtt-0.9.6.tar.gz",
+        "has_sig": false,
+        "md5_digest": "cc1f010f129465cc396339640fcffed9",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 74727,
+        "upload_time": "2020-01-25T14:12:45",
+        "upload_time_iso_8601": "2020-01-25T14:12:45.640961Z",
+        "url": "https://files.pythonhosted.org/packages/b4/7c/7e1d47e740915bd628f4038083469c5919e759a638f45abab01e09e933cb/hbmqtt-0.9.6.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ]
+  },
+  "urls": [
+    {
+      "comment_text": "",
+      "digests": {
+        "md5": "e7ecbb2bf3aa2b3b5b2a47dc5289039a",
+        "sha256": "c83ba91dc5cf9a01f83afb5380701504f69bdf9ea1c071f4dfdc1cba412fcd63"
+      },
+      "downloads": -1,
+      "filename": "hbmqtt-0.9.6.linux-x86_64.tar.gz",
+      "has_sig": false,
+      "md5_digest": "e7ecbb2bf3aa2b3b5b2a47dc5289039a",
+      "packagetype": "bdist_dumb",
+      "python_version": "any",
+      "requires_python": null,
+      "size": 126180,
+      "upload_time": "2020-01-25T14:12:53",
+      "upload_time_iso_8601": "2020-01-25T14:12:53.948778Z",
+      "url": "https://files.pythonhosted.org/packages/ee/27/912d1d8c307a72985edf0b6ad9fc1c32e22bfc42efbd0244902c43bd9307/hbmqtt-0.9.6.linux-x86_64.tar.gz",
+      "yanked": false,
+      "yanked_reason": null
+    },
+    {
+      "comment_text": "",
+      "digests": {
+        "md5": "d7896681b8d7d27b53302350b5b3c9c2",
+        "sha256": "57799a933500caadb472000ba0c1e043d4768608cd8142104f89c53930d8613c"
+      },
+      "downloads": -1,
+      "filename": "hbmqtt-0.9.6-py3.8.egg",
+      "has_sig": false,
+      "md5_digest": "d7896681b8d7d27b53302350b5b3c9c2",
+      "packagetype": "bdist_egg",
+      "python_version": "3.8",
+      "requires_python": null,
+      "size": 186560,
+      "upload_time": "2020-01-25T14:13:44",
+      "upload_time_iso_8601": "2020-01-25T14:13:44.484402Z",
+      "url": "https://files.pythonhosted.org/packages/4f/4b/69014d0fd585b45bfdb77ef0e70bcf035fc8fc798c2a0610fd7cfae56cfd/hbmqtt-0.9.6-py3.8.egg",
+      "yanked": false,
+      "yanked_reason": null
+    },
+    {
+      "comment_text": "",
+      "digests": {
+        "md5": "cc1f010f129465cc396339640fcffed9",
+        "sha256": "6764d3c7cf6d056238c04709c23dbb72e2b0227495efd871c2f1da10a4472cd9"
+      },
+      "downloads": -1,
+      "filename": "hbmqtt-0.9.6.tar.gz",
+      "has_sig": false,
+      "md5_digest": "cc1f010f129465cc396339640fcffed9",
+      "packagetype": "sdist",
+      "python_version": "source",
+      "requires_python": null,
+      "size": 74727,
+      "upload_time": "2020-01-25T14:12:45",
+      "upload_time_iso_8601": "2020-01-25T14:12:45.640961Z",
+      "url": "https://files.pythonhosted.org/packages/b4/7c/7e1d47e740915bd628f4038083469c5919e759a638f45abab01e09e933cb/hbmqtt-0.9.6.tar.gz",
+      "yanked": false,
+      "yanked_reason": null
+    }
+  ],
+  "vulnerabilities": []
+}

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -330,3 +330,25 @@ def test_use_pypi_pretty_name() -> None:
     package = repo.find_packages(Factory.create_dependency("twisted", "*"))
     assert len(package) == 1
     assert package[0].pretty_name == "Twisted"
+
+
+def test_find_links_for_package_of_supported_types():
+    repo = MockRepository()
+    package = repo.find_packages(Factory.create_dependency("hbmqtt", "0.9.6"))
+
+    assert len(package) == 1
+
+    links = repo.find_links_for_package(package[0])
+
+    assert len(links) == 1
+    assert links[0].is_sdist
+    assert links[0].show_url == "hbmqtt-0.9.6.tar.gz"
+
+
+def test_get_release_info_includes_only_supported_types():
+    repo = MockRepository()
+
+    release_info = repo._get_release_info(name="hbmqtt", version="0.9.6")
+
+    assert len(release_info["files"]) == 1
+    assert release_info["files"][0]["file"] == "hbmqtt-0.9.6.tar.gz"


### PR DESCRIPTION
Only follow and lock links for packages of type `sdist` or `bdist_wheel` in PyPi repository.

Closes: https://github.com/python-poetry/poetry/issues/3649
Closes: https://github.com/python-poetry/poetry/issues/4903

(This is a port of https://github.com/python-poetry/poetry/pull/3656.)