### PR TITLE
ci: bump GitHub actions and Python/Node

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,14 +36,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "18"
 
       - name: Build Assets
         run: npm ci && npm run prod
@@ -63,7 +63,7 @@ jobs:
         run: hugo -v --minify
 
       - name: Deploy
-        uses: amondnet/vercel-action@v20
+        uses: amondnet/vercel-action@v25
         id: vercel-action
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -68,7 +68,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: .venv
@@ -103,7 +103,7 @@ jobs:
             poetry show poetry-plugin-export  | grep version | cut -d : -f 2 | xargs)
 
       - name: Checkout Plugin Source (poetry-plugin-export)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: poetry-plugin-export
           repository: python-poetry/poetry-plugin-export

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -148,7 +148,7 @@ poetry run pytest tests/
 ```
 
 Poetry uses [mypy](https://github.com/python/mypy) for typechecking, and the CI
-will fail if it finds any errors.  To run mypy locally:
+will fail if it finds any errors. To run mypy locally:
 
 ```bash
 poetry run mypy


### PR DESCRIPTION
# Pull Request Check List

Bump actions used in GitHub Actions workflows, as well as Python/Node versions used for the docs preview.

Backporting to 1.2 will allow us to set the minimum Python version to 3.10 on https://github.com/python-poetry/website without breaking docs preview on 1.2.

Changelogs:
- [actions/cache](https://github.com/actions/cache/releases)
- [actions/checkout](https://github.com/actions/checkout/releases)
- [amondnet/vercel-action](https://github.com/amondnet/vercel-action/releases)
- [setup-node](https://github.com/actions/setup-node/releases)
- [setup-python](https://github.com/actions/setup-python/releases)