### PR TITLE
fix: ensure no duplicate package names are stored in pyproject.toml

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -215,7 +215,15 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
 
             constraint_name = _constraint["name"]
             assert isinstance(constraint_name, str)
-            section[constraint_name] = constraint
+
+            canonical_constraint_name = canonicalize_name(constraint_name)
+
+            for key in section:
+                if canonicalize_name(key) == canonical_constraint_name:
+                    section[key] = constraint
+                    break
+            else:
+                section[constraint_name] = constraint
 
             with contextlib.suppress(ValueError):
                 self.poetry.package.dependency_group(group).remove_dependency(


### PR DESCRIPTION
When upgrading dependencies via `poetry add <package>@latest` it may result in multiple entries in `pyproject.toml` if the name returned by the API differs from the name given in the `pyproject.toml`, e.g. different upper/lower cases.

This PR fixes this by keeping the name given in the `pyproject.toml` and updating the version constraint.

Resolves: #6831

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

