### PR TITLE
Refactor packages variables into fixture

### DIFF
--- a/tests/repositories/test_lockfile_repository.py
+++ b/tests/repositories/test_lockfile_repository.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+from struct import pack
+
+import pytest
 
 from copy import deepcopy
 
@@ -6,23 +9,29 @@ from poetry.core.packages.package import Package
 
 from poetry.repositories.lockfile_repository import LockfileRepository
 
+@pytest.fixture(scope="module")
+def packages():
+    return [
+        Package(
+            "a", "1.0", source_type="url", source_url="https://example.org/a.whl"
+        ),
+        Package("a", "1.0"),
+        Package(
+            "a", "1.0", source_type="url", source_url="https://example.org/a-1.whl"
+        )
+    ]
 
-def test_has_package():
+
+def test_has_package(packages):
+    url_package, pypi_package, url_package_2 = packages
     repo = LockfileRepository()
 
-    url_package = Package(
-        "a", "1.0", source_type="url", source_url="https://example.org/a.whl"
-    )
     assert not repo.has_package(url_package)
     repo.add_package(url_package)
 
-    pypi_package = Package("a", "1.0")
     assert not repo.has_package(pypi_package)
     repo.add_package(pypi_package)
 
-    url_package_2 = Package(
-        "a", "1.0", source_type="url", source_url="https://example.org/a-1.whl"
-    )
     assert not repo.has_package(url_package_2)
     repo.add_package(url_package_2)
 
@@ -32,14 +41,8 @@ def test_has_package():
     assert repo.has_package(deepcopy(url_package_2))
 
 
-def test_remove_package():
-    url_package = Package(
-        "a", "1.0", source_type="url", source_url="https://example.org/a.whl"
-    )
-    pypi_package = Package("a", "1.0")
-    url_package_2 = Package(
-        "a", "1.0", source_type="url", source_url="https://example.org/a-1.whl"
-    )
+def test_remove_package(packages):
+    url_package, pypi_package, url_package_2 = packages
 
     repo = LockfileRepository()
     repo.add_package(url_package)


### PR DESCRIPTION
# Pull Request Check List

Relates: #3155

Extracted the duplicated `packages` variables into a new fixture to be used by the tests in the `lockfile_repository` test module