### PR TITLE
provider: fetch optional vcs dependency only if required

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -572,18 +572,6 @@ class Provider:
             dependency = dependency_package.dependency
             requires = package.requires
 
-        if self._load_deferred:
-            # Retrieving constraints for deferred dependencies
-            for r in requires:
-                if r.is_direct_origin():
-                    locked = self.get_locked(r)
-                    # If lock file contains exactly the same URL and reference
-                    # (commit hash) of dependency as is requested,
-                    # do not analyze it again: nothing could have changed.
-                    if locked is not None and locked.package.is_same_package_as(r):
-                        continue
-                    self.search_for_direct_origin_dependency(r)
-
         optional_dependencies = []
         _dependencies = []
 
@@ -635,6 +623,18 @@ class Provider:
                 continue
 
             _dependencies.append(dep)
+
+        if self._load_deferred:
+            # Retrieving constraints for deferred dependencies
+            for dep in _dependencies:
+                if dep.is_direct_origin():
+                    locked = self.get_locked(dep)
+                    # If lock file contains exactly the same URL and reference
+                    # (commit hash) of dependency as is requested,
+                    # do not analyze it again: nothing could have changed.
+                    if locked is not None and locked.package.is_same_package_as(dep):
+                        continue
+                    self.search_for_direct_origin_dependency(dep)
 
         dependencies = self._get_dependencies_with_overrides(
             _dependencies, dependency_package


### PR DESCRIPTION
Supersedes: #6130

Don't fetch vcs dependencies of extras that were not requested.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
