### PR TITLE
Partially revert "refactor: use contextlib.suppress instead of except pass"

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import functools
 import glob
 import logging
@@ -557,10 +556,12 @@ def get_pep517_metadata(path: Path) -> PackageInfo:
     :param path: Path to package source to build and read metadata for.
     """
     info = None
-    with contextlib.suppress(PackageInfoError):
+    try:
         info = PackageInfo.from_setup_files(path)
         if all([info.version, info.name, info.requires_dist]):
             return info
+    except PackageInfoError:
+        pass
 
     with ephemeral_environment(
         flags={"no-pip": False, "no-setuptools": False, "no-wheel": False}

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import functools
 import glob
 import logging
@@ -556,12 +557,11 @@ def get_pep517_metadata(path: Path) -> PackageInfo:
     :param path: Path to package source to build and read metadata for.
     """
     info = None
-    try:
+
+    with contextlib.suppress(PackageInfoError):
         info = PackageInfo.from_setup_files(path)
         if all([info.version, info.name, info.requires_dist]):
             return info
-    except PackageInfoError:
-        pass
 
     with ephemeral_environment(
         flags={"no-pip": False, "no-setuptools": False, "no-wheel": False}

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import contextlib
 import hashlib
 import itertools
 import json
@@ -14,6 +13,7 @@ import sys
 import sysconfig
 import warnings
 
+from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -279,9 +279,11 @@ class SitePackages:
         candidates = self._candidates if not writable_only else self.writable_candidates
         if path.is_absolute():
             for candidate in candidates:
-                with contextlib.suppress(ValueError):
+                try:
                     path.relative_to(candidate)
                     return [path]
+                except ValueError:
+                    pass
             site_type = "writable " if writable_only else ""
             raise ValueError(
                 f"{path} is not relative to any discovered {site_type}sites"
@@ -1332,9 +1334,11 @@ class Env:
 
     def is_path_relative_to_lib(self, path: Path) -> bool:
         for lib_path in [self.purelib, self.platlib]:
-            with contextlib.suppress(ValueError):
+            try:
                 path.relative_to(lib_path)
                 return True
+            except ValueError:
+                pass
 
         return False
 
@@ -1733,7 +1737,7 @@ class VirtualEnv(Env):
         kwargs["env"] = self.get_temp_environ(environ=kwargs.get("env"))
         return super().execute(bin, *args, **kwargs)
 
-    @contextlib.contextmanager
+    @contextmanager
     def temp_environ(self) -> Iterator[None]:
         environ = dict(os.environ)
         try:
@@ -1867,7 +1871,7 @@ class NullEnv(SystemEnv):
         return bin
 
 
-@contextlib.contextmanager
+@contextmanager
 def ephemeral_environment(
     executable: str | Path | None = None,
     flags: dict[str, bool] | None = None,
@@ -1883,7 +1887,7 @@ def ephemeral_environment(
         yield VirtualEnv(venv_dir, venv_dir)
 
 
-@contextlib.contextmanager
+@contextmanager
 def build_environment(
     poetry: CorePoetry, env: Env | None = None, io: IO | None = None
 ) -> Iterator[Env]:

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import itertools
 import json
@@ -279,11 +280,9 @@ class SitePackages:
         candidates = self._candidates if not writable_only else self.writable_candidates
         if path.is_absolute():
             for candidate in candidates:
-                try:
+                with contextlib.suppress(ValueError):
                     path.relative_to(candidate)
                     return [path]
-                except ValueError:
-                    pass
             site_type = "writable " if writable_only else ""
             raise ValueError(
                 f"{path} is not relative to any discovered {site_type}sites"
@@ -1334,11 +1333,9 @@ class Env:
 
     def is_path_relative_to_lib(self, path: Path) -> bool:
         for lib_path in [self.purelib, self.platlib]:
-            try:
+            with contextlib.suppress(ValueError):
                 path.relative_to(lib_path)
                 return True
-            except ValueError:
-                pass
 
         return False
 

--- a/tests/utils/fixtures/setups/ansible/setup.py
+++ b/tests/utils/fixtures/setups/ansible/setup.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import json
 import os
 import os.path
@@ -205,10 +204,12 @@ def read_extras():
         extra_req_file_path = os.path.join(
             extra_requirements_dir, extra_requirements_filename
         )
-        with contextlib.suppress(RuntimeError):
+        try:
             extras[filename_match.group(1)] = read_file(
                 extra_req_file_path
             ).splitlines()
+        except RuntimeError:
+            pass
     return extras
 
 

--- a/tests/utils/fixtures/setups/pyyaml/setup.py
+++ b/tests/utils/fixtures/setups/pyyaml/setup.py
@@ -56,7 +56,6 @@ int main(void) {
 """
 
 
-import contextlib
 import os.path
 import platform
 import sys
@@ -82,11 +81,13 @@ if "setuptools.extension" in sys.modules:
     sys.modules["distutils.command.build_ext"].Extension = _Extension
 
 with_cython = False
-with contextlib.suppress(ImportError):
+try:
     from Cython.Distutils import build_ext as _build_ext
     from Cython.Distutils.extension import Extension as _Extension
 
     with_cython = True
+except ImportError:
+    pass
 
 try:
     from wheel.bdist_wheel import bdist_wheel


### PR DESCRIPTION
Reverts python-poetry/poetry#5840

This change touched vendored files -- it should be reapplied to Poetry files only.