### PR TITLE
[1.2] fix: skip configure env for SelfCommand

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -276,9 +276,10 @@ class Application(BaseApplication):  # type: ignore[misc]
         self, event: ConsoleCommandEvent, event_name: str, _: Any
     ) -> None:
         from poetry.console.commands.env_command import EnvCommand
+        from poetry.console.commands.self.self_command import SelfCommand
 
         command = event.command
-        if not isinstance(command, EnvCommand):
+        if not isinstance(command, EnvCommand) or isinstance(command, SelfCommand):
             return
 
         if command._env is not None:


### PR DESCRIPTION
Port of https://github.com/python-poetry/poetry/pull/6225