### PR TITLE
Do not fetch VCS deps when reference didn't change

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -581,6 +581,12 @@ class Provider:
             # Retrieving constraints for deferred dependencies
             for r in requires:
                 if r.is_direct_origin():
+                    locked = self.get_locked(r)
+                    # If lock file contains exactly the same URL and reference
+                    # (commit hash) of dependency as is requested,
+                    # do not analyze it again: nothing could have changed.
+                    if locked is not None and locked.package.is_same_package_as(r):
+                        continue
                     self.search_for_direct_origin_dependency(r)
 
         optional_dependencies = []


### PR DESCRIPTION
# Pull Request Check List

If we have `root` -> `foo` -> `VCSDependency(bar, ref="sha256")`, and lock file contains `bar @ sha256` and user ran `poetry lock --no-update`, do not fetch `bar` repo from git: as commit hash is explicitly locked, nothing could have changed.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

As with #6130, I'll backport this to 1.1 once merged. And I'll need guidance on adding tests.
