### PR TITLE
fix: poetry-core>=1.1.0 is needed as build-system requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ poetry = "poetry.console.application:main"
 
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.1.0"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
Because Poetry itself uses dependency groups now, the minimum required `poetry-core` version for the `[build-system]` is `1.1.0`.
