### PR TITLE
poc: replace cachy with cache module

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -41,7 +41,7 @@ redis = ["redis (>=2.10.5)"]
 name = "cachy"
 version = "0.3.0"
 description = "Cachy provides a simple yet effective caching library."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -247,7 +247,7 @@ python-versions = ">=3"
 
 [[package]]
 name = "identify"
-version = "2.5.5"
+version = "2.5.6"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -283,7 +283,7 @@ testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packag
 
 [[package]]
 name = "importlib-resources"
-version = "5.9.0"
+version = "5.10.0"
 description = "Read resources from Python packages"
 category = "main"
 optional = false
@@ -293,8 +293,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -396,7 +396,7 @@ python-versions = "*"
 
 [[package]]
 name = "mypy"
-version = "0.981"
+version = "0.982"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -674,7 +674,7 @@ pytest = ">=4.0.0"
 
 [[package]]
 name = "pytest-mock"
-version = "3.9.0"
+version = "3.10.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 category = "dev"
 optional = false
@@ -861,7 +861,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.28.11"
+version = "2.28.11.2"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -880,7 +880,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -938,20 +938,20 @@ cffi = ">=1.0"
 
 [[package]]
 name = "zipp"
-version = "3.8.1"
+version = "3.9.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6e19a6f10b73d0236013c755105f3ee0ef1b4a619aaab90134cff5bd88dcdb96"
+content-hash = "7db62de4ee4f2831829fc08b6a3d190f177c62d5af7676e20fb228bb58274850"
 
 [metadata.files]
 attrs = [
@@ -1200,8 +1200,8 @@ httpretty = [
     {file = "httpretty-1.1.4.tar.gz", hash = "sha256:20de0e5dd5a18292d36d928cc3d6e52f8b2ac73daec40d41eb62dee154933b68"},
 ]
 identify = [
-    {file = "identify-2.5.5-py2.py3-none-any.whl", hash = "sha256:ef78c0d96098a3b5fe7720be4a97e73f439af7cf088ebf47b620aeaa10fadf97"},
-    {file = "identify-2.5.5.tar.gz", hash = "sha256:322a5699daecf7c6fd60e68852f36f2ecbb6a36ff6e6e973e0d2bb6fca203ee6"},
+    {file = "identify-2.5.6-py2.py3-none-any.whl", hash = "sha256:b276db7ec52d7e89f5bc4653380e33054ddc803d25875952ad90b0f012cbcdaa"},
+    {file = "identify-2.5.6.tar.gz", hash = "sha256:6c32dbd747aa4ceee1df33f25fed0b0f6e0d65721b15bd151307ff7056d50245"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -1212,8 +1212,8 @@ importlib-metadata = [
     {file = "importlib_metadata-4.13.0.tar.gz", hash = "sha256:dd0173e8f150d6815e098fd354f6414b0f079af4644ddfe90c71e2fc6174346d"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.9.0-py3-none-any.whl", hash = "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"},
-    {file = "importlib_resources-5.9.0.tar.gz", hash = "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681"},
+    {file = "importlib_resources-5.10.0-py3-none-any.whl", hash = "sha256:ee17ec648f85480d523596ce49eae8ead87d5631ae1551f913c0100b5edd3437"},
+    {file = "importlib_resources-5.10.0.tar.gz", hash = "sha256:c01b1b94210d9849f286b86bb51bcea7cd56dde0600d8db721d7b81330711668"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1298,30 +1298,30 @@ msgpack = [
     {file = "msgpack-1.0.4.tar.gz", hash = "sha256:f5d869c18f030202eb412f08b28d2afeea553d6613aee89e200d7aca7ef01f5f"},
 ]
 mypy = [
-    {file = "mypy-0.981-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4bc460e43b7785f78862dab78674e62ec3cd523485baecfdf81a555ed29ecfa0"},
-    {file = "mypy-0.981-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:756fad8b263b3ba39e4e204ee53042671b660c36c9017412b43af210ddee7b08"},
-    {file = "mypy-0.981-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a16a0145d6d7d00fbede2da3a3096dcc9ecea091adfa8da48fa6a7b75d35562d"},
-    {file = "mypy-0.981-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce65f70b14a21fdac84c294cde75e6dbdabbcff22975335e20827b3b94bdbf49"},
-    {file = "mypy-0.981-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e35d764784b42c3e256848fb8ed1d4292c9fc0098413adb28d84974c095b279"},
-    {file = "mypy-0.981-cp310-cp310-win_amd64.whl", hash = "sha256:e53773073c864d5f5cec7f3fc72fbbcef65410cde8cc18d4f7242dea60dac52e"},
-    {file = "mypy-0.981-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ee196b1d10b8b215e835f438e06965d7a480f6fe016eddbc285f13955cca659"},
-    {file = "mypy-0.981-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ad21d4c9d3673726cf986ea1d0c9fb66905258709550ddf7944c8f885f208be"},
-    {file = "mypy-0.981-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d1debb09043e1f5ee845fa1e96d180e89115b30e47c5d3ce53bc967bab53f62d"},
-    {file = "mypy-0.981-cp37-cp37m-win_amd64.whl", hash = "sha256:9f362470a3480165c4c6151786b5379351b790d56952005be18bdbdd4c7ce0ae"},
-    {file = "mypy-0.981-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c9e0efb95ed6ca1654951bd5ec2f3fa91b295d78bf6527e026529d4aaa1e0c30"},
-    {file = "mypy-0.981-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e178eaffc3c5cd211a87965c8c0df6da91ed7d258b5fc72b8e047c3771317ddb"},
-    {file = "mypy-0.981-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:06e1eac8d99bd404ed8dd34ca29673c4346e76dd8e612ea507763dccd7e13c7a"},
-    {file = "mypy-0.981-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa38f82f53e1e7beb45557ff167c177802ba7b387ad017eab1663d567017c8ee"},
-    {file = "mypy-0.981-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:64e1f6af81c003f85f0dfed52db632817dabb51b65c0318ffbf5ff51995bbb08"},
-    {file = "mypy-0.981-cp38-cp38-win_amd64.whl", hash = "sha256:e1acf62a8c4f7c092462c738aa2c2489e275ed386320c10b2e9bff31f6f7e8d6"},
-    {file = "mypy-0.981-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b6ede64e52257931315826fdbfc6ea878d89a965580d1a65638ef77cb551f56d"},
-    {file = "mypy-0.981-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eb3978b191b9fa0488524bb4ffedf2c573340e8c2b4206fc191d44c7093abfb7"},
-    {file = "mypy-0.981-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:77f8fcf7b4b3cc0c74fb33ae54a4cd00bb854d65645c48beccf65fa10b17882c"},
-    {file = "mypy-0.981-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f64d2ce043a209a297df322eb4054dfbaa9de9e8738291706eaafda81ab2b362"},
-    {file = "mypy-0.981-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2ee3dbc53d4df7e6e3b1c68ac6a971d3a4fb2852bf10a05fda228721dd44fae1"},
-    {file = "mypy-0.981-cp39-cp39-win_amd64.whl", hash = "sha256:8e8e49aa9cc23aa4c926dc200ce32959d3501c4905147a66ce032f05cb5ecb92"},
-    {file = "mypy-0.981-py3-none-any.whl", hash = "sha256:794f385653e2b749387a42afb1e14c2135e18daeb027e0d97162e4b7031210f8"},
-    {file = "mypy-0.981.tar.gz", hash = "sha256:ad77c13037d3402fbeffda07d51e3f228ba078d1c7096a73759c9419ea031bf4"},
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5"},
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41fd1cf9bc0e1c19b9af13a6580ccb66c381a5ee2cf63ee5ebab747a4badeba3"},
+    {file = "mypy-0.982-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f793e3dd95e166b66d50e7b63e69e58e88643d80a3dcc3bcd81368e0478b089c"},
+    {file = "mypy-0.982-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86ebe67adf4d021b28c3f547da6aa2cce660b57f0432617af2cca932d4d378a6"},
+    {file = "mypy-0.982-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:175f292f649a3af7082fe36620369ffc4661a71005aa9f8297ea473df5772046"},
+    {file = "mypy-0.982-cp310-cp310-win_amd64.whl", hash = "sha256:8ee8c2472e96beb1045e9081de8e92f295b89ac10c4109afdf3a23ad6e644f3e"},
+    {file = "mypy-0.982-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58f27ebafe726a8e5ccb58d896451dd9a662a511a3188ff6a8a6a919142ecc20"},
+    {file = "mypy-0.982-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6af646bd46f10d53834a8e8983e130e47d8ab2d4b7a97363e35b24e1d588947"},
+    {file = "mypy-0.982-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7aeaa763c7ab86d5b66ff27f68493d672e44c8099af636d433a7f3fa5596d40"},
+    {file = "mypy-0.982-cp37-cp37m-win_amd64.whl", hash = "sha256:724d36be56444f569c20a629d1d4ee0cb0ad666078d59bb84f8f887952511ca1"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14d53cdd4cf93765aa747a7399f0961a365bcddf7855d9cef6306fa41de01c24"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:26ae64555d480ad4b32a267d10cab7aec92ff44de35a7cd95b2b7cb8e64ebe3e"},
+    {file = "mypy-0.982-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6389af3e204975d6658de4fb8ac16f58c14e1bacc6142fee86d1b5b26aa52bda"},
+    {file = "mypy-0.982-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b35ce03a289480d6544aac85fa3674f493f323d80ea7226410ed065cd46f206"},
+    {file = "mypy-0.982-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c6e564f035d25c99fd2b863e13049744d96bd1947e3d3d2f16f5828864506763"},
+    {file = "mypy-0.982-cp38-cp38-win_amd64.whl", hash = "sha256:cebca7fd333f90b61b3ef7f217ff75ce2e287482206ef4a8b18f32b49927b1a2"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a705a93670c8b74769496280d2fe6cd59961506c64f329bb179970ff1d24f9f8"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75838c649290d83a2b83a88288c1eb60fe7a05b36d46cbea9d22efc790002146"},
+    {file = "mypy-0.982-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:91781eff1f3f2607519c8b0e8518aad8498af1419e8442d5d0afb108059881fc"},
+    {file = "mypy-0.982-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaa97b9ddd1dd9901a22a879491dbb951b5dec75c3b90032e2baa7336777363b"},
+    {file = "mypy-0.982-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a692a8e7d07abe5f4b2dd32d731812a0175626a90a223d4b58f10f458747dd8a"},
+    {file = "mypy-0.982-cp39-cp39-win_amd64.whl", hash = "sha256:eb7a068e503be3543c4bd329c994103874fa543c1727ba5288393c21d912d795"},
+    {file = "mypy-0.982-py3-none-any.whl", hash = "sha256:1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d"},
+    {file = "mypy-0.982.tar.gz", hash = "sha256:85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -1465,8 +1465,8 @@ pytest-github-actions-annotate-failures = [
     {file = "pytest_github_actions_annotate_failures-0.1.7-py2.py3-none-any.whl", hash = "sha256:c4a7346d1d95f731a6b53e9a45f10ca56593978149266dd7526876cce403ea38"},
 ]
 pytest-mock = [
-    {file = "pytest-mock-3.9.0.tar.gz", hash = "sha256:c899a0dcc8a5f22930acd020b500abd5f956911f326864a3b979e4866e14da82"},
-    {file = "pytest_mock-3.9.0-py3-none-any.whl", hash = "sha256:1a1b9264224d026932d6685a0f9cef3b61d91563c3e74af9fe5afb2767e13812"},
+    {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
+    {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
 ]
 pytest-randomly = [
     {file = "pytest-randomly-3.12.0.tar.gz", hash = "sha256:d60c2db71ac319aee0fc6c4110a7597d611a8b94a5590918bfa8583f00caccb2"},
@@ -1597,16 +1597,16 @@ types-jsonschema = [
     {file = "types_jsonschema-4.16.1-py3-none-any.whl", hash = "sha256:21ca9a227185b83655c71755b5834c36d66ca43f9de77c018d61c4f917f851ab"},
 ]
 types-requests = [
-    {file = "types-requests-2.28.11.tar.gz", hash = "sha256:7ee827eb8ce611b02b5117cfec5da6455365b6a575f5e3ff19f655ba603e6b4e"},
-    {file = "types_requests-2.28.11-py3-none-any.whl", hash = "sha256:af5f55e803cabcfb836dad752bd6d8a0fc8ef1cd84243061c0e27dee04ccf4fd"},
+    {file = "types-requests-2.28.11.2.tar.gz", hash = "sha256:fdcd7bd148139fb8eef72cf4a41ac7273872cad9e6ada14b11ff5dfdeee60ed3"},
+    {file = "types_requests-2.28.11.2-py3-none-any.whl", hash = "sha256:14941f8023a80b16441b3b46caffcbfce5265fd14555844d6029697824b5a2ef"},
 ]
 types-urllib3 = [
     {file = "types-urllib3-1.26.25.tar.gz", hash = "sha256:5aef0e663724eef924afa8b320b62ffef2c1736c1fa6caecfc9bc6c8ae2c3def"},
     {file = "types_urllib3-1.26.25-py3-none-any.whl", hash = "sha256:c1d78cef7bd581e162e46c20a57b2e1aa6ebecdcf01fd0713bb90978ff3e3427"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
@@ -1678,6 +1678,6 @@ xattr = [
     {file = "xattr-0.9.9.tar.gz", hash = "sha256:09cb7e1efb3aa1b4991d6be4eb25b73dc518b4fe894f0915f5b0dcede972f346"},
 ]
 zipp = [
-    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
-    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
+    {file = "zipp-3.9.0-py3-none-any.whl", hash = "sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980"},
+    {file = "zipp-3.9.0.tar.gz", hash = "sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ poetry-core = "^1.3.2"
 poetry-plugin-export = "^1.1.2"
 "backports.cached-property" = { version = "^1.0.2", python = "<3.8" }
 cachecontrol = { version = "^0.12.9", extras = ["filecache"] }
-cachy = "^0.3.0"
 cleo = "^1.0.0a5"
 crashtest = "^0.3.0"
 dulwich = "^0.20.46"
@@ -80,6 +79,8 @@ urllib3 = "^1.26.0"
 pre-commit = "^2.6"
 
 [tool.poetry.group.test.dependencies]
+# Cachy frozen to test backwards compatibility for `poetry.utils.cache`.
+cachy = "0.3.0"
 deepdiff = "^5.0"
 flatdict = "^4.0.1"
 httpretty = "^1.0"

--- a/src/poetry/console/commands/cache/clear.py
+++ b/src/poetry/console/commands/cache/clear.py
@@ -8,6 +8,7 @@ from packaging.utils import canonicalize_name
 
 from poetry.config.config import Config
 from poetry.console.commands.command import Command
+from poetry.utils.cache import FileCache
 
 
 class CacheClearCommand(Command):
@@ -18,8 +19,6 @@ class CacheClearCommand(Command):
     options = [option("all", description="Clear all entries in the cache.")]
 
     def handle(self) -> int:
-        from cachy import CacheManager
-
         cache = self.argument("cache")
 
         parts = cache.split(":")
@@ -33,13 +32,7 @@ class CacheClearCommand(Command):
         except ValueError:
             raise ValueError(f"{root} is not a valid repository cache")
 
-        cache = CacheManager(
-            {
-                "default": parts[0],
-                "serializer": "json",
-                "stores": {parts[0]: {"driver": "file", "path": str(cache_dir)}},
-            }
-        )
+        cache = FileCache(cache_dir)
 
         if len(parts) == 1:
             if not self.option("all"):

--- a/src/poetry/repositories/cached.py
+++ b/src/poetry/repositories/cached.py
@@ -5,12 +5,12 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING
 from typing import Any
 
-from cachy import CacheManager
 from packaging.utils import canonicalize_name
 from poetry.core.constraints.version import parse_constraint
 
 from poetry.config.config import Config
 from poetry.repositories.repository import Repository
+from poetry.utils.cache import FileCache
 
 
 if TYPE_CHECKING:
@@ -30,17 +30,7 @@ class CachedRepository(Repository, ABC):
         super().__init__(name)
         self._disable_cache = disable_cache
         self._cache_dir = (config or Config.create()).repository_cache_directory / name
-        self._cache = CacheManager(
-            {
-                "default": "releases",
-                "serializer": "json",
-                "stores": {
-                    "releases": {"driver": "file", "path": str(self._cache_dir)},
-                    "packages": {"driver": "dict"},
-                    "matches": {"driver": "dict"},
-                },
-            }
-        )
+        self._release_cache: FileCache[dict[str, Any]] = FileCache(path=self._cache_dir)
 
     @abstractmethod
     def _get_release_info(
@@ -60,7 +50,7 @@ class CachedRepository(Repository, ABC):
         if self._disable_cache:
             return PackageInfo.load(self._get_release_info(name, version))
 
-        cached = self._cache.remember_forever(
+        cached = self._release_cache.remember(
             f"{name}:{version}", lambda: self._get_release_info(name, version)
         )
 
@@ -73,7 +63,7 @@ class CachedRepository(Repository, ABC):
             )
             cached = self._get_release_info(name, version)
 
-            self._cache.forever(f"{name}:{version}", cached)
+            self._release_cache.put(f"{name}:{version}", cached)
 
         return PackageInfo.load(cached)
 

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -90,23 +90,19 @@ class LegacyRepository(HTTPRepository):
         if not constraint.is_any():
             key = f"{key}:{constraint!s}"
 
-        if self._cache.store("matches").has(key):
-            versions = self._cache.store("matches").get(key)
-        else:
-            page = self._get_page(f"/{name}/")
-            if page is None:
-                self._log(
-                    f"No packages found for {name}",
-                    level="debug",
-                )
-                return []
+        page = self._get_page(f"/{name}/")
+        if page is None:
+            self._log(
+                f"No packages found for {name}",
+                level="debug",
+            )
+            return []
 
-            versions = [
-                (version, page.yanked(name, version))
-                for version in page.versions(name)
-                if constraint.allows(version)
-            ]
-            self._cache.store("matches").put(key, versions, 5)
+        versions = [
+            (version, page.yanked(name, version))
+            for version in page.versions(name)
+            if constraint.allows(version)
+        ]
 
         return [
             Package(

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -100,13 +100,7 @@ class PyPiRepository(HTTPRepository):
         The information is returned from the cache if it exists
         or retrieved from the remote server.
         """
-        if self._disable_cache:
-            return self._get_package_info(name)
-
-        package_info: dict[str, Any] = self._cache.store("packages").remember_forever(
-            name, lambda: self._get_package_info(name)
-        )
-        return package_info
+        return self._get_package_info(name)
 
     def _find_packages(
         self, name: NormalizedName, constraint: VersionConstraint
@@ -129,15 +123,11 @@ class PyPiRepository(HTTPRepository):
         if not constraint.is_any():
             key = f"{key}:{constraint!s}"
 
-        if self._cache.store("matches").has(key):
-            versions = self._cache.store("matches").get(key)
-        else:
-            versions = [
-                (version, json_page.yanked(name, version))
-                for version in json_page.versions(name)
-                if constraint.allows(version)
-            ]
-            self._cache.store("matches").put(key, versions, 5)
+        versions = [
+            (version, json_page.yanked(name, version))
+            for version in json_page.versions(name)
+            if constraint.allows(version)
+        ]
 
         pretty_name = json_page.content["name"]
         packages = [

--- a/src/poetry/utils/cache.py
+++ b/src/poetry/utils/cache.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import hashlib
+import json
+import shutil
+import time
+
+from pathlib import Path
+from typing import Any
+from typing import Callable
+from typing import Generic
+from typing import TypeVar
+
+
+# Used by Cachy for items that do not expire.
+MAX_DATE = 9999999999
+T = TypeVar("T")
+
+
+def decode(string: bytes, encodings: list[str] | None = None) -> str:
+    """
+    Compatiblity decode function pulled from cachy.
+
+    :param string: The byte string to decode.
+    :param encodings: List of encodings to apply
+    :return: Decoded string
+    """
+    if encodings is None:
+        encodings = ["utf-8", "latin1", "ascii"]
+
+    for encoding in encodings:
+        with contextlib.suppress(UnicodeDecodeError):
+            return string.decode(encoding)
+
+    return string.decode(encodings[0], errors="ignore")
+
+
+def encode(string: str, encodings: list[str] | None = None) -> bytes:
+    """
+    Compatibility encode function from cachy.
+
+    :param string: The string to encode.
+    :param encodings: List of encodings to apply
+    :return: Encoded byte string
+    """
+    if encodings is None:
+        encodings = ["utf-8", "latin1", "ascii"]
+
+    for encoding in encodings:
+        with contextlib.suppress(UnicodeDecodeError):
+            return string.encode(encoding)
+
+    return string.encode(encodings[0], errors="ignore")
+
+
+def _expiration(minutes: int) -> int:
+    """
+    Calculates the time in seconds since epoch that occurs 'minutes' from now.
+
+    :param minutes: The number of minutes to count forward
+    """
+    return round(time.time()) + minutes * 60
+
+
+_HASHES = {
+    "md5": (hashlib.md5, 2),
+    "sha1": (hashlib.sha1, 4),
+    "sha256": (hashlib.sha256, 8),
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class CacheItem(Generic[T]):
+    """
+    Stores data and metadata for cache items.
+    """
+
+    data: T
+    expires: int | None = None
+
+    @property
+    def expired(self) -> bool:
+        """
+        Return true if the cache item has exceeded its expiration period.
+        """
+        return self.expires is not None and time.time() >= self.expires
+
+
+@dataclasses.dataclass(frozen=True)
+class FileCache(Generic[T]):
+    """
+    Cachy-compatible minimal file cache. Stores subsequent data in a JSON format.
+
+    :param path: The path that the cache starts at.
+    :param hash_type: The hash to use for encoding keys/building directories.
+    """
+
+    path: Path
+    hash_type: str = "sha256"
+
+    def get(self, key: str) -> T | None:
+        return self._get_payload(key)
+
+    def has(self, key: str) -> bool:
+        """
+        Determine if a file exists and has not expired in the cache.
+        :param key: The cache key
+        :returns: True if the key exists in the cache
+        """
+        return self.get(key) is not None
+
+    def put(self, key: str, value: Any, minutes: int | None = None) -> None:
+        """
+        Store an item in the cache.
+
+        :param key: The cache key
+        :param value: The cache value
+        :param minutes: The lifetime in minutes of the cached value
+        """
+        payload: CacheItem[Any] = CacheItem(
+            value, expires=_expiration(minutes) if minutes is not None else None
+        )
+        path = self._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(self._serialize(payload))
+
+    def forget(self, key: str) -> None:
+        """
+        Remove an item from the cache.
+
+        :param key: The cache key
+        """
+        path = self._path(key)
+        if path.exists():
+            path.unlink()
+
+    def flush(self) -> None:
+        """
+        Clear the cache.
+        """
+        shutil.rmtree(self.path)
+
+    def remember(
+        self, key: str, callback: T | Callable[[], T], minutes: int | None = None
+    ) -> T:
+        """
+        Get an item from the cache, or use a default from callback.
+
+        :param key: The cache key
+        :param callback: Callback function providing default value
+        :param minutes: The lifetime in minutes of the cached value
+        """
+        value = self.get(key)
+        if value is None:
+            value = callback() if callable(callback) else callback
+            self.put(key, value, minutes)
+        return value
+
+    def _get_payload(self, key: str) -> T | None:
+        path = self._path(key)
+
+        if not path.exists():
+            return None
+
+        with open(path, "rb") as f:
+            payload = self._deserialize(f.read())
+
+        if payload.expired:
+            self.forget(key)
+            return None
+        else:
+            return payload.data
+
+    def _path(self, key: str) -> Path:
+        hash_type, parts_count = _HASHES[self.hash_type]
+        h = hash_type(encode(key)).hexdigest()
+        parts = [h[i : i + 2] for i in range(0, len(h), 2)][:parts_count]
+        return Path(self.path, *parts, h)
+
+    def _serialize(self, payload: CacheItem[T]) -> bytes:
+        expires = payload.expires or MAX_DATE
+        data = json.dumps(payload.data)
+        return encode(f"{expires:010d}{data}")
+
+    def _deserialize(self, data_raw: bytes) -> CacheItem[T]:
+        data_str = decode(data_raw)
+        data = json.loads(data_str[10:])
+        expires = int(data_str[:10])
+        return CacheItem(data, expires)

--- a/tests/console/commands/cache/test_clear.py
+++ b/tests/console/commands/cache/test_clear.py
@@ -30,11 +30,12 @@ def test_cache_clear_all(
     cache: CacheManager,
 ):
     exit_code = tester.execute(f"cache clear {repository_one} --all", inputs="yes")
+    repository_one_dir = repository_cache_dir / repository_one
 
     assert exit_code == 0
     assert tester.io.fetch_output() == ""
-    # ensure directory is empty
-    assert not any((repository_cache_dir / repository_one).iterdir())
+    # ensure directory is empty or doesn't exist
+    assert not repository_one_dir.exists() or not any(repository_one_dir.iterdir())
     assert not cache.has("cachy:0.1")
     assert not cache.has("cleo:0.2")
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from poetry.core.constraints.version import Version
+from poetry.core.packages.package import Package
 
 from poetry.repositories.legacy_repository import LegacyRepository
 from tests.helpers import get_dependency
@@ -819,12 +820,26 @@ Package operations: 1 install, 0 updates, 0 removals
 
 
 def test_add_constraint_with_source(
-    app: PoetryTestApplication, poetry: Poetry, tester: CommandTester
+    app: PoetryTestApplication,
+    poetry: Poetry,
+    tester: CommandTester,
+    mocker: MockerFixture,
 ):
     repo = LegacyRepository(name="my-index", url="https://my-index.fake")
     repo.add_package(get_package("cachy", "0.2.0"))
-    repo._cache.store("matches").put(
-        "cachy:0.2.0", [(Version.parse("0.2.0"), False)], 5
+    mocker.patch.object(
+        repo,
+        "_find_packages",
+        wraps=lambda _, name: [
+            Package(
+                "cachy",
+                Version.parse("0.2.0"),
+                source_type="legacy",
+                source_reference=repo.name,
+                source_url=repo._url,
+                yanked=False,
+            )
+        ],
     )
 
     poetry.pool.add_repository(repo)
@@ -1809,11 +1824,23 @@ def test_add_constraint_with_source_old_installer(
     poetry: Poetry,
     installer: NoopInstaller,
     old_tester: CommandTester,
+    mocker: MockerFixture,
 ):
     repo = LegacyRepository(name="my-index", url="https://my-index.fake")
     repo.add_package(get_package("cachy", "0.2.0"))
-    repo._cache.store("matches").put(
-        "cachy:0.2.0", [(Version.parse("0.2.0"), False)], 5
+    mocker.patch.object(
+        repo,
+        "_find_packages",
+        wraps=lambda _, name: [
+            Package(
+                "cachy",
+                Version.parse("0.2.0"),
+                source_type="legacy",
+                source_reference=repo.name,
+                source_url=repo._url,
+                yanked=False,
+            )
+        ],
     )
 
     poetry.pool.add_repository(repo)

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import TypeVar
+from typing import Union
+from unittest.mock import Mock
+
+import pytest
+
+from cachy import CacheManager
+
+from poetry.utils.cache import FileCache
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.monkeypatch import MonkeyPatch
+    from pytest import FixtureRequest
+    from pytest_mock import MockerFixture
+
+    from tests.conftest import Config
+
+
+FILE_CACHE = Union[FileCache, CacheManager]
+T = TypeVar("T")
+
+
+@pytest.fixture
+def repository_cache_dir(monkeypatch: MonkeyPatch, config: Config) -> Path:
+    return config.repository_cache_directory
+
+
+def patch_cachy(cache: CacheManager) -> CacheManager:
+    old_put = cache.put
+    old_remember = cache.remember
+
+    def new_put(key: str, value: Any, minutes: int | None = None) -> Any:
+        if minutes is not None:
+            return old_put(key, value, minutes=minutes)
+        else:
+            return cache.forever(key, value)
+
+    cache.put = new_put
+
+    def new_remember(key: str, value: Any, minutes: int | None = None) -> Any:
+        if minutes is not None:
+            return old_remember(key, value, minutes=minutes)
+        else:
+            return cache.remember_forever(key, value)
+
+    cache.remember = new_remember
+    return cache
+
+
+@pytest.fixture
+def cachy_file_cache(repository_cache_dir: Path) -> CacheManager:
+    cache = CacheManager(
+        {
+            "default": "cache",
+            "serializer": "json",
+            "stores": {
+                "cache": {"driver": "file", "path": str(repository_cache_dir / "cache")}
+            },
+        }
+    )
+    return patch_cachy(cache)
+
+
+@pytest.fixture
+def poetry_file_cache(repository_cache_dir: Path) -> FileCache[T]:
+    return FileCache(repository_cache_dir / "cache")
+
+
+@pytest.fixture
+def cachy_dict_cache() -> CacheManager:
+    cache = CacheManager(
+        {
+            "default": "cache",
+            "serializer": "json",
+            "stores": {"cache": {"driver": "dict"}},
+        }
+    )
+    return patch_cachy(cache)
+
+
+@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
+def test_cache_get_put_has(cache_name: str, request: FixtureRequest) -> None:
+    cache = request.getfixturevalue(cache_name)
+    cache.put("key1", "value")
+    cache.put("key2", {"a": ["json-encoded", "value"]})
+
+    assert cache.get("key1") == "value"
+    assert cache.get("key2") == {"a": ["json-encoded", "value"]}
+    assert cache.has("key1")
+    assert cache.has("key2")
+    assert not cache.has("key3")
+
+
+@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
+def test_cache_forget(cache_name: str, request: FixtureRequest) -> None:
+    cache = request.getfixturevalue(cache_name)
+    cache.put("key1", "value")
+    cache.put("key2", "value")
+
+    assert cache.has("key1")
+    assert cache.has("key2")
+
+    cache.forget("key1")
+
+    assert not cache.has("key1")
+    assert cache.has("key2")
+
+
+@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
+def test_cache_flush(cache_name: str, request: FixtureRequest) -> None:
+    cache = request.getfixturevalue(cache_name)
+    cache.put("key1", "value")
+    cache.put("key2", "value")
+
+    assert cache.has("key1")
+    assert cache.has("key2")
+
+    cache.flush()
+
+    assert not cache.has("key1")
+    assert not cache.has("key2")
+
+
+@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
+def test_cache_remember(
+    cache_name: str, request: FixtureRequest, mocker: MockerFixture
+) -> None:
+    cache = request.getfixturevalue(cache_name)
+
+    method = Mock(return_value="value2")
+    cache.put("key1", "value1")
+    assert cache.remember("key1", method) == "value1"
+    method.assert_not_called()
+
+    assert cache.remember("key2", method) == "value2"
+    method.assert_called()
+
+
+@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
+def test_cache_get_limited_minutes(
+    mocker: MockerFixture,
+    cache_name: str,
+    request: FixtureRequest,
+) -> None:
+    cache = request.getfixturevalue(cache_name)
+
+    # needs to be 10 digits because cachy assumes it's a 10-digit int.
+    start_time = 1111111111
+
+    mocker.patch("time.time", return_value=start_time)
+    cache.put("key1", "value", minutes=5)
+    cache.put("key2", "value", minutes=5)
+
+    assert cache.get("key1") is not None
+    assert cache.get("key2") is not None
+
+    mocker.patch("time.time", return_value=start_time + 5 * 60 + 1)
+    # check to make sure that the cache deletes for has() and get()
+    assert not cache.has("key1")
+    assert cache.get("key2") is None
+
+
+def test_cachy_compatibility(
+    cachy_file_cache: CacheManager, poetry_file_cache: FileCache[T]
+) -> None:
+    """
+    The new file cache should be able to support reading legacy caches.
+    """
+    test_str = "value"
+    test_obj = {"a": ["json", "object"]}
+    cachy_file_cache.put("key1", test_str)
+    cachy_file_cache.put("key2", test_obj)
+
+    assert poetry_file_cache.get("key1") == test_str
+    assert poetry_file_cache.get("key2") == test_obj
+
+    poetry_file_cache.put("key3", test_str)
+    poetry_file_cache.put("key4", test_obj)
+
+    assert cachy_file_cache.get("key3") == test_str
+    assert cachy_file_cache.get("key4") == test_obj


### PR DESCRIPTION
Related to the discussion in #5720.

This is a test to see what would be needed to pull out of cachy to get it into Poetry entirely. The result is a new utils module, `poetry.utils.cache`, that is about 250 LOC. I also went ahead and made a couple of small improvements:

* Broke up cachy into simpler classes, mainly to push stuff out of config and into typed variables. Now caches are declared separately -- `FileCache`, `DictCache`
* Add types to methods and generics
* Update the file format. Before it was the expiration time concatenated with the payload, now it's purely JSON encoded. Added compatibility tests and checks to ensure the migration won't break existing caches.


# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
