### PR TITLE
docs: fix reference to invalid option --require

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,7 +126,7 @@ poetry init
 * `--author`: Author of the package.
 * `--python` Compatible Python versions.
 * `--dependency`: Package to require with a version constraint. Should be in format `foo:1.0.0`.
-* `--dev-dependency`: Development requirements, see `--require`.
+* `--dev-dependency`: Development requirements, see `--dependency`.
 
 
 ## install


### PR DESCRIPTION
The "--require" option does not exist. I guess it should be the previously mentioned `--dependency` option.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
