### PR TITLE
Define git default revision under a constant in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from poetry.utils.env import EnvManager
 from poetry.utils.env import SystemEnv
 from poetry.utils.env import VirtualEnv
 from poetry.utils.helpers import remove_directory
+from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import TestLocker
 from tests.helpers import TestRepository
 from tests.helpers import get_package
@@ -268,7 +269,7 @@ def git_mock(mocker: MockerFixture) -> None:
     # Patch git module to not actually clone projects
     mocker.patch("poetry.vcs.git.Git.clone", new=mock_clone)
     p = mocker.patch("poetry.vcs.git.Git.get_revision")
-    p.return_value = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+    p.return_value = MOCK_DEFAULT_GIT_REVISION
 
 
 @pytest.fixture

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -8,6 +8,7 @@ from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.dependency_group import DependencyGroup
 
 from poetry.factory import Factory
+from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import get_package
 
 
@@ -1121,10 +1122,8 @@ def test_show_outdated_git_dev_dependency(
                     "checksum": [],
                     "source": {
                         "type": "git",
-                        "reference": "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
-                        "resolved_reference": (
-                            "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
-                        ),
+                        "reference": MOCK_DEFAULT_GIT_REVISION,
+                        "resolved_reference": MOCK_DEFAULT_GIT_REVISION,
                         "url": "https://github.com/demo/demo.git",
                     },
                 },
@@ -1223,7 +1222,7 @@ def test_show_outdated_no_dev_git_dev_dependency(
                     "checksum": [],
                     "source": {
                         "type": "git",
-                        "reference": "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+                        "reference": MOCK_DEFAULT_GIT_REVISION,
                         "url": "https://github.com/demo/pyproject-demo.git",
                     },
                 },

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -14,6 +14,7 @@ from cleo.testers.command_tester import CommandTester
 from poetry.installation import Installer
 from poetry.installation.noop_installer import NoopInstaller
 from poetry.utils.env import MockEnv
+from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import PoetryTestApplication
 from tests.helpers import TestExecutor
 from tests.helpers import mock_clone
@@ -71,7 +72,7 @@ def setup(
     # Patch git module to not actually clone projects
     mocker.patch("poetry.vcs.git.Git.clone", new=mock_clone)
     p = mocker.patch("poetry.vcs.git.Git.get_revision")
-    p.return_value = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+    p.return_value = MOCK_DEFAULT_GIT_REVISION
 
     # Patch the virtual environment creation do actually do nothing
     mocker.patch("poetry.utils.env.EnvManager.create_venv", return_value=env)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,6 +41,9 @@ if TYPE_CHECKING:
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures"
 
+# Used as a mock for latest git revision.
+MOCK_DEFAULT_GIT_REVISION = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+
 
 def get_package(name: str, version: str | Version) -> Package:
     return Package(name, version)
@@ -97,7 +100,7 @@ class MockDulwichRepo:
         self.path = str(root)
 
     def head(self) -> bytes:
-        return b"9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+        return MOCK_DEFAULT_GIT_REVISION.encode()
 
 
 def mock_clone(

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -30,6 +30,7 @@ from poetry.repositories import Repository
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.utils.env import MockEnv
 from poetry.utils.env import NullEnv
+from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import get_dependency
 from tests.helpers import get_package
 from tests.repositories.test_legacy_repository import (
@@ -2488,7 +2489,7 @@ def test_installer_should_use_the_locked_version_of_git_dependencies_with_extras
         locker.mock_lock_data(fixture("with-vcs-dependency-with-extras"))
         expected_reference = "123456"
     else:
-        expected_reference = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+        expected_reference = MOCK_DEFAULT_GIT_REVISION
 
     package.add_dependency(
         Factory.create_dependency(

--- a/tests/mixology/version_solver/test_dependency_cache.py
+++ b/tests/mixology/version_solver/test_dependency_cache.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from poetry.factory import Factory
 from poetry.mixology.version_solver import DependencyCache
+from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.mixology.helpers import add_to_repo
 
 
@@ -56,10 +57,7 @@ def test_solver_dependency_cache_respects_source_type(
     assert package_git.package.version.text == "0.1.2"
     assert package_git.package.source_type == dependency_git.source_type
     assert package_git.package.source_url == dependency_git.source_url
-    assert (
-        package_git.package.source_resolved_reference
-        == "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
-    )
+    assert package_git.package.source_resolved_reference == MOCK_DEFAULT_GIT_REVISION
 
 
 def test_solver_dependency_cache_respects_subdirectories(
@@ -114,7 +112,7 @@ def test_solver_dependency_cache_respects_subdirectories(
     assert (
         package_one.package.source_resolved_reference
         == package_one_copy.package.source_resolved_reference
-        == "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+        == MOCK_DEFAULT_GIT_REVISION
     )
     assert (
         package_one.package.source_subdirectory

--- a/tests/puzzle/conftest.py
+++ b/tests/puzzle/conftest.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import mock_clone
 
 
@@ -16,4 +17,4 @@ def setup(mocker: MockerFixture) -> None:
     # Patch git module to not actually clone projects
     mocker.patch("poetry.vcs.git.Git.clone", new=mock_clone)
     p = mocker.patch("poetry.vcs.git.Git.get_revision")
-    p.return_value = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+    p.return_value = MOCK_DEFAULT_GIT_REVISION

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -22,6 +22,7 @@ from poetry.repositories.installed_repository import InstalledRepository
 from poetry.repositories.pool import Pool
 from poetry.repositories.repository import Repository
 from poetry.utils.env import MockEnv
+from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import get_dependency
 from tests.helpers import get_package
 from tests.repositories.test_legacy_repository import (
@@ -1426,7 +1427,7 @@ def test_solver_duplicate_dependencies_different_sources_types_are_preserved(
         source_type="git",
         source_url="https://github.com/demo/demo.git",
         source_reference=DEFAULT_SOURCE_REF,
-        source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+        source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
     )
 
     transaction = solver.solve()
@@ -1782,7 +1783,7 @@ def test_solver_can_resolve_git_dependencies(
         source_type="git",
         source_url="https://github.com/demo/demo.git",
         source_reference=DEFAULT_SOURCE_REF,
-        source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+        source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
     )
 
     ops = check_solver_result(
@@ -1819,7 +1820,7 @@ def test_solver_can_resolve_git_dependencies_with_extras(
         source_type="git",
         source_url="https://github.com/demo/demo.git",
         source_reference=DEFAULT_SOURCE_REF,
-        source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+        source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
     )
 
     check_solver_result(
@@ -1851,7 +1852,7 @@ def test_solver_can_resolve_git_dependencies_with_ref(
         source_type="git",
         source_url="https://github.com/demo/demo.git",
         source_reference=ref[list(ref.keys())[0]],
-        source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+        source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
     )
 
     git_config = {demo.source_type: demo.source_url}
@@ -2144,7 +2145,7 @@ def test_solver_git_dependencies_update(
         source_type="git",
         source_url="https://github.com/demo/demo.git",
         source_reference=DEFAULT_SOURCE_REF,
-        source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+        source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
     )
     installed.add_package(demo_installed)
 
@@ -2185,7 +2186,7 @@ def test_solver_git_dependencies_update_skipped(
         source_type="git",
         source_url="https://github.com/demo/demo.git",
         source_reference="master",
-        source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+        source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
     )
     installed.add_package(demo)
 
@@ -2217,8 +2218,8 @@ def test_solver_git_dependencies_short_hash_update_skipped(
         "0.1.2",
         source_type="git",
         source_url="https://github.com/demo/demo.git",
-        source_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
-        source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+        source_reference=MOCK_DEFAULT_GIT_REVISION,
+        source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
     )
     installed.add_package(demo)
 
@@ -2241,10 +2242,8 @@ def test_solver_git_dependencies_short_hash_update_skipped(
                     "0.1.2",
                     source_type="git",
                     source_url="https://github.com/demo/demo.git",
-                    source_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
-                    source_resolved_reference=(
-                        "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
-                    ),
+                    source_reference=MOCK_DEFAULT_GIT_REVISION,
+                    source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
                 ),
                 "skipped": True,
             },
@@ -2983,7 +2982,7 @@ def test_solver_does_not_fail_with_locked_git_and_non_git_dependencies(
         source_type="git",
         source_url="https://github.com/demo/demo.git",
         source_reference=DEFAULT_SOURCE_REF,
-        source_resolved_reference="9cf87a285a2d3fbb0b9fa621997b3acc3631ed24",
+        source_resolved_reference=MOCK_DEFAULT_GIT_REVISION,
     )
 
     installed.add_package(git_package)


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Follow up of https://github.com/python-poetry/poetry/pull/6185#discussion_r950390792, this change's purposes are to better highlight that the resolved git reference is mocked, and to avoid duplicating a random hash in multiple tests.