### PR TITLE
Adds 'self source add|remove|show' for managing Poetry plugin sources

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -86,6 +86,9 @@ COMMANDS = [
     "self update",
     "self show",
     "self show plugins",
+    "self source add",
+    "self source remove",
+    "self source show",
     # Source commands
     "source add",
     "source remove",

--- a/src/poetry/console/commands/self/self_command.py
+++ b/src/poetry/console/commands/self/self_command.py
@@ -57,7 +57,7 @@ class SelfCommand(InstallerCommand):
     def activated_groups(self) -> set[str]:
         return {self.default_group}
 
-    def generate_system_pyproject(self) -> None:
+    def generate_system_pyproject(self) -> str:
         preserved = {}
 
         if self.system_pyproject.exists():
@@ -77,11 +77,16 @@ class SelfCommand(InstallerCommand):
         for key in preserved:
             content["tool"]["poetry"][key] = preserved[key]  # type: ignore[index]
 
-        self.system_pyproject.write_text(content.as_string(), encoding="utf-8")
+        return content.as_string()
+
+    def overwrite_system_pyproject(self) -> None:
+        self.system_pyproject.write_text(
+            self.generate_system_pyproject(), encoding="utf-8"
+        )
 
     def reset_poetry(self) -> None:
         with directory(self.system_pyproject.parent):
-            self.generate_system_pyproject()
+            self.overwrite_system_pyproject()
             self._poetry = Factory().create_poetry(
                 self.system_pyproject.parent, io=self.io, disable_plugins=True
             )

--- a/src/poetry/console/commands/self/source/add.py
+++ b/src/poetry/console/commands/self/source/add.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from poetry.console.commands.self.self_command import SelfCommand
+from poetry.console.commands.source.add import SourceAddCommand
+
+
+class SelfSourceAddCommand(SelfCommand, SourceAddCommand):
+    name = "self source add"
+    description = "Add additional sources to Poetry's runtime environment."
+    options = [
+        o for o in SourceAddCommand.options if o.name in {"default", "secondary"}
+    ]
+    help = f"""\
+The <c1>self source add</c1> command adds additional sources to Poetry's runtime \
+environment.
+
+This is managed in the <comment>{SelfCommand.get_default_system_pyproject_file()}</> \
+file.
+"""

--- a/src/poetry/console/commands/self/source/remove.py
+++ b/src/poetry/console/commands/self/source/remove.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from poetry.console.commands.self.self_command import SelfCommand
+from poetry.console.commands.source.remove import SourceRemoveCommand
+
+
+class SelfSourceRemoveCommand(SelfCommand, SourceRemoveCommand):
+    name = "self source remove"
+    description = "Removes sources from Poetry's runtime environment."
+    options = [o for o in SourceRemoveCommand.options if o.name in {"name"}]
+    help = f"""\
+The <c1>self source remove</c1> command removes sources from Poetry's runtime \
+environment.
+
+This is managed in the <comment>{SelfCommand.get_default_system_pyproject_file()}</> \
+file.
+"""

--- a/src/poetry/console/commands/self/source/show.py
+++ b/src/poetry/console/commands/self/source/show.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from poetry.console.commands.self.self_command import SelfCommand
+from poetry.console.commands.source.show import SourceShowCommand
+
+
+class SelfSourceShowCommand(SelfCommand, SourceShowCommand):
+    name = "self source show"
+    description = "Show sources in Poetry's runtime environment."
+    options = [o for o in SourceShowCommand.options if o.name in {"source"}]
+    help = f"""\
+The <c1>self source show</c1> command shows sources from Poetry's runtime \
+environment.
+
+This is managed in the <comment>{SelfCommand.get_default_system_pyproject_file()}</> \
+file.
+"""


### PR DESCRIPTION
This reuses the existing command infra provided by the `source` command, using the SelfCommand infra to change which pyproject.toml is the target.

I tried to write some tests for this, but realized that the tests would be modifying the developer's valued Poetry system pyproject.toml. I think it might be OK to rely on the existing source add, remove, and show tests, but I'll share my test code in a comment on the PR for this branch.

## Pull Request Check List

Resolves: #6705 

- [ ] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

