### PR TITLE
remove getattr from SitePackages

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -451,12 +451,6 @@ class SitePackages:
             if value[-1] is True
         ]
 
-    def __getattr__(self, item: str) -> Any:
-        try:
-            return super().__getattribute__(item)
-        except AttributeError:
-            return getattr(self.path, item)
-
 
 class EnvError(Exception):
     pass


### PR DESCRIPTION
`__getattr__` can be cute and all, but it's unhelpful for typechecking (and human code readers): suddenly any attribute on an object might be valid, and might return any type at all.

mypy and the unit tests agree that no use is made of the `__getattr__` on `SitePackages` anyway, so removing it is simply making it clear that there is no magic.