### PR TITLE
keyring and virtualenv are not using calver

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -956,7 +956,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0cbb342d793a9fec2c99fbcc07434f320c618054a30dfc4af44896ebc3e9f676"
+content-hash = "52b7d1bdfdd8e2e16cb1a51eb82bfd8e0c8a5abbbe194637ac8a24a43648642a"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,7 @@ filelock = "^3.8.0"
 html5lib = "^1.0"
 importlib-metadata = { version = "^4.4", python = "<3.10" }
 jsonschema = "^4.10.0"
-# keyring uses calver, so version is unclamped
-keyring = ">=21.2.0"
+keyring = "^23.9.0"
 # packaging uses calver, so version is unclamped
 packaging = ">=20.4"
 pexpect = "^4.7.0"
@@ -69,7 +68,7 @@ shellingham = "^1.5"
 # exclude 0.11.2 and 0.11.3 due to https://github.com/sdispater/tomlkit/issues/225
 tomlkit = ">=0.11.1,<1.0.0,!=0.11.2,!=0.11.3"
 # exclude 20.4.5 - 20.4.6 due to https://github.com/pypa/pip/issues/9953
-virtualenv = ">=20.4.3,!=20.4.5,!=20.4.6"
+virtualenv = "^20.4.3,!=20.4.5,!=20.4.6"
 xattr = { version = "^0.9.7", markers = "sys_platform == 'darwin'" }
 urllib3 = "^1.26.0"
 


### PR DESCRIPTION
`keyring` had a `>=` dependency on the grounds that it used calendar versioning: but since they have reached `23.x.x` that's clearly not true.  

`virtualenv` had a `>=` dependency, presumably for similar reasons.  It looks as though they maybe did use calendar versioning up to 2020, but they've made plenty of releases in the last couple of years and only reached 20.16.5.

I am not claiming that these projects follow semver in a way that can be relied on: but that's just how life is in the python world.  Eg the [virtualenv changelog](https://virtualenv.pypa.io/en/latest/changelog.html) regularly includes 'Features' in patch releases.  

So far as adherence to semver goes, poetry and poetry-core are likely living in a glass house and should not throw any stones.

However I am claiming that it is inconsistent to use `>=` for these dependencies when, so far as I can tell, they are as close to using semver as any other project.