### PR TITLE
updated docs to remove mentions of py2.7

### DIFF
--- a/docs/dependency-specification.md
+++ b/docs/dependency-specification.md
@@ -263,12 +263,12 @@ You can also specify that a dependency should be installed only for specific Pyt
 
 ```toml
 [tool.poetry.dependencies]
-pathlib2 = { version = "^2.2", python = "~2.7" }
+pathlib2 = { version = "^2.0.1", python = "<3.11" }
 ```
 
 ```toml
 [tool.poetry.dependencies]
-pathlib2 = { version = "^2.2", python = "~2.7 || ^3.2" }
+pathlib2 = { version = "^2.2", python = "^3.2" }
 ```
 
 ## Using environment markers
@@ -279,7 +279,7 @@ via the `markers` property:
 
 ```toml
 [tool.poetry.dependencies]
-pathlib2 = { version = "^2.2", markers = "python_version ~= '2.7' or sys_platform == 'win32'" }
+pathlib2 = { version = "^2.2", markers = "python_version <= '3.4' or sys_platform == 'win32'" }
 ```
 
 ## Multiple constraints dependencies
@@ -294,7 +294,7 @@ you would declare it like so:
 ```toml
 [tool.poetry.dependencies]
 foo = [
-    {version = "<=1.9", python = "^2.7"},
+    {version = "<=1.9", python = "^3.6"},
     {version = "^2.0", python = "^3.8"}
 ]
 ```

--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -41,6 +41,10 @@ poetry install
 ```
 {{% /note %}}
 
+{{% note %}}
+Since version 1.2, Poetry no longer supports managing environments for Python 2.7.
+{{% /note %}}
+
 ## Switching between environments
 
 Sometimes this might not be feasible for your system, especially Windows where `pyenv`
@@ -114,7 +118,6 @@ poetry env list
 will output something like the following:
 
 ```text
-test-O3eWbxRl-py2.7
 test-O3eWbxRl-py3.6
 test-O3eWbxRl-py3.7 (Activated)
 ```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -38,7 +38,7 @@ version = "1.0.0"
 
 # ...
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.7"
+python = "^3.7"
 poetry = "^1.0"
 
 [tool.poetry.plugins."poetry.plugin"]

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -369,7 +369,7 @@ mandatory = "^1.0"
 
 # A list of all of the optional dependencies, some of which are included in the
 # below `extras`. They can be opted into by apps.
-psycopg2 = { version = "^2.7", optional = true }
+psycopg2 = { version = "^2.9", optional = true }
 mysqlclient = { version = "^1.3", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5529

Same as Secrus:remove_2.7 without env.py file.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
