### PR TITLE
Refactor: move get_locked() from VersionSolver to Provider

### DIFF
--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from cleo.io.io import IO
+    from packaging.utils import NormalizedName
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.config.config import Config
@@ -60,7 +61,7 @@ class Installer:
         self._execute_operations = True
         self._lock = False
 
-        self._whitelist: list[str] = []
+        self._whitelist: list[NormalizedName] = []
 
         self._extras: list[str] = []
 

--- a/src/poetry/mixology/__init__.py
+++ b/src/poetry/mixology/__init__.py
@@ -9,16 +9,10 @@ if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.mixology.result import SolverResult
-    from poetry.packages import DependencyPackage
     from poetry.puzzle.provider import Provider
 
 
-def resolve_version(
-    root: ProjectPackage,
-    provider: Provider,
-    locked: dict[str, list[DependencyPackage]] | None = None,
-    use_latest: list[str] | None = None,
-) -> SolverResult:
-    solver = VersionSolver(root, provider, locked=locked, use_latest=use_latest)
+def resolve_version(root: ProjectPackage, provider: Provider) -> SolverResult:
+    solver = VersionSolver(root, provider)
 
     return solver.solve()

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -134,7 +134,6 @@ class Provider:
         self._env: Env | None = None
         self._python_constraint = package.python_constraint
         self._is_debugging: bool = self._io.is_debug() or self._io.is_very_verbose()
-        self._in_progress = False
         self._overrides: dict[DependencyPackage, dict[str, Dependency]] = {}
         self._deferred_cache: dict[Dependency, Package] = {}
         self._load_deferred = True
@@ -887,24 +886,6 @@ class Provider:
             )
 
             self._io.write(debug_info)
-
-    @contextmanager
-    def progress(self) -> Iterator[None]:
-        if not self._io.output.is_decorated() or self.is_debugging():
-            self._io.write_line("Resolving dependencies...")
-            yield
-        else:
-            indicator = Indicator(
-                self._io, "{message}{context}<debug>({elapsed:2s})</debug>"
-            )
-
-            with indicator.auto(
-                "<info>Resolving dependencies...</info>",
-                "<info>Resolving dependencies...</info>",
-            ):
-                yield
-
-        self._in_progress = False
 
     def _merge_dependencies_by_constraint(
         self, dependencies: Iterable[Dependency]

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -125,13 +125,13 @@ class Provider:
         package: Package,
         pool: Pool,
         io: IO,
-        env: Env | None = None,
+        *,
         installed: list[Package] | None = None,
     ) -> None:
         self._package = package
         self._pool = pool
         self._io = io
-        self._env = env
+        self._env: Env | None = None
         self._python_constraint = package.python_constraint
         self._is_debugging: bool = self._io.is_debug() or self._io.is_very_verbose()
         self._in_progress = False
@@ -168,7 +168,6 @@ class Provider:
 
     @contextmanager
     def use_environment(self, env: Env) -> Iterator[Provider]:
-        original_env = self._env
         original_python_constraint = self._python_constraint
 
         self._env = env
@@ -176,7 +175,7 @@ class Provider:
 
         yield self
 
-        self._env = original_env
+        self._env = None
         self._python_constraint = original_python_constraint
 
     @staticmethod

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -40,7 +40,6 @@ class Solver:
         installed: list[Package],
         locked: list[Package],
         io: IO,
-        provider: Provider | None = None,
     ) -> None:
         self._package = package
         self._pool = pool
@@ -48,12 +47,9 @@ class Solver:
         self._locked_packages = locked
         self._io = io
 
-        if provider is None:
-            provider = Provider(
-                self._package, self._pool, self._io, installed=installed
-            )
-
-        self._provider = provider
+        self._provider = Provider(
+            self._package, self._pool, self._io, installed=installed
+        )
         self._overrides: list[dict[DependencyPackage, dict[str, Dependency]]] = []
 
     @property

--- a/tests/mixology/helpers.py
+++ b/tests/mixology/helpers.py
@@ -7,10 +7,11 @@ from poetry.core.packages.package import Package
 from poetry.factory import Factory
 from poetry.mixology.failure import SolveFailure
 from poetry.mixology.version_solver import VersionSolver
-from poetry.packages import DependencyPackage
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
+    from poetry.core.factory import DependencyConstraint
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.mixology import SolverResult
@@ -22,7 +23,7 @@ def add_to_repo(
     repository: Repository,
     name: str,
     version: str,
-    deps: dict[str, str] | None = None,
+    deps: dict[str, DependencyConstraint] | None = None,
     python: str | None = None,
     yanked: bool = False,
 ) -> None:
@@ -43,32 +44,26 @@ def check_solver_result(
     result: dict[str, str] | None = None,
     error: str | None = None,
     tries: int | None = None,
-    locked: dict[str, Package] | None = None,
-    use_latest: list[str] | None = None,
+    use_latest: list[NormalizedName] | None = None,
 ) -> SolverResult | None:
-    if locked is not None:
-        locked = {
-            k: [DependencyPackage(l.to_dependency(), l)] for k, l in locked.items()
-        }
+    solver = VersionSolver(root, provider)
+    with provider.use_latest_for(use_latest or []):
+        try:
+            solution = solver.solve()
+        except SolveFailure as e:
+            if error:
+                assert str(e) == error
 
-    solver = VersionSolver(root, provider, locked=locked, use_latest=use_latest)
-    try:
-        solution = solver.solve()
-    except SolveFailure as e:
-        if error:
-            assert str(e) == error
-
-            if tries is not None:
-                assert solver.solution.attempted_solutions == tries
+                if tries is not None:
+                    assert solver.solution.attempted_solutions == tries
 
             return None
 
-        raise
-    except AssertionError as e:
-        if error:
-            assert str(e) == error
-            return None
-        raise
+        except AssertionError as e:
+            if error:
+                assert str(e) == error
+                return
+            raise
 
     packages = {}
     for package in solution.packages:

--- a/tests/mixology/version_solver/test_with_lock.py
+++ b/tests/mixology/version_solver/test_with_lock.py
@@ -2,21 +2,25 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from cleo.io.null_io import NullIO
+from packaging.utils import canonicalize_name
+
 from poetry.factory import Factory
 from tests.helpers import get_package
 from tests.mixology.helpers import add_to_repo
 from tests.mixology.helpers import check_solver_result
+from tests.mixology.version_solver.conftest import Provider
 
 
 if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
 
+    from poetry.repositories import Pool
     from poetry.repositories import Repository
-    from tests.mixology.version_solver.conftest import Provider
 
 
 def test_with_compatible_locked_dependencies(
-    root: ProjectPackage, provider: Provider, repo: Repository
+    root: ProjectPackage, repo: Repository, pool: Pool
 ):
     root.add_dependency(Factory.create_dependency("foo", "*"))
 
@@ -27,16 +31,18 @@ def test_with_compatible_locked_dependencies(
     add_to_repo(repo, "bar", "1.0.1")
     add_to_repo(repo, "bar", "1.0.2")
 
+    locked = [get_package("foo", "1.0.1"), get_package("bar", "1.0.1")]
+    provider = Provider(root, pool, NullIO(), locked=locked)
+
     check_solver_result(
         root,
         provider,
         result={"foo": "1.0.1", "bar": "1.0.1"},
-        locked={"foo": get_package("foo", "1.0.1"), "bar": get_package("bar", "1.0.1")},
     )
 
 
 def test_with_incompatible_locked_dependencies(
-    root: ProjectPackage, provider: Provider, repo: Repository
+    root: ProjectPackage, repo: Repository, pool: Pool
 ):
     root.add_dependency(Factory.create_dependency("foo", ">1.0.1"))
 
@@ -47,16 +53,18 @@ def test_with_incompatible_locked_dependencies(
     add_to_repo(repo, "bar", "1.0.1")
     add_to_repo(repo, "bar", "1.0.2")
 
+    locked = [get_package("foo", "1.0.1"), get_package("bar", "1.0.1")]
+    provider = Provider(root, pool, NullIO(), locked=locked)
+
     check_solver_result(
         root,
         provider,
         result={"foo": "1.0.2", "bar": "1.0.2"},
-        locked={"foo": get_package("foo", "1.0.1"), "bar": get_package("bar", "1.0.1")},
     )
 
 
 def test_with_unrelated_locked_dependencies(
-    root: ProjectPackage, provider: Provider, repo: Repository
+    root: ProjectPackage, repo: Repository, pool: Pool
 ):
     root.add_dependency(Factory.create_dependency("foo", "*"))
 
@@ -68,16 +76,18 @@ def test_with_unrelated_locked_dependencies(
     add_to_repo(repo, "bar", "1.0.2")
     add_to_repo(repo, "baz", "1.0.0")
 
+    locked = [get_package("baz", "1.0.1")]
+    provider = Provider(root, pool, NullIO(), locked=locked)
+
     check_solver_result(
         root,
         provider,
         result={"foo": "1.0.2", "bar": "1.0.2"},
-        locked={"baz": get_package("baz", "1.0.1")},
     )
 
 
 def test_unlocks_dependencies_if_necessary_to_ensure_that_a_new_dependency_is_satisfied(
-    root: ProjectPackage, provider: Provider, repo: Repository
+    root: ProjectPackage, repo: Repository, pool: Pool
 ):
     root.add_dependency(Factory.create_dependency("foo", "*"))
     root.add_dependency(Factory.create_dependency("newdep", "2.0.0"))
@@ -92,6 +102,14 @@ def test_unlocks_dependencies_if_necessary_to_ensure_that_a_new_dependency_is_sa
     add_to_repo(repo, "qux", "2.0.0")
     add_to_repo(repo, "newdep", "2.0.0", deps={"baz": ">=1.5.0"})
 
+    locked = [
+        get_package("foo", "2.0.0"),
+        get_package("bar", "1.0.0"),
+        get_package("baz", "1.0.0"),
+        get_package("qux", "1.0.0"),
+    ]
+    provider = Provider(root, pool, NullIO(), locked=locked)
+
     check_solver_result(
         root,
         provider,
@@ -102,17 +120,11 @@ def test_unlocks_dependencies_if_necessary_to_ensure_that_a_new_dependency_is_sa
             "qux": "1.0.0",
             "newdep": "2.0.0",
         },
-        locked={
-            "foo": get_package("foo", "2.0.0"),
-            "bar": get_package("bar", "1.0.0"),
-            "baz": get_package("baz", "1.0.0"),
-            "qux": get_package("qux", "1.0.0"),
-        },
     )
 
 
 def test_with_compatible_locked_dependencies_use_latest(
-    root: ProjectPackage, provider: Provider, repo: Repository
+    root: ProjectPackage, repo: Repository, pool: Pool
 ):
     root.add_dependency(Factory.create_dependency("foo", "*"))
     root.add_dependency(Factory.create_dependency("baz", "*"))
@@ -126,21 +138,23 @@ def test_with_compatible_locked_dependencies_use_latest(
     add_to_repo(repo, "baz", "1.0.0")
     add_to_repo(repo, "baz", "1.0.1")
 
+    locked = [
+        get_package("foo", "1.0.1"),
+        get_package("bar", "1.0.1"),
+        get_package("baz", "1.0.0"),
+    ]
+    provider = Provider(root, pool, NullIO(), locked=locked)
+
     check_solver_result(
         root,
         provider,
         result={"foo": "1.0.2", "bar": "1.0.2", "baz": "1.0.0"},
-        locked={
-            "foo": get_package("foo", "1.0.1"),
-            "bar": get_package("bar", "1.0.1"),
-            "baz": get_package("baz", "1.0.0"),
-        },
-        use_latest=["foo"],
+        use_latest=[canonicalize_name("foo")],
     )
 
 
 def test_with_compatible_locked_dependencies_with_extras(
-    root: ProjectPackage, provider: Provider, repo: Repository
+    root: ProjectPackage, repo: Repository, pool: Pool
 ):
     root.add_dependency(Factory.create_dependency("foo", "^1.0"))
 
@@ -159,20 +173,22 @@ def test_with_compatible_locked_dependencies_with_extras(
     add_to_repo(repo, "baz", "1.0.0")
     add_to_repo(repo, "baz", "1.0.1")
 
+    locked = [
+        get_package("foo", "1.0.0"),
+        get_package("bar", "1.0.0"),
+        get_package("baz", "1.0.0"),
+    ]
+    provider = Provider(root, pool, NullIO(), locked=locked)
+
     check_solver_result(
         root,
         provider,
         result={"foo": "1.0.0", "bar": "1.0.0", "baz": "1.0.0"},
-        locked={
-            "foo": get_package("foo", "1.0.0"),
-            "bar": get_package("bar", "1.0.0"),
-            "baz": get_package("baz", "1.0.0"),
-        },
     )
 
 
 def test_with_yanked_package_in_lock(
-    root: ProjectPackage, provider: Provider, repo: Repository
+    root: ProjectPackage, repo: Repository, pool: Pool
 ):
     root.add_dependency(Factory.create_dependency("foo", "*"))
 
@@ -182,16 +198,17 @@ def test_with_yanked_package_in_lock(
     # yanked version is kept in lock file
     locked_foo = get_package("foo", "2")
     assert not locked_foo.yanked
+    provider = Provider(root, pool, NullIO(), locked=[locked_foo])
     result = check_solver_result(
         root,
         provider,
         result={"foo": "2"},
-        locked={"foo": locked_foo},
     )
     foo = result.packages[0]
     assert foo.yanked
 
     # without considering the lock file, the other version is chosen
+    provider = Provider(root, pool, NullIO())
     check_solver_result(
         root,
         provider,


### PR DESCRIPTION
This refactoring is motivated by #6131. While the change in #6131 seems to be functionally correct, I don't like it from an architectural point of view (passing a `get_locked` from `VersionSolver` to `Provider`). However, for the fix `Provider` has to know about locked packages. After careful consideration, I came to the conclusion that it makes more sense, if `Provider` provides the `get_locked` method since `Provider` already has different methods that take a dependency as input and give one ore more packages. Further, it already has knowledge about installed packages so it makes sense to extend that to locked packages.

To put it in a nutshell, the main objective of this PR is to move `get_locked()` from `VersionSolver` to `Provider`. On the way, I noticed some other shortcomings I changed in separate commits.

In case anyone is wondering why the `installed` and `locked` fixtures in `test_solver` can't be used anymore: Since `Provider` transforms the list of locked packages into a dict, changes to the list of locked packages after creating a `Provider` instance have no effect. Since changing locked packages after creating the solver/provider is no real use case (was only done in tests), I decided to adapt the tests in favor of a more clear interface that fits better to the real world use case.