### PR TITLE
Add changelog URL to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 
 [tool.poetry.urls]
-"Release notes" = "https://python-poetry.org/history/"
+changelog = "https://python-poetry.org/history/"
 
 [tool.poetry.build]
 generate-setup-file = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 
+[tool.poetry.urls]
+"Release notes" = "https://python-poetry.org/history/"
+
 [tool.poetry.build]
 generate-setup-file = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 
 [tool.poetry.urls]
-changelog = "https://python-poetry.org/history/"
+Changelog = "https://python-poetry.org/history/"
 
 [tool.poetry.build]
 generate-setup-file = false


### PR DESCRIPTION
When Renovate bot creates an automated pull request to update Poetry, it can automatically include the link to changelog so it's easier to find out what changed.

The URL name has to be one of: 'changelog', 'change log', 'changes', 'release notes', 'news', "what's new" (case insensitive)

https://github.com/renovatebot/renovate/blob/c3a87b687ed44a1a100e0e4f91b81e22b7c32482/lib/modules/datasource/pypi/index.ts#L130-L140
