### PR TITLE
fix: remove side effects from tests

### DIFF
--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -174,8 +174,8 @@ def locker(project_root: Path) -> Locker:
 
 
 @pytest.fixture()
-def env() -> NullEnv:
-    return NullEnv()
+def env(tmp_dir: str) -> NullEnv:
+    return NullEnv(path=Path(tmp_dir))
 
 
 @pytest.fixture()

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1151,12 +1151,13 @@ def test_installer_with_pypi_repository(
     locker: Locker,
     installed: CustomInstalledRepository,
     config: Config,
+    env: NullEnv,
 ):
     pool = RepositoryPool()
     pool.add_repository(MockRepository())
 
     installer = Installer(
-        NullIO(), NullEnv(), package, locker, pool, config, installed=installed
+        NullIO(), env, package, locker, pool, config, installed=installed
     )
 
     package.add_dependency(Factory.create_dependency("pytest", "^3.5", groups=["dev"]))

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -175,7 +175,7 @@ def locker(project_root: Path) -> Locker:
 
 @pytest.fixture()
 def env(tmp_path: Path) -> NullEnv:
-    return NullEnv(path=Path(tmp_path))
+    return NullEnv(path=tmp_path)
 
 
 @pytest.fixture()

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -174,8 +174,8 @@ def locker(project_root: Path) -> Locker:
 
 
 @pytest.fixture()
-def env(tmp_dir: str) -> NullEnv:
-    return NullEnv(path=Path(tmp_dir))
+def env(tmp_path: Path) -> NullEnv:
+    return NullEnv(path=Path(tmp_path))
 
 
 @pytest.fixture()

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -126,8 +126,8 @@ def locker(project_root: Path) -> Locker:
 
 
 @pytest.fixture()
-def env() -> NullEnv:
-    return NullEnv()
+def env(tmp_dir: str) -> NullEnv:
+    return NullEnv(path=Path(tmp_dir))
 
 
 @pytest.fixture()

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -127,7 +127,7 @@ def locker(project_root: Path) -> Locker:
 
 @pytest.fixture()
 def env(tmp_path: Path) -> NullEnv:
-    return NullEnv(path=Path(tmp_path))
+    return NullEnv(path=tmp_path)
 
 
 @pytest.fixture()

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -126,8 +126,8 @@ def locker(project_root: Path) -> Locker:
 
 
 @pytest.fixture()
-def env(tmp_dir: str) -> NullEnv:
-    return NullEnv(path=Path(tmp_dir))
+def env(tmp_path: Path) -> NullEnv:
+    return NullEnv(path=Path(tmp_path))
 
 
 @pytest.fixture()

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -819,12 +819,13 @@ def test_installer_with_pypi_repository(
     locker: Locker,
     installed: CustomInstalledRepository,
     config: Config,
+    env: NullEnv,
 ):
     pool = RepositoryPool()
     pool.add_repository(MockRepository())
 
     installer = Installer(
-        NullIO(), NullEnv(), package, locker, pool, config, installed=installed
+        NullIO(), env, package, locker, pool, config, installed=installed
     )
 
     package.add_dependency(Factory.create_dependency("pytest", "^3.5", groups=["dev"]))

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -58,8 +58,8 @@ def pool() -> RepositoryPool:
 
 
 @pytest.fixture()
-def env(tmp_dir: str) -> NullEnv:
-    return NullEnv(path=Path(tmp_dir))
+def env(tmp_path: Path) -> NullEnv:
+    return NullEnv(path=tmp_path)
 
 
 @pytest.fixture

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -63,8 +63,8 @@ def env(tmp_dir: str) -> NullEnv:
 
 
 @pytest.fixture
-def installer(pool: RepositoryPool) -> PipInstaller:
-    return PipInstaller(NullEnv(), NullIO(), pool)
+def installer(pool: RepositoryPool, env: NullEnv) -> PipInstaller:
+    return PipInstaller(env, NullIO(), pool)
 
 
 def test_requirement(installer: PipInstaller):

--- a/tests/installation/test_pip_installer.py
+++ b/tests/installation/test_pip_installer.py
@@ -57,6 +57,11 @@ def pool() -> RepositoryPool:
     return RepositoryPool()
 
 
+@pytest.fixture()
+def env(tmp_dir: str) -> NullEnv:
+    return NullEnv(path=Path(tmp_dir))
+
+
 @pytest.fixture
 def installer(pool: RepositoryPool) -> PipInstaller:
     return PipInstaller(NullEnv(), NullIO(), pool)
@@ -83,8 +88,8 @@ def test_requirement(installer: PipInstaller):
     assert result == expected
 
 
-def test_requirement_source_type_url():
-    installer = PipInstaller(NullEnv(), NullIO(), RepositoryPool())
+def test_requirement_source_type_url(env: NullEnv):
+    installer = PipInstaller(env, NullIO(), RepositoryPool())
 
     foo = Package(
         "foo",
@@ -100,10 +105,9 @@ def test_requirement_source_type_url():
 
 
 def test_requirement_git_subdirectory(
-    pool: RepositoryPool, package_git_with_subdirectory: Package
+    pool: RepositoryPool, package_git_with_subdirectory: Package, env: NullEnv
 ) -> None:
-    null_env = NullEnv()
-    installer = PipInstaller(null_env, NullIO(), pool)
+    installer = PipInstaller(env, NullIO(), pool)
     result = installer.requirement(package_git_with_subdirectory)
     expected = (
         "git+https://github.com/demo/subdirectories.git"
@@ -112,8 +116,8 @@ def test_requirement_git_subdirectory(
 
     assert result == expected
     installer.install(package_git_with_subdirectory)
-    assert len(null_env.executed) == 1
-    cmd = null_env.executed[0]
+    assert len(env.executed) == 1
+    cmd = env.executed[0]
     assert Path(cmd[-1]).parts[-3:] == ("demo", "subdirectories", "two")
 
 
@@ -160,7 +164,7 @@ def test_install_with_non_pypi_default_repository(
         ("cert", "cert"),
     ],
 )
-def test_install_with_certs(mocker: MockerFixture, key: str, option: str):
+def test_install_with_certs(mocker: MockerFixture, key: str, option: str, env: NullEnv):
     client_path = "path/to/client.pem"
     mocker.patch(
         "poetry.utils.authenticator.Authenticator.get_certs_for_url",
@@ -171,9 +175,7 @@ def test_install_with_certs(mocker: MockerFixture, key: str, option: str):
     pool = RepositoryPool()
     pool.add_repository(default, default=True)
 
-    null_env = NullEnv()
-
-    installer = PipInstaller(null_env, NullIO(), pool)
+    installer = PipInstaller(env, NullIO(), pool)
 
     foo = Package(
         "foo",
@@ -185,8 +187,8 @@ def test_install_with_certs(mocker: MockerFixture, key: str, option: str):
 
     installer.install(foo)
 
-    assert len(null_env.executed) == 1
-    cmd = null_env.executed[0]
+    assert len(env.executed) == 1
+    cmd = env.executed[0]
     assert f"--{option}" in cmd
     cert_index = cmd.index(f"--{option}")
     # Need to do the str(Path()) bit because Windows paths get modified by Path
@@ -242,16 +244,14 @@ def test_uninstall_git_package_nspkg_pth_cleanup(
     assert not re.match(rf"Error processing line 1 of .*{pth_file}", output)
 
 
-def test_install_with_trusted_host(config: Config):
+def test_install_with_trusted_host(config: Config, env: NullEnv):
     config.merge({"certificates": {"default": {"cert": False}}})
 
     default = LegacyRepository("default", "https://foo.bar")
     pool = RepositoryPool()
     pool.add_repository(default, default=True)
 
-    null_env = NullEnv()
-
-    installer = PipInstaller(null_env, NullIO(), pool)
+    installer = PipInstaller(env, NullIO(), pool)
 
     foo = Package(
         "foo",
@@ -263,8 +263,8 @@ def test_install_with_trusted_host(config: Config):
 
     installer.install(foo)
 
-    assert len(null_env.executed) == 1
-    cmd = null_env.executed[0]
+    assert len(env.executed) == 1
+    cmd = env.executed[0]
     assert "--trusted-host" in cmd
     cert_index = cmd.index("--trusted-host")
     assert cmd[cert_index + 1] == "foo.bar"

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -288,10 +288,10 @@ def test_builder_installs_proper_files_when_packages_configured(
 
 
 def test_builder_should_execute_build_scripts(
-    mocker: MockerFixture, extended_without_setup_poetry: Poetry, tmp_dir: str
+    mocker: MockerFixture, extended_without_setup_poetry: Poetry, tmp_path: Path
 ):
-    env = MockEnv(path=Path(tmp_dir) / "foo")
-    site_packages_dir = Path(tmp_dir) / "site-packages"
+    env = MockEnv(path=tmp_path / "foo")
+    site_packages_dir = tmp_path / "site-packages"
     site_packages_dir.mkdir(parents=True, exist_ok=True)
     mocker.patch.object(
         env,

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -290,12 +290,7 @@ def test_builder_installs_proper_files_when_packages_configured(
 def test_builder_should_execute_build_scripts(
     mocker: MockerFixture, extended_without_setup_poetry: Poetry, tmp_dir: str
 ):
-    import sys
-
-    sys.stdout = sys.stderr
-    env = MockEnv(
-        path=Path(tmp_dir) / "foo",
-    )
+    env = MockEnv(path=Path(tmp_dir) / "foo")
     site_packages_dir = Path(tmp_dir) / "site-packages"
     site_packages_dir.mkdir(parents=True, exist_ok=True)
     mocker.patch.object(

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -290,7 +290,22 @@ def test_builder_installs_proper_files_when_packages_configured(
 def test_builder_should_execute_build_scripts(
     mocker: MockerFixture, extended_without_setup_poetry: Poetry, tmp_dir: str
 ):
-    env = MockEnv(path=Path(tmp_dir) / "foo")
+    import sys
+
+    sys.stdout = sys.stderr
+    env = MockEnv(
+        path=Path(tmp_dir) / "foo",
+    )
+    site_packages_dir = Path(tmp_dir) / "site-packages"
+    site_packages_dir.mkdir(parents=True, exist_ok=True)
+    mocker.patch.object(
+        env,
+        "get_paths",
+        return_value={
+            "purelib": str(site_packages_dir),
+            "platlib": str(site_packages_dir),
+        },
+    )
     mocker.patch(
         "poetry.masonry.builders.editable.build_environment"
     ).return_value.__enter__.return_value = env


### PR DESCRIPTION
# Pull Request Check List

Found some cases where tests were writing to the Poetry test runtime environment rather than a mocked local directory. This is an issue, since it meant that some tests were technically stateful when rerunning locally.

Added in placeholders for those tests. Tested that this succeeds by using a build where my Poetry venv was made entirely read-only.

Resolves: N/A

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
