### PR TITLE
Some improvements over `init` command

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -168,7 +168,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         question = "Would you like to define your main dependencies interactively?"
         help_message = """\
 You can specify a package in the following forms:
-  - A single name (<b>requests</b>)
+  - A single name (<b>requests</b>): this will search for matches on PyPI
   - A name and a constraint (<b>requests@^2.23.0</b>)
   - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)
   - A git url with a revision\
@@ -266,7 +266,7 @@ You can specify a package in the following forms:
             result = []
 
             question = self.create_question(
-                "Search for package to add (or leave blank to continue):"
+                "Package to add or search for (leave blank to skip):"
             )
             question.set_validator(self._validate_package)
 

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -265,9 +265,12 @@ You can specify a package in the following forms:
         if not requires:
             result = []
 
-            package = self.ask(
+            question = self.create_question(
                 "Search for package to add (or leave blank to continue):"
             )
+            question.set_validator(self._validate_package)
+
+            package = self.ask(question)
             while package:
                 constraint = self._parse_requirements([package])[0]
                 if (
@@ -449,6 +452,13 @@ You can specify a package in the following forms:
             )
 
         return author
+
+    @staticmethod
+    def _validate_package(package: str | None) -> str | None:
+        if package and len(package.split()) > 2:
+            raise ValueError("Invalid package definition.")
+
+        return package
 
     def _get_pool(self) -> Pool:
         from poetry.repositories import Pool

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -118,12 +118,9 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         )
         version = self.ask(question)
 
-        description = self.option("description") or ""
-        question = self.create_question(
-            f"Description [<comment>{description}</comment>]: ",
-            default=description,
-        )
-        description = self.ask(question)
+        description = self.option("description")
+        if not description:
+            description = self.ask(self.create_question("Description []: ", default=""))
 
         author = self.option("author")
         if not author and vcs_config.get("user.name"):

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -140,12 +140,9 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         else:
             authors = [author]
 
-        license = self.option("license") or ""
-
-        question = self.create_question(
-            f"License [<comment>{license}</comment>]: ", default=license
-        )
-        license = self.ask(question)
+        license = self.option("license")
+        if not license:
+            license = self.ask(self.create_question("License []: ", default=""))
 
         python = self.option("python")
         if not python:

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -145,7 +145,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         question = self.create_question(
             f"License [<comment>{license}</comment>]: ", default=license
         )
-        question.set_validator(self._validate_license)
         license = self.ask(question)
 
         python = self.option("python")
@@ -453,14 +452,6 @@ You can specify a package in the following forms:
             )
 
         return author
-
-    def _validate_license(self, license: str) -> str:
-        from poetry.core.spdx.helpers import license_by_id
-
-        if license:
-            license_by_id(license)
-
-        return license
 
     def _get_pool(self) -> Pool:
         from poetry.repositories import Pool

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -786,7 +786,6 @@ def test_predefined_all_options(tester: CommandTester, repo: TestRepository):
     inputs = [
         "1.2.3",  # Version
         "",  # Author
-        "",  # License
         "n",  # Interactive packages
         "n",  # Interactive dev packages
         "\n",  # Generate

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -785,7 +785,6 @@ def test_predefined_all_options(tester: CommandTester, repo: TestRepository):
 
     inputs = [
         "1.2.3",  # Version
-        "",  # Description
         "",  # Author
         "",  # License
         "n",  # Interactive packages

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -779,6 +779,53 @@ pytest-requests = "^0.2.0"
     assert 'pytest = "^3.6.0"' in output
 
 
+def test_predefined_all_options(tester: CommandTester, repo: TestRepository):
+    repo.add_package(get_package("pendulum", "2.0.0"))
+    repo.add_package(get_package("pytest", "3.6.0"))
+
+    inputs = [
+        "1.2.3",  # Version
+        "",  # Description
+        "",  # Author
+        "",  # License
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    tester.execute(
+        "--name my-package "
+        "--description 'This is a description' "
+        "--author 'Foo Bar <foo@example.com>' "
+        "--python '^3.8' "
+        "--license MIT "
+        "--dependency pendulum "
+        "--dev-dependency pytest",
+        inputs="\n".join(inputs),
+    )
+
+    expected = """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Foo Bar <foo@example.com>"]
+license = "MIT"
+readme = "README.md"
+packages = [{include = "my_package"}]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+pendulum = "^2.0.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^3.6.0"
+"""
+
+    output = tester.io.fetch_output()
+    assert expected in output
+
+
 def test_add_package_with_extras_and_whitespace(tester: CommandTester):
     result = tester.command._parse_requirements(["databases[postgresql, sqlite]"])
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2554

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Few improvements over `init` command:
- don't ask for description if already set through the CLI, similarly to what we do for other arguments
- don't ask for license if already set through the CLI and remove useless `license` validator, since it doesn't raise any error if set to empty or invalid (see the removed `_validate_package` and [poetry-core helper](https://github.com/python-poetry/poetry-core/blob/d6d33de68e48cd2da4730dd01b69b8d32f51ae41/src/poetry/core/spdx/helpers.py#L10-L17) that can confirm that)
- validate package definition by not accepting more than 2 whitespace separated parts, to validate the following things:
  - `requests` (valid, will search on PyPI API)
  - `requests@^2.0` (valid)
  - `requests 2.0` (valid)
  - `requests 2.0 foo` (invalid, and crashing today, as highlighted by #2554)
- reword package add prompt a bit to better indicate that a search through PyPI is performed when only specifying the name of the dependency


On a non-directly related note, I was thinking that it would be nice to be able to pass validators to the different options of the command, similarly to what we can already do in `cleo` for questions.

Right now, we are only able to apply the validators on interactive mode, but not when the user provides the options through the CLI.

Going even further and additionally to this, maybe adding a dedicated boolean in `option` could make it possible to automatically ask questions if an argument is not provided?
That way, the validator would be on `option`, and if the user doesn't provide it through the CLI, then they are asked to provide it, without having to create the question ourselves, and with the exact same validator as for `option`.