### PR TITLE
Remove Python 3.11 from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - os: Ubuntu
             image: ubuntu-22.04


### PR DESCRIPTION
Python 3.11 checks fail constantly and mark CI status with the dreaded red X. This change can be easily reversed when 3.11 is released, but until then, let's save ourselves some failure notifications.