### PR TITLE
respect --no-cache at poetry install

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -327,6 +327,7 @@ class Application(BaseApplication):  # type: ignore[misc]
             poetry.locker,
             poetry.pool,
             poetry.config,
+            disable_cache=poetry.disable_cache,
         )
         installer.use_executor(poetry.config.get("experimental.new-installer", False))
         command.set_installer(installer)

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -92,6 +92,7 @@ class Factory(BaseFactory):
             base_poetry.package,
             locker,
             config,
+            disable_cache,
         )
 
         # Configuring sources

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -53,13 +53,16 @@ class Executor:
         config: Config,
         io: IO,
         parallel: bool | None = None,
+        disable_cache: bool = False,
     ) -> None:
         self._env = env
         self._io = io
         self._dry_run = False
         self._enabled = True
         self._verbose = False
-        self._authenticator = Authenticator(config, self._io)
+        self._authenticator = Authenticator(
+            config, self._io, disable_cache=disable_cache
+        )
         self._chef = Chef(config, self._env)
         self._chooser = Chooser(pool, self._env, config)
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -43,6 +43,7 @@ class Installer:
         config: Config,
         installed: Repository | None = None,
         executor: Executor | None = None,
+        disable_cache: bool = False,
     ) -> None:
         self._io = io
         self._env = env
@@ -65,7 +66,9 @@ class Installer:
         self._extras: list[str] = []
 
         if executor is None:
-            executor = Executor(self._env, self._pool, config, self._io)
+            executor = Executor(
+                self._env, self._pool, config, self._io, disable_cache=disable_cache
+            )
 
         self._executor = executor
         self._use_executor = False

--- a/src/poetry/poetry.py
+++ b/src/poetry/poetry.py
@@ -30,6 +30,7 @@ class Poetry(BasePoetry):
         package: ProjectPackage,
         locker: Locker,
         config: Config,
+        disable_cache: bool = False,
     ) -> None:
         from poetry.repositories.pool import Pool
 
@@ -39,6 +40,7 @@ class Poetry(BasePoetry):
         self._config = config
         self._pool = Pool()
         self._plugin_manager: PluginManager | None = None
+        self._disable_cache = disable_cache
 
     @property
     def locker(self) -> Locker:
@@ -51,6 +53,10 @@ class Poetry(BasePoetry):
     @property
     def config(self) -> Config:
         return self._config
+
+    @property
+    def disable_cache(self) -> bool:
+        return self._disable_cache
 
     def set_locker(self, locker: Locker) -> Poetry:
         self._locker = locker

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -11,6 +11,7 @@ from cleo.testers.application_tester import ApplicationTester
 from poetry.console.application import Application
 from poetry.console.commands.command import Command
 from poetry.plugins.application_plugin import ApplicationPlugin
+from poetry.utils.authenticator import Authenticator
 from tests.helpers import mock_metadata_entry_points
 
 
@@ -99,3 +100,26 @@ def test_application_verify_source_cache_flag(disable_cache: bool):
 
     for repo in app.poetry.pool.repositories:
         assert repo._disable_cache == disable_cache
+
+
+@pytest.mark.parametrize("disable_cache", [True, False])
+def test_application_verify_cache_flag_at_install(
+    mocker: MockerFixture, disable_cache: bool
+) -> None:
+    app = Application()
+
+    tester = ApplicationTester(app)
+    command = "install --dry-run"
+
+    if disable_cache:
+        command = f"{command} --no-cache"
+
+    spy = mocker.spy(Authenticator, "__init__")
+
+    tester.execute(command)
+
+    assert spy.call_count == 2
+    for call in spy.mock_calls:
+        (name, args, kwargs) = call
+        assert "disable_cache" in kwargs
+        assert disable_cache is kwargs["disable_cache"]


### PR DESCRIPTION
Authenticator created by executor eg at `poetry install` did not respect `--no-cache`