### PR TITLE
locker: locked_repository should be a LockfileRepository

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from tomlkit.items import Table
     from tomlkit.toml_document import TOMLDocument
 
-    from poetry.repositories import Repository
+    from poetry.repositories.lockfile_repository import LockfileRepository
 
 logger = logging.getLogger(__name__)
 _GENERATED_IDENTIFIER = "@" + "generated"
@@ -91,22 +91,23 @@ class Locker:
 
         return False
 
-    def locked_repository(self) -> Repository:
+    def locked_repository(self) -> LockfileRepository:
         """
         Searches and returns a repository of locked packages.
         """
         from poetry.factory import Factory
-        from poetry.repositories import Repository
+        from poetry.repositories.lockfile_repository import LockfileRepository
+
+        repository = LockfileRepository()
 
         if not self.is_locked():
-            return Repository("poetry-locked")
+            return repository
 
         lock_data = self.lock_data
-        packages = Repository("poetry-locked")
         locked_packages = cast("list[dict[str, Any]]", lock_data["package"])
 
         if not locked_packages:
-            return packages
+            return repository
 
         for info in locked_packages:
             source = info.get("source", {})
@@ -208,9 +209,9 @@ class Locker:
             if "develop" in info:
                 package.develop = info["develop"]
 
-            packages.add_package(package)
+            repository.add_package(package)
 
-        return packages
+        return repository
 
     def set_lock_data(self, root: Package, packages: list[Package]) -> bool:
         files: dict[str, Any] = table()


### PR DESCRIPTION
`locked_repository` should return a `LockfileRepository` instead of a `Repository` because it can contain multiple variants of the same version of a package (from different sources). Using a `Repository` only works because packages are added without calling `has_package` before (in other words `Repository` is somehow used like a `LockfileRepository`).