### PR TITLE
chore: Update outdated LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Sébastien Eustace
+Copyright (c) 2018-present Sébastien Eustace
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Updated the outdated copyright year to the present. 
So there will not be a need for any further license year updates