### PR TITLE
revert #5770, provide new fix

### DIFF
--- a/src/poetry/mixology/partial_solution.py
+++ b/src/poetry/mixology/partial_solution.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from poetry.mixology.assignment import Assignment
 from poetry.mixology.set_relation import SetRelation
-from poetry.mixology.term import Term
 
 
 if TYPE_CHECKING:
@@ -12,6 +11,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.package import Package
 
     from poetry.mixology.incompatibility import Incompatibility
+    from poetry.mixology.term import Term
 
 
 class PartialSolution:
@@ -146,15 +146,6 @@ class PartialSolution:
         """
         name = assignment.dependency.complete_name
         old_positive = self._positive.get(name)
-        if old_positive is None and assignment.dependency.features:
-            old_positive_without_features = self._positive.get(
-                assignment.dependency.name
-            )
-            if old_positive_without_features is not None:
-                dep = old_positive_without_features.dependency.with_features(
-                    assignment.dependency.features
-                )
-                old_positive = Term(dep, is_positive=True)
         if old_positive is not None:
             value = old_positive.intersect(assignment)
             assert value is not None

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -279,10 +279,9 @@ class Provider:
         # We rely on the VersionSolver resolving direct-origin dependencies first.
         direct_origin_package = self._direct_origin_packages.get(dependency.name)
         if direct_origin_package is not None:
-            package = direct_origin_package.with_features(dependency.features)
             packages = (
-                [package]
-                if package.satisfies(dependency, ignore_source_type=True)
+                [direct_origin_package]
+                if dependency.constraint.allows(direct_origin_package.version)
                 else []
             )
             return PackageCollection(dependency, packages)

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -7,9 +7,12 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.io.null_io import NullIO
+from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.directory_dependency import DirectoryDependency
 from poetry.core.packages.file_dependency import FileDependency
+from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
+from poetry.core.packages.url_dependency import URLDependency
 from poetry.core.packages.vcs_dependency import VCSDependency
 
 from poetry.factory import Factory
@@ -25,6 +28,9 @@ from tests.helpers import get_dependency
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+
+SOME_URL = "https://example.com/path.tar.gz"
 
 
 class MockEnv(BaseMockEnv):
@@ -53,6 +59,108 @@ def pool(repository: Repository) -> Pool:
 @pytest.fixture
 def provider(root: ProjectPackage, pool: Pool) -> Provider:
     return Provider(root, pool, NullIO())
+
+
+@pytest.mark.parametrize(
+    "dependency, expected",
+    [
+        (Dependency("foo", "<2"), [Package("foo", "1")]),
+        (Dependency("foo", "<2", extras=["bar"]), [Package("foo", "1")]),
+        (Dependency("foo", ">=1"), [Package("foo", "2"), Package("foo", "1")]),
+        (
+            Dependency("foo", ">=1a"),
+            [
+                Package("foo", "3a"),
+                Package("foo", "2"),
+                Package("foo", "2a"),
+                Package("foo", "1"),
+            ],
+        ),
+        (
+            Dependency("foo", ">=1", allows_prereleases=True),
+            [
+                Package("foo", "3a"),
+                Package("foo", "2"),
+                Package("foo", "2a"),
+                Package("foo", "1"),
+            ],
+        ),
+    ],
+)
+def test_search_for(
+    provider: Provider,
+    repository: Repository,
+    dependency: Dependency,
+    expected: list[Package],
+) -> None:
+    foo1 = Package("foo", "1")
+    foo2a = Package("foo", "2a")
+    foo2 = Package("foo", "2")
+    foo3a = Package("foo", "3a")
+    repository.add_package(foo1)
+    repository.add_package(foo2a)
+    repository.add_package(foo2)
+    repository.add_package(foo3a)
+    assert provider.search_for(dependency) == expected
+
+
+@pytest.mark.parametrize(
+    "dependency, direct_origin_dependency, expected_before, expected_after",
+    [
+        (
+            Dependency("foo", ">=1"),
+            URLDependency("foo", SOME_URL),
+            [Package("foo", "3")],
+            [Package("foo", "2a", source_type="url", source_url=SOME_URL)],
+        ),
+        (
+            Dependency("foo", ">=2"),
+            URLDependency("foo", SOME_URL),
+            [Package("foo", "3")],
+            [],
+        ),
+        (
+            Dependency("foo", ">=1", extras=["bar"]),
+            URLDependency("foo", SOME_URL),
+            [Package("foo", "3")],
+            [Package("foo", "2a", source_type="url", source_url=SOME_URL)],
+        ),
+        (
+            Dependency("foo", ">=1"),
+            URLDependency("foo", SOME_URL, extras=["baz"]),
+            [Package("foo", "3")],
+            [Package("foo", "2a", source_type="url", source_url=SOME_URL)],
+        ),
+        (
+            Dependency("foo", ">=1", extras=["bar"]),
+            URLDependency("foo", SOME_URL, extras=["baz"]),
+            [Package("foo", "3")],
+            [Package("foo", "2a", source_type="url", source_url=SOME_URL)],
+        ),
+    ],
+)
+def test_search_for_direct_origin_and_extras(
+    provider: Provider,
+    repository: Repository,
+    mocker: MockerFixture,
+    dependency: Dependency,
+    direct_origin_dependency: Dependency,
+    expected_before: list[Package],
+    expected_after: list[Package],
+) -> None:
+    foo2a_direct_origin = Package("foo", "2a", source_type="url", source_url=SOME_URL)
+    mocker.patch(
+        "poetry.puzzle.provider.Provider.search_for_direct_origin_dependency",
+        return_value=foo2a_direct_origin,
+    )
+    foo2a = Package("foo", "2a")
+    foo3 = Package("foo", "3")
+    repository.add_package(foo2a)
+    repository.add_package(foo3)
+
+    assert provider.search_for(dependency) == expected_before
+    assert provider.search_for(direct_origin_dependency) == [foo2a_direct_origin]
+    assert provider.search_for(dependency) == expected_after
 
 
 @pytest.mark.parametrize("value", [True, False])


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6054

I think that the fix made at #5770 was not good.  (I did review it at the time without seeing problems, so no blame!)

As I now understand it, the problem that it was trying to solve was:
- we register a direct-origin assignment for `foo`
- we then register a regular assignment for `foo[extras]`
- we'd like for the result to be that all `foo`-related assignments find the direct-origin package
- but that's not what happens

#5770 fixed this by finding the `foo` assignment at the second bullet, and then the intersection of a direct-origin and not-direct-origin term always favours the direct-origin.

I think this is probably unreliable: eg in the first bullet we might have registered a direct-origin assignment for `foo[other-extras]`.  Or bullets 1 and 2 might happen the other way round.

Apart from that, #6054 exposed a problem where we registered regular assignments for `foo` and `foo[extras]`, but with incompatible version ranges.  Before #5770 that was fine and is unwound later in the search, but after #5770 we try to update the `foo` assignment and go wrong.

This MR undoes the fix of #5770 and tries another.  I have arranged that:
- we always try to resolve direct-origin dependencies first
- the provider remembers direct-origin dependencies and returns them again if asked for the same package but with different features

That fixes the original #5311 because now the direct-origin version of the `foo` package is the only one that we ever see; and, per the new testcase, unbreaks #6054