### PR TITLE
Use hash of dependency instead of object in a provider's deferred cache

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -288,7 +288,7 @@ class Provider:
         dependency._source_resolved_reference = package.source_resolved_reference
         dependency._source_subdirectory = package.source_subdirectory
 
-        self._deferred_cache[dependency] = package
+        self._deferred_cache[hash(dependency)] = package
 
         return [package]
 
@@ -315,8 +315,8 @@ class Provider:
         )
 
     def search_for_file(self, dependency: FileDependency) -> list[Package]:
-        if dependency in self._deferred_cache:
-            _package = self._deferred_cache[dependency]
+        if hash(dependency) in self._deferred_cache:
+            _package = self._deferred_cache[hash(dependency)]
 
             package = _package.clone()
         else:
@@ -325,7 +325,7 @@ class Provider:
             dependency._constraint = package.version
             dependency._pretty_constraint = package.version.text
 
-            self._deferred_cache[dependency] = package
+            self._deferred_cache[hash(dependency)] = package
 
         self.validate_package_for_dependency(dependency=dependency, package=package)
 
@@ -352,8 +352,8 @@ class Provider:
         return package
 
     def search_for_directory(self, dependency: DirectoryDependency) -> list[Package]:
-        if dependency in self._deferred_cache:
-            _package = self._deferred_cache[dependency]
+        if hash(dependency) in self._deferred_cache:
+            _package = self._deferred_cache[hash(dependency)]
 
             package = _package.clone()
         else:
@@ -362,7 +362,7 @@ class Provider:
             dependency._constraint = package.version
             dependency._pretty_constraint = package.version.text
 
-            self._deferred_cache[dependency] = package
+            self._deferred_cache[hash(dependency)] = package
 
         self.validate_package_for_dependency(dependency=dependency, package=package)
 
@@ -378,8 +378,8 @@ class Provider:
         return PackageInfo.from_directory(path=directory).to_package(root_dir=directory)
 
     def search_for_url(self, dependency: URLDependency) -> list[Package]:
-        if dependency in self._deferred_cache:
-            return [self._deferred_cache[dependency]]
+        if hash(dependency) in self._deferred_cache:
+            return [self._deferred_cache[hash(dependency)]]
 
         package = self.get_package_from_url(dependency.url)
 
@@ -396,7 +396,7 @@ class Provider:
         dependency._constraint = package.version
         dependency._pretty_constraint = package.version.text
 
-        self._deferred_cache[dependency] = package
+        self._deferred_cache[hash(dependency)] = package
 
         return [package]
 

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -138,7 +138,7 @@ class Provider:
         self._is_debugging: bool = self._io.is_debug() or self._io.is_very_verbose()
         self._in_progress = False
         self._overrides: dict[DependencyPackage, dict[str, Dependency]] = {}
-        self._deferred_cache: dict[Dependency, Package] = {}
+        self._deferred_cache: dict[int, Package] = {}
         self._load_deferred = True
         self._source_root: Path | None = None
         self._installed = installed


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5902

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [n.a.] Updated **documentation** for changed code. 

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This is my first pull request so apologies if I did something wrong, I am open to feedback!

As described in the referred issue poetry often repeatedly re-downloads packages when resolving dependencies. This is due a bug which causing poetry thinking cached packages are not cached yet. The providers cache is a dictionary which uses a Dependency object a key (and the package as the value). During a dictionary lookup python checks equivalence on both the hash and __eq__ for keys, but in some cases the Dependency object can change breaking the __eq__ check. 

This for example happens with the URL dependency, where the package version in only known after downloading which leads to the following:

1. we check if the dependency is in the cache using the URLDependency as the key
2. we download the package
3. we check the package version from the downloaded file
4. we update the version in the dependency object
5. we store the package into the cache using the updated dependency object

This is shown in the code snippet below:
```python
if dependency in self._deferred_cache:
    return [self._deferred_cache[dependency]]

package = self.get_package_from_url(dependency.url)

self.validate_package_for_dependency(dependency=dependency, package=package)

# truncated irrelevant stuff for this example

dependency._constraint = package.version
dependency._pretty_constraint = package.version.text

self._deferred_cache[dependency] = package
```

When searching for this dependency again we check the cache dictionary with a new URLDependency as a key, which has not been updated with the version number yet. We have missed the cache.

Adding the package to the cache before updating the dependency object is not an elegant solution in my opinion because that would make a package search with the updated dependency object miss the cache.

This pull request solves the problem by using the hashes of the Dependency objects as keys in the cache dictionary. The currently implemented __hash__ methods already uniquely describe the package they download. (For example the URLDependency hash is made up of the url and package name; the VCS cache hash is made up of the package name, repository, branch, tag, and revision).

Another approach would have been to re-implement the __eq__ method but I think this is also the wrong approach, because an URL dependency with an unbounded version is different than a URL dependency with a set version.
