### PR TITLE
strict flake8-type-checking

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,7 @@ ban-relative-imports = true
 format-greedy = 1
 inline-quotes = double
 enable-extensions = TC, TC1
-type-checking-exempt-modules = typing, typing-extensions
+strict-type-checking = true
 eradicate-whitelist-extend = ^-.*;
 extend-ignore =
     # E203: Whitespace before ':' (pycqa/pycodestyle#373)

--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,7 @@ ban-relative-imports = true
 format-greedy = 1
 inline-quotes = double
 enable-extensions = TC, TC1
-strict-type-checking = true
+type-checking-strict = true
 eradicate-whitelist-extend = ^-.*;
 extend-ignore =
     # E203: Whitespace before ':' (pycqa/pycodestyle#373)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           - flake8-quotes==3.3.1
           - flake8-simplify==0.19.3
           - flake8-tidy-imports==4.8.0
-          - flake8-type-checking==2.1.2
+          - flake8-type-checking==2.2.0
           - flake8-typing-imports==1.12.0
           - flake8-use-fstring==1.4
           - pep8-naming==0.13.1

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -257,7 +257,8 @@ class Factory(BaseFactory):
                     constraint["optional"] = True
 
                 if len(constraint) == 1 and "version" in constraint:
-                    constraint = cast(str, constraint["version"])
+                    assert isinstance(constraint["version"], str)
+                    constraint = constraint["version"]
                 elif not constraint:
                     constraint = "*"
 

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import cast
 
 from cleo.io.null_io import NullIO
 from poetry.core.packages.file_dependency import FileDependency
@@ -771,7 +770,8 @@ class Executor:
             for dist in self._env.site_packages.distributions(
                 name=package.name, writable_only=True
             ):
-                dist_path = cast(Path, dist._path)  # type: ignore[attr-defined]
+                dist_path = dist._path  # type: ignore[attr-defined]
+                assert isinstance(dist_path, Path)
                 url = dist_path / "direct_url.json"
                 url.write_text(json.dumps(url_reference), encoding="utf-8")
 

--- a/src/poetry/mixology/failure.py
+++ b/src/poetry/mixology/failure.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import cast
 
 from poetry.core.constraints.version import parse_constraint
 
@@ -114,7 +113,8 @@ class _Writer:
         conjunction = "So," if conclusion or incompatibility == self._root else "And"
         incompatibility_string = str(incompatibility)
 
-        cause: ConflictCause = cast(ConflictCause, incompatibility.cause)
+        cause = incompatibility.cause
+        assert isinstance(cause, ConflictCause)
 
         if isinstance(cause.conflict.cause, ConflictCause) and isinstance(
             cause.other.cause, ConflictCause
@@ -198,7 +198,8 @@ class _Writer:
                     numbered=numbered,
                 )
             elif self._is_collapsible(derived):
-                derived_cause: ConflictCause = cast(ConflictCause, derived.cause)
+                derived_cause = derived.cause
+                assert isinstance(derived_cause, ConflictCause)
                 if isinstance(derived_cause.conflict.cause, ConflictCause):
                     collapsed_derived = derived_cause.conflict
                     collapsed_ext = derived_cause.other
@@ -233,7 +234,8 @@ class _Writer:
         if self._derivations[incompatibility] > 1:
             return False
 
-        cause: ConflictCause = cast(ConflictCause, incompatibility.cause)
+        cause = incompatibility.cause
+        assert isinstance(cause, ConflictCause)
         if isinstance(cause.conflict.cause, ConflictCause) and isinstance(
             cause.other.cause, ConflictCause
         ):

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
 from typing import Mapping
-from typing import cast
 
 from poetry.utils.constants import REQUESTS_TIMEOUT
 
@@ -189,7 +188,8 @@ def _get_win_folder_from_registry(csidl_name: str) -> str:
     )
     dir, type = _winreg.QueryValueEx(key, shell_folder_name)
 
-    return cast(str, dir)
+    assert isinstance(dir, str)
+    return dir
 
 
 def _get_win_folder_with_ctypes(csidl_name: str) -> str:


### PR DESCRIPTION
recent flake8-type-checking encourages cast() using the name of the class rather than the actual class, presumably with the aim that you might find more things you don't need to import at runtime

however here, consistent with other recent MRs, I've taken the view that it's better to assert that you have the expected type than to trust that it's so