### PR TITLE
not every GroupCommand needs to be an EnvCommand

### DIFF
--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from cleo.helpers import option
 from poetry.core.packages.dependency_group import MAIN_GROUP
 
-from poetry.console.commands.env_command import EnvCommand
+from poetry.console.commands.command import Command
 
 
 if TYPE_CHECKING:
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
 
 
-class GroupCommand(EnvCommand):
+class GroupCommand(Command):
     @staticmethod
     def _group_dependency_options() -> list[Option]:
         return [

--- a/src/poetry/console/commands/installer_command.py
+++ b/src/poetry/console/commands/installer_command.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from poetry.console.commands.env_command import EnvCommand
 from poetry.console.commands.group_command import GroupCommand
 
 
@@ -9,7 +10,7 @@ if TYPE_CHECKING:
     from poetry.installation.installer import Installer
 
 
-class InstallerCommand(GroupCommand):
+class InstallerCommand(GroupCommand, EnvCommand):
     def __init__(self) -> None:
         # Set in poetry.console.application.Application.configure_installer
         self._installer: Installer | None = None

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -6,6 +6,7 @@ from cleo.helpers import argument
 from cleo.helpers import option
 from packaging.utils import canonicalize_name
 
+from poetry.console.commands.env_command import EnvCommand
 from poetry.console.commands.group_command import GroupCommand
 
 
@@ -30,7 +31,7 @@ def reverse_deps(pkg: Package, repo: Repository) -> dict[str, str]:
     return required_by
 
 
-class ShowCommand(GroupCommand):
+class ShowCommand(GroupCommand, EnvCommand):
     name = "show"
     description = "Shows information about packages."
 


### PR DESCRIPTION
Relating to #6275 and https://github.com/python-poetry/poetry-plugin-export/issues/78

Not every `GroupCommand` needs to be an `EnvCommand` (though it's true that every `GroupCommand` in this repository is also an `EnvCommand`, so this refactoring changes nothing here).

The intention is to make a change to the export plugin so that the `ExportCommand` can be a `GroupCommand` but not an `EnvCommand`: it does need access to the group options, but it does not need a virtual environment.