### PR TITLE
[1.2] fix: fix support for packaging v20.4

### DIFF
--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cleo.io.null_io import NullIO
-from packaging.utils import NormalizedName
 from packaging.utils import canonicalize_name
 
 from poetry.installation.executor import Executor
@@ -24,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from cleo.io.io import IO
+    from packaging.utils import NormalizedName
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.config.config import Config


### PR DESCRIPTION
**This bug only affects the `1.2` branch (caused by a bad cherry-pick from `master`)**

Poetry v1.2.2 does not work with packaging v20.4 (which is an allowed version of packaging in the pyproject.toml file).

This is because the `from packaging.utils import NormalizedName` line before [packaging v20.5][1] only works if `typing.TYPE_CHECKING` is True.

This is not an issue on the `master` branch, since there this import is already hidden behind an `if TYPE_CHECKING:` guard. However, the v1.2 branch never cherry-picked the appropriate commit adding this change.

See the current `master` branch, which works fine:
https://github.com/python-poetry/poetry/blob/16046d9ac9b72a49e1bc4618fb686695cc64821c/src/poetry/installation/installer.py#L21-L26

[1]: https://github.com/pypa/packaging/commit/eca30e0435f99084682d529d997f5c5fe1cd43fb

Fixes: https://github.com/python-poetry/poetry/commit/04c5cbf043610dd5d89b7d980bf8a137948c4fa5 (this was the broken cherry-pick)

# Pull Request Check List

Resolves: #6807

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
  - The only way to test this is to install `packaging` v20.4, and I can't see an easy way to do this.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
