### PR TITLE
Post `1.2.0b3` release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -887,7 +887,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9f6938a60e25fe99bbed6db53e34edac39379a93fb12468c527706fc740bd4f2"
+content-hash = "f7433da9d05dd21eb937d8f67e8324ae24cd85ad5655b421f636b648fae6b3a6"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry"
-version = "1.2.0b3"
+version = "1.2.0rc1.dev0"
 description = "Python dependency management and packaging made easy."
 authors = [
     "Sébastien Eustace <sebastien@eustace.io>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ generate-setup-file = false
 [tool.poetry.dependencies]
 python = "^3.7"
 
-poetry-core = "1.1.0b3"
+poetry-core = "^1.1.0b3"
 poetry-plugin-export = "^1.0.5"
 cachecontrol = { version = "^0.12.9", extras = ["filecache"] }
 cachy = "^0.3.0"


### PR DESCRIPTION
Now that [1.2.0b3](https://github.com/python-poetry/poetry/releases/tag/1.2.0b3) is out, unpinning `poetry-core` and bumping version for future release.