### PR TITLE
Update `flake8` additional dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,16 +33,16 @@ repos:
         additional_dependencies: &flake8_deps
           - flake8-annotations==2.9.0
           - flake8-broken-line==0.4.0
-          - flake8-bugbear==22.4.25
+          - flake8-bugbear==22.7.1
           - flake8-comprehensions==3.10.0
           - flake8-eradicate==1.2.1
           - flake8-quotes==3.3.1
-          - flake8-simplify==0.19.2
+          - flake8-simplify==0.19.3
           - flake8-tidy-imports==4.8.0
-          - flake8-type-checking==1.5.0
+          - flake8-type-checking==2.1.0
           - flake8-typing-imports==1.12.0
-          - flake8-use-fstring==1.3
-          - pep8-naming==0.12.1
+          - flake8-use-fstring==1.4
+          - pep8-naming==0.13.1
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.37.2

--- a/src/poetry/plugins/application_plugin.py
+++ b/src/poetry/plugins/application_plugin.py
@@ -24,4 +24,6 @@ class ApplicationPlugin(BasePlugin):
     def activate(self, application: Application) -> None:
         for command in self.commands:
             assert command.name is not None
-            application.command_loader.register_factory(command.name, lambda: command())
+            application.command_loader.register_factory(
+                command.name, lambda: command()  # noqa: B023
+            )

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -670,10 +670,10 @@ class Provider:
             #   - {<Package foo (1.2.3): {"bar": <Dependency bar (<2.0)>}
 
             def fmt_warning(d: Dependency) -> str:
-                marker = d.marker if not d.marker.is_any() else "*"
+                dependency_marker = d.marker if not d.marker.is_any() else "*"
                 return (
                     f"<c1>{d.name}</c1> <fg=default>(<c2>{d.pretty_constraint}</c2>)</>"
-                    f" with markers <b>{marker}</b>"
+                    f" with markers <b>{dependency_marker}</b>"
                 )
 
             warnings = ", ".join(fmt_warning(d) for d in deps[:-1])

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -220,7 +220,7 @@ def _get_win_folder_with_ctypes(csidl_name: str) -> str:
 def get_win_folder(csidl_name: str) -> Path:
     if sys.platform == "win32":
         try:
-            from ctypes import windll  # noqa: F401
+            from ctypes import windll  # noqa: F401, TC003
 
             _get_win_folder = _get_win_folder_with_ctypes
         except ImportError:

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 try:
     import zipp  # nopycln: import
 except ImportError:
-    import zipfile as zipp  # noqa: F401, TC002
+    import zipfile as zipp  # noqa: F401, TC003
 
 try:
     from typing import Protocol  # nopycln: import

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import sys
 
-try:
-    import zipp  # nopycln: import
-except ImportError:
-    import zipfile as zipp  # noqa: F401, TC003
+
+if sys.version_info < (3, 8):
+    import zipp as zipfile  # nopycln: import
+else:
+    import zipfile  # noqa: F401
 
 try:
     from typing import Protocol  # nopycln: import

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -9,7 +9,7 @@ import pytest
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.utils._compat import metadata
 from poetry.utils.env import MockEnv as BaseMockEnv
-from tests.compat import zipp
+from tests.compat import zipfile
 
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ INSTALLED_RESULTS = [
     metadata.PathDistribution(SITE_PURELIB / "cleo-0.7.6.dist-info"),
     metadata.PathDistribution(SRC / "pendulum" / "pendulum.egg-info"),
     metadata.PathDistribution(
-        zipp.Path(str(SITE_PURELIB / "foo-0.1.0-py3.8.egg"), "EGG-INFO")
+        zipfile.Path(str(SITE_PURELIB / "foo-0.1.0-py3.8.egg"), "EGG-INFO")
     ),
     metadata.PathDistribution(VENDOR_DIR / "attrs-19.3.0.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "standard-1.2.3.dist-info"),


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Update `flake8` additional dependencies and update code to comply with:
- https://github.com/PyCQA/flake8-bugbear/releases/tag/22.7.1 that added late binding check as `B023`
- https://github.com/snok/flake8-type-checking/releases/tag/v2.0.0 that now uses `TC002` for third-party imports, and `TC003` for built-in imports