### PR TITLE
allow use of not-embedded pip

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1425,7 +1425,7 @@ class Env:
         return self._run(cmd, **kwargs)
 
     def run_pip(self, *args: str, **kwargs: Any) -> int | str:
-        pip = self.get_pip_command(embedded=True)
+        pip = self.get_pip_command()
         cmd = pip + list(args)
         return self._run(cmd, **kwargs)
 

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -226,7 +226,7 @@ def test_info_setup_missing_mandatory_should_trigger_pep517(
     except PackageInfoError:
         assert spy.call_count == 3
     else:
-        assert spy.call_count == 2
+        assert spy.call_count == 1
 
 
 def test_info_prefer_poetry_config_over_egg_info():


### PR DESCRIPTION
Fixes #6060 

The code still falls back to embedded pip if no other pip can be found - see the implementation of `Env.pip()`.

(Tests change because we save ourselves a call to `get_embedded_wheel()` which causes a python script to be run to get environment info.)

I realise that the discussion in #6060 hasn't yet reached a conclusion but this is trivial enough that we might as well have it available.

