### PR TITLE
Turn spaces in project name to underscore.

### DIFF
--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 
 from contextlib import suppress
@@ -48,6 +49,7 @@ class NewCommand(Command):
         name = self.option("name")
         if not name:
             name = path.name
+        name = re.sub(r"\s+", "_", name)
 
         if path.exists() and list(path.glob("*")):
             # Directory is not empty. Aborting.


### PR DESCRIPTION
# Pull Request Check List

Currently, if the project name you typed contains whitespaces, the package name will also contain whitespaces. For example:

```
poetry new "New Project"
```

will cause test file contain:

```
from new project import __version__
```

which will cause error. In this case, we should automatically change project name to `new_project`.

I know that set `--name` argument can solve this problem. But I think maybe this process can be automated.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.

I have not include a tests for this PR. Mainly because I have not figured out a suitable testing method, also because this is a draft PR. If anyone have good idea on how to test, please help, thanks.

- [ ] Updated **documentation** for changed code.

No documentation change required for this PR.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
