### PR TITLE
example won't work with poetry (1.2.2) install

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -82,7 +82,7 @@ If you want to add dependencies to your project, you can specify them in the `to
 
 ```toml
 [tool.poetry.dependencies]
-pendulum = "^2.1"
+pendulum = "^2.1.1"
 ```
 
 As you can see, it takes a mapping of **package names** and **version constraints**.


### PR DESCRIPTION
in toml file
[tool.poetry.dependencies]
pendulum = "^2.1"

This will cause "pendumlum (^2.1) which doesn't match any versions, version solving failed."

need to specify a full version like "^2.1.1"

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
