### PR TITLE
Fix the wrong key and URL of adding publishable repositories in documetation

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -288,17 +288,17 @@ configuration unlike [package sources](#package-sources). Poetry, today, only su
 your project.
 
 These are configured using the [`config`]({{< relref "cli#config" >}}) command, under the
-`repository` key.
+`repositories` key.
 
 ```bash
-poetry config repository.testpypi https://upload.test.pypi.org/legacy/
+poetry config repositories.testpypi https://test.pypi.org/legacy/
 ```
 
 {{% note %}}
 
 [Legacy Upload API](https://warehouse.pypa.io/api-reference/legacy.html#upload-api) URLs are
 typically different to the same one provided by the repository for the simple API. You'll note that
-in the example of [Test PyPI](https://test.pypi.org/), both the host (`upload.test.pypi.org`) as
+in the example of [Test PyPI](https://test.pypi.org/), both the host (`test.pypi.org`) as
 well as the path (`/legacy`) are different to it's simple API (`https://test.pypi.org/simple`).
 
 {{% /note %}}


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5808

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

~~- [ ] Added **tests** for changed code.~~
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Revise the documentation to fix #5808.