### PR TITLE
Add note about publishable repositories to publish

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -515,6 +515,10 @@ poetry publish
 
 It can also build the package if you pass it the `--build` option.
 
+{{% note %}}
+See the [Publishable Repositories]({{< relref "repositories/#publishable-repositories" >}}) page for more information publishing repositories.
+{{% /note %}}
+
 ### Options
 
 * `--repository (-r)`: The repository to register the package to (default: `pypi`).


### PR DESCRIPTION
This pull request adds a note under publish about publishing repositories.

relevant discord message thread: https://discord.com/channels/487711540787675139/487711540787675143/1024346792793485412

light mode:
![image](https://user-images.githubusercontent.com/43019162/192586082-374ce25b-414a-4f21-8c53-cb146114ca59.png)
dark mode:
![image](https://user-images.githubusercontent.com/43019162/192586160-5761ea4b-73e4-4f14-b8c3-9911c1425520.png)
