### PR TITLE
docs(plugins): change the example's minimum poetry version to 1.2

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -39,7 +39,7 @@ version = "1.0.0"
 # ...
 [tool.poetry.dependencies]
 python = "^3.7"
-poetry = "^1.0"
+poetry = "^1.2"
 
 [tool.poetry.plugins."poetry.plugin"]
 demo = "poetry_demo_plugin.plugin:MyPlugin"


### PR DESCRIPTION
poetry 1.2 is the first poetry version with plugin support, so plugins cannot be compatible with any version before 1.2.