### PR TITLE
Update type hints of `register_factory` to be compatible with examples

### DIFF
--- a/src/poetry/console/command_loader.py
+++ b/src/poetry/console/command_loader.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
     Command = Union[CleoCommand, PoetryCommand]
 
+
 class CommandLoader(FactoryCommandLoader):  # type: ignore[misc]
     def register_factory(
         self, command_name: str, factory: Callable[[], Command]

--- a/src/poetry/console/command_loader.py
+++ b/src/poetry/console/command_loader.py
@@ -8,7 +8,6 @@ from cleo.loaders.factory_command_loader import FactoryCommandLoader
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Union
 
     from cleo.commands.command import Command
 

--- a/src/poetry/console/command_loader.py
+++ b/src/poetry/console/command_loader.py
@@ -10,11 +10,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Union
 
-    from cleo.commands.command import Command as CleoCommand
-
-    from poetry.console.commands.command import Command as PoetryCommand
-
-    Command = Union[CleoCommand, PoetryCommand]
+    from cleo.commands.command import Command
 
 
 class CommandLoader(FactoryCommandLoader):  # type: ignore[misc]

--- a/src/poetry/console/command_loader.py
+++ b/src/poetry/console/command_loader.py
@@ -8,9 +8,11 @@ from cleo.loaders.factory_command_loader import FactoryCommandLoader
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from cleo.commands.command import Command as CleoCommand
+    from poetry.console.commands.command import Command as PoetryCommand
+    from typing import Union
 
-    from poetry.console.commands.command import Command
-
+    Command = Union[CleoCommand, PoetryCommand]
 
 class CommandLoader(FactoryCommandLoader):  # type: ignore[misc]
     def register_factory(

--- a/src/poetry/console/command_loader.py
+++ b/src/poetry/console/command_loader.py
@@ -8,9 +8,11 @@ from cleo.loaders.factory_command_loader import FactoryCommandLoader
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from cleo.commands.command import Command as CleoCommand
-    from poetry.console.commands.command import Command as PoetryCommand
     from typing import Union
+
+    from cleo.commands.command import Command as CleoCommand
+
+    from poetry.console.commands.command import Command as PoetryCommand
 
     Command = Union[CleoCommand, PoetryCommand]
 


### PR DESCRIPTION
The example:
https://python-poetry.org/docs/plugins/#application-plugins

Creates a `cleo.commands.command` from the factory, which is not compatible with the type `poetry.console.commands.command`. This returns a union type to address this, assuming this isn't an error in the documentation.

Affects: Poetry 1.2.x

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
