### PR TITLE
tests: add test for `poetry show` with multiple constraints dependencies

### DIFF
--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1368,6 +1368,103 @@ pendulum  2.0.0 Pendulum package
     assert tester.io.fetch_output() == expected
 
 
+def test_show_hides_incompatible_package_with_duplicate(
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: TestRepository,
+):
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "0.1.0", "platform": "linux"})
+    )
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "0.1.1", "platform": "darwin"})
+    )
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "files": [],
+                },
+                {
+                    "name": "cachy",
+                    "version": "0.1.1",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "files": [],
+                },
+            ],
+            "metadata": {"content-hash": "123456789"},
+        }
+    )
+
+    tester.execute()
+
+    expected = """\
+cachy (!) 0.1.1 Cachy package
+"""
+
+    assert tester.io.fetch_output() == expected
+
+
+def test_show_all_shows_all_duplicates(
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: TestRepository,
+):
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "0.1.0", "platform": "linux"})
+    )
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "0.1.1", "platform": "darwin"})
+    )
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "files": [],
+                },
+                {
+                    "name": "cachy",
+                    "version": "0.1.1",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "files": [],
+                },
+            ],
+            "metadata": {"content-hash": "123456789"},
+        }
+    )
+
+    tester.execute("--all")
+
+    expected = """\
+cachy     0.1.0 Cachy package
+cachy (!) 0.1.1 Cachy package
+"""
+
+    assert tester.io.fetch_output() == expected
+
+
 def test_show_non_dev_with_basic_installed_packages(
     tester: CommandTester, poetry: Poetry, installed: Repository
 ):


### PR DESCRIPTION
While reviewing #6843, I noticed insufficient test coverage for multiple-constraints depdendencies.