### PR TITLE
Fix repository cache inconsistency issue

### DIFF
--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -46,7 +46,9 @@ class LegacyRepository(HTTPRepository):
         ignored_pre_release_versions = []
 
         if self._cache.store("matches").has(key):
-            versions = self._cache.store("matches").get(key)
+            versions, ignored_pre_release_versions = self._cache.store("matches").get(
+                key
+            )
         else:
             page = self._get_page(f"/{dependency.name.replace('.', '-')}/")
             if page is None:
@@ -63,7 +65,9 @@ class LegacyRepository(HTTPRepository):
                 if constraint.allows(version):
                     versions.append(version)
 
-            self._cache.store("matches").put(key, versions, 5)
+            self._cache.store("matches").put(
+                key, (versions, ignored_pre_release_versions), 5
+            )
 
         for package_versions in (versions, ignored_pre_release_versions):
             for version in package_versions:

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -823,7 +823,7 @@ def test_add_constraint_with_source(
 ):
     repo = LegacyRepository(name="my-index", url="https://my-index.fake")
     repo.add_package(get_package("cachy", "0.2.0"))
-    repo._cache.store("matches").put("cachy:0.2.0", [Version.parse("0.2.0")], 5)
+    repo._cache.store("matches").put("cachy:0.2.0", ([Version.parse("0.2.0")], []), 5)
 
     poetry.pool.add_repository(repo)
 
@@ -1810,7 +1810,7 @@ def test_add_constraint_with_source_old_installer(
 ):
     repo = LegacyRepository(name="my-index", url="https://my-index.fake")
     repo.add_package(get_package("cachy", "0.2.0"))
-    repo._cache.store("matches").put("cachy:0.2.0", [Version.parse("0.2.0")], 5)
+    repo._cache.store("matches").put("cachy:0.2.0", ([Version.parse("0.2.0")], []), 5)
 
     poetry.pool.add_repository(repo)
 


### PR DESCRIPTION
Fixes an inconsistency when caching matches of a `LegacyRepository`. Without the fix `find_packages()` might return an empty list on second call for packages with only pre-releases because only (released) `versions` are cached but not `ignored_pre_release_versions` (which cannot be ignored at all events).

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
