### PR TITLE
Adds --assume-yes to cache clear command to suppress prompts

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -728,6 +728,8 @@ To only remove a specific package from a cache, you have to specify the cache en
 poetry cache clear pypi:requests:2.24.0
 ```
 
+To suppress prompts and proceed with the action without interaction, pass `--assume-yes` or `-y`.
+
 ## source
 
 The `source` namespace regroups sub commands to manage repository sources for a Poetry project.

--- a/tests/console/commands/cache/test_clear.py
+++ b/tests/console/commands/cache/test_clear.py
@@ -39,6 +39,22 @@ def test_cache_clear_all(
     assert not cache.has("cleo:0.2")
 
 
+def test_cache_clear_all_assume_yes(
+    tester: ApplicationTester,
+    repository_one: str,
+    repository_cache_dir: Path,
+    cache: CacheManager,
+):
+    exit_code = tester.execute(f"cache clear {repository_one} --all --assume-yes")
+
+    assert exit_code == 0
+    assert tester.io.fetch_output() == "Deleting 2 entries.\n"
+    # ensure directory is empty
+    assert not any((repository_cache_dir / repository_one).iterdir())
+    assert not cache.has("cachy:0.1")
+    assert not cache.has("cleo:0.2")
+
+
 def test_cache_clear_all_no(
     tester: ApplicationTester,
     repository_one: str,
@@ -64,6 +80,19 @@ def test_cache_clear_pkg(
 
     assert exit_code == 0
     assert tester.io.fetch_output() == ""
+    assert not cache.has("cachy:0.1")
+    assert cache.has("cleo:0.2")
+
+
+def test_cache_clear_pkg_assume_yes(
+    tester: ApplicationTester,
+    repository_one: str,
+    cache: CacheManager,
+):
+    exit_code = tester.execute(f"cache clear {repository_one}:cachy:0.1 -y")
+
+    assert exit_code == 0
+    assert tester.io.fetch_output() == "Deleting cache entry cachy:0.1\n"
     assert not cache.has("cachy:0.1")
     assert cache.has("cleo:0.2")
 


### PR DESCRIPTION
I had a perceived need to blow away my cache entirely and did so with:

    for cache in `poetry cache list`; do poetry cache clear $cache --all; done

but was annoyed by having to answer _yes_ for each of the _many_ caches I had. This PR adds an `--assume-yes|-y` command like `apt`'s that skips prompts.

Potential future work: Add a special syntax `poetry cache clear '*' --all --assume-yes` or `poetry cache implode` that will clear all entries in all caches.


# Pull Request Check List

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

