### PR TITLE
more typechecking

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -38,13 +38,13 @@ if TYPE_CHECKING:
     from poetry.poetry import Poetry
 
 
-def load_command(name: str) -> Callable[[], type[Command]]:
-    def _load() -> type[Command]:
+def load_command(name: str) -> Callable[[], Command]:
+    def _load() -> Command:
         words = name.split(" ")
         module = import_module("poetry.console.commands." + ".".join(words))
         command_class = getattr(module, "".join(c.title() for c in words) + "Command")
-        command_type: type[Command] = command_class()
-        return command_type
+        command: Command = command_class()
+        return command
 
     return _load
 
@@ -136,7 +136,8 @@ class Application(BaseApplication):  # type: ignore[misc]
 
     @property
     def command_loader(self) -> CommandLoader:
-        command_loader: CommandLoader = self._command_loader
+        command_loader: CommandLoader | None = self._command_loader
+        assert command_loader is not None
         return command_loader
 
     def reset_poetry(self) -> None:
@@ -333,7 +334,7 @@ class Application(BaseApplication):  # type: ignore[misc]
         installer.use_executor(poetry.config.get("experimental.new-installer", False))
         command.set_installer(installer)
 
-    def _load_plugins(self, io: IO = None) -> None:
+    def _load_plugins(self, io: IO | None = None) -> None:
         if self._plugins_loaded:
             return
 

--- a/src/poetry/console/commands/debug/resolve.py
+++ b/src/poetry/console/commands/debug/resolve.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from cleo.helpers import argument
 from cleo.helpers import option
 from cleo.io.outputs.output import Verbosity
 
 from poetry.console.commands.init import InitCommand
-
-
-if TYPE_CHECKING:
-    from poetry.console.commands.show import ShowCommand
+from poetry.console.commands.show import ShowCommand
 
 
 class DebugResolveCommand(InitCommand):
@@ -94,7 +89,8 @@ class DebugResolveCommand(InitCommand):
         self.line("")
 
         if self.option("tree"):
-            show_command: ShowCommand = self.application.find("show")
+            show_command = self.application.find("show")
+            assert isinstance(show_command, ShowCommand)
             show_command.init_styles(self.io)
 
             packages = [op.package for op in ops]

--- a/src/poetry/console/commands/plugin/add.py
+++ b/src/poetry/console/commands/plugin/add.py
@@ -45,7 +45,8 @@ It works similarly to the <c1>add</c1> command:
         self.line_error(self.deprecation)
 
         application = self.get_application()
-        command: SelfAddCommand = application.find("self add")
+        command = application.find("self add")
+        assert isinstance(command, SelfAddCommand)
         application.configure_installer_for_command(command, self.io)
 
         argv: list[str] = ["add", *self.argument("plugins")]

--- a/src/poetry/console/commands/plugin/remove.py
+++ b/src/poetry/console/commands/plugin/remove.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from cleo.helpers import argument
 from cleo.helpers import option
 from cleo.io.inputs.string_input import StringInput
 from cleo.io.io import IO
 
 from poetry.console.commands.command import Command
-
-
-if TYPE_CHECKING:
-    from poetry.console.commands.self.remove import SelfRemoveCommand
+from poetry.console.commands.self.remove import SelfRemoveCommand
 
 
 class PluginRemoveCommand(Command):
@@ -43,7 +38,8 @@ class PluginRemoveCommand(Command):
         self.line_error(self.help)
 
         application = self.get_application()
-        command: SelfRemoveCommand = application.find("self remove")
+        command = application.find("self remove")
+        assert isinstance(command, SelfRemoveCommand)
         application.configure_installer_for_command(command, self.io)
 
         argv: list[str] = ["remove", *self.argument("plugins")]

--- a/src/poetry/console/commands/plugin/show.py
+++ b/src/poetry/console/commands/plugin/show.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from cleo.io.inputs.string_input import StringInput
 from cleo.io.io import IO
 
 from poetry.console.commands.command import Command
-
-
-if TYPE_CHECKING:
-    from poetry.console.commands.self.show.plugins import SelfShowPluginsCommand
 
 
 class PluginShowCommand(Command):
@@ -26,7 +20,7 @@ class PluginShowCommand(Command):
         self.line_error(self.help)
 
         application = self.get_application()
-        command: SelfShowPluginsCommand = application.find("self show plugins")
+        command = application.find("self show plugins")
 
         exit_code: int = command.run(
             IO(

--- a/src/poetry/console/commands/self/update.py
+++ b/src/poetry/console/commands/self/update.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from cleo.helpers import argument
 from cleo.helpers import option
 from cleo.io.inputs.string_input import StringInput
 from cleo.io.io import IO
 
+from poetry.console.commands.add import AddCommand
 from poetry.console.commands.self.self_command import SelfCommand
-
-
-if TYPE_CHECKING:
-    from poetry.console.commands.add import AddCommand
 
 
 class SelfUpdateCommand(SelfCommand):
@@ -40,7 +35,8 @@ environment.
     def _system_project_handle(self) -> int:
         self.write("<info>Updating Poetry version ...</info>\n\n")
         application = self.get_application()
-        add_command: AddCommand = application.find("add")
+        add_command = application.find("add")
+        assert isinstance(add_command, AddCommand)
         add_command.set_env(self.env)
         application.configure_installer_for_command(add_command, self.io)
 

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -45,6 +45,7 @@ class Factory(BaseFactory):
     def create_poetry(
         self,
         cwd: Path | None = None,
+        with_groups: bool = True,
         io: IO | None = None,
         disable_plugins: bool = False,
         disable_cache: bool = False,
@@ -52,7 +53,7 @@ class Factory(BaseFactory):
         if io is None:
             io = NullIO()
 
-        base_poetry = super().create_poetry(cwd)
+        base_poetry = super().create_poetry(cwd=cwd, with_groups=with_groups)
 
         locker = Locker(
             base_poetry.file.parent / "poetry.lock", base_poetry.local_config

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -258,6 +258,7 @@ class Executor:
             try:
                 from cleo.ui.exception_trace import ExceptionTrace
 
+                io: IO | SectionOutput
                 if not self.supports_fancy_output():
                     io = self._io
                 else:

--- a/src/poetry/plugins/application_plugin.py
+++ b/src/poetry/plugins/application_plugin.py
@@ -23,4 +23,5 @@ class ApplicationPlugin(BasePlugin):
 
     def activate(self, application: Application) -> None:
         for command in self.commands:
+            assert command.name is not None
             application.command_loader.register_factory(command.name, lambda: command())

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -11,8 +11,7 @@ from poetry.utils.authenticator import Authenticator
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from cleo.io import BufferedIO
-    from cleo.io import ConsoleIO
+    from cleo.io.io import IO
 
     from poetry.poetry import Poetry
 
@@ -24,7 +23,7 @@ class Publisher:
     Registers and publishes packages to remote repositories.
     """
 
-    def __init__(self, poetry: Poetry, io: BufferedIO | ConsoleIO) -> None:
+    def __init__(self, poetry: Poetry, io: IO) -> None:
         self._poetry = poetry
         self._package = poetry.package
         self._io = io

--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -27,7 +27,7 @@ from poetry.utils.patterns import wheel_file_re
 
 
 if TYPE_CHECKING:
-    from cleo.io.null_io import NullIO
+    from cleo.io.io import IO
 
     from poetry.poetry import Poetry
 
@@ -52,7 +52,7 @@ class UploadError(Exception):
 
 
 class Uploader:
-    def __init__(self, poetry: Poetry, io: NullIO) -> None:
+    def __init__(self, poetry: Poetry, io: IO) -> None:
         self._poetry = poetry
         self._package = poetry.package
         self._io = io

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -79,6 +79,7 @@ class Indicator(ProgressIndicator):  # type: ignore[misc]
             return f" <c1>{Indicator.CONTEXT}</> "
 
     def _formatter_elapsed(self) -> str:
+        assert self._start_time is not None
         elapsed = time.time() - self._start_time
 
         return f"{elapsed:.1f}s"

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1909,7 +1909,10 @@ def build_environment(
     """
     if not env or poetry.package.build_script:
         with ephemeral_environment(executable=env.python if env else None) as venv:
-            overwrite = io and io.output.is_decorated() and not io.is_debug()
+            overwrite = (
+                io is not None and io.output.is_decorated() and not io.is_debug()
+            )
+
             if io:
                 if not overwrite:
                     io.write_line("")
@@ -1923,6 +1926,7 @@ def build_environment(
                     "<b>Preparing</b> build environment with build-system requirements"
                     f" {', '.join(requires)}"
                 )
+
             venv.run_pip(
                 "install",
                 "--disable-pip-version-check",
@@ -1931,6 +1935,7 @@ def build_environment(
             )
 
             if overwrite:
+                assert io is not None
                 io.write_line("")
 
             yield venv


### PR DESCRIPTION
Fixing most, though not quite all, of the mypy errors that would be revealed if cleo had a `py.typed`.