### PR TITLE
fix(flake8): drop F401 from __init__.py ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,7 +20,7 @@ extend-ignore =
 per-file-ignores =
     # F401: Module imported by unused (non-implicit modules)
     # TC002: Move third-party import '...' into a type-checking block
-    __init__.py:F401,TC002,
+    __init__.py:TC002,
     # ANN201: Missing return type annotation for public function
     tests/test_*:ANN201
     tests/**/test_*:ANN201

--- a/.flake8
+++ b/.flake8
@@ -18,7 +18,6 @@ extend-ignore =
     # ANN102: Missing type annotation for cls in classmethod
     ANN102,
 per-file-ignores =
-    # F401: Module imported by unused (non-implicit modules)
     # TC002: Move third-party import '...' into a type-checking block
     __init__.py:TC002,
     # ANN201: Missing return type annotation for public function


### PR DESCRIPTION
Drop F401 since we switched to an implicit package.