### PR TITLE
locker: less verbose output for `package.files` in lock file 2.0

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -23,10 +23,8 @@ from tomlkit import array
 from tomlkit import comment
 from tomlkit import document
 from tomlkit import inline_table
-from tomlkit import item
 from tomlkit import table
 from tomlkit.exceptions import TOMLKitError
-from tomlkit.items import Array
 
 
 if TYPE_CHECKING:
@@ -228,24 +226,19 @@ class Locker:
         return repository
 
     def set_lock_data(self, root: Package, packages: list[Package]) -> bool:
-        files: dict[str, Any] = table()
         package_specs = self._lock_packages(packages)
         # Retrieving hashes
         for package in package_specs:
-            if package["name"] not in files:
-                files[package["name"]] = []
+            files = array()
 
             for f in package["files"]:
                 file_metadata = inline_table()
                 for k, v in sorted(f.items()):
                     file_metadata[k] = v
 
-                files[package["name"]].append(file_metadata)
+                files.append(file_metadata)
 
-            if files[package["name"]]:
-                package_files = item(files[package["name"]])
-                assert isinstance(package_files, Array)
-                files[package["name"]] = package_files.multiline(True)
+            package["files"] = files.multiline(True)
 
         lock = document()
         lock.add(comment(GENERATED_COMMENT))

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -104,14 +104,10 @@ description = ""
 category = "main"
 optional = false
 python-versions = "*"
-
-[[package.files]]
-file = "bar"
-hash = "123"
-
-[[package.files]]
-file = "foo"
-hash = "456"
+files = [
+    {{file = "bar", hash = "123"}},
+    {{file = "foo", hash = "456"}},
+]
 
 [package.dependencies]
 B = "^1.0"
@@ -123,10 +119,9 @@ description = ""
 category = "main"
 optional = false
 python-versions = "*"
-
-[[package.files]]
-file = "baz"
-hash = "345"
+files = [
+    {{file = "baz", hash = "345"}},
+]
 
 [[package]]
 name = "B"


### PR DESCRIPTION
Before #6393 (poetry 1.2 lockfile format) package files where reported in a separate section called metadata like that:

```
[metadata.files]
cffi = [
    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
    ...
]
cryptography = [
    ...
]
```

With #6393 package files are reported in the concerning package section like that:

```
[[package]]
name = "cffi"
version = "1.15.1"
description = "Foreign Function Interface for Python calling C code."
category = "main"
optional = false
python-versions = "*"

[[package.files]]
file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl"
hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"

[[package.files]]
file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl"
hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"

[[package.files]]
file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl"
hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"

[[package.files]]
file = "cffi-1.15.1-cp27-cp27m-win32.whl"
hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"

...
```

That's a bit too verbose to my taste, escpecially if a package has many files. Just try adding `cryptography` as a dependency for example. (I shortened the output in this description.) With this PR the package section will look like this:

```
[[package]]
name = "cffi"
version = "1.15.1"
description = "Foreign Function Interface for Python calling C code."
category = "main"
optional = false
python-versions = "*"
files = [
    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
    ...
]
```

In case anyone is wondering, the lines of code I changed in `locker.py` had no effect anymore because they prepared the `metadata.files` table which is not written anymore.