### PR TITLE
docs: fix example for --with option combined with --without

### DIFF
--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -142,7 +142,7 @@ poetry install --with docs
 
 {{% warning %}}
 When used together, `--without` takes precedence over `--with`. For example, the following command
-will only install the dependencies specified in the `test` group.
+will only install the dependencies specified in the optional `test` group.
 
 ```bash
 poetry install --with test,docs --without docs

--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -145,7 +145,7 @@ When used together, `--without` takes precedence over `--with`. For example, the
 will only install the dependencies specified in the `test` group.
 
 ```bash
-poetry install --with docs --without test,docs
+poetry install --with test,docs --without docs
 ```
 {{% /warning %}}
 


### PR DESCRIPTION
The current "Managing Dependencies" documentation contains an error at
[Installing group dependencies](https://python-poetry.org/docs/managing-dependencies/#installing-group-dependencies)

Within the warning concerning the combined use of  `--with` and `--without` the parameters were swapped.

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** 
