### PR TITLE
chore(ci): upgrade `pip` for 3.11 on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,11 @@ jobs:
         if: steps.cache.outputs.cache-hit == 'true'
         run: timeout 10s poetry run pip --version || rm -rf .venv
 
+      # XXX: https://github.com/pypa/pip/issues/11352 causes random failures -- remove once fixed in a release.
+      - name: Upgrade pip on 3.11 for macOS
+        if: ${{ matrix.python-version == '3.11-dev' && matrix.os == 'macOS' }}
+        run: poetry run pip install git+https://github.com/pypa/pip.git@fbb7f0b293f1d9289d8c76a556540325b9a172b2
+
       - name: Install dependencies
         run: poetry install
 


### PR DESCRIPTION
We are hit by https://github.com/pypa/pip/issues/11352 which has been fixed on the main branch, but not yet on a release.
Upgrading `pip` used by Poetry to a recent version that includes the fix seems to make the issue disappear (tested multiple times on the fork, but this would be best assessed once/if merged).

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

