### PR TITLE
Sort extras and extras dependencies in lockfile

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -587,7 +587,7 @@ class Locker:
 
         if package.extras:
             extras = {}
-            for name, deps in package.extras.items():
+            for name, deps in sorted(package.extras.items()):
                 # TODO: This should use dep.to_pep_508() once this is fixed
                 # https://github.com/python-poetry/poetry-core/pull/102
                 extras[name] = sorted(

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -590,10 +590,10 @@ class Locker:
             for name, deps in package.extras.items():
                 # TODO: This should use dep.to_pep_508() once this is fixed
                 # https://github.com/python-poetry/poetry-core/pull/102
-                extras[name] = [
+                extras[name] = sorted(
                     dep.base_pep_508_name if not dep.constraint.is_any() else dep.name
                     for dep in deps
-                ]
+                )
 
             data["extras"] = extras
 

--- a/tests/installation/fixtures/with-pypi-repository.test
+++ b/tests/installation/fixtures/with-pypi-repository.test
@@ -7,7 +7,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-dev = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope-interface", "sphinx", "zope-interface"]
+dev = ["coverage", "hypothesis", "pympler", "pytest", "six", "sphinx", "zope-interface", "zope-interface"]
 docs = ["sphinx", "zope-interface"]
 tests = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope-interface"]
 
@@ -73,14 +73,6 @@ funcsigs = {"version" = "*", "markers" = "python_version < \"3.0\""}
 colorama = {"version" = "*", "markers" = "sys_platform == \"win32\""}
 
 [[package]]
-name = "six"
-version = "1.11.0"
-description = "Python 2 and 3 compatibility utilities"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "setuptools"
 version = "39.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -91,6 +83,14 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*"
 [package.extras]
 certs = ["certifi (==2016.9.26)"]
 ssl = ["wincertstore (==0.2)"]
+
+[[package]]
+name = "six"
+version = "1.11.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [metadata]
 python-versions = "*"

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -14,7 +14,6 @@ from cleo.io.io import IO
 from cleo.io.null_io import NullIO
 from cleo.io.outputs.buffered_output import BufferedOutput
 from cleo.io.outputs.output import Verbosity
-from deepdiff import DeepDiff
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.dependency_group import DependencyGroup
 from poetry.core.packages.package import Package
@@ -1164,7 +1163,7 @@ def test_installer_with_pypi_repository(
 
     expected = fixture("with-pypi-repository")
 
-    assert not DeepDiff(expected, locker.written_data, ignore_order=True)
+    assert expected == locker.written_data
 
 
 def test_run_installs_with_local_file(

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cleo.io.null_io import NullIO
-from deepdiff import DeepDiff
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.toml.file import TOMLFile
 
@@ -833,7 +832,7 @@ def test_installer_with_pypi_repository(
 
     expected = fixture("with-pypi-repository")
 
-    assert not DeepDiff(expected, locker.written_data, ignore_order=True)
+    assert expected == locker.written_data
 
 
 def test_run_installs_with_local_file(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6153

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR sorts extras under `[package.extras]` in the lockfile, as well as their dependencies.

Note: https://github.com/python-poetry/poetry/blob/ed88e34dd769019d365140e4d2526a248a872ab5/src/poetry/packages/locker.py#L591-L592 suggests to use `to_pep_508` once https://github.com/python-poetry/poetry-core/pull/102 is merged, but doing so, even with `with_extras=False`, would add environment markers, which I'm not sure is the desired behaviour, so I preferred to leave that untouched.
If it is the expected behaviour, I'd be happy to do the change in a follow-up PR.