### PR TITLE
Include strtobool in utils.extras to speed up the shell command

### DIFF
--- a/src/poetry/console/commands/shell.py
+++ b/src/poetry/console/commands/shell.py
@@ -5,7 +5,7 @@ import sys
 from os import environ
 
 from poetry.console.commands.env_command import EnvCommand
-from poetry.utils.extras import strtobool
+from poetry.utils.extras import str_to_bool
 
 
 class ShellCommand(EnvCommand):
@@ -22,7 +22,7 @@ If one doesn't exist yet, it will be created.
         from poetry.utils.shell import Shell
 
         # Check if it's already activated or doesn't exist and won't be created
-        venv_activated = strtobool(environ.get("POETRY_ACTIVE", "0")) or getattr(
+        venv_activated = str_to_bool(environ.get("POETRY_ACTIVE", "0")) or getattr(
             sys, "real_prefix", sys.prefix
         ) == str(self.env.path)
         if venv_activated:

--- a/src/poetry/console/commands/shell.py
+++ b/src/poetry/console/commands/shell.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import sys
 
-from distutils.util import strtobool
 from os import environ
 
 from poetry.console.commands.env_command import EnvCommand
+from poetry.utils.extras import strtobool
 
 
 class ShellCommand(EnvCommand):

--- a/src/poetry/utils/extras.py
+++ b/src/poetry/utils/extras.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
     from typing import Mapping
 
     from poetry.core.packages.package import Package
-    from typing_extensions import Literal
 
 
 def get_extra_package_names(
@@ -67,7 +66,7 @@ def get_extra_package_names(
     return _extra_packages(extra_package_names)
 
 
-def strtobool(val: str) -> Literal[0, 1]:
+def str_to_bool(val: str) -> bool:
     """Convert a string representation of truth to true (1) or false (0).
 
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
@@ -76,8 +75,8 @@ def strtobool(val: str) -> Literal[0, 1]:
     """
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
-        return 1
+        return True
     elif val in ("n", "no", "f", "false", "off", "0"):
-        return 0
+        return False
     else:
         raise ValueError(f"invalid truth value {val!r}")

--- a/src/poetry/utils/extras.py
+++ b/src/poetry/utils/extras.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from typing import Mapping
 
     from poetry.core.packages.package import Package
+    from typing_extensions import Literal
 
 
 def get_extra_package_names(
@@ -64,3 +65,19 @@ def get_extra_package_names(
                     yield dependency_package_name
 
     return _extra_packages(extra_package_names)
+
+
+def strtobool(val: str) -> Literal[0, 1]:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")

--- a/src/poetry/utils/extras.py
+++ b/src/poetry/utils/extras.py
@@ -76,7 +76,6 @@ def str_to_bool(val: str) -> bool:
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
         return True
-    elif val in ("n", "no", "f", "false", "off", "0"):
+    if val in ("n", "no", "f", "false", "off", "0"):
         return False
-    else:
-        raise ValueError(f"invalid truth value {val!r}")
+    raise ValueError(f"invalid truth value {val!r}")

--- a/tests/utils/test_extras.py
+++ b/tests/utils/test_extras.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 from poetry.core.packages.package import Package
 
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
-
 from poetry.factory import Factory
 from poetry.utils.extras import get_extra_package_names
-from poetry.utils.extras import strtobool
+from poetry.utils.extras import str_to_bool
 
 
 _PACKAGE_FOO = Package("foo", "0.1.0")
@@ -100,5 +94,5 @@ def test_get_extra_package_names(
         ("N", False),
     ],
 )
-def test_strtobool(var: str, expected_result: Literal[0, 1]):
-    assert strtobool(var) == expected_result
+def test_strtobool(var: str, expected_result: bool):
+    assert str_to_bool(var) == expected_result

--- a/tests/utils/test_extras.py
+++ b/tests/utils/test_extras.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from poetry.core.packages.package import Package
 
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
+
 from poetry.factory import Factory
 from poetry.utils.extras import get_extra_package_names
+from poetry.utils.extras import strtobool
 
 
 _PACKAGE_FOO = Package("foo", "0.1.0")
@@ -68,3 +75,30 @@ def test_get_extra_package_names(
         list(get_extra_package_names(packages, extras, extra_names))
         == expected_extra_package_names
     )
+
+
+@pytest.mark.parametrize(
+    ["var", "expected_result"],
+    [
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("1", True),
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        ("0", False),
+        ("on", True),
+        ("On", True),
+        ("ON", True),
+        ("off", False),
+        ("Off", False),
+        ("OFF", False),
+        ("y", True),
+        ("Y", True),
+        ("n", False),
+        ("N", False),
+    ],
+)
+def test_strtobool(var: str, expected_result: Literal[0, 1]):
+    assert strtobool(var) == expected_result


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (The change doesn't reflect in the current doc)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

# What does this PR do?

This line `from distutils.util import strtobool` in  `console.commands.shell` is slow and makes poetry shell command slow, since importing `distutils.util` also does a bunch of other things. 

`strtobool` is a very simple function (~10 lines), if poetry includes this function itself, for example, putting it in utils.extras.py and use from poetry.utils.extras import strtobool, poetry shell would run faster.

[Discord discussion link](https://discord.com/channels/487711540787675139/974839878669987840/988024065933594704)