### PR TITLE
[1.1] Recommend usage of `install.python-poetry.org` instead of `install-poetry.py`

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -33,7 +33,7 @@ from the rest of your system by vendorizing its dependencies. This is the
 recommended way of installing `poetry`.
 
 {{% warning %}}
-The `get-poetry.py` script described here will be replaced in Poetry 1.2 by `install-poetry.py`.
+The `get-poetry.py` script described here will be replaced in Poetry 1.2 by `install.python-poetry.org`.
 From Poetry **1.1.7 onwards**, you can already use this script as described [here]({{< relref "docs/master/#installation" >}}).
 {{% /warning %}}
 


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Documentation is a bit confusing because `1.1` one recommends `install-poetry.py` instead of `get-poetry.py`, but `master` documentation recommends `install.python-poetry.org` (and even deprecates usage of `install-poetry.py`).

`1.1`:
![Screenshot from 2022-07-13 19-50-15](https://user-images.githubusercontent.com/5970971/178799347-167ceba4-7a08-45a1-b4ec-f781979f4b0e.png)

`master`:
![Screenshot from 2022-07-13 19-51-29](https://user-images.githubusercontent.com/5970971/178799411-95e2a820-3d8e-4913-8ed3-0d5911d77f94.png)

So recommending `install.python-poetry.org` in `1.1` documentation should make things less confusing.