### PR TITLE
Use tomli for reading the lock file

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -951,7 +951,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f1ebc914a6733399d6dfb591c7c0e1aaef549a809a99c092a6fa04db0c209819"
+content-hash = "15420e602f85e17a36f549d671458e0439697ce2337b85023c9309d49b74f5e4"
 
 [metadata.files]
 attrs = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -524,15 +524,15 @@ importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "poetry-plugin-export"
-version = "1.1.2"
+version = "1.2.0"
 description = "Poetry plugin to export the dependencies to various formats"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
-poetry = ">=1.2.0,<2.0.0"
-poetry-core = ">=1.1.0,<2.0.0"
+poetry = ">=1.2.2,<2.0.0"
+poetry-core = ">=1.3.0,<2.0.0"
 
 [[package]]
 name = "pre-commit"
@@ -951,7 +951,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "15420e602f85e17a36f549d671458e0439697ce2337b85023c9309d49b74f5e4"
+content-hash = "703e97d65aae512130b6a43ef7c82a27c914b9f4023f5267824b54e901d4bde3"
 
 [metadata.files]
 attrs = [
@@ -1364,8 +1364,8 @@ poetry-core = [
     {file = "poetry_core-1.3.2-py3-none-any.whl", hash = "sha256:ea0f5a90b339cde132b4e43cff78a1b440cd928db864bb67cfc97fdfcefe7218"},
 ]
 poetry-plugin-export = [
-    {file = "poetry-plugin-export-1.1.2.tar.gz", hash = "sha256:5e92525dd63f38ce74a51ed68ea91d753523f21ce5f9ef8d3b793e2a4b2222ef"},
-    {file = "poetry_plugin_export-1.1.2-py3-none-any.whl", hash = "sha256:946e3313b3d00c18fb9a50522e9d5e6a7e111beaba8d6ae33297662fc2070ac1"},
+    {file = "poetry_plugin_export-1.2.0-py3-none-any.whl", hash = "sha256:109fb43ebfd0e79d8be2e7f9d43ba2ae357c4975a18dfc0cfdd9597dd086790e"},
+    {file = "poetry_plugin_export-1.2.0.tar.gz", hash = "sha256:9a1dd42765408931d7831738749022651d43a2968b67c988db1b7a567dfe41ef"},
 ]
 pre-commit = [
     {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -820,14 +820,6 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "tomli-w"
-version = "1.0.0"
-description = "A lil' TOML writer"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[[package]]
 name = "tomlkit"
 version = "0.11.5"
 description = "Style preserving TOML library"
@@ -959,7 +951,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "b73851a7dab18e19eed5349cf3f5b4a42e4adeb2c76a561b75b4fe9c5d08d069"
+content-hash = "f1ebc914a6733399d6dfb591c7c0e1aaef549a809a99c092a6fa04db0c209819"
 
 [metadata.files]
 attrs = [
@@ -1561,10 +1553,6 @@ toml = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-tomli-w = [
-    {file = "tomli_w-1.0.0-py3-none-any.whl", hash = "sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463"},
-    {file = "tomli_w-1.0.0.tar.gz", hash = "sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9"},
 ]
 tomlkit = [
     {file = "tomlkit-0.11.5-py3-none-any.whl", hash = "sha256:f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -10,7 +10,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "backports.cached-property"
@@ -86,7 +86,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "cleo"
@@ -749,7 +749,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -815,7 +815,15 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "tomli-w"
+version = "1.0.0"
+description = "A lil' TOML writer"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -951,7 +959,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "7db62de4ee4f2831829fc08b6a3d190f177c62d5af7676e20fb228bb58274850"
+content-hash = "b73851a7dab18e19eed5349cf3f5b4a42e4adeb2c76a561b75b4fe9c5d08d069"
 
 [metadata.files]
 attrs = [
@@ -1553,6 +1561,10 @@ toml = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tomli-w = [
+    {file = "tomli_w-1.0.0-py3-none-any.whl", hash = "sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463"},
+    {file = "tomli_w-1.0.0.tar.gz", hash = "sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9"},
 ]
 tomlkit = [
     {file = "tomlkit-0.11.5-py3-none-any.whl", hash = "sha256:f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ platformdirs = "^2.5.2"
 requests = "^2.18"
 requests-toolbelt = ">=0.9.1,<0.11.0"
 shellingham = "^1.5"
-tomli = "^2.0.1"
+tomli = { version = "^2.0.1", python = "<3.11" }
 # exclude 0.11.2 and 0.11.3 due to https://github.com/sdispater/tomlkit/issues/225
 tomlkit = ">=0.11.1,<1.0.0,!=0.11.2,!=0.11.3"
 trove-classifiers = "^2022.5.19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ generate-setup-file = false
 python = "^3.7"
 
 poetry-core = "^1.3.2"
-poetry-plugin-export = "^1.1.2"
+poetry-plugin-export = "^1.2.0"
 "backports.cached-property" = { version = "^1.0.2", python = "<3.8" }
 cachecontrol = { version = "^0.12.9", extras = ["filecache"] }
 cleo = "^1.0.0a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ requests = "^2.18"
 requests-toolbelt = ">=0.9.1,<0.11.0"
 shellingham = "^1.5"
 tomli = "^2.0.1"
-tomli-w = "^1.0.0"
 # exclude 0.11.2 and 0.11.3 due to https://github.com/sdispater/tomlkit/issues/225
 tomlkit = ">=0.11.1,<1.0.0,!=0.11.2,!=0.11.3"
 trove-classifiers = "^2022.5.19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ platformdirs = "^2.5.2"
 requests = "^2.18"
 requests-toolbelt = ">=0.9.1,<0.11.0"
 shellingham = "^1.5"
+tomli = "^2.0.1"
+tomli-w = "^1.0.0"
 # exclude 0.11.2 and 0.11.3 due to https://github.com/sdispater/tomlkit/issues/225
 tomlkit = ">=0.11.1,<1.0.0,!=0.11.2,!=0.11.3"
 trove-classifiers = "^2022.5.19"

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -241,7 +241,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
 
         # Refresh the locker
         self.poetry.set_locker(
-            self.poetry.locker.__class__(self.poetry.locker.lock.path, poetry_content)
+            self.poetry.locker.__class__(self.poetry.locker.lock, poetry_content)
         )
         self.installer.set_locker(self.poetry.locker)
 

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -103,7 +103,7 @@ list of installed packages
 
         # Refresh the locker
         self.poetry.set_locker(
-            self.poetry.locker.__class__(self.poetry.locker.lock.path, poetry_content)
+            self.poetry.locker.__class__(self.poetry.locker.lock, poetry_content)
         )
         self.installer.set_locker(self.poetry.locker)
 

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -11,8 +11,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
-import tomli
-
 from packaging.utils import canonicalize_name
 from poetry.core.constraints.version import Version
 from poetry.core.constraints.version import parse_constraint
@@ -26,6 +24,8 @@ from tomlkit import comment
 from tomlkit import document
 from tomlkit import inline_table
 from tomlkit import table
+
+from poetry.utils._compat import tomllib
 
 
 if TYPE_CHECKING:
@@ -80,7 +80,7 @@ class Locker:
         Checks whether the lock file is still up to date with the current hash.
         """
         with self.lock.open("rb") as f:
-            lock = tomli.load(f)
+            lock = tomllib.load(f)
         metadata = lock.get("metadata", {})
 
         if "content-hash" in metadata:
@@ -300,8 +300,8 @@ class Locker:
 
         with self.lock.open("rb") as f:
             try:
-                lock_data = tomli.load(f)
-            except tomli.TOMLDecodeError as e:
+                lock_data = tomllib.load(f)
+            except tomllib.TOMLDecodeError as e:
                 raise RuntimeError(f"Unable to read the lock file ({e}).")
 
         metadata = lock_data["metadata"]

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -271,10 +271,6 @@ class Locker:
         lockfile = TOMLFile(self.lock)
         lockfile.write(data)
 
-        # Checking lock file data consistency
-        if data != lockfile.read():
-            raise RuntimeError("Inconsistent lock file data.")
-
         self._lock_data = None
 
     def _get_content_hash(self) -> str:

--- a/src/poetry/utils/_compat.py
+++ b/src/poetry/utils/_compat.py
@@ -7,6 +7,14 @@ from contextlib import suppress
 
 # TODO: use try/except ImportError when
 # https://github.com/python/mypy/issues/1393 is fixed
+
+if sys.version_info < (3, 11):
+    # compatibility for python <3.11
+    import tomli as tomllib
+else:
+    import tomllib  # nopycln: import
+
+
 if sys.version_info < (3, 10):
     # compatibility for python <3.10
     import importlib_metadata as metadata
@@ -67,4 +75,5 @@ __all__ = [
     "list_to_shell_command",
     "metadata",
     "to_str",
+    "tomllib",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -412,7 +412,7 @@ def project_factory(
         poetry = Factory().create_poetry(project_dir)
 
         locker = TestLocker(
-            poetry.locker.lock.path, locker_config or poetry.locker._local_config
+            poetry.locker.lock, locker_config or poetry.locker._local_config
         )
         locker.write()
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -181,7 +181,7 @@ class PoetryTestApplication(Application):
         self._poetry.set_pool(poetry.pool)
         self._poetry.set_config(poetry.config)
         self._poetry.set_locker(
-            TestLocker(poetry.locker.lock.path, self._poetry.local_config)
+            TestLocker(poetry.locker.lock, self._poetry.local_config)
         )
 
 

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -105,8 +105,8 @@ category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {{ file = "bar", hash = "123" }},
-    {{ file = "foo", hash = "456" }},
+    {{file = "bar", hash = "123"}},
+    {{file = "foo", hash = "456"}},
 ]
 
 [package.dependencies]
@@ -120,7 +120,7 @@ category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {{ file = "baz", hash = "345" }},
+    {{file = "baz", hash = "345"}},
 ]
 
 [[package]]
@@ -590,14 +590,12 @@ files = []
 
 [package.dependencies]
 B = [
-    {{ version = "^1.0.0" }},
-    {{ version = ">=1.0.0", optional = true }},
+    {{version = "^1.0.0"}},
+    {{version = ">=1.0.0", optional = true}},
 ]
 
 [package.extras]
-foo = [
-    "B (>=1.0.0)",
-]
+foo = ["B (>=1.0.0)"]
 
 [metadata]
 lock-version = "2.0"
@@ -762,14 +760,8 @@ optional = false
 python-versions = "*"
 files = []
 
-[package.dependencies.B]
-version = "^1.0.0"
-extras = [
-    "a",
-    "b",
-    "c",
-]
-optional = true
+[package.dependencies]
+B = {{version = "^1.0.0", extras = ["a", "b", "c"], optional = true}}
 
 [metadata]
 lock-version = "2.0"
@@ -858,22 +850,12 @@ optional = false
 python-versions = "*"
 files = []
 
-[package.dependencies.B]
-path = "project_with_extras"
-develop = true
-
-[package.dependencies.C]
-path = "directory/project_with_transitive_directory_dependencies"
-
-[package.dependencies.D]
-path = "distributions/demo-0.1.0.tar.gz"
-
-[package.dependencies.E]
-url = "https://python-poetry.org/poetry-1.2.0.tar.gz"
-
-[package.dependencies.F]
-git = "https://github.com/python-poetry/poetry.git"
-branch = "foo"
+[package.dependencies]
+B = {{path = "project_with_extras", develop = true}}
+C = {{path = "directory/project_with_transitive_directory_dependencies"}}
+D = {{path = "distributions/demo-0.1.0.tar.gz"}}
+E = {{url = "https://python-poetry.org/poetry-1.2.0.tar.gz"}}
+F = {{git = "https://github.com/python-poetry/poetry.git", branch = "foo"}}
 
 [metadata]
 lock-version = "2.0"
@@ -963,16 +945,8 @@ python-versions = "*"
 files = []
 
 [package.extras]
-B = [
-    "first (==1.0.0)",
-    "second (==1.0.0)",
-    "third (==1.0.0)",
-]
-C = [
-    "first (==1.0.0)",
-    "second (==1.0.0)",
-    "third (==1.0.0)",
-]
+B = ["first (==1.0.0)", "second (==1.0.0)", "third (==1.0.0)"]
+C = ["first (==1.0.0)", "second (==1.0.0)", "third (==1.0.0)"]
 
 [metadata]
 lock-version = "2.0"

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -105,8 +105,8 @@ category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {{file = "bar", hash = "123"}},
-    {{file = "foo", hash = "456"}},
+    {{ file = "bar", hash = "123" }},
+    {{ file = "foo", hash = "456" }},
 ]
 
 [package.dependencies]
@@ -120,7 +120,7 @@ category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {{file = "baz", hash = "345"}},
+    {{ file = "baz", hash = "345" }},
 ]
 
 [[package]]
@@ -231,7 +231,9 @@ python-versions = "~2.7 || ^3.4"
 content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77"
 """  # noqa: E800
 
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
 
     packages = locker.locked_repository().packages
 
@@ -294,7 +296,9 @@ lock-version = "2.0"
 content-hash = "123456789"
 """  # noqa: E800
 
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
 
     repository = locker.locked_repository()
     assert len(repository.packages) == 3
@@ -359,7 +363,9 @@ lock-version = "2.0"
 content-hash = "123456789"
 """  # noqa: E800
 
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
 
     repository = locker.locked_repository()
     assert len(repository.packages) == 2
@@ -399,7 +405,9 @@ lock-version = "2.0"
 python-versions = "*"
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
 """
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
 
     repository = locker.locked_repository()
     assert len(repository.packages) == 1
@@ -495,7 +503,9 @@ demo = [
     {file = "demo-1.0-py3-none-any.whl", hash = "sha256"},
 ]
 """
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
 
     repository = locker.locked_repository()
     assert len(repository.packages) == 5
@@ -580,12 +590,14 @@ files = []
 
 [package.dependencies]
 B = [
-    {{version = "^1.0.0"}},
-    {{version = ">=1.0.0", optional = true}},
+    {{ version = "^1.0.0" }},
+    {{ version = ">=1.0.0", optional = true }},
 ]
 
 [package.extras]
-foo = ["B (>=1.0.0)"]
+foo = [
+    "B (>=1.0.0)",
+]
 
 [metadata]
 lock-version = "2.0"
@@ -687,7 +699,9 @@ content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77
 """
     caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
 
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
 
     _ = locker.lock_data
 
@@ -717,7 +731,9 @@ content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77
 """  # noqa: E800
     caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
 
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
 
     with pytest.raises(RuntimeError, match="^The lock file is not compatible"):
         _ = locker.lock_data
@@ -746,8 +762,14 @@ optional = false
 python-versions = "*"
 files = []
 
-[package.dependencies]
-B = {{version = "^1.0.0", extras = ["a", "b", "c"], optional = true}}
+[package.dependencies.B]
+version = "^1.0.0"
+extras = [
+    "a",
+    "b",
+    "c",
+]
+optional = true
 
 [metadata]
 lock-version = "2.0"
@@ -775,7 +797,9 @@ content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77
 """
     caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
 
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
 
     _ = locker.lock_data
 
@@ -834,12 +858,22 @@ optional = false
 python-versions = "*"
 files = []
 
-[package.dependencies]
-B = {{path = "project_with_extras", develop = true}}
-C = {{path = "directory/project_with_transitive_directory_dependencies"}}
-D = {{path = "distributions/demo-0.1.0.tar.gz"}}
-E = {{url = "https://python-poetry.org/poetry-1.2.0.tar.gz"}}
-F = {{git = "https://github.com/python-poetry/poetry.git", branch = "foo"}}
+[package.dependencies.B]
+path = "project_with_extras"
+develop = true
+
+[package.dependencies.C]
+path = "directory/project_with_transitive_directory_dependencies"
+
+[package.dependencies.D]
+path = "distributions/demo-0.1.0.tar.gz"
+
+[package.dependencies.E]
+url = "https://python-poetry.org/poetry-1.2.0.tar.gz"
+
+[package.dependencies.F]
+git = "https://github.com/python-poetry/poetry.git"
+branch = "foo"
 
 [metadata]
 lock-version = "2.0"
@@ -929,8 +963,16 @@ python-versions = "*"
 files = []
 
 [package.extras]
-B = ["first (==1.0.0)", "second (==1.0.0)", "third (==1.0.0)"]
-C = ["first (==1.0.0)", "second (==1.0.0)", "third (==1.0.0)"]
+B = [
+    "first (==1.0.0)",
+    "second (==1.0.0)",
+    "third (==1.0.0)",
+]
+C = [
+    "first (==1.0.0)",
+    "second (==1.0.0)",
+    "third (==1.0.0)",
+]
 
 [metadata]
 lock-version = "2.0"
@@ -970,7 +1012,10 @@ python-versions = "*"
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
 """  # noqa: E800
 
-    locker.lock.write(tomlkit.parse(content))
+    data = tomlkit.parse(content)
+    with open(locker.lock, "w", encoding="utf-8") as f:
+        f.write(data.as_string())
+
     create_dependency_patch = mocker.patch(
         "poetry.factory.Factory.create_dependency", autospec=True
     )
@@ -983,7 +1028,7 @@ content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8
     root_dir = call_kwargs["root_dir"]
     assert root_dir.match("*/lib/libA")
     # relative_to raises an exception if not relative - is_relative_to comes in py3.9
-    assert root_dir.relative_to(locker.lock.path.parent.resolve()) is not None
+    assert root_dir.relative_to(locker.lock.parent.resolve()) is not None
 
 
 @pytest.mark.parametrize(
@@ -1017,7 +1062,7 @@ def test_content_hash_with_legacy_is_compatible(
         relevant_content[key] = local_config.get(key)
 
     locker = locker.__class__(
-        lock=locker.lock.path,
+        lock=locker.lock,
         local_config=local_config,
     )
 


### PR DESCRIPTION
Pros and cons in this one, opinions are invited.

tomlkit is significantly slower than tomli / tomli-w.  And also, at least in a project that uses type-checking, it's a pain in the neck.

Even for a modestly sized project like poetry itself, reading `poetry.lock` on my laptop takes 0.6 - 0.7 seconds (timings obtained with some `time.time()` statements inserted into the codebase).  `tomli` manages it in ~0.02 seconds.

On larger projects the difference is more significant, in my experimentation that ratio of of 30-ish remains consistent.

Admittedly this is only likely to save folk a small number of seconds on any given command.  But fast tools are nicer to use than slow tools.

Against this: we already have `tomlkit` in the dependency tree, adding `tomli` and `tomli-w` looks a bit weird.  

The difference is that `pyproject.toml` is human-readable and it's highly desirable to maintain formatting and comments etc in interactions with it (`poetry add`, `poetry remove`).  Much as I'd like to use `tomli` and `tomli-w` everywhere: they just don't offer that feature.

`poetry.lock` however is machine-generated and machine-read and there is no reason to pay the tomlkit performance penalty in reading and writing it.

(I've also removed the code that re-reads the lockfile after writing it, "checking lock file data consistency".  Not clear to me what that was for: do you trust your toml writer or not?  That same code could be removed independent of the switch away from tomlkit)