### PR TITLE
Correct URL in test_parse_dependency_specification

### DIFF
--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -46,8 +46,11 @@ if TYPE_CHECKING:
         ("../demo", {"name": "demo", "path": "../demo"}),
         ("../demo/demo.whl", {"name": "demo", "path": "../demo/demo.whl"}),
         (
-            "https://example.com/packages/demo-0.1.0.tar.gz",
-            {"name": "demo", "url": "https://example.com/packages/demo-0.1.0.tar.gz"},
+            "https://example.com/distributions/demo-0.1.0.tar.gz",
+            {
+                "name": "demo",
+                "url": "https://example.com/distributions/demo-0.1.0.tar.gz",
+            },
         ),
         # PEP 508 inputs
         (


### PR DESCRIPTION
The URL path is used by `mock_download` to determine the path relative to the fixtures directory to get the download result.

I believe this has been passing on CI because the `copy_or_symlink` call in `mock_download` happily creates a symlink to a non-existent path, but when running on Windows without permission to create symlinks, `shutil.copyfile` is called as a fallback, and fails trying to copy a non-existent file.

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.