### PR TITLE
fix: fix venv paths redirected by Python from MS Store

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -36,10 +36,12 @@ from poetry.core.toml.file import TOMLFile
 from poetry.core.utils.helpers import temporary_directory
 from virtualenv.seed.wheels.embed import get_embed_wheel
 
+from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import decode
 from poetry.utils._compat import encode
 from poetry.utils._compat import list_to_shell_command
 from poetry.utils._compat import metadata
+from poetry.utils.helpers import get_real_windows_path
 from poetry.utils.helpers import is_dir_writable
 from poetry.utils.helpers import paths_csv
 from poetry.utils.helpers import remove_directory
@@ -960,7 +962,10 @@ class EnvManager:
 
                 return self.get_system_env()
 
-            io.write_line(f"Creating virtualenv <c1>{name}</> in {venv_path!s}")
+            io.write_line(
+                f"Creating virtualenv <c1>{name}</> in"
+                f" {venv_path if not WINDOWS else get_real_windows_path(venv_path)!s}"
+            )
         else:
             create_venv = False
             if force:
@@ -1012,6 +1017,10 @@ class EnvManager:
         with_setuptools: bool | None = None,
         prompt: str | None = None,
     ) -> virtualenv.run.session.Session:
+        if WINDOWS:
+            path = get_real_windows_path(path)
+            executable = get_real_windows_path(executable) if executable else None
+
         flags = flags or {}
 
         flags["no-pip"] = (
@@ -1152,6 +1161,10 @@ class Env:
         self._is_windows = sys.platform == "win32"
         self._is_mingw = sysconfig.get_platform().startswith("mingw")
         self._is_conda = bool(os.environ.get("CONDA_DEFAULT_ENV"))
+
+        if self._is_windows:
+            path = get_real_windows_path(path)
+            base = get_real_windows_path(base) if base else None
 
         if not self._is_windows or self._is_mingw:
             bin_dir = "bin"

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -240,3 +240,20 @@ def get_win_folder(csidl_name: str) -> Path:
         return Path(_get_win_folder(csidl_name))
 
     raise RuntimeError("Method can only be called on Windows.")
+
+
+def get_real_windows_path(path: str | Path) -> Path:
+    program_files = get_win_folder("CSIDL_PROGRAM_FILES")
+    local_appdata = get_win_folder("CSIDL_LOCAL_APPDATA")
+
+    path = Path(
+        str(path).replace(
+            str(program_files / "WindowsApps"),
+            str(local_appdata / "Microsoft/WindowsApps"),
+        )
+    )
+
+    if path.as_posix().startswith(local_appdata.as_posix()):
+        path = path.resolve()
+
+    return path

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import stat
+import sys
 import tempfile
 
 from contextlib import contextmanager
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
 from typing import Mapping
+from typing import cast
 
 from poetry.utils.constants import REQUESTS_TIMEOUT
 
@@ -171,3 +173,70 @@ def safe_extra(extra: str) -> str:
     https://github.com/pypa/setuptools/blob/452e13c/pkg_resources/__init__.py#L1423-L1431.
     """
     return re.sub("[^A-Za-z0-9.-]+", "_", extra).lower()
+
+
+def _get_win_folder_from_registry(csidl_name: str) -> str:
+    if sys.platform != "win32":
+        raise RuntimeError("Method can only be called on Windows.")
+
+    import winreg as _winreg
+
+    shell_folder_name = {
+        "CSIDL_APPDATA": "AppData",
+        "CSIDL_COMMON_APPDATA": "Common AppData",
+        "CSIDL_LOCAL_APPDATA": "Local AppData",
+        "CSIDL_PROGRAM_FILES": "Program Files",
+    }[csidl_name]
+
+    key = _winreg.OpenKey(
+        _winreg.HKEY_CURRENT_USER,
+        r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",
+    )
+    dir, type = _winreg.QueryValueEx(key, shell_folder_name)
+
+    return cast(str, dir)
+
+
+def _get_win_folder_with_ctypes(csidl_name: str) -> str:
+    if sys.platform != "win32":
+        raise RuntimeError("Method can only be called on Windows.")
+
+    import ctypes
+
+    csidl_const = {
+        "CSIDL_APPDATA": 26,
+        "CSIDL_COMMON_APPDATA": 35,
+        "CSIDL_LOCAL_APPDATA": 28,
+        "CSIDL_PROGRAM_FILES": 38,
+    }[csidl_name]
+
+    buf = ctypes.create_unicode_buffer(1024)
+    ctypes.windll.shell32.SHGetFolderPathW(None, csidl_const, None, 0, buf)
+
+    # Downgrade to short path name if have highbit chars. See
+    # <http://bugs.activestate.com/show_bug.cgi?id=85099>.
+    has_high_char = False
+    for c in buf:
+        if ord(c) > 255:
+            has_high_char = True
+            break
+    if has_high_char:
+        buf2 = ctypes.create_unicode_buffer(1024)
+        if ctypes.windll.kernel32.GetShortPathNameW(buf.value, buf2, 1024):
+            buf = buf2
+
+    return buf.value
+
+
+def get_win_folder(csidl_name: str) -> Path:
+    if sys.platform == "win32":
+        try:
+            from ctypes import windll  # noqa: F401
+
+            _get_win_folder = _get_win_folder_with_ctypes
+        except ImportError:
+            _get_win_folder = _get_win_folder_from_registry
+
+        return Path(_get_win_folder(csidl_name))
+
+    raise RuntimeError("Method can only be called on Windows.")


### PR DESCRIPTION
Running Poetry with Python installed from the Microsoft Store have to tackle multiple issues.

The system's Python interpreter is located at something like `C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0`. But the user is not allowed to run any executable from there. Instead one should use the binaries locates at `C:\Users\username\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\`.

Another problem us, that applications from the Microsoft Store are not allowed to write directly into `%LocalAppdata%`, instead any attempt to do this is redirected to a sandbox folder located at `C:\Users\username\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0`.

The first problem described above is an issue, when trying to find the interpreter, that should be used for creating a new venv. This can be solved by replacing the `%ProgramFiles%` part of the path by `%LocalAppdata/Microsoft%`.

The second problem described above is an issue, when a new venv should be created at the default location under `C:\Users\klare\AppData\Local\pypoetry\Cache\virtualenvs`. Fortunately when one try to access this place during runtime, the `Path` object is a symlink that can be resolved and than be passed to the subprocess call that creates the venv.

This `install-poetry.py` script is affected by the same problems. A possible fix is prepared at https://github.com/python-poetry/install.python-poetry.org/pull/18

Resolves: #5331