### PR TITLE
Fixed broken link

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -215,7 +215,7 @@ For libraries it is not necessary to commit the lock file.
 
 ### Installing dependencies only
 
-The current project is installed in [editable](https://pip.pypa.io/en/stable/cli/pip_install/#install-editable) mode by default.
+The current project is installed in [editable](https://pip.pypa.io/en/stable/topics/local-project-installs/) mode by default.
 
 If you want to install the dependencies only, run the `install` command with the `--no-root` flag:
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: Simple broken link in documentation.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ x] Added **tests** for changed code. (none required)
- [x ] Updated **documentation** for changed code. (exactly what I'm doing ;P)

The current link https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs goes to a page that looks like following:

```
This page has moved
You should be redirected automatically in 3 seconds. If that didn’t work, here’s a link: [pip install](https://pip.pypa.io/en/stable/cli/pip_install/)
```
It redirects as noted, but one must search for the section about editable installs. It notes that editable installs are " now covered in the local project installs" section.

Thanks for such a great project!