### PR TITLE
poc: foreign pip

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -23,7 +23,7 @@ from poetry.core.utils.helpers import temporary_directory
 from poetry.core.version.markers import InvalidMarker
 
 from poetry.utils.env import EnvCommandError
-from poetry.utils.env import ephemeral_environment
+from poetry.utils.env.context import ephemeral_environment
 from poetry.utils.setup_reader import SetupReader
 
 

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -30,7 +30,7 @@ from poetry.utils.authenticator import Authenticator
 from poetry.utils.env import EnvCommandError
 from poetry.utils.helpers import pluralize
 from poetry.utils.helpers import remove_directory
-from poetry.utils.pip import pip_install
+from poetry.utils.pip import Pip
 
 
 if TYPE_CHECKING:
@@ -118,7 +118,8 @@ class Executor:
         self, req: Path, upgrade: bool = False, editable: bool = False
     ) -> int:
         try:
-            pip_install(req, self._env, upgrade=upgrade, editable=editable)
+            pip = Pip(target_env=self._env)
+            pip.install_archive(req, editable=editable, upgrade=upgrade)
         except EnvCommandError as e:
             output = decode(e.e.output)
             if (

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -17,9 +17,9 @@ from poetry.core.semver.version import Version
 
 from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import decode
-from poetry.utils.env import build_environment
+from poetry.utils.env.context import build_environment
 from poetry.utils.helpers import is_dir_writable
-from poetry.utils.pip import pip_install
+from poetry.utils.pip import Pip
 
 
 if TYPE_CHECKING:
@@ -101,15 +101,17 @@ class EditableBuilder(Builder):
                 f.write(decode(builder.build_setup()))
 
         try:
-            if self._env.pip_version < Version.from_parts(19, 0):
-                pip_install(self._path, self._env, upgrade=True, editable=True)
+            pip = Pip(target_env=self._env)
+
+            if pip.version() < Version.from_parts(19, 0):
+                pip.install_archive(self._path, editable=True, upgrade=True)
             else:
                 # Temporarily rename pyproject.toml
                 shutil.move(
                     str(self._poetry.file), str(self._poetry.file.with_suffix(".tmp"))
                 )
                 try:
-                    pip_install(self._path, self._env, upgrade=True, editable=True)
+                    pip.install_archive(self._path, editable=True, upgrade=True)
                 finally:
                     shutil.move(
                         str(self._poetry.file.with_suffix(".tmp")),

--- a/src/poetry/utils/env/context.py
+++ b/src/poetry/utils/env/context.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Iterator
+
+from poetry.core.utils.helpers import temporary_directory
+
+from poetry.utils.env import Env
+from poetry.utils.env import EnvManager
+from poetry.utils.env import VirtualEnv
+from poetry.utils.pip import Pip
+
+
+if TYPE_CHECKING:
+    from cleo.io.io import IO
+    from poetry.core.poetry import Poetry as CorePoetry
+
+
+@contextmanager
+def ephemeral_environment(
+    executable: str | Path | None = None,
+    flags: dict[str, bool] | None = None,
+) -> Iterator[VirtualEnv]:
+    with temporary_directory() as tmp_dir:
+        # TODO: cache PEP 517 build environment corresponding to each project venv
+        venv_dir = Path(tmp_dir) / ".venv"
+        EnvManager.build_venv(
+            path=venv_dir.as_posix(),
+            executable=executable,
+            flags=flags,
+        )
+        yield VirtualEnv(venv_dir, venv_dir)
+
+
+@contextmanager
+def build_environment(
+    poetry: CorePoetry, env: Env | None = None, io: IO | None = None
+) -> Iterator[Env]:
+    """
+    If a build script is specified for the project, there could be additional build
+    time dependencies, eg: cython, setuptools etc. In these cases, we create an
+    ephemeral build environment with all requirements specified under
+    `build-system.requires` and return this. Otherwise, the given default project
+    environment is returned.
+    """
+    if not env or poetry.package.build_script:
+        with ephemeral_environment(executable=env.python if env else None) as venv:
+            overwrite = (
+                io is not None and io.output.is_decorated() and not io.is_debug()
+            )
+
+            if io:
+                if not overwrite:
+                    io.write_error_line("")
+
+                requires = [
+                    f"<c1>{requirement}</c1>"
+                    for requirement in poetry.pyproject.build_system.requires
+                ]
+
+                io.overwrite_error(
+                    "<b>Preparing</b> build environment with build-system requirements"
+                    f" {', '.join(requires)}"
+                )
+
+            pip = Pip(target_env=venv)
+            pip.install_requirements(poetry.pyproject.build_system.requires)
+
+            if overwrite:
+                assert io is not None
+                io.write_error_line("")
+
+            yield venv
+    else:
+        yield env

--- a/src/poetry/utils/pip.py
+++ b/src/poetry/utils/pip.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
+import itertools
+import os
+import tempfile
+
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import Collection
+
+from poetry.core.semver.version import Version
 
 from poetry.exceptions import PoetryException
 from poetry.utils.env import EnvCommandError
+from poetry.utils.env import EnvManager
 
 
 if TYPE_CHECKING:
@@ -12,40 +21,94 @@ if TYPE_CHECKING:
     from poetry.utils.env import Env
 
 
-def pip_install(
-    path: Path,
-    environment: Env,
-    editable: bool = False,
-    deps: bool = False,
-    upgrade: bool = False,
-) -> int | str:
-    is_wheel = path.suffix == ".whl"
+class Pip:
+    def __init__(self, target_env: Env | None) -> None:
+        self._poetry_env = EnvManager.get_system_env(naive=True)
 
-    # We disable version check here as we are already pinning to version available in
-    # either the virtual environment or the virtualenv package embedded wheel. Version
-    # checks are a wasteful network call that adds a lot of wait time when installing a
-    # lot of packages.
-    args = ["install", "--disable-pip-version-check", "--prefix", str(environment.path)]
+        if not target_env:
+            target_env = self._poetry_env
 
-    if not is_wheel and not editable:
-        args.insert(1, "--use-pep517")
+        self._target_env = target_env
 
-    if upgrade:
-        args.append("--upgrade")
+    def run(self, *args: str, **kwargs: Any) -> int | str:
+        return self._poetry_env.run(
+            "python", "-m", "pip", "--disable-pip-version-check", *args, **kwargs
+        )
 
-    if not deps:
-        args.append("--no-deps")
+    def _install(self, *args: str) -> int | str:
+        platform_args = itertools.chain.from_iterable(
+            ["--platform", platform]
+            for platform in {tag.platform for tag in self._target_env.supported_tags}
+        )
+        abi_args = itertools.chain.from_iterable(
+            ["--abi", abi]
+            for abi in {tag.abi for tag in self._target_env.supported_tags}
+        )
 
-    if editable:
-        if not path.is_dir():
-            raise PoetryException(
-                "Cannot install non directory dependencies in editable mode"
-            )
-        args.append("-e")
+        run_result = self.run(
+            "install",
+            "--no-warn-script-location",
+            "--target",
+            str(self._target_env.platlib),
+            "--implementation",
+            self._target_env.marker_env["interpreter_name"],
+            "--python-version",
+            self._target_env.marker_env["python_version"],
+            *platform_args,
+            *abi_args,
+            *args,
+        )
 
-    args.append(str(path))
+        return run_result
 
-    try:
-        return environment.run_pip(*args)
-    except EnvCommandError as e:
-        raise PoetryException(f"Failed to install {path.as_posix()}") from e
+    def install_archive(
+        self,
+        path: Path,
+        editable: bool = False,
+        deps: bool = False,
+        upgrade: bool = False,
+    ) -> int | str:
+        args = []
+
+        if path.suffix != ".whl" and not editable:
+            args.append("--use-pep517")
+
+        if upgrade:
+            args.append("--upgrade")
+
+        if not deps:
+            args.append("--no-deps")
+
+        if editable:
+            if not path.is_dir():
+                raise PoetryException(
+                    "Only directory dependencies can be installed in editable mode"
+                )
+            args.append("-e")
+
+        args.append(str(path))
+
+        try:
+            return self._install(*args)
+        except EnvCommandError as e:
+            raise PoetryException(f"Failed to install {path.as_posix()}") from e
+
+    def install_requirements(self, requirements: Collection[str]) -> int | str:
+        with tempfile.NamedTemporaryFile(
+            "w+", prefix="requirements-", suffix=".txt"
+        ) as requirements_txt:
+            requirements_txt.write(os.linesep.join(requirements))
+            try:
+                return self._install(
+                    "--use-pep517", "-r", os.path.abspath(requirements_txt.name)
+                )
+            except EnvCommandError as e:
+                raise PoetryException(
+                    f"Failed to install requirements {', '.join(requirements)}"
+                ) from e
+
+    @staticmethod
+    def version() -> Version:
+        from pip import __version__
+
+        return Version.parse(__version__)

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -21,7 +21,7 @@ from poetry.utils.env import EnvCommandError
 from poetry.utils.env import EnvManager
 from poetry.utils.env import MockEnv
 from poetry.utils.env import VirtualEnv
-from poetry.utils.env import ephemeral_environment
+from poetry.utils.env.context import ephemeral_environment
 
 
 if TYPE_CHECKING:

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1385,7 +1385,7 @@ def test_build_environment_called_build_script_specified(
     ephemeral_env = MockEnv(path=Path(tmp_dir) / "ephemeral")
 
     mocker.patch(
-        "poetry.utils.env.ephemeral_environment"
+        "poetry.utils.env.context.ephemeral_environment"
     ).return_value.__enter__.return_value = ephemeral_env
 
     with build_environment(extended_without_setup_poetry, project_env) as env:
@@ -1409,7 +1409,7 @@ def test_build_environment_not_called_without_build_script_specified(
     ephemeral_env = MockEnv(path=Path(tmp_dir) / "ephemeral")
 
     mocker.patch(
-        "poetry.utils.env.ephemeral_environment"
+        "poetry.utils.env.context.ephemeral_environment"
     ).return_value.__enter__.return_value = ephemeral_env
 
     with build_environment(poetry, project_env) as env:


### PR DESCRIPTION
This is a take on an alternate solution to our current embedded/in-venv pip woes: use a 'foreign' pip installed in Poetry's env to manage files in the project venv.

This works, except for scripts as `--target` does not install scripts properly, and `--prefix` cannot be used with the wheel platform overrides. However, if pip grows support for `--prefix` instead of `--target` in our use case, this could be a viable transitional approach for 1.2.

Tests are going to be totally busted as I have not upgraded any of them for the new code yet.
