### PR TITLE
fix: write to stderr in utils.env

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -536,15 +536,15 @@ class EnvManager:
         executable = None
 
         try:
-            io.write_line(
+            io.write_error_line(
                 "Trying to detect current active python executable as specified in the"
                 " config.",
                 verbosity=Verbosity.VERBOSE,
             )
             executable = self._full_python_path("python")
-            io.write_line(f"Found: {executable}", verbosity=Verbosity.VERBOSE)
+            io.write_error_line(f"Found: {executable}", verbosity=Verbosity.VERBOSE)
         except CalledProcessError:
-            io.write_line(
+            io.write_error_line(
                 "Unable to detect the current active python executable. Falling back to"
                 " default.",
                 verbosity=Verbosity.VERBOSE,
@@ -651,7 +651,9 @@ class EnvManager:
             env = envs.get(name)
             if env is not None:
                 venv = venv_path / f"{name}-py{env['minor']}"
-                io.write_line(f"Deactivating virtualenv: <comment>{venv}</comment>")
+                io.write_error_line(
+                    f"Deactivating virtualenv: <comment>{venv}</comment>"
+                )
                 del envs[name]
 
                 envs_file.write(envs)
@@ -911,7 +913,7 @@ class EnvManager:
                 python = "python" + python_to_try
 
                 if io.is_debug():
-                    io.write_line(f"<debug>Trying {python}</debug>")
+                    io.write_error_line(f"<debug>Trying {python}</debug>")
 
                 try:
                     python_patch = decode(
@@ -930,7 +932,7 @@ class EnvManager:
                     continue
 
                 if supported_python.allows(Version.parse(python_patch)):
-                    io.write_line(f"Using <c1>{python}</c1> ({python_patch})")
+                    io.write_error_line(f"Using <c1>{python}</c1> ({python_patch})")
                     executable = python
                     python_minor = ".".join(python_patch.split(".")[:2])
                     break
@@ -955,7 +957,7 @@ class EnvManager:
 
         if not venv.exists():
             if create_venv is False:
-                io.write_line(
+                io.write_error_line(
                     "<fg=black;bg=yellow>"
                     "Skipping virtualenv creation, "
                     "as specified in config file."
@@ -964,7 +966,7 @@ class EnvManager:
 
                 return self.get_system_env()
 
-            io.write_line(
+            io.write_error_line(
                 f"Creating virtualenv <c1>{name}</> in"
                 f" {venv_path if not WINDOWS else get_real_windows_path(venv_path)!s}"
             )
@@ -976,11 +978,11 @@ class EnvManager:
                         f"<warning>The virtual environment found in {env.path} seems to"
                         " be broken.</warning>"
                     )
-                io.write_line(f"Recreating virtualenv <c1>{name}</> in {venv!s}")
+                io.write_error_line(f"Recreating virtualenv <c1>{name}</> in {venv!s}")
                 self.remove_venv(venv)
                 create_venv = True
             elif io.is_very_verbose():
-                io.write_line(f"Virtualenv <c1>{name}</> already exists.")
+                io.write_error_line(f"Virtualenv <c1>{name}</> already exists.")
 
         if create_venv:
             self.build_venv(
@@ -1917,14 +1919,14 @@ def build_environment(
 
             if io:
                 if not overwrite:
-                    io.write_line("")
+                    io.write_error_line("")
 
                 requires = [
                     f"<c1>{requirement}</c1>"
                     for requirement in poetry.pyproject.build_system.requires
                 ]
 
-                io.overwrite(
+                io.overwrite_error(
                     "<b>Preparing</b> build environment with build-system requirements"
                     f" {', '.join(requires)}"
                 )
@@ -1938,7 +1940,7 @@ def build_environment(
 
             if overwrite:
                 assert io is not None
-                io.write_line("")
+                io.write_error_line("")
 
             yield venv
     else:

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -86,12 +86,11 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     assert envs[venv_name]["minor"] == "3.7"
     assert envs[venv_name]["patch"] == "3.7.1"
 
-    expected = f"""\
-Creating virtualenv {venv_py37.name} in {venv_py37.parent}
-Using virtualenv: {venv_py37}
-"""
-
-    assert tester.io.fetch_output() == expected
+    assert (
+        tester.io.fetch_error()
+        == f"Creating virtualenv {venv_py37.name} in {venv_py37.parent}\n"
+    )
+    assert tester.io.fetch_output() == f"Using virtualenv: {venv_py37}\n"
 
 
 def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
@@ -149,9 +148,8 @@ def test_get_prefers_explicitly_activated_non_existing_virtualenvs_over_env_var(
 
     tester.execute(python_minor)
 
-    expected = f"""\
-Creating virtualenv {venv_dir.name} in {venv_dir.parent}
-Using virtualenv: {venv_dir}
-"""
-
-    assert tester.io.fetch_output() == expected
+    assert (
+        tester.io.fetch_error()
+        == f"Creating virtualenv {venv_dir.name} in {venv_dir.parent}\n"
+    )
+    assert tester.io.fetch_output() == f"Using virtualenv: {venv_dir}\n"


### PR DESCRIPTION
This is a quick fix to avoid polluting stdout unexpectedly when Poetry's
environment management comes into play.

It's apparent from how much the complexity of this file has grown that
this needs to be refactored moderately, as well as each major class
deserving its own source file.

Future work should also include a rethink of how IO objects are passed
around the codebase, how we reason about verbosity at a function level,
and how code is re-used -- one command may wish to output to stdout, but
if that code is reused by another command, the calculus of what is
command output and what is informative (or even needs to be hidden/shown
based on verbosity level) changes.

Work on output would likely have to be fairly comprehensive and
invasive, but things have grown complex enough that a top-down design
pass is likely the best route.

Regardless, this is a simple change today, and low risk. Resolves #6427.
