### PR TITLE
Handle locked pip version on Windows

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1393,7 +1393,10 @@ class Env:
         raise NotImplementedError()
 
     def get_pip_command(self, embedded: bool = False) -> list[str]:
-        return [self.python, self.pip_embedded if embedded else self.pip]
+        if embedded or not Path(self._bin(self._pip_executable)).exists():
+            return [self.python, self.pip_embedded]
+        # run as module so that pip can update itself on Windows
+        return [self.python, "-m", "pip"]
 
     def get_supported_tags(self) -> list[Tag]:
         raise NotImplementedError()

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1392,7 +1392,7 @@ def test_build_environment_called_build_script_specified(
         assert env == ephemeral_env
         assert env.executed == [
             [
-                "python",
+                sys.executable,
                 env.pip_embedded,
                 "install",
                 "--disable-pip-version-check",


### PR DESCRIPTION
Resolves: #6138

Use `poetry -m pip ...` instead of calling pip directly so that pip can update itself on Windows.

Just to be sure that this has no influence on performance, a little test:

```
setup = "import subprocess"

variants = {
    'embedded': [PYTHON_PATH, EMBEDDED_PIP_PATH, "-V"],  # fallback + prior #6062
    'bin': [PYTHON_PATH, PIP_PATH, "-V"],  # current
    'module': [PYTHON_PATH, "-m", "pip", "-V"],  # new
}

for name, cmd in variants.items():
    stmt = f"subprocess.check_output({cmd})"
    print(f"{name}: {timeit(stmt, setup, number=5)}")
```

Sample output:
```
embedded: 5.4903443
bin: 1.8143028999999995
module: 1.7508081999999998
```

As expected it makes no difference whether pip is called directly or as module.