### PR TITLE
Allow requests-toolbelt 0.10.* releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ pexpect = "^4.7.0"
 pkginfo = "^1.5"
 platformdirs = "^2.5.2"
 requests = "^2.18"
-requests-toolbelt = "^0.9.1"
+requests-toolbelt = ">=0.9.1,<0.11.0"
 shellingham = "^1.5"
 # exclude 0.11.2 and 0.11.3 due to https://github.com/sdispater/tomlkit/issues/225
 tomlkit = ">=0.11.1,<1.0.0,!=0.11.2,!=0.11.3"


### PR DESCRIPTION
requests-toolbelt has released 0.10.0 and 0.10.1 recently. These don't look to make any backwards-incompatible changes (they only add features) so poetry should be able to work with them fine.

Signed-off-by: Adam Williamson <awilliam@redhat.com>

# Pull Request Check List

Resolves: #6922

- [-] Added **tests** for changed code.
- [-] Updated **documentation** for changed code.