### PR TITLE
chore(ci): check lock file consistency

### DIFF
--- a/.github/workflows/check-lock-file-consistency.yml
+++ b/.github/workflows/check-lock-file-consistency.yml
@@ -1,0 +1,34 @@
+name: Check lock file consistency
+
+on:
+  pull_request:
+    paths:
+      - pyproject.toml
+      - poetry.lock
+  push:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-lock-file-consistency:
+    name: Check lock file consistency
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: curl -sSL https://install.python-poetry.org | python - -y
+
+      - name: Update PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Check lock file consistency with pyproject.toml
+        run: poetry lock --check


### PR DESCRIPTION
Check lock file consistency on the CI, to ensure that `poetry.lock` is correctly updated on PRs updating dependencies in `pyproject.toml`.

This has been tested on my fork, with 2 cases:
- [files are consistent](https://github.com/mkniewallner/poetry/actions/runs/3048704409/jobs/4914048095)
- [files are not consistent](https://github.com/mkniewallner/poetry/actions/runs/3048698671/jobs/4914036858)

# Pull Request Check List

Closes: #6480

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.