### PR TITLE
chore(ci): setup certificates for 3.11 on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
-      # Certificates are not correctly installed for 3.11-dev.
+      # XXX: Certificates are not correctly installed for 3.11-dev -- remove when fixed.
       - name: Install missing certificates on 3.11 for macOS
         if: ${{ matrix.python-version == '3.11-dev' && matrix.os == 'macOS' }}
         run: /Applications/Python\ 3.11/Install\ Certificates.command

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,11 @@ jobs:
         id: full-python-version
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
+      # Certificates are not correctly installed for 3.11-dev.
+      - name: Install missing certificates on 3.11 for macOS
+        if: ${{ matrix.python-version == '3.11-dev' && matrix.os == 'macOS' }}
+        run: /Applications/Python\ 3.11/Install\ Certificates.command
+
       - name: Bootstrap poetry
         run: |
           curl -sL https://install.python-poetry.org | python - -y


### PR DESCRIPTION
CI is failing on Python 3.11.0rc2 for macOS because of missing certificates. For some reasons, they don't seem to be correctly installed, so we manually bundle them with `certifi` and symlink them.