### PR TITLE
direct URL dependencies are never outdated

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -502,7 +502,7 @@ lists all packages available."""
         from poetry.version.version_selector import VersionSelector
 
         # find the latest version allowed in this pool
-        if package.source_type in ("git", "file", "directory"):
+        if package.is_direct_origin():
             requires = root.all_requires
 
             for dep in requires:

--- a/src/poetry/installation/pip_installer.py
+++ b/src/poetry/installation/pip_installer.py
@@ -48,10 +48,7 @@ class PipInstaller(BaseInstaller):
 
         args = ["install", "--no-deps"]
 
-        if (
-            package.source_type not in {"git", "directory", "file", "url"}
-            and package.source_url
-        ):
+        if not package.is_direct_origin() and package.source_url:
             assert package.source_reference is not None
             repository = self._pool.repository(package.source_reference)
             parsed = urllib.parse.urlparse(package.source_url)

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -546,12 +546,9 @@ class Provider:
             package = dependency_package.package
             dependency = dependency_package.dependency
             requires = package.all_requires
-        elif package.source_type not in {
-            "directory",
-            "file",
-            "url",
-            "git",
-        }:
+        elif package.is_direct_origin():
+            requires = package.requires
+        else:
             try:
                 dependency_package = DependencyPackage(
                     dependency,
@@ -573,8 +570,6 @@ class Provider:
 
             package = dependency_package.package
             dependency = dependency_package.dependency
-            requires = package.requires
-        else:
             requires = package.requires
 
         if self._load_deferred:


### PR DESCRIPTION
I had intended just to tidy up a couple of places that missed the opportunity to use `package.is_direct_origin()`, but in doing so I found one that ought to do that - and that missed "url" source type.

If a requirement specifies a direct URL, then that doesn't become outdated just because a newer version of the same package happens to be available in a repository.

(Or anyway if it does, then the same ought to apply to other direct-origin types, the url source type is not special)