### PR TITLE
add timeouts to all requests

### DIFF
--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -22,6 +22,7 @@ from requests_toolbelt.multipart import MultipartEncoderMonitor
 from urllib3 import util
 
 from poetry.__version__ import __version__
+from poetry.utils.constants import REQUESTS_TIMEOUT
 from poetry.utils.patterns import wheel_file_re
 
 
@@ -262,7 +263,7 @@ class Uploader:
                         data=monitor,
                         allow_redirects=False,
                         headers={"Content-Type": monitor.content_type},
-                        timeout=5,
+                        timeout=REQUESTS_TIMEOUT,
                     )
                 if resp is None or 200 <= resp.status_code < 300:
                     bar.set_format(
@@ -321,7 +322,7 @@ class Uploader:
             data=encoder,
             allow_redirects=False,
             headers={"Content-Type": encoder.content_type},
-            timeout=5,
+            timeout=REQUESTS_TIMEOUT,
         )
 
         resp.raise_for_status()

--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -262,6 +262,7 @@ class Uploader:
                         data=monitor,
                         allow_redirects=False,
                         headers={"Content-Type": monitor.content_type},
+                        timeout=5,
                     )
                 if resp is None or 200 <= resp.status_code < 300:
                     bar.set_format(
@@ -320,6 +321,7 @@ class Uploader:
             data=encoder,
             allow_redirects=False,
             headers={"Content-Type": encoder.content_type},
+            timeout=5,
         )
 
         resp.raise_for_status()

--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -24,6 +24,7 @@ from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.link_sources.html import HTMLPage
 from poetry.utils.authenticator import Authenticator
+from poetry.utils.constants import REQUESTS_TIMEOUT
 from poetry.utils.helpers import download_file
 from poetry.utils.patterns import wheel_file_re
 
@@ -261,7 +262,7 @@ class HTTPRepository(CachedRepository, ABC):
         url = self._url + endpoint
         try:
             response: requests.Response = self.session.get(
-                url, raise_for_status=False, timeout=5
+                url, raise_for_status=False, timeout=REQUESTS_TIMEOUT
             )
             if response.status_code in (401, 403):
                 self._log(

--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -260,7 +260,9 @@ class HTTPRepository(CachedRepository, ABC):
     def _get_response(self, endpoint: str) -> requests.Response | None:
         url = self._url + endpoint
         try:
-            response: requests.Response = self.session.get(url, raise_for_status=False)
+            response: requests.Response = self.session.get(
+                url, raise_for_status=False, timeout=5
+            )
             if response.status_code in (401, 403):
                 self._log(
                     f"Authorization error accessing {url}",

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -103,7 +103,9 @@ class PyPiRepository(HTTPRepository):
 
         search = {"q": query}
 
-        response = requests.session().get(self._base_url + "search", params=search)
+        response = requests.session().get(
+            self._base_url + "search", params=search, timeout=5
+        )
         content = parse(response.content, namespaceHTMLElements=False)
         for result in content.findall(".//*[@class='package-snippet']"):
             name_element = result.find("h3/*[@class='package-snippet__name']")
@@ -244,14 +246,14 @@ class PyPiRepository(HTTPRepository):
     def _get(self, endpoint: str) -> dict[str, Any] | None:
         try:
             json_response = self.session.get(
-                self._base_url + endpoint, raise_for_status=False
+                self._base_url + endpoint, raise_for_status=False, timeout=5
             )
         except requests.exceptions.TooManyRedirects:
             # Cache control redirect loop.
             # We try to remove the cache and try again
             self.session.delete_cache(self._base_url + endpoint)
             json_response = self.session.get(
-                self._base_url + endpoint, raise_for_status=False
+                self._base_url + endpoint, raise_for_status=False, timeout=5
             )
 
         if json_response.status_code != 200:

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -17,6 +17,7 @@ from poetry.core.version.exceptions import InvalidVersion
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.http import HTTPRepository
 from poetry.utils._compat import to_str
+from poetry.utils.constants import REQUESTS_TIMEOUT
 
 
 cache_control_logger.setLevel(logging.ERROR)
@@ -104,7 +105,7 @@ class PyPiRepository(HTTPRepository):
         search = {"q": query}
 
         response = requests.session().get(
-            self._base_url + "search", params=search, timeout=5
+            self._base_url + "search", params=search, timeout=REQUESTS_TIMEOUT
         )
         content = parse(response.content, namespaceHTMLElements=False)
         for result in content.findall(".//*[@class='package-snippet']"):
@@ -246,14 +247,18 @@ class PyPiRepository(HTTPRepository):
     def _get(self, endpoint: str) -> dict[str, Any] | None:
         try:
             json_response = self.session.get(
-                self._base_url + endpoint, raise_for_status=False, timeout=5
+                self._base_url + endpoint,
+                raise_for_status=False,
+                timeout=REQUESTS_TIMEOUT,
             )
         except requests.exceptions.TooManyRedirects:
             # Cache control redirect loop.
             # We try to remove the cache and try again
             self.session.delete_cache(self._base_url + endpoint)
             json_response = self.session.get(
-                self._base_url + endpoint, raise_for_status=False, timeout=5
+                self._base_url + endpoint,
+                raise_for_status=False,
+                timeout=REQUESTS_TIMEOUT,
             )
 
         if json_response.status_code != 200:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -21,6 +21,7 @@ from cachecontrol.caches import FileCache
 
 from poetry.config.config import Config
 from poetry.exceptions import PoetryException
+from poetry.utils.constants import REQUESTS_TIMEOUT
 from poetry.utils.password_manager import HTTPAuthCredential
 from poetry.utils.password_manager import PasswordManager
 
@@ -219,7 +220,7 @@ class Authenticator:
 
         # Send the request.
         send_kwargs = {
-            "timeout": kwargs.get("timeout", 5),
+            "timeout": kwargs.get("timeout", REQUESTS_TIMEOUT),
             "allow_redirects": kwargs.get("allow_redirects", True),
         }
         send_kwargs.update(settings)

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -219,7 +219,7 @@ class Authenticator:
 
         # Send the request.
         send_kwargs = {
-            "timeout": kwargs.get("timeout"),
+            "timeout": kwargs.get("timeout", 5),
             "allow_redirects": kwargs.get("allow_redirects", True),
         }
         send_kwargs.update(settings)

--- a/src/poetry/utils/constants.py
+++ b/src/poetry/utils/constants.py
@@ -1,2 +1,5 @@
+from __future__ import annotations
+
+
 # Timeout for HTTP requests using the requests library.
 REQUESTS_TIMEOUT = 15

--- a/src/poetry/utils/constants.py
+++ b/src/poetry/utils/constants.py
@@ -1,0 +1,2 @@
+# Timeout for HTTP requests using the requests library.
+REQUESTS_TIMEOUT = 15

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -89,7 +89,7 @@ def download_file(
 
     get = requests.get if not session else session.get
 
-    response = get(url, stream=True)
+    response = get(url, stream=True, timeout=5)
     response.raise_for_status()
 
     set_indicator = False

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -13,6 +13,8 @@ from typing import Any
 from typing import Iterator
 from typing import Mapping
 
+from poetry.utils.constants import REQUESTS_TIMEOUT
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -89,7 +91,7 @@ def download_file(
 
     get = requests.get if not session else session.get
 
-    response = get(url, stream=True, timeout=5)
+    response = get(url, stream=True, timeout=REQUESTS_TIMEOUT)
     response.raise_for_status()
 
     set_indicator = False

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -426,7 +426,9 @@ def test_get_redirected_response_url(
     repo = MockHttpRepository({"/foo": 200}, http)
     redirect_url = "http://legacy.redirect.bar"
 
-    def get_mock(url: str, raise_for_status: bool = True) -> requests.Response:
+    def get_mock(
+        url: str, raise_for_status: bool = True, timeout: int = 5
+    ) -> requests.Response:
         response = requests.Response()
         response.status_code = 200
         response.url = redirect_url + "/foo"


### PR DESCRIPTION
https://requests.readthedocs.io/en/latest/user/advanced/#timeouts

> Most requests to external servers should have a timeout attached, in case the server is not responding in a timely manner. By default, requests do not time out unless a timeout value is set explicitly. Without a timeout, your code may hang for minutes or more.

Seems like not a great default.

I've added a timeout to all the requests that I could find.  Probably fixes some of the examples of poetry being "slow" or "stuck" that have been reported eg #3352, though it's hard to be sure.