### PR TITLE
Dulwich config type

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -160,7 +160,7 @@ class Git:
             url = ""
             if config.has_section(section):
                 value = config.get(section, b"url")
-                assert value is not None
+                assert isinstance(value, bytes)
                 url = value.decode("utf-8")
 
             return url


### PR DESCRIPTION
It turns out that the type of things in a dulwich `ConfigDict` is `Union[bytes, bool]` - and the next release will include that type information - https://github.com/jelmer/dulwich/blob/67e03acd14fa9cc0e5456d2bee36485ccb146556/dulwich/config.py#L256.

IMO dulwich would be better if this dictionary did just contain `bytes` but it is what it is, so here's a preemptive fix to the typechecking here.