### PR TITLE
Handle distribution.files being None

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -328,8 +328,8 @@ class SitePackages:
         for distribution in self.distributions(
             name=distribution_name, writable_only=writable_only
         ):
-            assert distribution.files is not None
-            for file in distribution.files:
+            files = [] if distribution.files is None else distribution.files
+            for file in files:
                 if file.name.endswith(suffix):
                     yield Path(
                         distribution.locate_file(file),  # type: ignore[no-untyped-call]
@@ -341,8 +341,8 @@ class SitePackages:
         for distribution in self.distributions(
             name=distribution_name, writable_only=writable_only
         ):
-            assert distribution.files is not None
-            for file in distribution.files:
+            files = [] if distribution.files is None else distribution.files
+            for file in files:
                 if file.name == name:
                     yield Path(
                         distribution.locate_file(file),  # type: ignore[no-untyped-call]
@@ -372,8 +372,8 @@ class SitePackages:
         for distribution in self.distributions(
             name=distribution_name, writable_only=True
         ):
-            assert distribution.files is not None
-            for file in distribution.files:
+            files = [] if distribution.files is None else distribution.files
+            for file in files:
                 path = Path(
                     distribution.locate_file(file),  # type: ignore[no-untyped-call]
                 )


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6788 

We discovered that in some unknown situations, `distribution.files` can be `None`, causing the assertion to fail. To handle `distribution.files` being `None` more gracefully, we treat it as if it were an empty list.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
