### PR TITLE
Update env remove logic

### DIFF
--- a/tests/console/commands/env/conftest.py
+++ b/tests/console/commands/env/conftest.py
@@ -18,7 +18,10 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def venv_name(app: PoetryTestApplication) -> str:
-    return EnvManager.generate_env_name("simple-project", str(app.poetry.file.parent))
+    return EnvManager.generate_env_name(
+        app.poetry.package.name,
+        str(app.poetry.file.parent),
+    )
 
 
 @pytest.fixture

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+
+if TYPE_CHECKING:
+    from poetry.poetry import Poetry
+    from poetry.utils.env import EnvManager
+
+
+@pytest.fixture
+def venv_name(
+    manager: EnvManager,
+    poetry: Poetry,
+) -> str:
+    return manager.generate_env_name(
+        poetry.package.name,
+        str(poetry.file.parent),
+    )

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -208,6 +208,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
@@ -225,7 +226,6 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     m = mocker.patch("poetry.utils.env.EnvManager.build_venv", side_effect=build_venv)
 
     env = manager.activate("python3.7", NullIO())
-    venv_name = EnvManager.generate_env_name("simple-project", str(poetry.file.parent))
 
     m.assert_called_with(
         Path(tmp_dir) / f"{venv_name}-py3.7",
@@ -255,11 +255,10 @@ def test_activate_activates_existing_virtualenv_no_envs_file(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
-
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     os.mkdir(os.path.join(tmp_dir, f"{venv_name}-py3.7"))
 
@@ -295,11 +294,10 @@ def test_activate_activates_same_virtualenv_with_envs_file(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
-
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     envs_file = TOMLFile(Path(tmp_dir) / "envs.toml")
     doc = tomlkit.document()
@@ -339,11 +337,11 @@ def test_activate_activates_different_virtualenv_with_envs_file(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     envs_file = TOMLFile(Path(tmp_dir) / "envs.toml")
     doc = tomlkit.document()
     doc[venv_name] = {"minor": "3.7", "patch": "3.7.1"}
@@ -392,11 +390,11 @@ def test_activate_activates_recreates_for_different_patch(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     envs_file = TOMLFile(Path(tmp_dir) / "envs.toml")
     doc = tomlkit.document()
     doc[venv_name] = {"minor": "3.7", "patch": "3.7.0"}
@@ -458,11 +456,11 @@ def test_activate_does_not_recreate_when_switching_minor(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     envs_file = TOMLFile(Path(tmp_dir) / "envs.toml")
     doc = tomlkit.document()
     doc[venv_name] = {"minor": "3.7", "patch": "3.7.0"}
@@ -509,11 +507,10 @@ def test_deactivate_non_activated_but_existing(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
-
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     python = ".".join(str(c) for c in sys.version_info[:2])
     (Path(tmp_dir) / f"{venv_name}-py{python}").mkdir()
@@ -538,11 +535,11 @@ def test_deactivate_activated(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     version = Version.from_parts(*sys.version_info[:3])
     other_version = Version.parse("3.4") if version.major == 2 else version.next_minor()
     (Path(tmp_dir) / f"{venv_name}-py{version.major}.{version.minor}").mkdir()
@@ -581,10 +578,9 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     os.environ["VIRTUAL_ENV"] = "/environment/prefix"
-
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
     (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
@@ -609,10 +605,15 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     assert env.base == Path("/prefix")
 
 
-def test_list(tmp_dir: str, manager: EnvManager, poetry: Poetry, config: Config):
+def test_list(
+    tmp_dir: str,
+    manager: EnvManager,
+    poetry: Poetry,
+    config: Config,
+    venv_name: str,
+):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
     (Path(tmp_dir) / f"{venv_name}-py3.6").mkdir()
 
@@ -629,10 +630,10 @@ def test_remove_by_python_version(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
     (Path(tmp_dir) / f"{venv_name}-py3.6").mkdir()
 
@@ -654,10 +655,10 @@ def test_remove_by_name(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
     (Path(tmp_dir) / f"{venv_name}-py3.6").mkdir()
 
@@ -679,10 +680,10 @@ def test_remove_also_deactivates(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     (Path(tmp_dir) / f"{venv_name}-py3.7").mkdir()
     (Path(tmp_dir) / f"{venv_name}-py3.6").mkdir()
 
@@ -712,12 +713,12 @@ def test_remove_keeps_dir_if_not_deleteable(
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
+    venv_name: str,
 ):
     # Ensure we empty rather than delete folder if its is an active mount point.
     # See https://github.com/python-poetry/poetry/pull/2064
     config.merge({"virtualenvs": {"path": str(tmp_dir)}})
 
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
     venv_path = Path(tmp_dir) / f"{venv_name}-py3.6"
     venv_path.mkdir()
 
@@ -848,12 +849,12 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
     config: Config,
     mocker: MockerFixture,
     config_virtualenvs_path: Path,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
     poetry.package.python_versions = "^3.6"
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     mocker.patch("sys.version_info", (2, 7, 16))
     mocker.patch(
@@ -885,12 +886,12 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     config: Config,
     mocker: MockerFixture,
     config_virtualenvs_path: Path,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
     poetry.package.python_versions = "^3.6"
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     mocker.patch("sys.version_info", (2, 7, 16))
     mocker.patch("subprocess.check_output", side_effect=["3.5.3", "3.9.0"])
@@ -971,6 +972,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
     config: Config,
     mocker: MockerFixture,
     config_virtualenvs_path: Path,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
@@ -979,7 +981,6 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
     poetry.package.python_versions = "^" + ".".join(
         str(c) for c in sys.version_info[:3]
     )
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     mocker.patch("sys.version_info", (version.major, version.minor, version.patch + 1))
     check_output = mocker.patch(
@@ -1012,13 +1013,13 @@ def test_create_venv_uses_patch_version_to_detect_compatibility_with_executable(
     config: Config,
     mocker: MockerFixture,
     config_virtualenvs_path: Path,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
     version = Version.from_parts(*sys.version_info[:3])
     poetry.package.python_versions = f"~{version.major}.{version.minor-1}.0"
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     check_output = mocker.patch(
         "subprocess.check_output",
@@ -1320,12 +1321,12 @@ def test_create_venv_accepts_fallback_version_w_nonzero_patchlevel(
     config: Config,
     mocker: MockerFixture,
     config_virtualenvs_path: Path,
+    venv_name: str,
 ):
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
     poetry.package.python_versions = "~3.5.1"
-    venv_name = manager.generate_env_name("simple-project", str(poetry.file.parent))
 
     check_output = mocker.patch(
         "subprocess.check_output",
@@ -1353,9 +1354,12 @@ def test_create_venv_accepts_fallback_version_w_nonzero_patchlevel(
     )
 
 
-def test_generate_env_name_ignores_case_for_case_insensitive_fs(tmp_dir: str):
-    venv_name1 = EnvManager.generate_env_name("simple-project", "MyDiR")
-    venv_name2 = EnvManager.generate_env_name("simple-project", "mYdIr")
+def test_generate_env_name_ignores_case_for_case_insensitive_fs(
+    poetry: Poetry,
+    tmp_dir: str,
+):
+    venv_name1 = EnvManager.generate_env_name(poetry.package.name, "MyDiR")
+    venv_name2 = EnvManager.generate_env_name(poetry.package.name, "mYdIr")
     if sys.platform == "win32":
         assert venv_name1 == venv_name2
     else:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6018 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code. (no documentation change is needed I think)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

### Changes

1. Added a check so that if `python` argument is a file (then it should be a python path) - extract it's venv name and raise `IncorrectEnvError` if it doesn't belong to this project
    **Before**
    ```
    └❯ poetry env remove ~/.cache/pypoetry/virtualenvs/different-project-OKfJHH_5-py3.10/bin/python
    /bin/sh: 1: different-project-OKfJHH_5-py3.10: not found

    Deleted virtualenv: ~/.cache/pypoetry/virtualenvs/poetry-4pWfmigs-py3.10
    ```
    Removes current project's env, which is wrong.
    **After**
    ```
    └❯ poetry env remove ~/.cache/pypoetry/virtualenvs/different-project-OKfJHH_5-py3.10/bin/python

    Env different-project-OKfJHH_5-py3.10 doesn't belong to this project.
    ```
2. Added the exact same check as before ^, but for cases where env name is passed.
    **Before**
    ```
    └❯ poetry env remove different-project-OKfJHH_5-py3.10      
     /bin/sh: 1: different-project-OKfJHH_5-py3.10: not found

     Command different-project-OKfJHH_5-py3.10 -c "import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))" errored with the following return code 127, and output: 
    ```
    Errors while trying to exec env name as an interpreter, error is not clear.
    **After**
    ```
    └❯ poetry env remove different-project-OKfJHH_5-py3.10                      

    Env different-project-OKfJHH_5-py3.10 doesn't belong to this project.
    ```
3. Added a couple of tests for **new** and for **old** scenarios which weren't tested.
4. Added `venv_name` fixture for `tests/utils` directory to use in `test_env`. Also replaced some of `"simple-project"` hardcoded value to use `poetry.package.name`

It's up to maintainers to choose what they want for this project - I'm happy either way if we at least fix the bug. I can remove/change any of the stuff I added on top of the fix. But yeah I just decided that if we fix the bug, we might also make some improvements/changes in this area of code. Any thoughts on this are welcome, thanks!