### PR TITLE
don't use normalize_version()

### DIFF
--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -11,7 +11,6 @@ import requests
 
 from poetry.core.masonry.metadata import Metadata
 from poetry.core.masonry.utils.helpers import escape_name
-from poetry.core.masonry.utils.helpers import escape_version
 from requests import adapters
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
@@ -80,10 +79,7 @@ class Uploader:
         version = self._package.version.to_string()
 
         wheels = list(
-            dist.glob(
-                f"{escape_name(self._package.pretty_name)}-{escape_version(version)}"
-                "-*.whl"
-            )
+            dist.glob(f"{escape_name(self._package.pretty_name)}-{version}-*.whl")
         )
         tars = list(dist.glob(f"{self._package.pretty_name}-{version}.tar.gz"))
 

--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -12,7 +12,6 @@ import requests
 from poetry.core.masonry.metadata import Metadata
 from poetry.core.masonry.utils.helpers import escape_name
 from poetry.core.masonry.utils.helpers import escape_version
-from poetry.core.utils.helpers import normalize_version
 from requests import adapters
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
@@ -78,7 +77,7 @@ class Uploader:
     @property
     def files(self) -> list[Path]:
         dist = self._poetry.file.parent / "dist"
-        version = normalize_version(self._package.version.text)
+        version = self._package.version.to_string()
 
         wheels = list(
             dist.glob(
@@ -305,10 +304,7 @@ class Uploader:
         Register a package to a repository.
         """
         dist = self._poetry.file.parent / "dist"
-        file = (
-            dist
-            / f"{self._package.name}-{normalize_version(self._package.version.text)}.tar.gz"  # noqa: E501
-        )
+        file = dist / f"{self._package.name}-{self._package.version.to_string()}.tar.gz"
 
         if not file.exists():
             raise RuntimeError(f'"{file.name}" does not exist.')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from poetry.core.masonry.utils.helpers import escape_name
-from poetry.core.masonry.utils.helpers import escape_version
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.toml.file import TOMLFile
@@ -237,7 +236,7 @@ class TestRepository(Repository):
         return [
             Link(
                 f"https://foo.bar/files/{escape_name(package.name)}"
-                f"-{escape_version(package.version.text)}-py2.py3-none-any.whl"
+                f"-{package.version.to_string()}-py2.py3-none-any.whl"
             )
         ]
 


### PR DESCRIPTION
When you already have a `Version` in hand, `normalize_version(version.text)` is a very roundabout way of calling `version.to_string()`: it re-parses the version text to give you the same `Version` you already had and then calls `to_string()` on that.

https://github.com/python-poetry/poetry-core/blob/37cee90a5dd4c7ee2c5ee836216ba813242b3ade/src/poetry/core/utils/helpers.py#L27-L28

Then calling `escape_version()` on such a version is actually counter-productive, per #6466.

Similar changes can and should be made over in poetry-core, but it should be safe to merge this before that is done.