### PR TITLE
tests: make tests forward compatible for tomlkit fix for consistent line endings

### DIFF
--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -870,8 +870,14 @@ Package operations: 1 install, 0 updates, 0 removals
 cachy = "^0.2.0"
 
 """
+    # At the moment line endings will be inconsistent on Windows.
+    # See https://github.com/sdispater/tomlkit/issues/200 for details.
+    # https://github.com/sdispater/tomlkit/pull/201 fixes this issue
+    # In order to make tests forward compatible for tomlkit downstream tests,
+    # we replace "\r\n" with "\n" for now.
+    string_content = content.as_string().replace("\r\n", "\n")
 
-    assert expected in content.as_string()
+    assert expected in string_content
 
 
 def test_add_to_dev_section_deprecated(

--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -93,8 +93,14 @@ baz = "^1.0.0"
 baz = "^1.0.0"
 
 """
+    # At the moment line endings will be inconsistent on Windows.
+    # See https://github.com/sdispater/tomlkit/issues/200 for details.
+    # https://github.com/sdispater/tomlkit/pull/201 fixes this issue
+    # In order to make tests forward compatible for tomlkit downstream tests,
+    # we replace "\r\n" with "\n" for now.
+    string_content = content.as_string().replace("\r\n", "\n")
 
-    assert expected in content.as_string()
+    assert expected in string_content
 
 
 def test_remove_without_specific_group_removes_from_specific_groups(
@@ -148,8 +154,14 @@ baz = "^1.0.0"
 baz = "^1.0.0"
 
 """
+    # At the moment line endings will be inconsistent on Windows.
+    # See https://github.com/sdispater/tomlkit/issues/200 for details.
+    # https://github.com/sdispater/tomlkit/pull/201 fixes this issue
+    # In order to make tests forward compatible for tomlkit downstream tests,
+    # we replace "\r\n" with "\n" for now.
+    string_content = content.as_string().replace("\r\n", "\n")
 
-    assert expected in content.as_string()
+    assert expected in string_content
 
 
 def test_remove_does_not_live_empty_groups(
@@ -251,8 +263,14 @@ baz = "^1.0.0"
 baz = "^1.0.0"
 
 """
+    # At the moment line endings will be inconsistent on Windows.
+    # See https://github.com/sdispater/tomlkit/issues/200 for details.
+    # https://github.com/sdispater/tomlkit/pull/201 fixes this issue
+    # In order to make tests forward compatible for tomlkit downstream tests,
+    # we replace "\r\n" with "\n" for now.
+    string_content = content.as_string().replace("\r\n", "\n")
 
-    assert expected in content.as_string()
+    assert expected in string_content
 
 
 def test_remove_command_should_not_write_changes_upon_installer_errors(


### PR DESCRIPTION
Required for tomlkit downstream tests: sdispater/tomlkit#201