### PR TITLE
Improve upload error output

### DIFF
--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -38,7 +38,8 @@ class UploadError(Exception):
     def __init__(self, error: ConnectionError | HTTPError | str) -> None:
         if isinstance(error, HTTPError):
             message = (
-                f"HTTP Error {error.response.status_code}: {error.response.reason}"
+                f"HTTP Error {error.response.status_code}: {error.response.reason} |"
+                f" {error.response.content!r}"
             )
         elif isinstance(error, ConnectionError):
             message = (

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -36,7 +36,7 @@ def test_publish_returns_non_zero_code_for_upload_errors(
 Publishing simple-project (1.2.3) to PyPI
 """
     expected_error_output = """\
-HTTP Error 400: Bad Request
+HTTP Error 400: Bad Request | b'Bad Request'
 """
 
     assert expected_output in app_tester.io.fetch_output()

--- a/tests/publishing/test_uploader.py
+++ b/tests/publishing/test_uploader.py
@@ -32,7 +32,7 @@ def test_uploader_properly_handles_400_errors(
     with pytest.raises(UploadError) as e:
         uploader.upload("https://foo.com")
 
-    assert str(e.value) == "HTTP Error 400: Bad Request"
+    assert str(e.value) == "HTTP Error 400: Bad Request | b'Bad request'"
 
 
 def test_uploader_properly_handles_403_errors(
@@ -43,7 +43,26 @@ def test_uploader_properly_handles_403_errors(
     with pytest.raises(UploadError) as e:
         uploader.upload("https://foo.com")
 
-    assert str(e.value) == "HTTP Error 403: Forbidden"
+    assert str(e.value) == "HTTP Error 403: Forbidden | b'Unauthorized'"
+
+
+def test_uploader_properly_handles_nonstandard_errors(
+    http: type[httpretty.httpretty], uploader: Uploader
+):
+    # content based off a true story.
+    # Message changed to protect the ~~innocent~~ guilty.
+    content = (
+        b'{\n "errors": [ {\n '
+        b'"status": 400,'
+        b'"message": "I cant let you do that, dave"\n'
+        b"} ]\n}"
+    )
+    http.register_uri(http.POST, "https://foo.com", status=400, body=content)
+
+    with pytest.raises(UploadError) as e:
+        uploader.upload("https://foo.com")
+
+    assert str(e.value) == f"HTTP Error 400: Bad Request | {content}"
 
 
 def test_uploader_properly_handles_301_redirects(


### PR DESCRIPTION
This PR improves the error output of `poetry publish` in the event of an upload error.
The current behavior is insufficient for debugging upload issues, especially for PyPi-like servers that don't use PyPi's code. 

This PR passes through the http content to the cli, to allow users to better debug failures without adding repository-specific special case code to poetry.

Using this, I was able to get enough information from poetry to figure out an upload error I had at work earlier today.
﻿- Improve information returned from upload errors
- Fix the tests to for new behavior, add one for this specific case

# Pull Request Check List

Resolves: #1100

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
What's the relevant documentation for this?
