### PR TITLE
match requests pool_maxsize to num workers

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -60,11 +60,6 @@ class Executor:
         self._dry_run = False
         self._enabled = True
         self._verbose = False
-        self._authenticator = Authenticator(
-            config, self._io, disable_cache=disable_cache
-        )
-        self._chef = Chef(config, self._env)
-        self._chooser = Chooser(pool, self._env, config)
 
         if parallel is None:
             parallel = config.get("installer.parallel", True)
@@ -75,6 +70,12 @@ class Executor:
             )
         else:
             self._max_workers = 1
+
+        self._authenticator = Authenticator(
+            config, self._io, disable_cache=disable_cache, pool_size=self._max_workers
+        )
+        self._chef = Chef(config, self._env)
+        self._chooser = Chooser(pool, self._env, config)
 
         self._executor = ThreadPoolExecutor(max_workers=self._max_workers)
         self._total_operations = 0


### PR DESCRIPTION
This avoids trashing connections just to immediately re-create them when `num-worker` > 10. This should provide a pretty solid speedup on beefy machines.

I'm not attaching any tests because this would be hard to test and if it doesn't crash with an unknown keyword argument or something it means it's probably going to be doing what we expect.