### PR TITLE
Document that `poetry lock --check` validates pyproject.toml

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -630,7 +630,7 @@ poetry lock
 
 ### Options
 
-* `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml`
+* `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml` and validates the structure of the `pyproject.toml` file.
 * `--no-update`: Do not update locked versions, only refresh lock file.
 
 ## version


### PR DESCRIPTION
Document that the behavior of `poetry lock --check` also essentially runs `poetry check`:

```
$ poetry lock --check

The Poetry configuration is invalid:
  - 'name' is a required property
  - Additional properties are not allowed ('nam' was unexpected)
```