### PR TITLE
chore(typing): replace typing.* types with native ones

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -5,9 +5,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
 from typing import Mapping
-from typing import Union
 
 from cleo.helpers import option
 from packaging.utils import canonicalize_name
@@ -25,7 +23,7 @@ if TYPE_CHECKING:
 
     from poetry.repositories import Pool
 
-Requirements = Dict[str, Union[str, Mapping[str, Any]]]
+Requirements = dict[str, str | Mapping[str, Any]]
 
 
 class InitCommand(Command):

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from typing import Collection
 from typing import FrozenSet
-from typing import Tuple
 from typing import TypeVar
 
 from poetry.core.packages.dependency_group import MAIN_GROUP
@@ -188,7 +187,7 @@ class Solver:
         return final_packages, depths
 
 
-DFSNodeID = Tuple[str, FrozenSet[str], bool]
+DFSNodeID = tuple[str, FrozenSet[str], bool]
 
 T = TypeVar("T", bound="DFSNode")
 

--- a/src/poetry/utils/dependency_specification.py
+++ b/src/poetry/utils/dependency_specification.py
@@ -7,10 +7,7 @@ import urllib.parse
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import List
 from typing import TypeVar
-from typing import Union
 from typing import cast
 
 from poetry.core.packages.dependency import Dependency
@@ -25,7 +22,7 @@ if TYPE_CHECKING:
     from poetry.utils.env import Env
 
 
-DependencySpec = Dict[str, Union[str, bool, Dict[str, Union[str, bool]], List[str]]]
+DependencySpec = dict[str, str | bool | dict[str, str | bool] | list[str]]
 
 
 def _parse_dependency_specification_git_url(


### PR DESCRIPTION
Simple replacement of `typing` based container types with native ones (available via `from __future__ import annotations`).
