### PR TITLE
typechecking - NormalizedNames from poetry-core

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -19,6 +19,7 @@ from poetry.utils.dependency_specification import parse_dependency_specification
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
     from poetry.core.packages.package import Package
     from tomlkit.items import InlineTable
 
@@ -238,7 +239,7 @@ You can specify a package in the following forms:
         return 0
 
     def _generate_choice_list(
-        self, matches: list[Package], canonicalized_name: str
+        self, matches: list[Package], canonicalized_name: NormalizedName
     ) -> list[str]:
         choices = []
         matches_names = [p.name for p in matches]

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -11,6 +11,7 @@ from poetry.console.commands.group_command import GroupCommand
 
 if TYPE_CHECKING:
     from cleo.io.io import IO
+    from packaging.utils import NormalizedName
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
     from poetry.core.packages.project_package import ProjectPackage
@@ -423,7 +424,7 @@ lists all packages available."""
         io: IO,
         dependency: Dependency,
         installed_packages: list[Package],
-        packages_in_tree: list[str],
+        packages_in_tree: list[NormalizedName],
         previous_tree_bar: str = "├",
         level: int = 1,
     ) -> None:

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -544,6 +544,7 @@ class Installer:
 
         Maybe we just let the solver handle it?
         """
+        extras: dict[str, list[str]]
         if self._update:
             extras = {k: [d.name for d in v] for k, v in self._package.extras.items()}
         else:

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -39,7 +39,7 @@ class LegacyRepository(HTTPRepository):
             dependency
         )
 
-        key = dependency.name
+        key: str = dependency.name
         if not constraint.is_any():
             key = f"{key}:{constraint!s}"
 

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -641,8 +641,9 @@ class EnvManager:
 
     def deactivate(self, io: IO) -> None:
         venv_path = self._poetry.config.virtualenvs_path
-        name = self._poetry.package.name
-        name = self.generate_env_name(name, str(self._poetry.file.parent))
+        name = self.generate_env_name(
+            self._poetry.package.name, str(self._poetry.file.parent)
+        )
 
         envs_file = TOMLFile(venv_path / self.ENVS_FILE)
         if envs_file.exists():

--- a/src/poetry/utils/extras.py
+++ b/src/poetry/utils/extras.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Mapping
 
+    from packaging.utils import NormalizedName
     from poetry.core.packages.package import Package
 
 
@@ -16,7 +17,7 @@ def get_extra_package_names(
     packages: Sequence[Package],
     extras: Mapping[str, list[str]],
     extra_names: Sequence[str],
-) -> Iterable[str]:
+) -> Iterable[NormalizedName]:
     """
     Returns all package names required by the given extras.
 
@@ -43,13 +44,15 @@ def get_extra_package_names(
     # keep record of packages seen during recursion in order to avoid recursion error
     seen_package_names = set()
 
-    def _extra_packages(package_names: Iterable[str]) -> Iterator[str]:
+    def _extra_packages(
+        package_names: Iterable[NormalizedName],
+    ) -> Iterator[NormalizedName]:
         """Recursively find dependencies for packages names"""
         # for each extra package name
         for package_name in package_names:
             # Find the actual Package object. A missing key indicates an implicit
             # dependency (like setuptools), which should be ignored
-            package = packages_by_name.get(canonicalize_name(package_name))
+            package = packages_by_name.get(package_name)
             if package:
                 if package.name not in seen_package_names:
                     seen_package_names.add(package.name)


### PR DESCRIPTION
https://github.com/python-poetry/poetry-core/pull/442 converted some poetry-core types into `NormalizedName`s, which is cool and all but does have knock-on effects here.

I expect that this MR will fail typechecking until poetry picks up a version of poetry-core including those changes.  So consider this a suggested set of typing updates to make, when that version bump happens.

cc @radoering 