### PR TITLE
uses python-finder during env activate

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -10,14 +10,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "attrs"
 version = "21.4.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope-interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "cloudpickle"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
@@ -36,6 +36,14 @@ requests = "*"
 [package.extras]
 filecache = ["lockfile (>=0.9)"]
 redis = ["redis (>=2.10.5)"]
+
+[[package]]
+name = "cached-property"
+version = "1.5.2"
+description = "A decorator for caching properties in classes."
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "cachy"
@@ -101,10 +109,22 @@ crashtest = ">=0.3.1,<0.4.0"
 pylev = ">=1.3.0,<2.0.0"
 
 [[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -280,7 +300,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl-flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -643,6 +663,25 @@ setproctitle = ["setproctitle"]
 testing = ["filelock"]
 
 [[package]]
+name = "pythonfinder"
+version = "1.2.10"
+description = "A cross-platform python discovery tool to help locate python on any system."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+attrs = "*"
+cached-property = "*"
+click = "*"
+packaging = "*"
+six = "*"
+
+[package.extras]
+dev = ["parver", "wheel (>=0.33.4)", "invoke", "twine", "lxml", "pre-commit", "towncrier"]
+tests = ["pytest", "pytest-cov", "pytest-timeout", "coverage (<5)"]
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.0"
 description = ""
@@ -882,12 +921,12 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco-itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "15542c18243196724e924f1145d082c3997843f33743544474a56747d144e480"
+content-hash = "cbd7928a08c9304fa2f0438791d93f41b7ee7bec5112bbb7e20c00615f6edad5"
 
 [metadata.files]
 atomicwrites = [
@@ -901,6 +940,10 @@ attrs = [
 cachecontrol = [
     {file = "CacheControl-0.12.11-py2.py3-none-any.whl", hash = "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b"},
     {file = "CacheControl-0.12.11.tar.gz", hash = "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"},
+]
+cached-property = [
+    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
+    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
 ]
 cachy = [
     {file = "cachy-0.3.0-py2.py3-none-any.whl", hash = "sha256:338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7"},
@@ -973,6 +1016,10 @@ charset-normalizer = [
 cleo = [
     {file = "cleo-1.0.0a5-py3-none-any.whl", hash = "sha256:ff53056589300976e960f75afb792dfbfc9c78dcbb5a448e207a17b643826360"},
     {file = "cleo-1.0.0a5.tar.gz", hash = "sha256:097c9d0e0332fd53cc89fc11eb0a6ba0309e6a3933c08f7b38558555486925d3"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -1329,6 +1376,10 @@ pytest-sugar = [
 pytest-xdist = [
     {file = "pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},
     {file = "pytest_xdist-2.5.0-py3-none-any.whl", hash = "sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65"},
+]
+pythonfinder = [
+    {file = "pythonfinder-1.2.10-py2.py3-none-any.whl", hash = "sha256:27818b4c6023c2b79dbe0e67b3da348ef30affa70dc4c256d5d5cb67e5e70573"},
+    {file = "pythonfinder-1.2.10.tar.gz", hash = "sha256:ce2a1c2b313d605788173caf68d074f80c00b067364bc57047e68735bc9037d0"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ virtualenv = "(>=20.4.3,<20.4.5 || >=20.4.7)"
 xattr = { version = "^0.9.7", markers = "sys_platform == 'darwin'" }
 urllib3 = "^1.26.0"
 dulwich = "^0.20.44"
+pythonfinder = "^1.2.10"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.18"
@@ -155,6 +156,7 @@ module = [
   'crashtest.*',
   'pexpect.*',
   'pkginfo.*',
+  'pythonfinder',
   'requests_toolbelt.*',
   'shellingham.*',
   'virtualenv.*',

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -124,7 +124,11 @@ class Config:
             "prefer-active-python": False,
             "prompt": "{project_name}-py{python_version}",
         },
-        "experimental": {"new-installer": True, "system-git-client": False},
+        "experimental": {
+            "new-installer": True,
+            "system-git-client": False,
+            "python-finder": True,
+        },
         "installer": {"parallel": True, "max-workers": None, "no-binary": None},
     }
 
@@ -266,6 +270,7 @@ class Config:
             "virtualenvs.options.system-site-packages",
             "virtualenvs.options.prefer-active-python",
             "experimental.new-installer",
+            "experimental.python-finder",
             "experimental.system-git-client",
             "installer.parallel",
         }:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
     from _pytest.config import Config as PyTestConfig
     from _pytest.config.argparsing import Parser
+    from _pytest.fixtures import FixtureRequest
     from pytest_mock import MockerFixture
 
     from poetry.poetry import Poetry
@@ -486,3 +487,16 @@ def load_required_fixtures(
 ) -> None:
     for fixture in required_fixtures:
         fixture_copier(fixture)
+
+
+@pytest.fixture(params=[True, False])
+def find_python_mode(config: Config, request: FixtureRequest) -> None:
+    config.merge(
+        {
+            "experimental": {
+                # param is an optional attribute present
+                # when fixtures are parameterized
+                "python-finder": request.param  # type: ignore
+            }
+        }
+    )

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -33,3 +33,13 @@ def check_output_wrapper(
             return str(Path("/prefix"))
 
     return check_output
+
+
+def find_python_wrapper(
+    version: PEP440Version = VERSION_3_7_1,
+) -> Callable[[str], tuple[str, str, str]]:
+    def find_python_output(python: str) -> tuple[str, str, str]:
+        path = f"/usr/bin/python{version.major}.{version.minor}"
+        return path, f"{version.major}.{version.minor}", version.text
+
+    return find_python_output

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -52,6 +52,7 @@ def test_list_displays_default_value_if_not_set(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 experimental.new-installer = true
+experimental.python-finder = true
 experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null
@@ -81,6 +82,7 @@ def test_list_displays_set_get_setting(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 experimental.new-installer = true
+experimental.python-finder = true
 experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null
@@ -134,6 +136,7 @@ def test_list_displays_set_get_local_setting(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 experimental.new-installer = true
+experimental.python-finder = true
 experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null


### PR DESCRIPTION
# Pull Request Check List

Resolves #3520

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
While resolving for python versions in the PATH, python-finder executes a python command to get the python version. It will execute the command for every supported python implementation in the path until it finds the right one. 

On windows, pythons registered per pep-514 take priority over path pythons. When checking registered pythons, it does not execute the version command. It does succeed in finding pythons installed through the MS Store (they are in the path).  Py.exe also prefers registered pythons over MS Store pythons, so the behavior here is consistent. To be clear this doesn't use py.exe. pyenv-win creates a python.bat shim in the path. The bat files are recognized as other pythons in the path so it just works.

I added an experimental flag to enable or disable the python-finder.

I haven't tested this with linux but I figured the implementation wouldn't change much so creating the draft PR. I also expected to just work since python-finder covers this testing. 
