### PR TITLE
fix: wrong nested table level when overwriting pyproject

### DIFF
--- a/src/poetry/console/commands/self/self_command.py
+++ b/src/poetry/console/commands/self/self_command.py
@@ -75,7 +75,7 @@ class SelfCommand(InstallerCommand):
         content = Factory.create_pyproject_from_package(package=package)
 
         for key in preserved:
-            content[key] = preserved[key]
+            content["tool"]["poetry"][key] = preserved[key]
 
         self.system_pyproject.write_text(content.as_string(), encoding="utf-8")
 

--- a/src/poetry/console/commands/self/self_command.py
+++ b/src/poetry/console/commands/self/self_command.py
@@ -75,7 +75,7 @@ class SelfCommand(InstallerCommand):
         content = Factory.create_pyproject_from_package(package=package)
 
         for key in preserved:
-            content["tool"]["poetry"][key] = preserved[key]
+            content["tool"]["poetry"][key] = preserved[key]  # type: ignore[index]
 
         self.system_pyproject.write_text(content.as_string(), encoding="utf-8")
 


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

Previously, we rely on the `display_name` stored with `tomlkit.Table`, which is an internal implementation detail, and it breaks https://github.com/sdispater/tomlkit/pull/234. This PR corrects the nested table level, because `preserved` map comes from the poetry config table.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
