### PR TITLE
ci: use env vars for exporting output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Get full Python version
         id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
 
       - name: Bootstrap poetry
         run: |
@@ -98,8 +98,7 @@ jobs:
       - name: Get Plugin Version (poetry-plugin-export)
         id: poetry-plugin-export-version
         run: |
-          echo ::set-output name=version::$(\
-            poetry show poetry-plugin-export  | grep version | cut -d : -f 2 | xargs)
+          echo version=$(poetry show poetry-plugin-export | grep version | cut -d : -f 2 | xargs) >> $GITHUB_OUTPUT
 
       - name: Checkout Plugin Source (poetry-plugin-export)
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Check Version
         id: check-version
         run: |
-          [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-            || echo ::set-output name=prerelease::true
+          [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo prerelease=true >> $GITHUB_OUTPUT
 
       - name: Create Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
https://github.com/python-poetry/poetry/actions/runs/3371708936 shows that `set-output` is now deprecated.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ shows the new way of exporting outputs.