### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -173,7 +173,7 @@ def test_uninstall_git_package_nspkg_pth_cleanup(
     # this test scenario requires a real installation using the pip installer
     installer = PipInstaller(tmp_venv, NullIO(), pool)
 
-    # use a namepspace package
+    # use a namespace package
     package = Package(
         "namespace-package-one",
         "1.0.0",

--- a/tests/utils/test_extras.py
+++ b/tests/utils/test_extras.py
@@ -43,7 +43,7 @@ _PACKAGE_QUIX.add_dependency(Factory.create_dependency("baz", "*"))
             ["group0"],
             ["bar", "foo"],
         ),
-        # Selecting multpile extras should get us the union of all package names
+        # Selecting multiple extras should get us the union of all package names
         (
             [_PACKAGE_FOO, _PACKAGE_SPAM, _PACKAGE_BAR],
             {"group0": ["bar"], "group1": ["spam"]},


### PR DESCRIPTION
There are small typos in:
- tests/installation/test_pip_installer.py
- tests/utils/test_extras.py

Fixes:
- Should read `namespace` rather than `namepspace`.
- Should read `multiple` rather than `multpile`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md