### PR TITLE
fix(env): run Python inside environments in isolated mode

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1475,7 +1475,9 @@ class Env:
         return self._run(cmd, **kwargs)
 
     def run_python_script(self, content: str, **kwargs: Any) -> int | str:
-        return self.run(self._executable, "-W", "ignore", "-", input_=content, **kwargs)
+        return self.run(
+            self._executable, "-I", "-W", "ignore", "-", input_=content, **kwargs
+        )
 
     def _run(self, cmd: list[str], **kwargs: Any) -> int | str:
         """


### PR DESCRIPTION
This avoids issues when `PYTHON*` environmental variables are set, and prevents the CWD from being added to `sys.path` (and thus clobbering stdlib names).

Resolves: #6627
