### PR TITLE
No unwanted update of packages from legacy source

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -843,7 +843,10 @@ class Provider:
                 # Thus, we can't use is_same_package_as() here because it compares
                 # the complete_name (including features).
                 dependency.name == package.name
-                and dependency.is_same_source_as(package)
+                and (
+                    dependency.source_type is None
+                    or dependency.is_same_source_as(package)
+                )
                 and dependency.constraint.allows(package.version)
             ):
                 return DependencyPackage(dependency, package)

--- a/tests/mixology/version_solver/test_with_lock.py
+++ b/tests/mixology/version_solver/test_with_lock.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from cleo.io.null_io import NullIO
 from packaging.utils import canonicalize_name
+from poetry.core.packages.package import Package
 
 from poetry.factory import Factory
 from tests.helpers import get_package
@@ -213,4 +214,26 @@ def test_with_yanked_package_in_lock(
         root,
         provider,
         result={"foo": "1"},
+    )
+
+
+def test_no_update_is_respected_for_legacy_repository(
+    root: ProjectPackage, repo: Repository, pool: Pool
+):
+    root.add_dependency(Factory.create_dependency("foo", "^1.0"))
+
+    foo_100 = Package(
+        "foo", "1.0.0", source_type="legacy", source_url="http://example.com"
+    )
+    foo_101 = Package(
+        "foo", "1.0.1", source_type="legacy", source_url="http://example.com"
+    )
+    repo.add_package(foo_100)
+    repo.add_package(foo_101)
+
+    provider = Provider(root, pool, NullIO(), locked=[foo_100])
+    check_solver_result(
+        root,
+        provider,
+        result={"foo": "1.0.0"},
     )


### PR DESCRIPTION
If a dependency doesn't specify a source type, then a locked package
from any source can satisfy it

# Pull Request Check List

Resolves: #6335

I'm pretty sure this is reinstating the earlier behaviour - see https://github.com/python-poetry/poetry/issues/6335#issuecomment-1234666240 for analysis