### PR TITLE
Pip no input

### DIFF
--- a/src/poetry/utils/pip.py
+++ b/src/poetry/utils/pip.py
@@ -29,6 +29,7 @@ def pip_install(
         "install",
         "--disable-pip-version-check",
         "--isolated",
+        "--no-input",
         "--prefix",
         str(environment.path),
     ]


### PR DESCRIPTION
Sometimes pip will ask for user input.

But in the context of poetry: the user never gets to see that request, and so it just looks as though poetry has hung.

I think this may have been what was going on in #6668 

Anyway passing `--no-input` seems sensible and safe.