### PR TITLE
docs: mention how to add a git dependency with a subdirectory

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -348,7 +348,13 @@ poetry add git+ssh://github.com/sdispater/pendulum.git#develop
 poetry add git+ssh://github.com/sdispater/pendulum.git#2.0.5
 ```
 
-or make them point to a local directory or file:
+or reference a subdirectory:
+
+```bash
+poetry add git+https://github.com/myorg/mypackage_with_subdirs.git@main#subdirectory=subdir
+```
+
+You can also add a local directory or file:
 
 ```bash
 poetry add ./my-package/


### PR DESCRIPTION
Currently, git dependencies with subdirectories are only mentioned in https://python-poetry.org/docs/master/dependency-specification/#git-dependencies so you can see the syntax in pyproject.toml.

It might be useful to add an example how to `poetry add` such a dependency.