### PR TITLE
skip cloning badly defined submodules

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -334,7 +334,7 @@ class Git:
             url: bytes
             path: bytes
             submodules = parse_submodules(config)
-            for path, url, _ in submodules:
+            for path, url, name in submodules:
                 path_relative = Path(path.decode("utf-8"))
                 path_absolute = repo_root.joinpath(path_relative)
 
@@ -345,6 +345,12 @@ class Git:
                     try:
                         revision = repo.open_index()[path].sha.decode("utf-8")
                     except KeyError:
+                        logger.debug(
+                            "Skip submodule %s in %s, path %s not found",
+                            name,
+                            repo.path,
+                            path,
+                        )
                         continue
 
                 cls.clone(

--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -342,7 +342,10 @@ class Git:
                 source_root.mkdir(parents=True, exist_ok=True)
 
                 with repo:
-                    revision = repo.open_index()[path].sha.decode("utf-8")
+                    try:
+                        revision = repo.open_index()[path].sha.decode("utf-8")
+                    except KeyError:
+                        continue
 
                 cls.clone(
                     url=url.decode("utf-8"),


### PR DESCRIPTION
eg with this dependency
```
pyscf = { git = "https://github.com/pyscf/pyscf", tag = "v2.0.1"}
```
the cloning of submodules fails - because that project has messed up and not committed the file saying what revision they want of the `doc` submodule.

Legacy git client just silently carries on, so I've done the same here.

So far as I can tell this code currently does not have any test coverage, I must say that I don't feel particularly motivated to do anything about that: if anyone is more disciplined than I am then please have at it...