### PR TITLE
fix virtualenv constraint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -931,7 +931,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "993e76b1334c28db52f3f8e8af2cfcd635431a71f505860073f6917cf170bc8d"
+content-hash = "1a3bec1367439db08fff0893d90204804ab6872bbaabdf88939c88c575776c77"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ shellingham = "^1.5"
 # exclude 0.11.2 and 0.11.3 due to https://github.com/sdispater/tomlkit/issues/225
 tomlkit = ">=0.11.1,<1.0.0,!=0.11.2,!=0.11.3"
 # exclude 20.4.5 - 20.4.6 due to https://github.com/pypa/pip/issues/9953
-virtualenv = "(>=20.4.3,<20.4.5 || >=20.4.7)"
+virtualenv = ">=20.4.3,<20.4.5 || >=20.4.7"
 xattr = { version = "^0.9.7", markers = "sys_platform == 'darwin'" }
 urllib3 = "^1.26.0"
 dulwich = "^0.20.44"


### PR DESCRIPTION
https://github.com/python-poetry/poetry-core/pull/461 reveals that poetry's own `pyproject.toml` contained an invalid constraint:
```
Could not parse version constraint: (>=20.4.3
```
oops.

I still think that poetry-core fix is good and desirable, but if this is an indication of the likely influx of issues... well that's something to think about.

Anyway this MR is clearly good, let's fix the error here.