### PR TITLE
remove a lot of casts

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -14,7 +14,6 @@ from cleo.events.console_events import COMMAND
 from cleo.events.event_dispatcher import EventDispatcher
 from cleo.exceptions import CleoException
 from cleo.formatters.style import Style
-from cleo.io.inputs.argv_input import ArgvInput
 from cleo.io.null_io import NullIO
 
 from poetry.__version__ import __version__
@@ -26,6 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from cleo.events.console_command_event import ConsoleCommandEvent
+    from cleo.io.inputs.argv_input import ArgvInput
     from cleo.io.inputs.definition import Definition
     from cleo.io.inputs.input import Input
     from cleo.io.io import IO
@@ -199,7 +199,7 @@ class Application(BaseApplication):  # type: ignore[misc]
         if name == "run":
             from poetry.console.io.inputs.run_argv_input import RunArgvInput
 
-            input = cast(ArgvInput, io.input)
+            input = cast("ArgvInput", io.input)
             run_input = RunArgvInput([self._name or ""] + input._tokens)
             # For the run command reset the definition
             # with only the set options (i.e. the options given before the command)
@@ -280,7 +280,7 @@ class Application(BaseApplication):  # type: ignore[misc]
     ) -> None:
         from poetry.console.commands.env_command import EnvCommand
 
-        command: EnvCommand = cast(EnvCommand, event.command)
+        command = event.command
         if not isinstance(command, EnvCommand):
             return
 
@@ -306,7 +306,7 @@ class Application(BaseApplication):  # type: ignore[misc]
     ) -> None:
         from poetry.console.commands.installer_command import InstallerCommand
 
-        command: InstallerCommand = cast(InstallerCommand, event.command)
+        command = event.command
         if not isinstance(command, InstallerCommand):
             return
 

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 
 from typing import Any
-from typing import cast
 
 from cleo.helpers import argument
 from cleo.helpers import option
@@ -250,7 +249,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
         if self.option("lock"):
             self._installer.lock()
 
-        self._installer.whitelist([cast(str, r["name"]) for r in requirements])
+        self._installer.whitelist([r["name"] for r in requirements])
 
         status = self._installer.run()
 

--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from typing import cast
-
 from cleo.helpers import argument
 from cleo.helpers import option
 from cleo.io.inputs.string_input import StringInput
 from cleo.io.io import IO
 
-from poetry.console.application import Application
 from poetry.console.commands.init import InitCommand
 from poetry.console.commands.self.add import SelfAddCommand
 
@@ -48,8 +45,8 @@ It works similarly to the <c1>add</c1> command:
     def handle(self) -> int:
         self.line_error(self.deprecation)
 
-        application = cast(Application, self.application)
-        command: SelfAddCommand = cast(SelfAddCommand, application.find("self add"))
+        application = self.get_application()
+        command: SelfAddCommand = application.find("self add")
         application.configure_installer_for_command(command, self.io)
 
         argv: list[str] = ["add", *self.argument("plugins")]

--- a/src/poetry/console/commands/plugin/remove.py
+++ b/src/poetry/console/commands/plugin/remove.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING
 
 from cleo.helpers import argument
 from cleo.helpers import option
 from cleo.io.inputs.string_input import StringInput
 from cleo.io.io import IO
 
-from poetry.console.application import Application
 from poetry.console.commands.command import Command
-from poetry.console.commands.self.remove import SelfRemoveCommand
+
+
+if TYPE_CHECKING:
+    from poetry.console.commands.self.remove import SelfRemoveCommand
 
 
 class PluginRemoveCommand(Command):
@@ -41,10 +43,8 @@ class PluginRemoveCommand(Command):
     def handle(self) -> int:
         self.line_error(self.help)
 
-        application = cast(Application, self.application)
-        command: SelfRemoveCommand = cast(
-            SelfRemoveCommand, application.find("self remove")
-        )
+        application = self.get_application()
+        command: SelfRemoveCommand = application.find("self remove")
         application.configure_installer_for_command(command, self.io)
 
         argv: list[str] = ["remove", *self.argument("plugins")]

--- a/src/poetry/console/commands/plugin/show.py
+++ b/src/poetry/console/commands/plugin/show.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING
 
 from cleo.io.inputs.string_input import StringInput
 from cleo.io.io import IO
 
-from poetry.console.application import Application
 from poetry.console.commands.command import Command
-from poetry.console.commands.self.show.plugins import SelfShowPluginsCommand
+
+
+if TYPE_CHECKING:
+    from poetry.console.commands.self.show.plugins import SelfShowPluginsCommand
 
 
 class PluginShowCommand(Command):
@@ -24,10 +26,8 @@ class PluginShowCommand(Command):
     def handle(self) -> int:
         self.line_error(self.help)
 
-        application = cast(Application, self.application)
-        command: SelfShowPluginsCommand = cast(
-            SelfShowPluginsCommand, application.find("self show plugins")
-        )
+        application = self.get_application()
+        command: SelfShowPluginsCommand = application.find("self show plugins")
 
         exit_code: int = command.run(
             IO(

--- a/src/poetry/console/commands/self/self_command.py
+++ b/src/poetry/console/commands/self/self_command.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import cast
 
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.project_package import ProjectPackage
@@ -11,13 +10,13 @@ from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.__version__ import __version__
 from poetry.console.commands.installer_command import InstallerCommand
 from poetry.factory import Factory
-from poetry.poetry import Poetry
 from poetry.utils.env import EnvManager
 from poetry.utils.env import SystemEnv
 from poetry.utils.helpers import directory
 
 
 if TYPE_CHECKING:
+    from poetry.poetry import Poetry
     from poetry.utils.env import Env
 
 
@@ -90,7 +89,9 @@ class SelfCommand(InstallerCommand):
     def poetry(self) -> Poetry:
         if self._poetry is None:
             self.reset_poetry()
-        return cast(Poetry, self._poetry)
+
+        assert self._poetry is not None
+        return self._poetry
 
     def _system_project_handle(self) -> int:
         """
@@ -102,7 +103,8 @@ class SelfCommand(InstallerCommand):
         The default implementations handles cases where a `self` command delegates
         handling to an existing command. Eg: `SelfAddCommand(SelfCommand, AddCommand)`.
         """
-        return cast(int, super().handle())
+        return_code: int = super().handle()
+        return return_code
 
     def reset(self) -> None:
         """

--- a/src/poetry/console/commands/self/update.py
+++ b/src/poetry/console/commands/self/update.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING
 
 from cleo.helpers import argument
 from cleo.helpers import option
 from cleo.io.inputs.string_input import StringInput
 from cleo.io.io import IO
 
-from poetry.console.application import Application
-from poetry.console.commands.add import AddCommand
 from poetry.console.commands.self.self_command import SelfCommand
+
+
+if TYPE_CHECKING:
+    from poetry.console.commands.add import AddCommand
 
 
 class SelfUpdateCommand(SelfCommand):
@@ -37,8 +39,8 @@ environment.
 
     def _system_project_handle(self) -> int:
         self.write("<info>Updating Poetry version ...</info>\n\n")
-        application = cast(Application, self.application)
-        add_command: AddCommand = cast(AddCommand, application.find("add"))
+        application = self.get_application()
+        add_command: AddCommand = application.find("add")
         add_command.set_env(self.env)
         application.configure_installer_for_command(add_command, self.io)
 

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -14,7 +14,6 @@ from poetry.core.factory import Factory as BaseFactory
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.toml.file import TOMLFile
-from tomlkit.toml_document import TOMLDocument
 
 from poetry.config.config import Config
 from poetry.json import validate_object
@@ -29,6 +28,7 @@ if TYPE_CHECKING:
 
     from cleo.io.io import IO
     from poetry.core.packages.package import Package
+    from tomlkit.toml_document import TOMLDocument
 
     from poetry.repositories.legacy_repository import LegacyRepository
     from poetry.utils.dependency_specification import DependencySpec
@@ -293,7 +293,7 @@ class Factory(BaseFactory):
         if extras_section:
             content["extras"] = extras_section
 
-        pyproject = cast(TOMLDocument, pyproject)
+        pyproject = cast("TOMLDocument", pyproject)
         pyproject.add(tomlkit.nl())
 
         if path:

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -11,7 +11,6 @@ import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import cast
 
 import pkginfo
 
@@ -171,12 +170,17 @@ class PackageInfo:
         package.python_versions = self.requires_python or "*"
         package.files = self.files
 
-        if root_dir or (self._source_type in {"directory"} and self._source_url):
-            # this is a local poetry project, this means we can extract "richer"
-            # requirement information, eg: development requirements etc.
-            poetry_package = self._get_poetry_package(
-                path=root_dir or Path(cast(str, self._source_url))
-            )
+        # If this is a local poetry project, we can extract "richer" requirement
+        # information, eg: development requirements etc.
+        if root_dir is not None:
+            path = root_dir
+        elif self._source_type == "directory" and self._source_url is not None:
+            path = Path(self._source_url)
+        else:
+            path = None
+
+        if path is not None:
+            poetry_package = self._get_poetry_package(path=path)
             if poetry_package:
                 package.extras = poetry_package.extras
                 for dependency in poetry_package.requires:

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -13,11 +13,7 @@ from typing import Any
 from typing import cast
 
 from poetry.core.packages.dependency import Dependency
-from poetry.core.packages.directory_dependency import DirectoryDependency
-from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.package import Package
-from poetry.core.packages.url_dependency import URLDependency
-from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version import Version
 from poetry.core.toml.file import TOMLFile
@@ -30,7 +26,6 @@ from tomlkit import item
 from tomlkit import table
 from tomlkit.exceptions import TOMLKitError
 from tomlkit.items import Array
-from tomlkit.items import Table
 
 from poetry.packages import DependencyPackage
 from poetry.utils.extras import get_extra_package_names
@@ -41,7 +36,12 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from collections.abc import Sequence
 
+    from poetry.core.packages.directory_dependency import DirectoryDependency
+    from poetry.core.packages.file_dependency import FileDependency
+    from poetry.core.packages.url_dependency import URLDependency
+    from poetry.core.packages.vcs_dependency import VCSDependency
     from poetry.core.version.markers import BaseMarker
+    from tomlkit.items import Table
     from tomlkit.toml_document import TOMLDocument
 
     from poetry.repositories import Repository
@@ -455,7 +455,7 @@ class Locker:
         except TOMLKitError as e:
             raise RuntimeError(f"Unable to read the lock file ({e}).")
 
-        metadata = cast(Table, lock_data["metadata"])
+        metadata = cast("Table", lock_data["metadata"])
         lock_version = Version.parse(metadata.get("lock-version", "1.0"))
         current_version = Version.parse(self._VERSION)
         # We expect the locker to be able to read lock files
@@ -513,22 +513,22 @@ class Locker:
             constraint = inline_table()
 
             if dependency.is_directory():
-                dependency = cast(DirectoryDependency, dependency)
+                dependency = cast("DirectoryDependency", dependency)
                 constraint["path"] = dependency.path.as_posix()
 
                 if dependency.develop:
                     constraint["develop"] = True
 
             elif dependency.is_file():
-                dependency = cast(FileDependency, dependency)
+                dependency = cast("FileDependency", dependency)
                 constraint["path"] = dependency.path.as_posix()
 
             elif dependency.is_url():
-                dependency = cast(URLDependency, dependency)
+                dependency = cast("URLDependency", dependency)
                 constraint["url"] = dependency.url
 
             elif dependency.is_vcs():
-                dependency = cast(VCSDependency, dependency)
+                dependency = cast("VCSDependency", dependency)
                 constraint[dependency.vcs] = dependency.source
 
                 if dependency.branch:

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -15,11 +15,7 @@ from typing import TYPE_CHECKING
 from typing import cast
 
 from cleo.ui.progress_indicator import ProgressIndicator
-from poetry.core.packages.directory_dependency import DirectoryDependency
-from poetry.core.packages.file_dependency import FileDependency
-from poetry.core.packages.url_dependency import URLDependency
 from poetry.core.packages.utils.utils import get_python_constraint_from_marker
-from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.semver.empty_constraint import EmptyConstraint
 from poetry.core.semver.version import Version
 from poetry.core.version.markers import AnyMarker
@@ -47,8 +43,12 @@ if TYPE_CHECKING:
 
     from cleo.io.io import IO
     from poetry.core.packages.dependency import Dependency
+    from poetry.core.packages.directory_dependency import DirectoryDependency
+    from poetry.core.packages.file_dependency import FileDependency
     from poetry.core.packages.package import Package
     from poetry.core.packages.specification import PackageSpecification
+    from poetry.core.packages.url_dependency import URLDependency
+    from poetry.core.packages.vcs_dependency import VCSDependency
     from poetry.core.semver.version_constraint import VersionConstraint
     from poetry.core.version.markers import BaseMarker
 
@@ -227,19 +227,19 @@ class Provider:
             pass
 
         elif dependency.is_vcs():
-            dependency = cast(VCSDependency, dependency)
+            dependency = cast("VCSDependency", dependency)
             package = self._search_for_vcs(dependency)
 
         elif dependency.is_file():
-            dependency = cast(FileDependency, dependency)
+            dependency = cast("FileDependency", dependency)
             package = self._search_for_file(dependency)
 
         elif dependency.is_directory():
-            dependency = cast(DirectoryDependency, dependency)
+            dependency = cast("DirectoryDependency", dependency)
             package = self._search_for_directory(dependency)
 
         elif dependency.is_url():
-            dependency = cast(URLDependency, dependency)
+            dependency = cast("URLDependency", dependency)
             package = self._search_for_url(dependency)
 
         else:


### PR DESCRIPTION
I reckon `cast` should be the last resort when appeasing the typechecker, mostly because it leaves you in a bad place for refactoring: once a `cast` is in the codebase it's all too easy to do some refactoring such that it's no longer true, but nothing can tell you so.

So I've gone and looked for places where `cast` can sensibly be removed altogether, or - in a couple of places - replaced by assertions.

I've also realised that if you `cast("Foo", foo)` instead of `cast(Foo, foo)` then you only need to import `Foo` during typechecking, which should be a small win.