### PR TITLE
Move duplicated `source_to_table` to `utils`

### DIFF
--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -1,20 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from cleo.helpers import argument
 from cleo.helpers import option
 from cleo.io.null_io import NullIO
-from tomlkit import nl
-from tomlkit import table
 from tomlkit.items import AoT
 
 from poetry.config.source import Source
 from poetry.console.commands.command import Command
-
-
-if TYPE_CHECKING:
-    from tomlkit.items import Table
 
 
 class SourceAddCommand(Command):
@@ -41,17 +33,10 @@ class SourceAddCommand(Command):
         option("secondary", "s", "Set this source as secondary."),
     ]
 
-    @staticmethod
-    def source_to_table(source: Source) -> Table:
-        source_table: Table = table()
-        for key, value in source.to_dict().items():
-            source_table.add(key, value)
-        source_table.add(nl())
-        return source_table
-
     def handle(self) -> int:
         from poetry.factory import Factory
         from poetry.repositories import Pool
+        from poetry.utils.source import source_to_table
 
         name = self.argument("name")
         url = self.argument("url")
@@ -92,11 +77,11 @@ class SourceAddCommand(Command):
                 source = new_source
                 new_source = None
 
-            sources.append(self.source_to_table(source))
+            sources.append(source_to_table(source))
 
         if new_source is not None:
             self.line(f"Adding source with name <c1>{name}</c1>.")
-            sources.append(self.source_to_table(new_source))
+            sources.append(source_to_table(new_source))
 
         # ensure new source is valid. eg: invalid name etc.
         self.poetry._pool = Pool()

--- a/src/poetry/console/commands/source/remove.py
+++ b/src/poetry/console/commands/source/remove.py
@@ -1,19 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from cleo.helpers import argument
-from tomlkit import nl
-from tomlkit import table
 from tomlkit.items import AoT
 
 from poetry.console.commands.command import Command
-
-
-if TYPE_CHECKING:
-    from tomlkit.items import Table
-
-    from poetry.config.source import Source
 
 
 class SourceRemoveCommand(Command):
@@ -28,15 +18,9 @@ class SourceRemoveCommand(Command):
         ),
     ]
 
-    @staticmethod
-    def source_to_table(source: Source) -> Table:
-        source_table: Table = table()
-        for key, value in source.to_dict().items():
-            source_table.add(key, value)
-        source_table.add(nl())
-        return source_table
-
     def handle(self) -> int:
+        from poetry.utils.source import source_to_table
+
         name = self.argument("name")
 
         sources = AoT([])
@@ -47,7 +31,7 @@ class SourceRemoveCommand(Command):
                 self.line(f"Removing source with name <c1>{source.name}</c1>.")
                 removed = True
                 continue
-            sources.append(self.source_to_table(source))
+            sources.append(source_to_table(source))
 
         if not removed:
             self.line_error(

--- a/src/poetry/utils/source.py
+++ b/src/poetry/utils/source.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from tomlkit.items import Table
+
+    from poetry.config.source import Source
+
+
+def source_to_table(source: Source) -> Table:
+    from tomlkit import nl
+    from tomlkit import table
+
+    source_table: Table = table()
+    for key, value in source.to_dict().items():
+        source_table.add(key, value)
+    source_table.add(nl())
+    return source_table

--- a/tests/utils/test_source.py
+++ b/tests/utils/test_source.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from tomlkit.container import Container
+from tomlkit.items import Table
+from tomlkit.items import Trivia
+
+from poetry.config.source import Source
+from poetry.utils.source import source_to_table
+
+
+@pytest.mark.parametrize(
+    "source,table_body",
+    [
+        (
+            Source("foo", "https://example.com"),
+            {
+                "default": False,
+                "name": "foo",
+                "secondary": False,
+                "url": "https://example.com",
+            },
+        ),
+        (
+            Source("bar", "https://example.com/bar", True, True),
+            {
+                "default": True,
+                "name": "bar",
+                "secondary": True,
+                "url": "https://example.com/bar",
+            },
+        ),
+    ],
+)
+def test_source_to_table(source: Source, table_body: dict[str, str | bool]):
+    table = Table(Container(), Trivia(), False)
+    table._value = table_body
+
+    assert source_to_table(source) == table


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Both `SourceAddCommand` and `SourceRemoveCommand` define the exact same `source_to_table` method, so thought it might be better to move this logic to a `poetry.utils.source` module.