### PR TITLE
docs (intro): Add missing dash to command enabling completion in bash

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -367,7 +367,7 @@ poetry completions bash >> ~/.bash_completion
 #### Lazy-loaded
 
 ```bash
-poetry completions bash > ${XDG_DATA_HOME:~/.local/share}/bash-completion/completions/poetry
+poetry completions bash > ${XDG_DATA_HOME:-~/.local/share}/bash-completion/completions/poetry
 ```
 
 ### Fish


### PR DESCRIPTION
The dash is needed to correctly specify the value to use for $XDG_DATA_HOME if not already set.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
