### PR TITLE
use packaging.utils.canonicalize_name()

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 
+from packaging.utils import canonicalize_name
 from poetry.core.toml import TOMLFile
-from poetry.core.utils.helpers import canonicalize_name
 
 from poetry.config.dict_config_source import DictConfigSource
 from poetry.config.file_config_source import FileConfigSource

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -6,12 +6,12 @@ from typing import Any
 
 from cleo.helpers import argument
 from cleo.helpers import option
+from packaging.utils import canonicalize_name
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from tomlkit.toml_document import TOMLDocument
 
 from poetry.console.commands.init import InitCommand
 from poetry.console.commands.installer_command import InstallerCommand
-from poetry.utils.helpers import canonicalize_name
 
 
 class AddCommand(InstallerCommand, InitCommand):

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -10,12 +10,12 @@ from typing import Mapping
 from typing import Union
 
 from cleo.helpers import option
+from packaging.utils import canonicalize_name
 from tomlkit import inline_table
 
 from poetry.console.commands.command import Command
 from poetry.console.commands.env_command import EnvCommand
 from poetry.utils.dependency_specification import parse_dependency_specification
-from poetry.utils.helpers import canonicalize_name
 
 
 if TYPE_CHECKING:

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -4,11 +4,11 @@ from typing import Any
 
 from cleo.helpers import argument
 from cleo.helpers import option
+from packaging.utils import canonicalize_name
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from tomlkit.toml_document import TOMLDocument
 
 from poetry.console.commands.installer_command import InstallerCommand
-from poetry.utils.helpers import canonicalize_name
 
 
 class RemoveCommand(InstallerCommand):

--- a/src/poetry/console/commands/self/show/plugins.py
+++ b/src/poetry/console/commands/self/show/plugins.py
@@ -49,12 +49,13 @@ commands respectively.
 """
 
     def _system_project_handle(self) -> int:
+        from packaging.utils import canonicalize_name
+
         from poetry.plugins.application_plugin import ApplicationPlugin
         from poetry.plugins.plugin import Plugin
         from poetry.plugins.plugin_manager import PluginManager
         from poetry.repositories.installed_repository import InstalledRepository
         from poetry.utils.env import EnvManager
-        from poetry.utils.helpers import canonicalize_name
         from poetry.utils.helpers import pluralize
 
         plugins: dict[str, PluginPackage] = {}

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING
 
 from cleo.helpers import argument
 from cleo.helpers import option
+from packaging.utils import canonicalize_name
 
 from poetry.console.commands.group_command import GroupCommand
-from poetry.utils.helpers import canonicalize_name
 
 
 if TYPE_CHECKING:

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cleo.io.null_io import NullIO
+from packaging.utils import canonicalize_name
 
 from poetry.installation.executor import Executor
 from poetry.installation.operations import Install
@@ -14,7 +15,6 @@ from poetry.repositories import Repository
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.repositories.lockfile_repository import LockfileRepository
 from poetry.utils.extras import get_extra_package_names
-from poetry.utils.helpers import canonicalize_name
 from poetry.utils.helpers import pluralize
 
 

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -4,14 +4,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 
+from packaging.utils import canonicalize_name
 from poetry.core.pyproject.toml import PyProjectTOML
+from poetry.core.utils.helpers import module_name
 from tomlkit import inline_table
 from tomlkit import loads
 from tomlkit import table
 from tomlkit.toml_document import TOMLDocument
-
-from poetry.utils.helpers import canonicalize_name
-from poetry.utils.helpers import module_name
 
 
 if TYPE_CHECKING:
@@ -52,9 +51,9 @@ class Layout:
         dependencies: dict[str, str | Mapping[str, Any]] | None = None,
         dev_dependencies: dict[str, str | Mapping[str, Any]] | None = None,
     ) -> None:
-        self._project = canonicalize_name(project).replace(".", "-")
+        self._project = canonicalize_name(project)
         self._package_path_relative = Path(
-            *(module_name(part) for part in canonicalize_name(project).split("."))
+            *(module_name(part) for part in project.split("."))
         )
         self._package_name = ".".join(self._package_path_relative.parts)
         self._version = version

--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -7,9 +7,9 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from packaging.utils import canonicalize_name
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.utils import url_to_path
-from poetry.core.utils.helpers import canonicalize_name
 from poetry.core.utils.helpers import module_name
 
 from poetry.repositories.repository import Repository

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
+from packaging.utils import canonicalize_name
 from poetry.core.packages.package import Package
 from poetry.core.semver.version import Version
 
@@ -10,7 +11,6 @@ from poetry.inspection.info import PackageInfo
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.http import HTTPRepository
 from poetry.repositories.link_sources.html import SimpleRepositoryPage
-from poetry.utils.helpers import canonicalize_name
 
 
 if TYPE_CHECKING:

--- a/src/poetry/repositories/link_sources/base.py
+++ b/src/poetry/repositories/link_sources/base.py
@@ -6,10 +6,10 @@ import re
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
+from packaging.utils import canonicalize_name
 from poetry.core.packages.package import Package
 from poetry.core.semver.version import Version
 
-from poetry.utils.helpers import canonicalize_name
 from poetry.utils.patterns import sdist_file_re
 from poetry.utils.patterns import wheel_file_re
 
@@ -69,7 +69,9 @@ class LinkSource:
 
     @classmethod
     def link_package_data(cls, link: Link) -> Package | None:
-        name, version_string, version = None, None, None
+        name: str | None = None
+        version_string: str | None = None
+        version: Version | None = None
         m = wheel_file_re.match(link.filename) or sdist_file_re.match(link.filename)
 
         if m:

--- a/src/poetry/utils/extras.py
+++ b/src/poetry/utils/extras.py
@@ -25,7 +25,7 @@ def get_extra_package_names(
         in the `extras` section of `poetry.lock`.
     :param extra_names: A list of strings specifying names of extra groups to resolve.
     """
-    from poetry.utils.helpers import canonicalize_name
+    from packaging.utils import canonicalize_name
 
     if not extra_names:
         return []

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -27,17 +27,6 @@ if TYPE_CHECKING:
     from poetry.utils.authenticator import Authenticator
 
 
-_canonicalize_regex = re.compile("[-_]+")
-
-
-def canonicalize_name(name: str) -> str:
-    return _canonicalize_regex.sub("-", name).lower()
-
-
-def module_name(name: str) -> str:
-    return canonicalize_name(name).replace(".", "_").replace("-", "_")
-
-
 @contextmanager
 def directory(path: Path) -> Iterator[Path]:
     cwd = Path.cwd()

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -10,11 +10,11 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.testers.command_tester import CommandTester
+from packaging.utils import canonicalize_name
 
 from poetry.console.commands.init import InitCommand
 from poetry.repositories import Pool
 from poetry.utils._compat import decode
-from poetry.utils.helpers import canonicalize_name
 from tests.helpers import PoetryTestApplication
 from tests.helpers import get_package
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import pytest
-
 from poetry.core.utils.helpers import parse_requires
 
-from poetry.utils.helpers import canonicalize_name
 from poetry.utils.helpers import safe_extra
 
 
@@ -62,22 +59,6 @@ isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e5283576
     ]
     # fmt: on
     assert result == expected
-
-
-test_canonicalize_name_cases = [
-    ("flask", "flask"),
-    ("Flask", "flask"),
-    ("FLASK", "flask"),
-    ("FlAsK", "flask"),
-    ("fLaSk57", "flask57"),
-    ("flask-57", "flask-57"),
-]
-
-
-@pytest.mark.parametrize("test, expected", test_canonicalize_name_cases)
-def test_canonicalize_name(test: str, expected: str):
-    canonicalized_name = canonicalize_name(test)
-    assert canonicalized_name == expected
 
 
 def test_safe_extra():


### PR DESCRIPTION
`poetry` currently has two different versions of `canonicalize_name()` floating around, which is slightly absurd - and what's worse, they don't even agree.

Since https://github.com/python-poetry/poetry-core/pull/328, `poetry-core` has an implementation that agrees with the implementation in `packaging` - but `poetry` has its own implementation that continues to disagree with that.  Sometimes `poetry` uses one of these, and sometimes the other.

Let's treat the version from `packaging` as the canonical `canonicalize_name()`, and get rid of _both_ of the re-implementations.

I don't know that this fixes - or breaks! - anything in particular; the unit tests don't detect a difference.  But two differing implementations is surely an accident waiting to happen.

Aside from being one-true-implementation, a potential advantage of the `packaging` version is that it returns a `NormalizedName`: which is a newtype around string, rather than a plain string.  That opens the door to future work in which the typechecker can verify that places which expect canonicalized names do indeed get them.

(Will follow up in `poetry-core`, but this one will need merging first since `poetry` sometimes uses the `poetry-core` version).