### PR TITLE
test(compat): conditionally import `Protocol`

### DIFF
--- a/tests/compat.py
+++ b/tests/compat.py
@@ -5,10 +5,9 @@ import sys
 
 if sys.version_info < (3, 8):
     import zipp as zipfile  # nopycln: import
+
+    from typing_extensions import Protocol  # nopycln: import
 else:
     import zipfile  # noqa: F401
 
-try:
-    from typing import Protocol  # nopycln: import
-except ImportError:
-    from typing_extensions import Protocol  # noqa: F401
+    from typing import Protocol  # noqa: F401


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Conditionally importing the module will make sure that in the future, once we remove support for `3.8`, `pyupgrade --py38-plus` [automatically rewrites](https://github.com/asottile/pyupgrade/#python2-and-old-python3x-blocks) the imports to:
```python
import zipfile  # noqa: F401

from typing import Protocol  # noqa: F401
```