### PR TITLE
Mention `install.python-poetry.org` in `get-poetry.py` deprecation message

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -472,7 +472,9 @@ class Installer:
                 "warning",
                 "This installer is deprecated. Poetry versions installed using this"
                 " script will not be able to use 'self update' command to upgrade to"
-                " 1.2.0a1 or later.",
+                " 1.2.0a1 or later. It is recommended to use"
+                " https://install.python-poetry.org instead. Instructions are"
+                " available at https://python-poetry.org/docs/#installation",
             )
         )
 


### PR DESCRIPTION
# Pull Request Check List

- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Companion PR of https://github.com/python-poetry/poetry/pull/5944.

This PR updates `get-poetry.py` deprecation message to more clearly indicate what should be used instead.
In combination with https://github.com/python-poetry/poetry/pull/5944, it would also link to proper installation instructions (since both `1.1` and the next `1.2` would use the new installer in installation instructions).