### PR TITLE
feat: add action to backport commits to release branches

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,29 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          title_template: "[<%= base %>] <%= title %>"
+          label_pattern: "^backport/(?<base>([^ ]+))$"


### PR DESCRIPTION
Creating this for feedback, but I wanted to make backporting PR's a little less manual. This adds a [GitHub Action](https://github.com/tibdex/backport) to create a backport PR when it's labeled with `backport/1.2`. You can see an example of the PR it creates [here](https://github.com/branchvincent/playground/pull/13).

If we decide to use this, the only required setup is creating the new label.