### PR TITLE
feat(locker): `poetry lock` works if an invalid/incompatible lock file exists

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: check-case-conflict
       - id: check-json
       - id: check-toml
+        exclude: tests/fixtures/invalid_lock/poetry\.lock
       - id: check-yaml
       - id: pretty-format-json
         args: [--autofix, --no-ensure-ascii, --no-sort-keys]

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -218,7 +218,7 @@ class Installer:
 
         locked_repository = Repository("poetry-locked")
         if self._update:
-            if self._locker.is_locked() and not self._lock:
+            if not self._lock and self._locker.is_locked():
                 locked_repository = self._locker.locked_repository()
 
                 # If no packages have been whitelisted (The ones we want to update),

--- a/tests/fixtures/incompatible_lock/poetry.lock
+++ b/tests/fixtures/incompatible_lock/poetry.lock
@@ -1,0 +1,2 @@
+[metadata]
+lock-version = "999.0"

--- a/tests/fixtures/incompatible_lock/pyproject.toml
+++ b/tests/fixtures/incompatible_lock/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "foobar"
+version = "0.1.0"
+description = ""
+authors = ["Poetry Developer <developer@python-poetry.org>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+sampleproject = ">=1.3.1"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/fixtures/invalid_lock/poetry.lock
+++ b/tests/fixtures/invalid_lock/poetry.lock
@@ -1,0 +1,1 @@
+This lock file is broken!

--- a/tests/fixtures/invalid_lock/pyproject.toml
+++ b/tests/fixtures/invalid_lock/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "foobar"
+version = "0.1.0"
+description = ""
+authors = ["Poetry Developer <developer@python-poetry.org>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+sampleproject = ">=1.3.1"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
After having created a lock file 2.0, running `poetry lock` with poetry 1.2.1 results in the following output:

```
The lock file is not compatible with the current version of Poetry.
Upgrade Poetry to be able to read the lock file or, alternatively, regenerate the lock file with the `poetry lock` command.
```

Ironically, the error message proposes to run `poetry lock` which results in this error message.

Further, it doesn't make sense that `poetry lock` fails because it creates a new lock file from scratch (in contrast to `poetry lock --no-update`).

Update: Running `poetry lock` is now also possible if there is a broken lock file.

Resolves: #1196