### PR TITLE
chore(dependabot): setup weekly schedule for `github-actions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     open-pull-requests-limit: 0
     reviewers:
       - "python-poetry/triage"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Pull Request Check List

In order to make GitHub Actions updates less manuals, let's leverage Dependabot for the updates.
Since we mostly pin major versions for the actions, the volume of PRs will be pretty low, so a weekly schedule may be a good fit.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
