### PR TITLE
docs: added note about `pre-commit autoupdate`

### DIFF
--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -24,7 +24,6 @@ the defaults are overwritten. You must fully specify all arguments for
 your hook if you make use of `args:`.
 {{% /note %}}
 
-
 ## poetry-check
 
 The `poetry-check` hook calls the `poetry check` command
@@ -99,3 +98,24 @@ repos:
       - id: poetry-export
         args: ["-f", "requirements.txt", "-o", "requirements.txt"]
 ```
+
+## FAQ
+
+### Why does `pre-commit autoupdate` not update to the latest version?
+
+`pre-commit autoupdate` updates the `rev` for each repository defined in your `.pre-commit-config.yaml`
+to the latest available tag in the default branch.
+
+Poetry follows a branching strategy, where the default branch is the active developement branch
+and fixes gets back ported to stable branches. New tags are assigned in these stable branches.
+
+`pre-commit` does not support such a branching strategy and has decided to not implement
+an option, either on the [user side](https://github.com/pre-commit/pre-commit/issues/2512)
+or [hook author side](https://github.com/pre-commit/pre-commit/issues/2508), to define a branch for lookup the latest
+available tag.
+
+Thus, `pre-commit autoupdate` is not usable for the hooks described here.
+
+You can avoid changing the `rev` to an unexpected value, by using the `--repo` parameter (may be specified multiple
+times), to explicit list repositories that should be updated. An option to explicit exclude
+repositories [will not be implemented](https://github.com/pre-commit/pre-commit/issues/1959) into `pre-commit`.


### PR DESCRIPTION
Added explanation to docs why `pre-commit autoupdate` will not find latest version for Poetry's hooks.