### PR TITLE
ci: define `timeout` on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,12 @@ jobs:
 
       - name: Ensure cache is healthy
         if: steps.cache.outputs.cache-hit == 'true'
-        run: timeout 10s poetry run pip --version || rm -rf .venv
+        run: |
+          # `timeout` is not available on macOS, so we define a custom function.
+          [ "$(command -v timeout)" ] || function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
+
+          # Using `timeout` is a safeguard against the Poetry command hanging for some reason.
+          timeout 10s poetry run pip --version || rm -rf .venv
 
       # XXX: https://github.com/pypa/pip/issues/11352 causes random failures -- remove once fixed in a release.
       - name: Upgrade pip on 3.11 for macOS


### PR DESCRIPTION
# Pull Request Check List

Closes #6602.

Cache is never reused on macOS because we use `timeout` to validate cache healthiness, but `timeout` is not available on macOS. So as the command fails, we execute the condition after `||` that deletes the virtual env, meaning we never use the cache on macOS (this can easily be seen [here](https://github.com/python-poetry/poetry/actions/runs/3107116318/jobs/5034833860) for instance).

This PR is an alternative implementation to #6602 following some feedback received in the PR.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.