### PR TITLE
tell git not to use terminal prompts

### DIFF
--- a/src/poetry/vcs/git/system.py
+++ b/src/poetry/vcs/git/system.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 
 from typing import TYPE_CHECKING
@@ -49,8 +50,14 @@ class SystemGit:
             ) + args
 
         git_command = find_git_command()
+        env = os.environ.copy()
+        env["GIT_TERMINAL_PROMPT"] = "0"
         return (
-            subprocess.check_output(git_command + list(args), stderr=subprocess.STDOUT)
+            subprocess.check_output(
+                git_command + list(args),
+                stderr=subprocess.STDOUT,
+                env=env,
+            )
             .decode()
             .strip()
         )


### PR DESCRIPTION
Fixes #3222

See https://git-scm.com/docs/git#Documentation/git.txt-codeGITTERMINALPROMPTcode

This environment variable is available since git 2.3 (2015) but should be harmless even in the unlikely event that someone has an older version than that.