### PR TITLE
avoid private tomlkit method

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -126,9 +126,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
             section = poetry_content["dependencies"]
         else:
             if "group" not in poetry_content:
-                poetry_content.value._insert_after(
-                    "dependencies", "group", table(is_super_table=True)
-                )
+                poetry_content["group"] = table(is_super_table=True)
 
             groups = poetry_content["group"]
             if group not in groups:

--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -67,9 +67,7 @@ baz = "^1.0.0"
 """
     )
     content["tool"]["poetry"]["dependencies"]["foo"] = "^2.0.0"
-    content["tool"]["poetry"].value._insert_after(
-        "dependencies", "group", groups_content["tool"]["poetry"]["group"]
-    )
+    content["tool"]["poetry"]["group"] = groups_content["tool"]["poetry"]["group"]
     app.poetry.file.write(content)
 
     app.poetry.package.add_dependency(Factory.create_dependency("foo", "^2.0.0"))
@@ -122,9 +120,7 @@ baz = "^1.0.0"
 """
     )
     content["tool"]["poetry"]["dependencies"]["foo"] = "^2.0.0"
-    content["tool"]["poetry"].value._insert_after(
-        "dependencies", "group", groups_content["tool"]["poetry"]["group"]
-    )
+    content["tool"]["poetry"]["group"] = groups_content["tool"]["poetry"]["group"]
     app.poetry.file.write(content)
 
     app.poetry.package.add_dependency(Factory.create_dependency("foo", "^2.0.0"))
@@ -177,9 +173,7 @@ baz = "^1.0.0"
 """
     )
     content["tool"]["poetry"]["dependencies"]["foo"] = "^2.0.0"
-    content["tool"]["poetry"].value._insert_after(
-        "dependencies", "group", groups_content["tool"]["poetry"]["group"]
-    )
+    content["tool"]["poetry"]["group"] = groups_content["tool"]["poetry"]["group"]
     app.poetry.file.write(content)
 
     app.poetry.package.add_dependency(Factory.create_dependency("foo", "^2.0.0"))


### PR DESCRIPTION
Fixes #4718

I don't know why the code was using the private method `_insert_after()`, in only this one place.  So far as I can see it's unnecessary; but tomlkit remains quite the mystery to me.

Following the repro of https://github.com/python-poetry/poetry/issues/4718#issuecomment-998955431, we now successfully achieve a pyproject.toml structured as follows:

```toml
[tool.poetry]
name = "foo"
and = "so on"

[tool.poetry.dependencies]
python = "^3.10"

[tool.poetry.group.dev.dependencies]
pytest = "^7.1.2"

[build-system]
requires = ["poetry-core"]
build-backend = "poetry.core.masonry.api"

[tool.poetry.plugins]
```

which has put the new entry in a sensible place anyway, so that's good.

Not sure how to write a test for this or that it's even worthwhile.  This branch is covered in existing tests so not breaking them is a strong start, the new code is much more obvious than the old code was, I feel that a new testcase would be testing tomlkit more than it would be testing poetry.