### PR TITLE
docs: improved description of `virtualenvs.create` option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,7 +257,23 @@ Use parallel execution when using the new (`>=1.1.0`) installer.
 
 Create a new virtual environment if one doesn't already exist.
 
-If set to `false`, poetry will install dependencies into the current python environment.
+If set to `false`, Poetry will not create a new virtual environment. If it detects a virtual environment
+in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` it will install dependencies into them, otherwise it will install
+dependencies into the systems python environment.
+
+{{% note %}}
+If Poetry detects it's running within an activated virtual environment, it will never create a new virtual environment,
+regardless of the value set for `virtualenvs.create`.
+{{% /note %}}
+
+{{% note %}}
+Be aware that installing dependencies into the system environment likely upgrade or uninstall existing packages and thus
+break other applications. Installing additional Python packages after installing the project might break the Poetry
+project in return.
+
+This is why it is recommended to always create a virtual environment. This is also true in Docker containers, as they
+might contain additional Python packages as well.
+{{% /note %}}
 
 ### `virtualenvs.in-project`
 


### PR DESCRIPTION
I tried to clarify how the `virtualenvs.create` config option works and why it is a good idea to have virtual environments in docker containers as well.