### PR TITLE
Remove references to `--dev-only` install option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -167,10 +167,6 @@ It's also possible to only install specific dependency groups by using the `only
 poetry install --only test,docs
 ```
 
-{{% note %}}
-The `--dev-only` option is now deprecated. You should use the `--only dev` notation instead.
-{{% /note %}}
-
 See [Dependency groups]({{< relref "managing-dependencies#dependency-groups" >}}) for more information
 about dependency groups.
 
@@ -231,7 +227,6 @@ option is used.
 * `--extras (-E)`: Features to install (multiple values allowed).
 * `--all-extras`: Install all extra features (conflicts with --extras).
 * `--no-dev`: Do not install dev dependencies. (**Deprecated**)
-* `--dev-only`: Only install dev dependencies. (**Deprecated**)
 * `--remove-untracked`: Remove dependencies not presented in the lock file. (**Deprecated**)
 
 {{% note %}}

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -88,7 +88,6 @@ class GroupCommand(EnvCommand):
             ("default", "only", MAIN_GROUP),
             ("no-dev", "only", MAIN_GROUP),
             ("dev", "with", "dev"),
-            ("dev-only", "without", MAIN_GROUP),
         ]:
             if self.io.input.has_option(opt) and self.option(opt):
                 self.line_error(

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -19,12 +19,6 @@ class InstallCommand(InstallerCommand):
             " (<warning>Deprecated</warning>)",
         ),
         option(
-            "dev-only",
-            None,
-            "Only install the development dependencies."
-            " (<warning>Deprecated</warning>)",
-        ),
-        option(
             "sync",
             None,
             "Synchronize the environment with the locked packages and the specified"

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -89,7 +89,6 @@ def tester(
         # deprecated options
         ("--default", {MAIN_GROUP}),
         ("--no-dev", {MAIN_GROUP}),
-        ("--dev-only", {"foo", "bar", "baz", "bim"}),
     ],
 )
 @pytest.mark.parametrize("with_root", [True, False])


### PR DESCRIPTION
According to @finswimmer in https://github.com/python-poetry/poetry/issues/4864#issuecomment-1002465303:
> The `--dev-only` option was never available in a release, but was already available in the master branch. Because it's a feature we will probably not backport this to the 1.1 branch.

Given that the option was only ever present when installing Poetry from master and was never available as part of a release, I think it's clearer to just remove all references to it rather than include a deprecation notice that would only be relevant to a tiny fraction of Poetry users.

# Pull Request Check List

Resolves: #4864

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] ~Added **tests** for changed code.~
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
