### PR TITLE
tighten typechecking

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -410,7 +410,7 @@ class Provider:
         file_name = os.path.basename(urllib.parse.urlparse(url).path)
         with tempfile.TemporaryDirectory() as temp_dir:
             dest = Path(temp_dir) / file_name
-            download_file(url, str(dest))
+            download_file(url, dest)
             package = cls.get_package_from_file(dest)
 
         package._source_type = "url"
@@ -528,7 +528,7 @@ class Provider:
                     dependency,
                     self._pool.package(
                         package.name,
-                        package.version.text,
+                        package.version,
                         extras=list(dependency.extras),
                         repository=dependency.source_name,
                     ),

--- a/src/poetry/repositories/cached.py
+++ b/src/poetry/repositories/cached.py
@@ -13,7 +13,9 @@ from poetry.repositories.repository import Repository
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
     from poetry.core.packages.package import Package
+    from poetry.core.semver.version import Version
 
     from poetry.inspection.info import PackageInfo
 
@@ -40,10 +42,12 @@ class CachedRepository(Repository, ABC):
         )
 
     @abstractmethod
-    def _get_release_info(self, name: str, version: str) -> dict[str, Any]:
+    def _get_release_info(
+        self, name: NormalizedName, version: Version
+    ) -> dict[str, Any]:
         raise NotImplementedError()
 
-    def get_release_info(self, name: str, version: str) -> PackageInfo:
+    def get_release_info(self, name: NormalizedName, version: Version) -> PackageInfo:
         """
         Return the release information given a package name and a version.
 
@@ -74,8 +78,8 @@ class CachedRepository(Repository, ABC):
 
     def package(
         self,
-        name: str,
-        version: str,
+        name: NormalizedName,
+        version: Version,
         extras: list[str] | None = None,
     ) -> Package:
         return self.get_release_info(name, version).to_package(name=name, extras=extras)

--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -68,7 +68,7 @@ class HTTPRepository(CachedRepository, ABC):
     def authenticated_url(self) -> str:
         return self._authenticator.authenticated_url(url=self.url)
 
-    def _download(self, url: str, dest: str) -> None:
+    def _download(self, url: str, dest: Path) -> None:
         return download_file(url, dest, session=self.session)
 
     def _get_info_from_wheel(self, url: str) -> PackageInfo:
@@ -81,7 +81,7 @@ class HTTPRepository(CachedRepository, ABC):
 
         with temporary_directory() as temp_dir:
             filepath = Path(temp_dir) / filename
-            self._download(url, str(filepath))
+            self._download(url, filepath)
 
             return PackageInfo.from_wheel(filepath)
 
@@ -97,7 +97,7 @@ class HTTPRepository(CachedRepository, ABC):
 
         with temporary_directory() as temp_dir:
             filepath = Path(temp_dir) / filename
-            self._download(url, str(filepath))
+            self._download(url, filepath)
 
             return PackageInfo.from_sdist(filepath)
 
@@ -226,7 +226,7 @@ class HTTPRepository(CachedRepository, ABC):
             ):
                 with temporary_directory() as temp_dir:
                     filepath = Path(temp_dir) / link.filename
-                    self._download(link.url, str(filepath))
+                    self._download(link.url, filepath)
 
                     known_hash = (
                         getattr(hashlib, link.hash_name)() if link.hash_name else None

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
-from packaging.utils import canonicalize_name
 from poetry.core.packages.package import Package
-from poetry.core.semver.version import Version
 
 from poetry.inspection.info import PackageInfo
 from poetry.repositories.exceptions import PackageNotFound
@@ -16,6 +14,7 @@ from poetry.repositories.link_sources.html import SimpleRepositoryPage
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
     from poetry.core.packages.utils.link import Link
+    from poetry.core.semver.version import Version
     from poetry.core.semver.version_constraint import VersionConstraint
 
     from poetry.config.config import Config
@@ -35,7 +34,7 @@ class LegacyRepository(HTTPRepository):
         super().__init__(name, url.rstrip("/"), config, disable_cache)
 
     def package(
-        self, name: str, version: str, extras: list[str] | None = None
+        self, name: NormalizedName, version: Version, extras: list[str] | None = None
     ) -> Package:
         """
         Retrieve the release information.
@@ -49,7 +48,7 @@ class LegacyRepository(HTTPRepository):
         should be much faster.
         """
         try:
-            index = self._packages.index(Package(name, version, version))
+            index = self._packages.index(Package(name, version))
 
             return self._packages[index]
         except ValueError:
@@ -106,18 +105,20 @@ class LegacyRepository(HTTPRepository):
             for version in versions
         ]
 
-    def _get_release_info(self, name: str, version: str) -> dict[str, Any]:
-        page = self._get_page(f"/{canonicalize_name(name)}/")
+    def _get_release_info(
+        self, name: NormalizedName, version: Version
+    ) -> dict[str, Any]:
+        page = self._get_page(f"/{name}/")
         if page is None:
             raise PackageNotFound(f'No package named "{name}"')
 
-        links = list(page.links_for_version(name, Version.parse(version)))
+        links = list(page.links_for_version(name, version))
 
         return self._links_to_data(
             links,
             PackageInfo(
                 name=name,
-                version=version,
+                version=version.text,
                 summary="",
                 platform=None,
                 requires_dist=[],

--- a/src/poetry/repositories/link_sources/base.py
+++ b/src/poetry/repositories/link_sources/base.py
@@ -17,6 +17,7 @@ from poetry.utils.patterns import wheel_file_re
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from packaging.utils import NormalizedName
     from poetry.core.packages.utils.link import Link
 
 
@@ -98,9 +99,9 @@ class LinkSource:
             pkg = Package(name, version, source_url=link.url)
         return pkg
 
-    def links_for_version(self, name: str, version: Version) -> Iterator[Link]:
-        name = canonicalize_name(name)
-
+    def links_for_version(
+        self, name: NormalizedName, version: Version
+    ) -> Iterator[Link]:
         for link in self.links:
             pkg = self.link_package_data(link)
 

--- a/src/poetry/repositories/pool.py
+++ b/src/poetry/repositories/pool.py
@@ -7,8 +7,10 @@ from poetry.repositories.repository import Repository
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
+    from poetry.core.semver.version import Version
 
 
 class Pool(Repository):
@@ -118,8 +120,8 @@ class Pool(Repository):
 
     def package(
         self,
-        name: str,
-        version: str,
+        name: NormalizedName,
+        version: Version,
         extras: list[str] | None = None,
         repository: str | None = None,
     ) -> Package:

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -168,7 +168,7 @@ class PyPiRepository(HTTPRepository):
         return links
 
     def _get_release_info(
-        self, name: str, version: str
+        self, name: NormalizedName, version: Version
     ) -> dict[str, str | list[str] | None]:
         from poetry.inspection.info import PackageInfo
 

--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
     from poetry.core.packages.utils.link import Link
+    from poetry.core.semver.version import Version
 
 
 class Repository:
@@ -133,12 +134,10 @@ class Repository:
         return []
 
     def package(
-        self, name: str, version: str, extras: list[str] | None = None
+        self, name: NormalizedName, version: Version, extras: list[str] | None = None
     ) -> Package:
-        name = name.lower()
-
         for package in self.packages:
-            if name == package.name and package.version.text == version:
+            if name == package.name and package.version == version:
                 return package.clone()
 
         raise PackageNotFound(f"Package {name} ({version}) not found.")

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -72,7 +72,7 @@ def merge_dicts(d1: dict[str, Any], d2: dict[str, Any]) -> None:
 
 def download_file(
     url: str,
-    dest: str,
+    dest: Path,
     session: Authenticator | Session | None = None,
     chunk_size: int = 1024,
 ) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -125,13 +125,13 @@ def mock_clone(
     return MockDulwichRepo(dest)
 
 
-def mock_download(url: str, dest: str, **__: Any) -> None:
+def mock_download(url: str, dest: Path) -> None:
     parts = urllib.parse.urlparse(url)
 
     fixtures = Path(__file__).parent / "fixtures"
     fixture = fixtures / parts.path.lstrip("/")
 
-    copy_or_symlink(fixture, Path(dest))
+    copy_or_symlink(fixture, dest)
 
 
 class TestExecutor(Executor):

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -12,6 +12,8 @@ import pytest
 
 from cleo.io.null_io import NullIO
 from deepdiff import DeepDiff
+from packaging.utils import canonicalize_name
+from poetry.core.semver.version import Version
 
 from poetry.factory import Factory
 from poetry.masonry.builders.editable import EditableBuilder
@@ -224,7 +226,7 @@ def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(
     assert [] == env.executed
 
 
-def test_builder_setup_generation_runs_with_pip_editable(tmp_dir: str):
+def test_builder_setup_generation_runs_with_pip_editable(tmp_dir: str) -> None:
     # create an isolated copy of the project
     fixture = Path(__file__).parent.parent.parent / "fixtures" / "extended_project"
     extended_project = Path(tmp_dir) / "extended_project"
@@ -241,7 +243,10 @@ def test_builder_setup_generation_runs_with_pip_editable(tmp_dir: str):
 
         # is the package installed?
         repository = InstalledRepository.load(venv)
-        assert repository.package("extended-project", "1.2.3")
+        package = repository.package(
+            canonicalize_name("extended-project"), Version.parse("1.2.3")
+        )
+        assert package.name == "extended-project"
 
         # check for the module built by build.py
         try:

--- a/tests/repositories/test_pool.py
+++ b/tests/repositories/test_pool.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 
 import pytest
 
+from packaging.utils import canonicalize_name
+from poetry.core.semver.version import Version
+
 from poetry.repositories import Pool
 from poetry.repositories import Repository
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.legacy_repository import LegacyRepository
 
 
-def test_pool_raises_package_not_found_when_no_package_is_found():
+def test_pool_raises_package_not_found_when_no_package_is_found() -> None:
     pool = Pool()
     pool.add_repository(Repository("repo"))
 
     with pytest.raises(PackageNotFound):
-        pool.package("foo", "1.0.0")
+        pool.package(canonicalize_name("foo"), Version.parse("1.0.0"))
 
 
 def test_pool():


### PR DESCRIPTION
Some places where we can use the `NormalizedName` to have the type-checker verify that we don't need to `canonicalize()` or `lower()` what we have in hand.

While doing that I also noticed that we might as well take a `Version` in these methods - we currently stringify the version and then re-parse it, which is unnecessary at best.

Also chanced across a spot where we can prefer a `Path` to a `str`.