### PR TITLE
release: bump to version 1.2.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [1.2.0rc2] - 2022-08-26
+
+### Fixed
+
+- Fixed an issue where venv were created unnecessarily on running  `poetry self` ([#6226](https://github.com/python-poetry/poetry/pull/6226))
+- Ensured that packages `pretty_name` is written to lockfile ([#6243](https://github.com/python-poetry/poetry/pull/6243))
+
+### Improvements
+
+- Improved the consistency of `Pool().remove_repository()` to make it easier to write poetry plugins ([#6231](https://github.com/python-poetry/poetry/pull/6231))
+
+### Docs
+
+- Removed mentions of Python 2.7 from docs ([#6235](https://github.com/python-poetry/poetry/pull/6235))
+- Added note about the difference between groups and extras ([#6232](https://github.com/python-poetry/poetry/pull/6232))
+
+
 ## [1.2.0rc1] - 2022-08-22
 
 ### Added
@@ -1483,7 +1500,8 @@ Initial release
 
 
 
-[Unreleased]: https://github.com/python-poetry/poetry/compare/1.2.0rc1...master
+[Unreleased]: https://github.com/python-poetry/poetry/compare/1.2.0rc2...master
+[1.2.0rc2]: https://github.com/python-poetry/poetry/releases/tag/1.2.0rc2
 [1.2.0rc1]: https://github.com/python-poetry/poetry/releases/tag/1.2.0rc1
 [1.2.0b3]: https://github.com/python-poetry/poetry/releases/tag/1.2.0b3
 [1.2.0b2]: https://github.com/python-poetry/poetry/releases/tag/1.2.0b2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- Fixed an issue where venv were created unnecessarily on running  `poetry self` ([#6226](https://github.com/python-poetry/poetry/pull/6226))
-- Ensured that packages `pretty_name` is written to lockfile ([#6243](https://github.com/python-poetry/poetry/pull/6243))
+- Fixed an issue where virtual environments were created unnecessarily when running `poetry self` commands ([#6226](https://github.com/python-poetry/poetry/pull/6226))
+- Ensure that packages' `pretty_name` are written to the lock file ([#6243](https://github.com/python-poetry/poetry/pull/6243))
 
 ### Improvements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry"
-version = "1.2.0rc1"
+version = "1.2.0rc2"
 description = "Python dependency management and packaging made easy."
 authors = [
     "Sébastien Eustace <sebastien@eustace.io>",
@@ -44,7 +44,7 @@ generate-setup-file = false
 [tool.poetry.dependencies]
 python = "^3.7"
 
-poetry-core = "^1.1.0rc1"
+poetry-core = "^1.1.0rc2"
 poetry-plugin-export = "^1.0.6"
 cachecontrol = { version = "^0.12.9", extras = ["filecache"] }
 cachy = "^0.3.0"


### PR DESCRIPTION
### Fixed

- Fixed an issue where virtual environments were created unnecessarily when running `poetry self` commands ([#6226](https://github.com/python-poetry/poetry/pull/6226))
- Ensure that packages' `pretty_name` are written to the lock file ([#6243](https://github.com/python-poetry/poetry/pull/6243))

### Improvements

- Improved the consistency of `Pool().remove_repository()` to make it easier to write poetry plugins ([#6231](https://github.com/python-poetry/poetry/pull/6231))

### Docs

- Removed mentions of Python 2.7 from docs ([#6235](https://github.com/python-poetry/poetry/pull/6235))
- Added note about the difference between groups and extras ([#6232](https://github.com/python-poetry/poetry/pull/6232))