### PR TITLE
direct access for performance and typechecking

### DIFF
--- a/src/poetry/packages/dependency_package.py
+++ b/src/poetry/packages/dependency_package.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Any
 
 
 if TYPE_CHECKING:
@@ -30,15 +29,6 @@ class DependencyPackage:
 
     def without_features(self) -> DependencyPackage:
         return self.with_features([])
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._package, name)
-
-    def __setattr__(self, key: str, value: Any) -> None:
-        if key in {"_dependency", "_package"}:
-            return super().__setattr__(key, value)
-
-        setattr(self._package, key, value)
 
     def __str__(self) -> str:
         return str(self._package)

--- a/tests/mixology/version_solver/test_dependency_cache.py
+++ b/tests/mixology/version_solver/test_dependency_cache.py
@@ -106,16 +106,19 @@ def test_solver_dependency_cache_respects_subdirectories(
     package_one = packages_one[0]
     package_one_copy = packages_one_copy[0]
 
-    assert package_one.package.name == package_one_copy.name
+    assert package_one.package.name == package_one_copy.package.name
     assert package_one.package.version.text == package_one_copy.package.version.text
-    assert package_one.package.source_type == package_one_copy.source_type == "git"
+    assert (
+        package_one.package.source_type == package_one_copy.package.source_type == "git"
+    )
     assert (
         package_one.package.source_resolved_reference
-        == package_one_copy.source_resolved_reference
+        == package_one_copy.package.source_resolved_reference
         == "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
     )
     assert (
-        package_one.package.source_subdirectory != package_one_copy.source_subdirectory
+        package_one.package.source_subdirectory
+        != package_one_copy.package.source_subdirectory
     )
     assert package_one.package.source_subdirectory == "one"
     assert package_one_copy.package.source_subdirectory == "one-copy"

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -1448,9 +1448,9 @@ def test_solver_duplicate_dependencies_different_sources_types_are_preserved(
         DependencyPackage(package.to_dependency(), package)
     )
 
-    assert len(complete_package.all_requires) == 2
+    assert len(complete_package.package.all_requires) == 2
 
-    pypi, git = complete_package.all_requires
+    pypi, git = complete_package.package.all_requires
 
     assert isinstance(pypi, Dependency)
     assert pypi == dependency_pypi


### PR DESCRIPTION
Revisiting https://github.com/python-poetry/poetry/pull/2149, which seems to have stalled or maybe got into some merge conflict horror.

As it goes, I can't reproduce anything like the performance gains reported over there, which is a shame because I'd really have liked to!

- in the example of the original report, resolution is simply much faster in the first place.  It's hard to tell whether that's because poetry has changed, or because the web of dependencies has changed such that this particular example is easier to resolve.  I am seeing times nearer 2 seconds than 200 seconds.
- in some examples I do have with slower resolves, I just don't see meaningful gains.

However: this surely can't _hurt_ performance...

Even if this doesn't turn out to be a big performance win though, I think that it is still good discipline.  In particular, removing the `__setattr__()` and `__getattr_()` tightens up the typechecking: we no longer have to wait to runtime to find that we have gone wrong.

Actually I'd have been a little scared to make this change without good mypy coverage: but that and the test suite makes me pretty confident that this is safe.