### PR TITLE
fixes the instructions to enable autocompletion in zsh

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -242,10 +242,11 @@ poetry completions zsh > ~/.zprezto/modules/completion/external/src/_poetry
 You may need to restart your shell in order for the changes to take effect.
 {{% /note %}}
 
-For `zsh`, you must then add the following line in your `~/.zshrc` before `compinit`:
+For `zsh`, you must then add the following lines in your `~/.zshrc`
 
 ```bash
 fpath+=~/.zfunc
+autoload -Uz compinit && compinit
 ```
 
 For `oh-my-zsh`, you must then enable poetry in your `~/.zshrc` plugins


### PR DESCRIPTION
This change to the documentation fixes the instructions to enable autocompletion in zsh shells. See the description of the solution in the comment here: https://superuser.com/q/1718843.

Basically, if you add only this

```
fpath+=~/.zfunc
compinit
```

to your `~/.zshrc` file, the autocompletion doesn't work and you also get an error that `compinit` is not a command. This happens in Mac OS Monterey (12.3.1). I am not familiar with `compinit`, but I assume that this commit fixes this issue for all users (it fixed it for me and the user that asked that question, at least). It's possible that this issue has been raised before (but I didn't find a duplicate yet). 