### PR TITLE
ci: remove cache health check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,14 +74,9 @@ jobs:
 
       - name: Set up cache
         uses: actions/cache@v3
-        id: cache
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: timeout 10s poetry run pip --version || rm -rf .venv
 
       # XXX: https://github.com/pypa/pip/issues/11352 causes random failures -- remove once fixed in a release.
       - name: Upgrade pip on 3.11 for macOS


### PR DESCRIPTION
# Pull Request Check List

Cache is never reused on macOS because we use `timeout` to validate cache healthiness, but `timeout` is not available on macOS. So as the command fail, we execute the condition after `||` that deletes the virtual env, meaning we never use the cache on macOS (this can easily be seen [here](https://github.com/python-poetry/poetry/actions/runs/3107116318/jobs/5034833860) for instance).

I personally never came across a busted cache, so this PR suggests to remove the health check entirely (it is regularly updated anyway whenever there's a new Python patch version, or a dependencies update).

Alternatively, if you think that the health check is still necessary, removing the `timeout` could be enough, but I'd personally be onboard with removing the check entirely, and if we ever spot issues about busted caches, add it back.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.