### PR TITLE
Change note to warning in installation instructions

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -32,10 +32,10 @@ Poetry provides a custom installer that will install `poetry` isolated
 from the rest of your system by vendorizing its dependencies. This is the
 recommended way of installing `poetry`.
 
-{{% note %}}
+{{% warning %}}
 The `get-poetry.py` script described here will be replaced in Poetry 1.2 by `install-poetry.py`.
 From Poetry **1.1.7 onwards**, you can already use this script as described [here]({{< relref "docs/master/#installation" >}}).
-{{% /note %}}
+{{% /warning %}}
 
 ### osx / linux / bashonwindows install instructions
 ```bash


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5220

- [x] Updated **documentation** for changed code.

As the 1.2 release is right around the corner, and there are still issues from people installing with the old `get-poetry` script, this simple change adds a visible warning about a change of installation script (see the attached issue for example).