### PR TITLE
repositories/http: support algorithms in hashlib.algorithms_guaranteed

### DIFF
--- a/src/poetry/repositories/http.py
+++ b/src/poetry/repositories/http.py
@@ -230,7 +230,7 @@ class HTTPRepository(CachedRepository, ABC):
 
             if not link.hash or (
                 link.hash_name is not None
-                and link.hash_name not in ("sha256", "sha384", "sha512")
+                and link.hash_name not in hashlib.algorithms_guaranteed
                 and hasattr(hashlib, link.hash_name)
             ):
                 with temporary_directory() as temp_dir:


### PR DESCRIPTION
PEP 503 says:

```
Repositories SHOULD choose a hash function from one of the ones guaranteed to be available via the hashlib module in the Python standard library (currently md5, sha1, sha224, sha256, sha384, sha512). The current recommendation is to use sha256.
```

It should make sense, then, to just check that the value returned is in `hashlib.algorithms_guaranteed` instead of a short subset of hashes.

Otherwise, the subset of hashes should be extended to those directly mentioned in the PEP though that list was compiled 7 years ago and does not reflect algorithms guaranteed to be present.

# Pull Request Check List

Resolves: #6301

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
