### PR TITLE
ci(cirrus): increase core count thanks to increased concurrency limits for OSS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 freebsd_instance:
   image_family: freebsd-13-1
-  cpu: 1
+  cpu: 2
   memory: 4G
 
 test_task:


### PR DESCRIPTION
Cirrus now allows for 8 vCPUs -- we can now run 4x 2 vCPU runners and speed up the tests.
