### PR TITLE
Fix Python 2 installation script by using UTF-8 to decode in get-poetry.py

### DIFF
--- a/get-poetry.py
+++ b/get-poetry.py
@@ -412,7 +412,7 @@ class Installer:
 
         print(colorize("info", "Retrieving Poetry metadata"))
 
-        metadata = json.loads(self._get(self.METADATA_URL).decode())
+        metadata = json.loads(self._get(self.METADATA_URL).decode("utf-8"))
 
         def _compare_versions(x, y):
             mx = self.VERSION_REGEX.match(x)


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5989

I know Python 2.7 is no longer supported but I think the fix is sufficiently trivial that it might be worth considering regardless?