### PR TITLE
don't export unwanted extras

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -272,8 +272,9 @@ class Locker:
             requirement.constraint = constraint
 
             for require in locked_package.requires:
-                if require.in_extras and locked_package.features.isdisjoint(
-                    require.in_extras
+                if require.is_optional() and not any(
+                    require in locked_package.extras[feature]
+                    for feature in locked_package.features
                 ):
                     continue
 


### PR DESCRIPTION
Fixes https://github.com/python-poetry/poetry/issues/5779, tested in https://github.com/python-poetry/poetry-plugin-export/pull/73.

Cross-repository unit testing continues to be hairy, good luck finding the right sequence to merge things and keep pipelines happy.

It looks as though `in_extras` is only set for packages in the top-level project extras.  Per https://github.com/python-poetry/poetry/issues/5779#issuecomment-1148011863 it's not clear to me whether that's expected, but the pragmatic thing to do seems to be to do the checking differently here, in a way that works for both cases.