### PR TITLE
Fix types as if cleo were typed

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -6,10 +6,10 @@ import re
 from contextlib import suppress
 from importlib import import_module
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import cast
 
 from cleo.application import Application as BaseApplication
+from cleo.events.console_command_event import ConsoleCommandEvent
 from cleo.events.console_events import COMMAND
 from cleo.events.event_dispatcher import EventDispatcher
 from cleo.exceptions import CleoException
@@ -24,7 +24,7 @@ from poetry.console.commands.command import Command
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from cleo.events.console_command_event import ConsoleCommandEvent
+    from cleo.events.event import Event
     from cleo.io.inputs.argv_input import ArgvInput
     from cleo.io.inputs.definition import Definition
     from cleo.io.inputs.input import Input
@@ -137,8 +137,8 @@ class Application(BaseApplication):  # type: ignore[misc]
 
     @property
     def command_loader(self) -> CommandLoader:
-        command_loader: CommandLoader | None = self._command_loader
-        assert command_loader is not None
+        command_loader = self._command_loader
+        assert isinstance(command_loader, CommandLoader)
         return command_loader
 
     def reset_poetry(self) -> None:
@@ -227,12 +227,13 @@ class Application(BaseApplication):  # type: ignore[misc]
         super()._configure_io(io)
 
     def register_command_loggers(
-        self, event: ConsoleCommandEvent, event_name: str, _: Any
+        self, event: Event, event_name: str, _: EventDispatcher
     ) -> None:
         from poetry.console.logging.filters import POETRY_FILTER
         from poetry.console.logging.io_formatter import IOFormatter
         from poetry.console.logging.io_handler import IOHandler
 
+        assert isinstance(event, ConsoleCommandEvent)
         command = event.command
         if not isinstance(command, Command):
             return
@@ -277,12 +278,11 @@ class Application(BaseApplication):  # type: ignore[misc]
 
             logger.setLevel(_level)
 
-    def configure_env(
-        self, event: ConsoleCommandEvent, event_name: str, _: Any
-    ) -> None:
+    def configure_env(self, event: Event, event_name: str, _: EventDispatcher) -> None:
         from poetry.console.commands.env_command import EnvCommand
         from poetry.console.commands.self.self_command import SelfCommand
 
+        assert isinstance(event, ConsoleCommandEvent)
         command = event.command
         if not isinstance(command, EnvCommand) or isinstance(command, SelfCommand):
             return
@@ -305,10 +305,11 @@ class Application(BaseApplication):  # type: ignore[misc]
 
     @classmethod
     def configure_installer_for_event(
-        cls, event: ConsoleCommandEvent, event_name: str, _: Any
+        cls, event: Event, event_name: str, _: EventDispatcher
     ) -> None:
         from poetry.console.commands.installer_command import InstallerCommand
 
+        assert isinstance(event, ConsoleCommandEvent)
         command = event.command
         if not isinstance(command, InstallerCommand):
             return

--- a/src/poetry/console/commands/command.py
+++ b/src/poetry/console/commands/command.py
@@ -28,7 +28,10 @@ class Command(BaseCommand):  # type: ignore[misc]
         self._poetry = poetry
 
     def get_application(self) -> Application:
-        application: Application = self.application
+        from poetry.console.application import Application
+
+        application = self.application
+        assert isinstance(application, Application)
         return application
 
     def reset_poetry(self) -> None:

--- a/src/poetry/console/commands/debug/info.py
+++ b/src/poetry/console/commands/debug/info.py
@@ -22,7 +22,7 @@ class DebugInfoCommand(Command):
                 ]
             )
         )
-        command = self.application.get("env info")
+        command = self.get_application().get("env info")
 
         exit_code: int = command.run(self.io)
         return exit_code

--- a/src/poetry/console/commands/debug/resolve.py
+++ b/src/poetry/console/commands/debug/resolve.py
@@ -86,7 +86,7 @@ class DebugResolveCommand(InitCommand):
         self.line("")
 
         if self.option("tree"):
-            show_command = self.application.find("show")
+            show_command = self.get_application().find("show")
             assert isinstance(show_command, ShowCommand)
             show_command.init_styles(self.io)
 

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -176,7 +176,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 self._determine_requirements(self.option("dependency"))
             )
 
-        question = "Would you like to define your main dependencies interactively?"
+        question_text = "Would you like to define your main dependencies interactively?"
         help_message = """\
 You can specify a package in the following forms:
   - A single name (<b>requests</b>): this will search for matches on PyPI
@@ -190,7 +190,7 @@ You can specify a package in the following forms:
 """
 
         help_displayed = False
-        if self.confirm(question, True):
+        if self.confirm(question_text, True):
             if self.io.is_interactive():
                 self.line(help_message)
                 help_displayed = True
@@ -206,10 +206,10 @@ You can specify a package in the following forms:
                 self._determine_requirements(self.option("dev-dependency"))
             )
 
-        question = (
+        question_text = (
             "Would you like to define your development dependencies interactively?"
         )
-        if self.confirm(question, True):
+        if self.confirm(question_text, True):
             if self.io.is_interactive() and not help_displayed:
                 self.line(help_message)
 
@@ -338,8 +338,8 @@ You can specify a package in the following forms:
                         "Enter the version constraint to require "
                         "(or leave blank to use the latest version):"
                     )
-                    question.attempts = 3
-                    question.validator = lambda x: (x or "").strip() or False
+                    question.set_max_attempts(3)
+                    question.set_validator(lambda x: (x or "").strip() or None)
 
                     package_constraint = self.ask(question)
 

--- a/src/poetry/mixology/solutions/providers/python_requirement_solution_provider.py
+++ b/src/poetry/mixology/solutions/providers/python_requirement_solution_provider.py
@@ -6,17 +6,15 @@ from typing import TYPE_CHECKING
 
 from crashtest.contracts.has_solutions_for_exception import HasSolutionsForException
 
+from poetry.puzzle.exceptions import SolverProblemError
+
 
 if TYPE_CHECKING:
     from crashtest.contracts.solution import Solution
 
-    from poetry.puzzle.exceptions import SolverProblemError
-
 
 class PythonRequirementSolutionProvider(HasSolutionsForException):  # type: ignore[misc]
     def can_solve(self, exception: Exception) -> bool:
-        from poetry.puzzle.exceptions import SolverProblemError
-
         if not isinstance(exception, SolverProblemError):
             return False
 
@@ -28,9 +26,10 @@ class PythonRequirementSolutionProvider(HasSolutionsForException):  # type: igno
 
         return bool(m)
 
-    def get_solutions(self, exception: SolverProblemError) -> list[Solution]:
+    def get_solutions(self, exception: Exception) -> list[Solution]:
         from poetry.mixology.solutions.solutions.python_requirement_solution import (
             PythonRequirementSolution,
         )
 
+        assert isinstance(exception, SolverProblemError)
         return [PythonRequirementSolution(exception)]


### PR DESCRIPTION
Continuing - and getting close to completing - the on-off project of adding a `py.typed` to cleo and seeing what damage that does in poetry.

Remaining errors when doing that are errors in cleo's typing.  Either cleo will fix them before publishing or poetry - and everyone else who uses cleo - will ignore them.  https://github.com/python-poetry/cleo/pull/254#issuecomment-1267445921.