### PR TITLE
🐛 fixes lazy-loaded bash completion path

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -367,7 +367,7 @@ poetry completions bash >> ~/.bash_completion
 #### Lazy-loaded
 
 ```bash
-poetry completions bash > ${XDG_DATA_HOME:~/.local/share}/bash_completion/completions/poetry
+poetry completions bash > ${XDG_DATA_HOME:~/.local/share}/bash-completion/completions/poetry
 ```
 
 ### Fish


### PR DESCRIPTION
See https://github.com/scop/bash-completion/blob/master/README.md#faq