### PR TITLE
[1.2] fix: performance regression when parsing links from legacy repositories

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,14 @@ tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900
 tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backports.cached-property"
+version = "1.0.2"
+description = "cached_property() - computed once per instance, cached as attribute"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[[package]]
 name = "CacheControl"
 version = "0.12.11"
 description = "httplib2 caching for requests"
@@ -969,12 +977,16 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "853bf1ff15c31c912ce1f017cab05956ac09e0fe1a8262a40d77363192c5f934"
+content-hash = "583302ecdf45ce586b5c640d3942765615bb6e0c4749be43230b1cf02fd7d16e"
 
 [metadata.files]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+]
+"backports.cached-property" = [
+    {file = "backports.cached-property-1.0.2.tar.gz", hash = "sha256:9306f9eed6ec55fd156ace6bc1094e2c86fae5fb2bf07b6a9c00745c656e75dd"},
+    {file = "backports.cached_property-1.0.2-py3-none-any.whl", hash = "sha256:baeb28e1cd619a3c9ab8941431fe34e8490861fb998c6c4590693d50171db0cc"},
 ]
 CacheControl = [
     {file = "CacheControl-0.12.11-py2.py3-none-any.whl", hash = "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ python = "^3.7"
 
 poetry-core = "1.1.0"
 poetry-plugin-export = "^1.0.6"
+"backports.cached-property" = { version = "^1.0.2", python = "<3.8" }
 cachecontrol = { version = "^0.12.9", extras = ["filecache"] }
 cachy = "^0.3.0"
 cleo = "^1.0.0a5"

--- a/src/poetry/utils/_compat.py
+++ b/src/poetry/utils/_compat.py
@@ -13,6 +13,12 @@ if sys.version_info < (3, 10):
 else:
     from importlib import metadata
 
+if sys.version_info < (3, 8):
+    # compatibility for python <3.8
+    from backports.cached_property import cached_property
+else:
+    from functools import cached_property
+
 WINDOWS = sys.platform == "win32"
 
 
@@ -53,4 +59,12 @@ def list_to_shell_command(cmd: list[str]) -> str:
     )
 
 
-__all__ = ["WINDOWS", "decode", "encode", "list_to_shell_command", "metadata", "to_str"]
+__all__ = [
+    "WINDOWS",
+    "cached_property",
+    "decode",
+    "encode",
+    "list_to_shell_command",
+    "metadata",
+    "to_str",
+]

--- a/tests/repositories/link_sources/test_base.py
+++ b/tests/repositories/link_sources/test_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING
 from unittest.mock import PropertyMock
 
@@ -24,16 +25,22 @@ def link_source(mocker: MockerFixture) -> LinkSource:
     url = "https://example.org"
     link_source = LinkSource(url)
     mocker.patch(
-        f"{LinkSource.__module__}.{LinkSource.__qualname__}.links",
+        f"{LinkSource.__module__}.{LinkSource.__qualname__}._link_cache",
         new_callable=PropertyMock,
-        return_value=iter(
-            [
-                Link(f"{url}/demo-0.1.0.tar.gz"),
-                Link(f"{url}/demo-0.1.0_invalid.tar.gz"),
-                Link(f"{url}/invalid.tar.gz"),
-                Link(f"{url}/demo-0.1.0-py2.py3-none-any.whl"),
-                Link(f"{url}/demo-0.1.1.tar.gz"),
-            ]
+        return_value=defaultdict(
+            lambda: defaultdict(list),
+            {
+                canonicalize_name("demo"): defaultdict(
+                    list,
+                    {
+                        Version.parse("0.1.0"): [
+                            Link(f"{url}/demo-0.1.0.tar.gz"),
+                            Link(f"{url}/demo-0.1.0-py2.py3-none-any.whl"),
+                        ],
+                        Version.parse("0.1.1"): [Link(f"{url}/demo-0.1.1.tar.gz")],
+                    },
+                ),
+            },
         ),
     )
     return link_source
@@ -63,7 +70,7 @@ def test_link_package_data(filename: str, expected: Package | None) -> None:
     ],
 )
 def test_versions(name: str, expected: set[Version], link_source: LinkSource) -> None:
-    assert set(link_source.versions(name)) == expected
+    assert set(link_source.versions(canonicalize_name(name))) == expected
 
 
 def test_packages(link_source: LinkSource) -> None:

--- a/tests/repositories/link_sources/test_html.py
+++ b/tests/repositories/link_sources/test_html.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from packaging.utils import canonicalize_name
 from poetry.core.packages.utils.link import Link
 from poetry.core.semver.version import Version
 
@@ -90,4 +91,4 @@ def test_yanked(yanked_attrs: tuple[str, str], expected: bool | str) -> None:
     content = DEMO_TEMPLATE.format(anchors)
     page = HTMLPage("https://example.org", content)
 
-    assert page.yanked("demo", Version.parse("0.1")) == expected
+    assert page.yanked(canonicalize_name("demo"), Version.parse("0.1")) == expected

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -102,24 +102,11 @@ def test_page_invalid_version_link() -> None:
     assert page is not None
 
     links = list(page.links)
-    assert len(links) == 2
+    assert len(links) == 1
 
-    versions = list(page.versions("poetry"))
+    versions = list(page.versions(canonicalize_name("poetry")))
     assert len(versions) == 1
     assert versions[0].to_string() == "0.1.0"
-
-    invalid_link = None
-
-    for link in links:
-        if link.filename.startswith("poetry-21"):
-            invalid_link = link
-            break
-
-    links_010 = list(page.links_for_version(canonicalize_name("poetry"), versions[0]))
-    assert invalid_link not in links_010
-
-    assert invalid_link
-    assert not page.link_package_data(invalid_link)
 
     packages = list(page.packages)
     assert len(packages) == 1


### PR DESCRIPTION
Backport of #6442