### PR TITLE
fix: fixed experimental.system-git-client reported as unknown setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,20 @@ Defaults to one of the following directories:
 - Windows: `C:\Users\<username>\AppData\Local\pypoetry\Cache`
 - Unix:    `~/.cache/pypoetry`
 
+### `experimental.system-git-client`
+
+**Type**: boolean
+
+*Introduced in 1.2.0*
+
+Use system git client backend for git related tasks.
+
+Poetry uses `dulwich` by default for git related tasks to not rely on the availability of a git client.
+
+If you encounter any problems with it, set to `true` to use the system git backend.
+
+Defaults to `false`.
+
 ### `installer.parallel`
 
 **Type**: boolean

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -96,6 +96,11 @@ To remove a repository (repo is a short alias for repositories):
                 boolean_normalizer,
                 True,
             ),
+            "experimental.system-git-client": (
+                boolean_validator,
+                boolean_normalizer,
+                False,
+            ),
             "installer.parallel": (
                 boolean_validator,
                 boolean_normalizer,


### PR DESCRIPTION
# Pull Request Check List
This PR fixed in issue were the config option `experimental.system-git-client reported` was reported as unknown, when trying to set it via `poetry config`.

It also updates the docs to include this option. 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
