### PR TITLE
[1.2] docs: `--only` no longer skips project's package installation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -218,9 +218,6 @@ If you want to skip this installation, use the `--no-root` option.
 poetry install --no-root
 ```
 
-Installation of your project's package is also skipped when the `--only`
-option is used.
-
 ### Options
 
 * `--without`: The dependency groups to ignore.


### PR DESCRIPTION
Port of https://github.com/python-poetry/poetry/pull/6263