### PR TITLE
[1.2] test(installer): use locked version of vcs dependency without referen…

### DIFF
--- a/tests/installation/fixtures/with-vcs-dependency-without-ref.test
+++ b/tests/installation/fixtures/with-vcs-dependency-without-ref.test
@@ -1,0 +1,34 @@
+[[package]]
+name = "demo"
+version = "0.1.2"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.dependencies]
+pendulum = ">=1.4.4"
+
+[package.source]
+type = "git"
+url = "https://github.com/demo/demo.git"
+reference = "HEAD"
+resolved_reference = "123456"
+
+[[package]]
+name = "pendulum"
+version = "1.4.4"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+
+[metadata]
+python-versions = "*"
+lock-version = "1.1"
+content-hash = "123456789"
+
+[metadata.files]
+demo = []
+pendulum = []


### PR DESCRIPTION
... without reference (branch, tag, rev) instead of latest

Backport of #6228