### PR TITLE
Csv fixes

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -761,7 +761,7 @@ class Executor:
 
                 record = dist_path / "RECORD"
                 if record.exists():
-                    with record.open(mode="a", encoding="utf-8") as f:
+                    with record.open(mode="a", encoding="utf-8", newline="") as f:
                         writer = csv.writer(f)
                         path = url.relative_to(record.parent.parent)
                         writer.writerow([str(path), "", ""])

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import hashlib
 import json
 import os
@@ -255,14 +256,15 @@ class EditableBuilder(Builder):
         added_files.append(direct_url_json)
 
         record = dist_info.joinpath("RECORD")
-        with record.open("w", encoding="utf-8") as f:
+        with record.open("w", encoding="utf-8", newline="") as f:
+            csv_writer = csv.writer(f)
             for path in added_files:
                 hash = self._get_file_hash(path)
                 size = path.stat().st_size
-                f.write(f"{path!s},sha256={hash},{size}\n")
+                csv_writer.writerow((path, f"sha256={hash}", size))
 
             # RECORD itself is recorded with no hash or size
-            f.write(f"{record},,\n")
+            csv_writer.writerow((record, "", ""))
 
     def _get_file_hash(self, filepath: Path) -> str:
         hashsum = hashlib.sha256()

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 import re
 import shutil
@@ -400,12 +401,14 @@ def verify_installed_distribution(
 
     if url_reference is not None:
         record_file = distribution._path.joinpath("RECORD")
+        with open(record_file, encoding="utf-8", newline="") as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        assert all(len(row) == 3 for row in rows)
+        record_entries = {row[0] for row in rows}
         direct_url_entry = direct_url_file.relative_to(record_file.parent.parent)
         assert direct_url_file.exists()
-        assert str(direct_url_entry) in {
-            row.split(",")[0]
-            for row in record_file.read_text(encoding="utf-8").splitlines()
-        }
+        assert str(direct_url_entry) in record_entries
         assert json.loads(direct_url_file.read_text(encoding="utf-8")) == url_reference
     else:
         assert not direct_url_file.exists()

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 import os
 import shutil
@@ -158,17 +159,22 @@ My Package
 """
     assert metadata == dist_info.joinpath("METADATA").read_text(encoding="utf-8")
 
-    records = dist_info.joinpath("RECORD").read_text()
+    with open(dist_info.joinpath("RECORD"), encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        records = list(reader)
+
+    assert all(len(row) == 3 for row in records)
+    record_entries = {row[0] for row in records}
     pth_file = "simple_project.pth"
     assert tmp_venv.site_packages.exists(pth_file)
-    assert str(tmp_venv.site_packages.find(pth_file)[0]) in records
-    assert str(tmp_venv._bin_dir.joinpath("foo")) in records
-    assert str(tmp_venv._bin_dir.joinpath("baz")) in records
-    assert str(dist_info.joinpath("METADATA")) in records
-    assert str(dist_info.joinpath("INSTALLER")) in records
-    assert str(dist_info.joinpath("entry_points.txt")) in records
-    assert str(dist_info.joinpath("RECORD")) in records
-    assert str(dist_info.joinpath("direct_url.json")) in records
+    assert str(tmp_venv.site_packages.find(pth_file)[0]) in record_entries
+    assert str(tmp_venv._bin_dir.joinpath("foo")) in record_entries
+    assert str(tmp_venv._bin_dir.joinpath("baz")) in record_entries
+    assert str(dist_info.joinpath("METADATA")) in record_entries
+    assert str(dist_info.joinpath("INSTALLER")) in record_entries
+    assert str(dist_info.joinpath("entry_points.txt")) in record_entries
+    assert str(dist_info.joinpath("RECORD")) in record_entries
+    assert str(dist_info.joinpath("direct_url.json")) in record_entries
 
     baz_script = f"""\
 #!{tmp_venv.python}


### PR DESCRIPTION
Some fixes for handling the csv RECORD file

First, open the file with `newline=""`.  Per https://docs.python.org/3/library/csv.html#id3

> If newline='' is not specified, newlines embedded inside quoted fields will not be interpreted correctly, and on platforms that use \r\n linendings on write an extra \r will be added

I'm almost sure this will fix #5799, although since I don't have a Windows environment of my own I can't prove it.

Then while I was there I noticed that poetry really ought to use `csv` in the other place that it creates this file, to make sure that escaping of funny filenames and suchlike happens properly.  cf https://github.com/python-poetry/poetry-core/pull/61