### PR TITLE
Remove try-except ValueError to allow UnicodeEncodeError to propagate

### DIFF
--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -395,10 +395,8 @@ class VersionSolver:
                 if locked:
                     return is_specific_marker, Preference.LOCKED, 1
 
-            try:
-                num_packages = len(self._dependency_cache.search_for(dependency))
-            except ValueError:
-                num_packages = 0
+            num_packages = len(self._dependency_cache.search_for(dependency))
+
             if num_packages < 2:
                 preference = Preference.NO_CHOICE
             elif use_latest:


### PR DESCRIPTION
UnicodeEncodeError is currently silently caught and not passed through to end-user when encountered.

UnicodeEncodeError is a subclass of UnicodeError and thus a subclass of ValueError which is currently caught in try-except ValueError in `mixology/version_solver.py`:

https://github.com/python-poetry/poetry/blob/0ffe91c0c8e2edde987cf2213d402614a9c2a6a6/src/poetry/mixology/version_solver.py#L398-L401

# Pull Request Check List

Resolves: #6784

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

