### PR TITLE
fix(cache clear): normalize package name

### DIFF
--- a/src/poetry/console/commands/cache/clear.py
+++ b/src/poetry/console/commands/cache/clear.py
@@ -4,6 +4,7 @@ import os
 
 from cleo.helpers import argument
 from cleo.helpers import option
+from packaging.utils import canonicalize_name
 
 from poetry.config.config import Config
 from poetry.console.commands.command import Command
@@ -66,7 +67,7 @@ class CacheClearCommand(Command):
                 "Add a specific version to clear"
             )
         elif len(parts) == 3:
-            package = parts[1]
+            package = canonicalize_name(parts[1])
             version = parts[2]
 
             if not cache.has(f"{package}:{version}"):

--- a/tests/console/commands/cache/test_clear.py
+++ b/tests/console/commands/cache/test_clear.py
@@ -55,12 +55,16 @@ def test_cache_clear_all_no(
     assert cache.has("cleo:0.2")
 
 
+@pytest.mark.parametrize("package_name", ["cachy", "Cachy"])
 def test_cache_clear_pkg(
     tester: ApplicationTester,
     repository_one: str,
     cache: CacheManager,
+    package_name: str,
 ):
-    exit_code = tester.execute(f"cache clear {repository_one}:cachy:0.1", inputs="yes")
+    exit_code = tester.execute(
+        f"cache clear {repository_one}:{package_name}:0.1", inputs="yes"
+    )
 
     assert exit_code == 0
     assert tester.io.fetch_output() == ""


### PR DESCRIPTION
When calling `poetry cache clear` for a specific package, the package name has to be normalized.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
