### PR TITLE
Fix an infinite loop in the solver

### DIFF
--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -513,11 +513,9 @@ class VersionSolver:
         locked = self._locked.get(dependency.name, [])
         for dependency_package in locked:
             package = dependency_package.package
-            if (allow_similar or dependency.is_same_package_as(package)) and (
-                dependency.constraint.allows(package.version)
-                or package.is_prerelease()
-                and dependency.constraint.allows(package.version.next_patch())
-            ):
+            if (
+                allow_similar or dependency.is_same_package_as(package)
+            ) and dependency.constraint.allows(package.version):
                 return DependencyPackage(dependency, package)
         return None
 

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
     from poetry.core.packages.directory_dependency import DirectoryDependency
     from poetry.core.packages.file_dependency import FileDependency
     from poetry.core.packages.package import Package
-    from poetry.core.packages.specification import PackageSpecification
     from poetry.core.packages.url_dependency import URLDependency
     from poetry.core.packages.vcs_dependency import VCSDependency
     from poetry.core.semver.version_constraint import VersionConstraint
@@ -193,11 +192,11 @@ class Provider:
 
     def search_for_installed_packages(
         self,
-        specification: PackageSpecification,
+        dependency: Dependency,
     ) -> list[Package]:
         """
-        Search for installed packages, when available, that provides the given
-        specification.
+        Search for installed packages, when available, that satisfy the given
+        dependency.
 
         This is useful when dealing with packages that are under development, not
         published on package sources and/or only available via system installations.
@@ -207,17 +206,17 @@ class Provider:
 
         logger.debug(
             "Falling back to installed packages to discover metadata for <c2>%s</>",
-            specification.complete_name,
+            dependency.complete_name,
         )
         packages = [
             package
             for package in self._installed_packages
-            if package.provides(specification)
+            if package.satisfies(dependency, ignore_source_type=True)
         ]
         logger.debug(
             "Found <c2>%d</> compatible packages for <c2>%s</>",
             len(packages),
-            specification.complete_name,
+            dependency.complete_name,
         )
         return packages
 


### PR DESCRIPTION
I tried bumping crashtest to 0.4.0 in poetry itself.  This can't work because cleo requires a lower version than that, but instead of failure I hit an infinite loop.

Turned out there are two separate bugs here, both with the effect that version 1.0.0a5 of cleo is retried even after it has been ruled out because of this incompatibility

- first, we go into `_get_locked()` with a constraint that should explicitly rule out 1.0.0a5 - `>1.0.0a5,<2.0.0` - but because of the prerelease we decide that 1.0.0a5 is fine after all.  So far as I can see the code that I've removed just doesn't want to be there: anyway removing it doesn't break any existing tests and helps this one...

- then we go into `search_for_installed_packages()` again having started with a constraint that should rule out 1.0.0a5: but in here we pay no attention to that constraint at all.  So we again rediscover the already ruled-out version.  I've fixed this one by respecting the dependency in that function.