### PR TITLE
B023 is real

### DIFF
--- a/src/poetry/plugins/application_plugin.py
+++ b/src/poetry/plugins/application_plugin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+
 from typing import TYPE_CHECKING
 
 from poetry.plugins.base_plugin import BasePlugin
@@ -22,8 +24,12 @@ class ApplicationPlugin(BasePlugin):
         return []
 
     def activate(self, application: Application) -> None:
+        def factory(command: type[Command]) -> Command:
+            return command()
+
         for command in self.commands:
             assert command.name is not None
+
             application.command_loader.register_factory(
-                command.name, lambda: command()  # noqa: B023
+                command.name, functools.partial(factory, command)
             )

--- a/src/poetry/plugins/application_plugin.py
+++ b/src/poetry/plugins/application_plugin.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import functools
-
 from typing import TYPE_CHECKING
 
 from poetry.plugins.base_plugin import BasePlugin
@@ -24,12 +22,6 @@ class ApplicationPlugin(BasePlugin):
         return []
 
     def activate(self, application: Application) -> None:
-        def factory(command: type[Command]) -> Command:
-            return command()
-
         for command in self.commands:
             assert command.name is not None
-
-            application.command_loader.register_factory(
-                command.name, functools.partial(factory, command)
-            )
+            application.command_loader.register_factory(command.name, command)


### PR DESCRIPTION
Here's some sample code approximating the poetry code:
```python
#!/usr/bin/env python3


def one() -> int:
    return 1


def two() -> int:
    return 2


def three() -> int:
    return 3


factories = [one, two, three]

registered = []
for factory in factories:
    registered.append(lambda: factory())

for registered_factory in registered:
    print(f"result is {registered_factory()}")
```
output is
```
result is 3
result is 3
result is 3
```
which is exactly the gotcha that flake8-bugbear's B023 was trying to warn about.

I've applied one of the workarounds that various parts of the internet recommend, and you can verify for yourself if you're so inclined that doing the same in the toy script gives the expected output.