### PR TITLE
feat: use shallow git clone and shallow submodule clone

### DIFF
--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -142,10 +142,10 @@ poetry install --with docs
 
 {{% warning %}}
 When used together, `--without` takes precedence over `--with`. For example, the following command
-will only install the dependencies specified in the `test` group.
+will only install the dependencies specified in the optional `test` group.
 
 ```bash
-poetry install --with docs --without test,docs
+poetry install --with test,docs --without docs
 ```
 {{% /warning %}}
 

--- a/src/poetry/vcs/git/system.py
+++ b/src/poetry/vcs/git/system.py
@@ -19,7 +19,7 @@ class SystemGit:
         cls._check_parameter(repository)
         return cls.run(
             "clone",
-            "--git-depth 1",
+            "--depth 1",
             "--recurse-submodules",
             "--shallow-submodules",
             "--",

--- a/src/poetry/vcs/git/system.py
+++ b/src/poetry/vcs/git/system.py
@@ -17,8 +17,14 @@ class SystemGit:
     @classmethod
     def clone(cls, repository: str, dest: Path) -> str:
         cls._check_parameter(repository)
-
-        return cls.run("clone", "--recurse-submodules", "--", repository, str(dest))
+        return cls.run(
+            "clone",
+            "--git-depth 1",
+            "--recurse-submodules",
+            "--",
+            repository,
+            str(dest),
+        )
 
     @classmethod
     def checkout(cls, rev: str, target: Path | None = None) -> str:

--- a/src/poetry/vcs/git/system.py
+++ b/src/poetry/vcs/git/system.py
@@ -21,6 +21,7 @@ class SystemGit:
             "clone",
             "--git-depth 1",
             "--recurse-submodules",
+            "--shallow-submodules",
             "--",
             repository,
             str(dest),


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2412
Relates to: #2094 

This should speed up `git clone` for all large repositories.

I am unsure what extra tests would be required for this.
I am also not sure if there is any case in which a non-shallow clone of a repository would be required, for instance if tags are needed.

Note that `--depth 1` automatically implies `--single-branch` per the [git docs](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt).

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
