### PR TITLE
unnecessary canonicalize_name()

### DIFF
--- a/src/poetry/repositories/link_sources/base.py
+++ b/src/poetry/repositories/link_sources/base.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from typing import DefaultDict
 from typing import List
 
-from packaging.utils import canonicalize_name
 from poetry.core.packages.package import Package
 from poetry.core.semver.version import Version
 
@@ -73,7 +72,7 @@ class LinkSource:
         m = wheel_file_re.match(link.filename) or sdist_file_re.match(link.filename)
 
         if m:
-            name = canonicalize_name(m.group("name"))
+            name = m.group("name")
             version_string = m.group("ver")
         else:
             info, ext = link.splitext()


### PR DESCRIPTION
I don't expect this to make any difference to anything, except that it saves one unnecessary call to `canonicalize_name()`.

As evidence that this was unnecessary
- the other branch that gets `name` doesn't canonicalize it
- the `Package` accepts an uncanonicalized string.