### PR TITLE
disambiguate direct-origin dependencies in show-outdated

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -505,7 +505,7 @@ lists all packages available."""
             requires = root.all_requires
 
             for dep in requires:
-                if dep.name == package.name:
+                if dep.name == package.name and dep.source_type == package.source_type:
                     provider = Provider(root, self.poetry.pool, NullIO())
                     return provider.search_for_direct_origin_dependency(dep)
 

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -243,7 +243,7 @@ class Provider:
 
         else:
             raise RuntimeError(
-                f"Unknown direct dependency type {dependency.source_type}"
+                f"{dependency}: unknown direct dependency type {dependency.source_type}"
             )
 
         if dependency.is_vcs():


### PR DESCRIPTION
if you have, say:
```toml
[tool.poetry.dependencies]
poetry = "^1.2.0b3"

[tool.poetry.dev-dependencies]
poetry = {git = "https://github.com/python-poetry/poetry.git"}
```
and go `poetry show --outdated` then you hit the runtime error `Unknown direct dependency type None`.

The reason is that poetry appears twice, once as a direct dependency and once not.  And we happen to search for the direct dependency using the one that isn't, if you see what I mean.

This MR also improves the error message by saying which package is the problematic one.