### PR TITLE
don't interpret HEAD as a faulty branch

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -60,6 +60,9 @@ class GitRefSpec:
             1. a branch or tag; if so, set corresponding properties.
             2. a short sha; if so, resolve full sha and set as revision
         """
+        if self.revision == "HEAD":
+            self.revision = None
+
         if self.revision:
             ref = f"refs/tags/{self.revision}".encode()
             if ref in remote_refs.refs or annotated_tag(ref) in remote_refs.refs:


### PR DESCRIPTION
with this requirement
```
caput = { git = "https://github.com/radiocosmology/caput.git", extras = ["compression"] }
```
and using dulwich as the git client, we get:
```
Failed to clone https://github.com/radiocosmology/caput.git at 'HEAD', verify ref exists on remote.
```
What seems to happen is we go through the branch https://github.com/python-poetry/poetry/blob/16046d9ac9b72a49e1bc4618fb686695cc64821c/src/poetry/vcs/git/backend.py#L69-L75, correcting "HEAD" to be treated as a branch with that name - and that later goes wrong.

I don't really understand what's going on in this code, maybe someone who does can contribute a testcase

Another fix that I tried was
```patch
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -111,7 +111,7 @@ def _get_package_from_git(
     package = Provider.get_package_from_directory(path)
     package._source_type = "git"
     package._source_url = url
-    package._source_reference = rev or tag or branch or "HEAD"
+    package._source_reference = rev or tag or branch
     package._source_resolved_reference = revision
     package._source_subdirectory = subdirectory
```
which solved this case, but did quite a bit more damage to the unit tests.  