### PR TITLE
Use locally cached wheels during install

### DIFF
--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -25,15 +25,10 @@ class Chef:
             Path(config.get("cache-dir")).expanduser().joinpath("artifacts")
         )
 
-    def get_cached_archive_for_link(self, link: Link) -> Link:
-        # If the archive is already a wheel, there is no need to cache it.
-        if link.is_wheel:
-            return link
-
+    def get_cached_archive_for_link(self, link: Link) -> Link | None:
         archives = self.get_cached_archives_for_link(link)
-
         if not archives:
-            return link
+            return None
 
         candidates: list[tuple[float | None, Link]] = []
         for archive in archives:
@@ -54,7 +49,7 @@ class Chef:
             )
 
         if not candidates:
-            return link
+            return None
 
         return min(candidates)[1]
 

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -6,13 +6,12 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from poetry.core.packages.utils.link import Link
-
 from poetry.installation.chooser import InvalidWheelName
 from poetry.installation.chooser import Wheel
 
 
 if TYPE_CHECKING:
+    from poetry.core.packages.utils.link import Link
 
     from poetry.config.config import Config
     from poetry.utils.env import Env
@@ -25,19 +24,19 @@ class Chef:
             Path(config.get("cache-dir")).expanduser().joinpath("artifacts")
         )
 
-    def get_cached_archive_for_link(self, link: Link) -> Link | None:
+    def get_cached_archive_for_link(self, link: Link) -> Path | None:
         archives = self.get_cached_archives_for_link(link)
         if not archives:
             return None
 
-        candidates: list[tuple[float | None, Link]] = []
+        candidates: list[tuple[float | None, Path]] = []
         for archive in archives:
-            if not archive.is_wheel:
+            if archive.suffix != ".whl":
                 candidates.append((float("inf"), archive))
                 continue
 
             try:
-                wheel = Wheel(archive.filename)
+                wheel = Wheel(archive.name)
             except InvalidWheelName:
                 continue
 
@@ -53,16 +52,16 @@ class Chef:
 
         return min(candidates)[1]
 
-    def get_cached_archives_for_link(self, link: Link) -> list[Link]:
+    def get_cached_archives_for_link(self, link: Link) -> list[Path]:
         cache_dir = self.get_cache_directory_for_link(link)
 
         archive_types = ["whl", "tar.gz", "tar.bz2", "bz2", "zip"]
-        links = []
+        paths = []
         for archive_type in archive_types:
             for archive in cache_dir.glob(f"*.{archive_type}"):
-                links.append(Link(archive.as_uri()))
+                paths.append(Path(archive))
 
-        return links
+        return paths
 
     def get_cache_directory_for_link(self, link: Link) -> Path:
         key_parts = {"url": link.url_without_fragment}

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -614,9 +614,9 @@ class Executor:
     def _download_link(self, operation: Install | Update, link: Link) -> Link | Path:
         package = operation.package
 
-        archive: Link | Path
+        archive: Link | Path | None
         archive = self._chef.get_cached_archive_for_link(link)
-        if archive is link:
+        if archive is None:
             # No cached distributions was found, so we download and prepare it
             try:
                 archive = self._download_archive(operation, link)

--- a/src/poetry/utils/pip.py
+++ b/src/poetry/utils/pip.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from poetry.core.packages.utils.link import Link
-from poetry.core.packages.utils.utils import url_to_path
-
 from poetry.exceptions import PoetryException
 from poetry.utils.env import EnvCommandError
 
@@ -16,13 +13,12 @@ if TYPE_CHECKING:
 
 
 def pip_install(
-    path: Path | Link,
+    path: Path,
     environment: Env,
     editable: bool = False,
     deps: bool = False,
     upgrade: bool = False,
 ) -> int | str:
-    path = url_to_path(path.url) if isinstance(path, Link) else path
     is_wheel = path.suffix == ".whl"
 
     # We disable version check here as we are already pinning to version available in

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -23,11 +23,11 @@ if TYPE_CHECKING:
     [
         (
             "https://files.python-poetry.org/demo-0.1.0.tar.gz",
-            "file:///foo/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
         ),
         (
             "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
-            "file:///foo/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
         ),
     ],
 )
@@ -50,16 +50,16 @@ def test_get_cached_archive_for_link(
         chef,
         "get_cached_archives_for_link",
         return_value=[
-            Link("file:///foo/demo-0.1.0-py2.py3-none-any"),
-            Link("file:///foo/demo-0.1.0.tar.gz"),
-            Link("file:///foo/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl"),
-            Link("file:///foo/demo-0.1.0-cp37-cp37-macosx_10_15_x86_64.whl"),
+            Path("/cache/demo-0.1.0-py2.py3-none-any"),
+            Path("/cache/demo-0.1.0.tar.gz"),
+            Path("/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl"),
+            Path("/cache/demo-0.1.0-cp37-cp37-macosx_10_15_x86_64.whl"),
         ],
     )
 
     archive = chef.get_cached_archive_for_link(Link(link))
 
-    assert Link(cached) == archive
+    assert Path(cached) == archive
 
 
 def test_get_cached_archives_for_link(config: Config, mocker: MockerFixture):
@@ -82,9 +82,7 @@ def test_get_cached_archives_for_link(config: Config, mocker: MockerFixture):
     )
 
     assert archives
-    assert set(archives) == {
-        Link(path.as_uri()) for path in distributions.glob("demo-0.1.0*")
-    }
+    assert set(archives) == {Path(path) for path in distributions.glob("demo-0.1.0*")}
 
 
 def test_get_cache_directory_for_link(config: Config, config_cache_dir: Path):

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 from packaging.tags import Tag
 from poetry.core.packages.utils.link import Link
 
@@ -16,7 +18,22 @@ if TYPE_CHECKING:
     from tests.conftest import Config
 
 
-def test_get_cached_archive_for_link(config: Config, mocker: MockerFixture):
+@pytest.mark.parametrize(
+    ("link", "cached"),
+    [
+        (
+            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            "file:///foo/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+        ),
+        (
+            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            "file:///foo/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+        ),
+    ],
+)
+def test_get_cached_archive_for_link(
+    config: Config, mocker: MockerFixture, link: str, cached: str
+):
     chef = Chef(
         config,
         MockEnv(
@@ -40,11 +57,9 @@ def test_get_cached_archive_for_link(config: Config, mocker: MockerFixture):
         ],
     )
 
-    archive = chef.get_cached_archive_for_link(
-        Link("https://files.python-poetry.org/demo-0.1.0.tar.gz")
-    )
+    archive = chef.get_cached_archive_for_link(Link(link))
 
-    assert Link("file:///foo/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl") == archive
+    assert Link(cached) == archive
 
 
 def test_get_cached_archives_for_link(config: Config, mocker: MockerFixture):

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -369,7 +369,7 @@ def test_executor_should_delete_incomplete_downloads(
     )
     mocker.patch(
         "poetry.installation.chef.Chef.get_cached_archive_for_link",
-        side_effect=lambda link: link,
+        side_effect=lambda link: None,
     )
     mocker.patch(
         "poetry.installation.chef.Chef.get_cache_directory_for_link",

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -436,11 +436,8 @@ def test_executor_should_not_write_pep610_url_references_for_cached_package(
     config: Config,
     io: BufferedIO,
 ):
-    link_cached = Link(
-        fixture_dir("distributions")
-        .joinpath("demo-0.1.0-py2.py3-none-any.whl")
-        .as_uri()
-    )
+    link_cached = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
+
     mocker.patch(
         "poetry.installation.executor.Executor._download", return_value=link_cached
     )
@@ -564,12 +561,8 @@ def test_executor_should_use_cached_link_and_hash(
     mocker: MockerFixture,
     fixture_dir: FixtureDirGetter,
 ):
-    # Produce a file:/// URI that is a valid link
-    link_cached = Link(
-        fixture_dir("distributions")
-        .joinpath("demo-0.1.0-py2.py3-none-any.whl")
-        .as_uri()
-    )
+    link_cached = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
+
     mocker.patch(
         "poetry.installation.chef.Chef.get_cached_archive_for_link",
         return_value=link_cached,

--- a/tests/utils/test_pip.py
+++ b/tests/utils/test_pip.py
@@ -6,9 +6,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from poetry.core.packages.utils.link import Link
-from poetry.core.packages.utils.utils import path_to_url
-
 from poetry.utils.pip import pip_install
 
 
@@ -23,17 +20,6 @@ def test_pip_install_successful(
     tmp_dir: str, tmp_venv: VirtualEnv, fixture_dir: FixtureDirGetter
 ):
     file_path = fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl")
-    result = pip_install(file_path, tmp_venv)
-
-    assert "Successfully installed demo-0.1.0" in result
-
-
-def test_pip_install_link(
-    tmp_dir: str, tmp_venv: VirtualEnv, fixture_dir: FixtureDirGetter
-):
-    file_path = Link(
-        path_to_url(fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl"))
-    )
     result = pip_install(file_path, tmp_venv)
 
     assert "Successfully installed demo-0.1.0" in result


### PR DESCRIPTION
Related to #2415, though it only addresses one of the many repeated downloads which that issue reports.

If we have a url dependency pointing at a wheel eg
```
hu-core-ud-lg = {url = "https://github.com/oroszgy/spacy-hungarian-models/releases/download/hu_core_ud_lg-0.3.1/hu_core_ud_lg-0.3.1-py3-none-any.whl"}
```
then poetry performs the download during `poetry install`, even though it has a perfectly good cached version in `~/.cache/pypoetry/artifacts`.

`get_cached_archive_for_link` looks kinda confused: returning the original input `Link` to mean "no cached archive found" is odd.  So I have tweaked it to return `None` instead which seems a lot clearer.  

It's always possible that I am the confused one, certainly I am struggling to understand what the intention of the changed code can have been.  So do please think about that when reviewing!