### PR TITLE
locker: do not assign unrelated filenames/hashes to direct origin dependencies

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -128,9 +128,18 @@ class Locker:
                 # Old lock so we create dummy files from the hashes
                 hashes = cast("dict[str, Any]", metadata["hashes"])
                 package.files = [{"name": h, "hash": h} for h in hashes[name]]
+            elif source_type in {"git", "directory", "url"}:
+                package.files = []
             else:
                 files = metadata["files"][name]
-                package.files = files
+                if source_type == "file":
+                    filename = Path(url).name
+                    package.files = [item for item in files if item["file"] == filename]
+                else:
+                    # Strictly speaking, this is not correct, but we have no chance
+                    # to always determine which are the correct files because the
+                    # lockfile doesn't keep track which files belong to which package.
+                    package.files = files
 
             package.python_versions = info["python-versions"]
             extras = info.get("extras", {})

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -409,6 +409,120 @@ git-package-subdir = []
     assert package.source_subdirectory == "subdir"
 
 
+def test_locker_properly_assigns_metadata_files(locker: Locker) -> None:
+    """
+    For multiple constraints dependencies, there is only one common entry in
+    metadata.files. However, we must not assign all the files to each of the packages
+    because this can result in duplicated and outdated entries when running
+    `poetry lock --no-update` and hash check failures when running `poetry install`.
+    """
+    content = """\
+[[package]]
+name = "demo"
+version = "1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[[package]]
+name = "demo"
+version = "1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/demo/demo.git"
+reference = "main"
+resolved_reference = "123456"
+
+[[package]]
+name = "demo"
+version = "1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "directory"
+url = "./folder"
+
+[[package]]
+name = "demo"
+version = "1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "file"
+url = "./demo-1.0-cp39-win_amd64.whl"
+
+[[package]]
+name = "demo"
+version = "1.0"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "url"
+url = "https://example.com/demo-1.0-cp38-win_amd64.whl"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "*"
+content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
+
+[metadata.files]
+# metadata.files are only tracked for non-direct origin and file dependencies
+demo = [
+    {file = "demo-1.0-cp39-win_amd64.whl", hash = "sha256"},
+    {file = "demo-1.0.tar.gz", hash = "sha256"},
+    {file = "demo-1.0-py3-none-any.whl", hash = "sha256"},
+]
+"""
+    locker.lock.write(tomlkit.parse(content))
+
+    repository = locker.locked_repository()
+    assert len(repository.packages) == 5
+    assert {package.source_type for package in repository.packages} == {
+        None,
+        "git",
+        "directory",
+        "file",
+        "url",
+    }
+    for package in repository.packages:
+        if package.source_type is None:
+            # non-direct origin package contains all files
+            # with the current lockfile format we have no chance to determine
+            # which files are correct, so we keep all for hash check
+            # correct files are set later in Provider.complete_package()
+            assert package.files == [
+                {"file": "demo-1.0-cp39-win_amd64.whl", "hash": "sha256"},
+                {"file": "demo-1.0.tar.gz", "hash": "sha256"},
+                {"file": "demo-1.0-py3-none-any.whl", "hash": "sha256"},
+            ]
+        elif package.source_type == "file":
+            assert package.files == [
+                {"file": "demo-1.0-cp39-win_amd64.whl", "hash": "sha256"}
+            ]
+        else:
+            package.files = []
+
+
 def test_lock_packages_with_null_description(locker: Locker, root: ProjectPackage):
     package_a = get_package("A", "1.0.0")
     package_a.description = None


### PR DESCRIPTION
Fix for duplicate (or outdated) hashes of multiple constraint dependencies

Resolves: #6327
Resolves: #6349

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Fixes a regression in `poetry lock --no-update` where filenames and hashes of multiple constraints dependencies are always kept/duplicated.

Background: There is only one `metadata.files` entry for all multiple constraints dependencies in poetry.lock. When reading the lock file we can't always decide for sure which filename/hash belongs to which of the multiple constraints dependencies so we just add all filenames/hashes for all packages. For non-direct origin dependencies, this is fixed later in `complete_package()` when the package is looked up in the repository. For direct origin dependencies this isn't fixed, so all entries are kept and duplicated once for each direct origin dependency. Even if one of the multiple constraints dependencies has been deleted from pyproject.toml, its filenames/hashes are kept if there is still one direct origin dependency.

(This issue did not occur in poetry 1.1.x because poetry was not able to recognize if a direct origin dependency had already been included in the lockfile and thus always updated it when running `poetry lock --no-update`.)

Update: Another manifestation of the fixed bug is that url, git or directory dependencies of multiple constraints dependencies can't be installed if there is a non-direct origin or file dependency among the multiple constraints dependencies.