### PR TITLE
fix: publisher reported successfully finding credentials for PyPI even when they did not exist

### DIFF
--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -62,7 +62,7 @@ class Publisher:
                 password = token
             else:
                 auth = self._authenticator.get_http_auth(repository_name)
-                if auth:
+                if auth.password:
                     logger.debug(
                         f"Found authentication information for {repository_name}."
                     )

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -78,7 +78,7 @@ class AuthenticatorRepositoryConfig:
         return [self.url, self.netloc, self.name]
 
     def get_http_credentials(
-        self, password_manager: PasswordManager, username: str | None = None
+        self, password_manager: PasswordManager
     ) -> HTTPAuthCredential:
         # try with the repository name via the password manager
         credential = HTTPAuthCredential(
@@ -257,7 +257,7 @@ class Authenticator:
 
         if key not in self._credentials:
             self._credentials[key] = repository.get_http_credentials(
-                password_manager=self._password_manager, username=username
+                password_manager=self._password_manager
             )
 
         return self._credentials[key]


### PR DESCRIPTION
Minor cleanup in the authentication code to prevent spuriously reporting finding PyPI credentials due to a special case.
It's also possible to return `None` in the PyPI special case itself -- suggestions are welcome.
