### PR TITLE
Support venv/src/ not being a valid git dir

### DIFF
--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -93,16 +93,18 @@ class InstalledRepository(Repository):
     def is_vcs_package(cls, package: Path | Package, env: Env) -> bool:
         # A VCS dependency should have been installed
         # in the src directory.
+        from poetry.vcs.git import Git
+
         src = env.path / "src"
         if isinstance(package, Package):
-            return src.joinpath(package.name).is_dir()
+            return Git.is_valid_repo(src.joinpath(package.name))
 
         try:
             package.relative_to(env.path / "src")
         except ValueError:
             return False
         else:
-            return True
+            return Git.is_valid_repo(package)
 
     @classmethod
     def create_package_from_distribution(

--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -177,6 +177,10 @@ class Git:
     def get_name_from_source_url(url: str) -> str:
         return re.sub(r"(.git)?$", "", url.rsplit("/", 1)[-1])
 
+    @staticmethod
+    def is_valid_repo(repo: Path | str) -> bool:
+        return Path(repo).joinpath(".git").is_dir()
+
     @classmethod
     def _fetch_remote_refs(cls, url: str, local: Repo) -> FetchPackResult:
         """

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -72,6 +72,10 @@ def env() -> MockEnv:
 @pytest.fixture(autouse=True)
 def mock_git_info(mocker: MockerFixture) -> None:
     mocker.patch(
+        "poetry.vcs.git.Git.is_valid_repo",
+        return_value=True,
+    )
+    mocker.patch(
         "poetry.vcs.git.Git.info",
         return_value=namedtuple("GitRepoLocalInfo", "origin revision")(
             origin="https://github.com/sdispater/pendulum.git",


### PR DESCRIPTION
# Pull Request Check List

After updating to latest 1.2, we ran into an issue where we had a lot of pre-existing /venv/src directories that we kept license metadata in for distribution which were suddenly being parsed by Poetry as git repos (and obviously failing).

This just adds a simple lookahead to make sure that we aren't trying to create git repositories where they don't belong.

We will be moving our license files into /venv/share/doc in the future, but I can't imagine we were the only folks to have run into this.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
