### PR TITLE
pip install --no-input everywhere

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -593,6 +593,7 @@ def get_pep517_metadata(path: Path) -> PackageInfo:
                 "install",
                 "--disable-pip-version-check",
                 "--ignore-installed",
+                "--no-input",
                 *PEP517_META_BUILD_DEPS,
             )
             venv.run(

--- a/src/poetry/installation/pip_installer.py
+++ b/src/poetry/installation/pip_installer.py
@@ -46,7 +46,7 @@ class PipInstaller(BaseInstaller):
 
             return
 
-        args = ["install", "--no-deps"]
+        args = ["install", "--no-deps", "--no-input"]
 
         if not package.is_direct_origin() and package.source_url:
             assert package.source_reference is not None

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1953,6 +1953,7 @@ def build_environment(
                 "install",
                 "--disable-pip-version-check",
                 "--ignore-installed",
+                "--no-input",
                 *poetry.pyproject.build_system.requires,
             )
 

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1535,6 +1535,7 @@ def test_build_environment_called_build_script_specified(
                 "install",
                 "--disable-pip-version-check",
                 "--ignore-installed",
+                "--no-input",
                 *extended_without_setup_poetry.pyproject.build_system.requires,
             ]
         ]


### PR DESCRIPTION
This is an extension of https://github.com/python-poetry/poetry/pull/6724. I think `pip install` invoked by poetry should never ask for user input. 

Motivation is that it happened to myself and a number of colleagues many times that poetry got seemingly stuck while it was just waiting for a user input because of a private pypi repository that needed authentication.

I hope this is a valuable contribution to a tool I like a lot and would like to use more and more :)