### PR TITLE
Add no interaction flag to 1.1 documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ then `--help` combined with any of those can give you more information.
 * `--ansi`: Force ANSI output.
 * `--no-ansi`: Disable ANSI output.
 * `--version (-V)`: Display this application version.
+* `--no-interaction (-n)`: Do not ask any interactive question.
 
 
 ## new


### PR DESCRIPTION


A small PR to update documentation of poetry 1.1 regarding the global option `-n` 
