### PR TITLE
chore(pre-commit): check lock file consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,3 +89,11 @@ repos:
     rev: v2.20.0
     hooks:
       - id: validate_manifest
+
+  - repo: https://github.com/python-poetry/poetry
+    rev: 1.2.0
+    hooks:
+      - id: poetry-lock
+        name: poetry-lock-check
+        args: [--check]
+        files: ^pyproject\.toml|poetry\.lock$


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Eat our own dogfood by checking that Poetry's own lock file is consistent with `pyproject.toml`.

A warning is already shown if we `poetry install` with an inconsistent lock file, but since this won't stop the dependencies from being installed, resulting in a green CI, running `poetry lock --check` will more explicitly show the issue and prevent any merge.