### PR TITLE
fix virtualenv constraint (PEP 440 compliant)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -931,7 +931,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "1a3bec1367439db08fff0893d90204804ab6872bbaabdf88939c88c575776c77"
+content-hash = "3810aef128102dea7cd2797cfcee77f1345831ed057aac5a962916a76e29fb6a"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ shellingham = "^1.5"
 # exclude 0.11.2 and 0.11.3 due to https://github.com/sdispater/tomlkit/issues/225
 tomlkit = ">=0.11.1,<1.0.0,!=0.11.2,!=0.11.3"
 # exclude 20.4.5 - 20.4.6 due to https://github.com/pypa/pip/issues/9953
-virtualenv = ">=20.4.3,<20.4.5 || >=20.4.7"
+virtualenv = ">=20.4.3,!=20.4.5,!=20.4.6"
 xattr = { version = "^0.9.7", markers = "sys_platform == 'darwin'" }
 urllib3 = "^1.26.0"
 dulwich = "^0.20.44"


### PR DESCRIPTION
#6376 made poetry uninstallable via pip 🙈 (Seems we are missing some kind of smoke test that builds poetry and tries to install it.)

This PR fixes this regression by making the constraint PEP 440 compliant.