### PR TITLE
refactor: use contextlib.suppress instead of except pass

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -30,7 +30,7 @@ import tarfile
 import tempfile
 
 from contextlib import closing
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from functools import cmp_to_key
 from gzip import GzipFile
 from io import UnsupportedOperation
@@ -46,10 +46,8 @@ except ImportError:
     from urllib2 import Request
     from urllib2 import urlopen
 
-try:
+with suppress(NameError):
     input = raw_input
-except NameError:
-    pass
 
 
 try:

--- a/get-poetry.py
+++ b/get-poetry.py
@@ -30,7 +30,7 @@ import tarfile
 import tempfile
 
 from contextlib import closing
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from functools import cmp_to_key
 from gzip import GzipFile
 from io import UnsupportedOperation
@@ -46,8 +46,10 @@ except ImportError:
     from urllib2 import Request
     from urllib2 import urlopen
 
-with suppress(NameError):
+try:
     input = raw_input
+except NameError:
+    pass
 
 
 try:

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -7,6 +7,7 @@ import os
 import tarfile
 import zipfile
 
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -556,12 +557,10 @@ def get_pep517_metadata(path: Path) -> PackageInfo:
     :param path: Path to package source to build and read metadata for.
     """
     info = None
-    try:
+    with suppress(PackageInfoError):
         info = PackageInfo.from_setup_files(path)
         if all([info.version, info.name, info.requires_dist]):
             return info
-    except PackageInfoError:
-        pass
 
     with ephemeral_environment(
         flags={"no-pip": False, "no-setuptools": False, "no-wheel": False}

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import functools
 import glob
 import logging
@@ -7,7 +8,6 @@ import os
 import tarfile
 import zipfile
 
-from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -557,7 +557,7 @@ def get_pep517_metadata(path: Path) -> PackageInfo:
     :param path: Path to package source to build and read metadata for.
     """
     info = None
-    with suppress(PackageInfoError):
+    with contextlib.suppress(PackageInfoError):
         info = PackageInfo.from_setup_files(path)
         if all([info.version, info.name, info.requires_dist]):
             return info

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import itertools
 import json
@@ -13,8 +14,6 @@ import sys
 import sysconfig
 import warnings
 
-from contextlib import contextmanager
-from contextlib import suppress
 from copy import deepcopy
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -280,7 +279,7 @@ class SitePackages:
         candidates = self._candidates if not writable_only else self.writable_candidates
         if path.is_absolute():
             for candidate in candidates:
-                with suppress(ValueError):
+                with contextlib.suppress(ValueError):
                     path.relative_to(candidate)
                     return [path]
             site_type = "writable " if writable_only else ""
@@ -1368,7 +1367,7 @@ class Env:
 
     def is_path_relative_to_lib(self, path: Path) -> bool:
         for lib_path in [self.purelib, self.platlib]:
-            with suppress(ValueError):
+            with contextlib.suppress(ValueError):
                 path.relative_to(lib_path)
                 return True
 
@@ -1769,7 +1768,7 @@ class VirtualEnv(Env):
         kwargs["env"] = self.get_temp_environ(environ=kwargs.get("env"))
         return super().execute(bin, *args, **kwargs)
 
-    @contextmanager
+    @contextlib.contextmanager
     def temp_environ(self) -> Iterator[None]:
         environ = dict(os.environ)
         try:
@@ -1903,7 +1902,7 @@ class NullEnv(SystemEnv):
         return bin
 
 
-@contextmanager
+@contextlib.contextmanager
 def ephemeral_environment(
     executable: str | Path | None = None,
     flags: dict[str, bool] | None = None,
@@ -1919,7 +1918,7 @@ def ephemeral_environment(
         yield VirtualEnv(venv_dir, venv_dir)
 
 
-@contextmanager
+@contextlib.contextmanager
 def build_environment(
     poetry: CorePoetry, env: Env | None = None, io: IO | None = None
 ) -> Iterator[Env]:

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -14,6 +14,7 @@ import sysconfig
 import warnings
 
 from contextlib import contextmanager
+from contextlib import suppress
 from copy import deepcopy
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -279,11 +280,9 @@ class SitePackages:
         candidates = self._candidates if not writable_only else self.writable_candidates
         if path.is_absolute():
             for candidate in candidates:
-                try:
+                with suppress(ValueError):
                     path.relative_to(candidate)
                     return [path]
-                except ValueError:
-                    pass
             site_type = "writable " if writable_only else ""
             raise ValueError(
                 f"{path} is not relative to any discovered {site_type}sites"
@@ -1369,11 +1368,9 @@ class Env:
 
     def is_path_relative_to_lib(self, path: Path) -> bool:
         for lib_path in [self.purelib, self.platlib]:
-            try:
+            with suppress(ValueError):
                 path.relative_to(lib_path)
                 return True
-            except ValueError:
-                pass
 
         return False
 

--- a/tests/utils/fixtures/setups/ansible/setup.py
+++ b/tests/utils/fixtures/setups/ansible/setup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import os.path
@@ -8,7 +9,6 @@ import sys
 import warnings
 
 from collections import defaultdict
-from contextlib import suppress
 from distutils.command.build_scripts import build_scripts as BuildScripts
 from distutils.command.sdist import sdist as SDist
 
@@ -205,7 +205,7 @@ def read_extras():
         extra_req_file_path = os.path.join(
             extra_requirements_dir, extra_requirements_filename
         )
-        with suppress(RuntimeError):
+        with contextlib.suppress(RuntimeError):
             extras[filename_match.group(1)] = read_file(
                 extra_req_file_path
             ).splitlines()

--- a/tests/utils/fixtures/setups/ansible/setup.py
+++ b/tests/utils/fixtures/setups/ansible/setup.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 
 from collections import defaultdict
+from contextlib import suppress
 from distutils.command.build_scripts import build_scripts as BuildScripts
 from distutils.command.sdist import sdist as SDist
 
@@ -204,12 +205,10 @@ def read_extras():
         extra_req_file_path = os.path.join(
             extra_requirements_dir, extra_requirements_filename
         )
-        try:
+        with suppress(RuntimeError):
             extras[filename_match.group(1)] = read_file(
                 extra_req_file_path
             ).splitlines()
-        except RuntimeError:
-            pass
     return extras
 
 

--- a/tests/utils/fixtures/setups/pyyaml/setup.py
+++ b/tests/utils/fixtures/setups/pyyaml/setup.py
@@ -60,6 +60,7 @@ import os.path
 import platform
 import sys
 
+from contextlib import suppress
 from distutils import log
 from distutils.command.bdist_rpm import bdist_rpm as _bdist_rpm
 from distutils.command.build_ext import build_ext as _build_ext
@@ -81,13 +82,11 @@ if "setuptools.extension" in sys.modules:
     sys.modules["distutils.command.build_ext"].Extension = _Extension
 
 with_cython = False
-try:
+with suppress(ImportError):
     from Cython.Distutils import build_ext as _build_ext
     from Cython.Distutils.extension import Extension as _Extension
 
     with_cython = True
-except ImportError:
-    pass
 
 try:
     from wheel.bdist_wheel import bdist_wheel

--- a/tests/utils/fixtures/setups/pyyaml/setup.py
+++ b/tests/utils/fixtures/setups/pyyaml/setup.py
@@ -56,11 +56,11 @@ int main(void) {
 """
 
 
+import contextlib
 import os.path
 import platform
 import sys
 
-from contextlib import suppress
 from distutils import log
 from distutils.command.bdist_rpm import bdist_rpm as _bdist_rpm
 from distutils.command.build_ext import build_ext as _build_ext
@@ -82,7 +82,7 @@ if "setuptools.extension" in sys.modules:
     sys.modules["distutils.command.build_ext"].Extension = _Extension
 
 with_cython = False
-with suppress(ImportError):
+with contextlib.suppress(ImportError):
     from Cython.Distutils import build_ext as _build_ext
     from Cython.Distutils.extension import Extension as _Extension
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: N/A

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

This merge request converts `try` / `except` blocks with no `except` action to use `contextlib.suppress` to silence a specific error, instead of passing in an exception handler.

#### Example Before

```python
try:
    travel_world(days=80)
except DistractionError:
    pass
```

#### Example After

```python
import contextlib

with contextlib.suppress(DistractionError):
    travel_world(days=80)
```

#### Explanation
The context manager slightly shortens the code and significantly clarifies the author's intention to ignore the specific errors. The standard library feature was introduced following a discussion, where the consensus was that

> A key benefit here is in the priming effect for readers... The with statement form makes it clear before you start reading the code that certain exceptions won't propagate.

This ignores a few locations that use `try` / `except` / `else`
