### PR TITLE
[1.2] refactor: replace cleo's removed `Terminal` class

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -68,8 +68,9 @@ lists all packages available."""
     colors = ["cyan", "yellow", "green", "magenta", "blue"]
 
     def handle(self) -> int:
+        import shutil
+
         from cleo.io.null_io import NullIO
-        from cleo.terminal import Terminal
 
         from poetry.puzzle.solver import Solver
         from poetry.repositories.installed_repository import InstalledRepository
@@ -209,8 +210,7 @@ lists all packages available."""
 
         show_latest = self.option("latest")
         show_all = self.option("all")
-        terminal = Terminal()
-        width = terminal.width
+        width = shutil.get_terminal_size().columns
         name_length = version_length = latest_length = required_by_length = 0
         latest_packages = {}
         latest_statuses = {}

--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -11,7 +12,6 @@ from typing import Any
 
 import pexpect
 
-from cleo.terminal import Terminal
 from shellingham import ShellDetectionFailure
 from shellingham import detect_shell
 
@@ -87,10 +87,10 @@ class Shell:
 
         import shlex
 
-        terminal = Terminal()
+        terminal = shutil.get_terminal_size()
         with env.temp_environ():
             c = pexpect.spawn(
-                self._path, ["-i"], dimensions=(terminal.height, terminal.width)
+                self._path, ["-i"], dimensions=(terminal.lines, terminal.columns)
             )
 
         if self._name in ["zsh", "nu"]:
@@ -99,8 +99,8 @@ class Shell:
         c.sendline(f"{self._get_source_command()} {shlex.quote(str(activate_path))}")
 
         def resize(sig: Any, data: Any) -> None:
-            terminal = Terminal()
-            c.setwinsize(terminal.height, terminal.width)
+            terminal = shutil.get_terminal_size()
+            c.setwinsize(terminal.lines, terminal.columns)
 
         signal.signal(signal.SIGWINCH, resize)
 


### PR DESCRIPTION
Backporting #6224