### PR TITLE
Handle restricted dependencies as implicit multiple-constraints dependencies

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -570,6 +570,9 @@ class Provider:
                         continue
                     self.search_for_direct_origin_dependency(dep)
 
+        active_extras = None if package.is_root() else dependency.extras
+        _dependencies = self._add_implicit_dependencies(_dependencies, active_extras)
+
         dependencies = self._get_dependencies_with_overrides(
             _dependencies, dependency_package
         )
@@ -606,7 +609,6 @@ class Provider:
 
             # For dependency resolution, markers of duplicate dependencies must be
             # mutually exclusive.
-            active_extras = None if package.is_root() else dependency.extras
             deps = self._resolve_overlapping_markers(package, deps, active_extras)
 
             if len(deps) == 1:
@@ -856,6 +858,42 @@ class Provider:
             and (not self._env or marker.validate(self._env.marker_env))
         )
 
+    def _add_implicit_dependencies(
+        self,
+        dependencies: Iterable[Dependency],
+        active_extras: Collection[NormalizedName] | None,
+    ) -> list[Dependency]:
+        """
+        This handles an edge case where the dependency is not required for a subset
+        of possible environments. We have to create such an implicit "not required"
+        dependency in order to not miss other dependencies later.
+        For instance:
+            • foo (1.0) ; python == 3.7
+            • foo (2.0) ; python == 3.8
+            • bar (2.0) ; python == 3.8
+            • bar (3.0) ; python == 3.9
+        the last dependency would be missed without this,
+        because the intersection with both foo dependencies is empty.
+
+        A special case of this edge case is a restricted dependency with a single
+        constraint, see https://github.com/python-poetry/poetry/issues/5506
+        for details.
+        """
+        by_name: dict[str, list[Dependency]] = defaultdict(list)
+        for dep in dependencies:
+            by_name[dep.name].append(dep)
+        for _name, deps in by_name.items():
+            marker = marker_union(*[d.marker for d in deps])
+            if marker.is_any():
+                continue
+            inverted_marker = marker.invert()
+            if self._is_relevant_marker(inverted_marker, active_extras):
+                # Set constraint to empty to mark dependency as "not required".
+                inverted_marker_dep = deps[0].with_constraint(EmptyConstraint())
+                inverted_marker_dep.marker = inverted_marker
+                deps.append(inverted_marker_dep)
+        return [dep for deps in by_name.values() for dep in deps]
+
     def _resolve_overlapping_markers(
         self,
         package: Package,
@@ -878,7 +916,20 @@ class Provider:
         dependencies = self._merge_dependencies_by_constraint(dependencies)
 
         new_dependencies = []
+
+        # We have can sort out the implicit "not required" dependency determined
+        # in _add_implicit_dependencies, because it does not overlap with
+        # any other dependency for sure.
+        for i, dep in enumerate(dependencies):
+            if dep.constraint.is_empty():
+                new_dependencies.append(dependencies.pop(i))
+                break
+
         for uses in itertools.product([True, False], repeat=len(dependencies)):
+            if not any(uses):
+                # handled by the implicit "not required" dependency
+                continue
+
             # intersection of markers
             # For performance optimization, we don't just intersect all markers at once,
             # but intersect them one after the other to get empty markers early.
@@ -916,21 +967,6 @@ class Provider:
             if constraint.is_empty():
                 # conflict in overlapping area
                 raise IncompatibleConstraintsError(package, *used_dependencies)
-
-            if not any(uses):
-                # This is an edge case where the dependency is not required
-                # for the resulting marker. However, we have to consider it anyway
-                #  in order to not miss other dependencies later, for instance:
-                #   • foo (1.0) ; python == 3.7
-                #   • foo (2.0) ; python == 3.8
-                #   • bar (2.0) ; python == 3.8
-                #   • bar (3.0) ; python == 3.9
-                # the last dependency would be missed without this,
-                # because the intersection with both foo dependencies is empty.
-
-                # Set constraint to empty to mark dependency as "not required".
-                constraint = EmptyConstraint()
-                used_dependencies = dependencies
 
             # build new dependency with intersected constraint and marker
             # (and correct source)

--- a/tests/installation/fixtures/update-with-locked-extras.test
+++ b/tests/installation/fixtures/update-with-locked-extras.test
@@ -8,7 +8,7 @@ files = []
 
 [package.dependencies]
 "B" = {version = "^1.0", optional = true}
-"C" = {version = "^1.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
+"C" = {version = ">=1.0,<2.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
 
 [package.extras]
 foo = ["B"]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #5506

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Although I think that this PR makes the solver more correct it comes with a massive performance regression that is far from acceptible.

I carried out some measurements with example pyproject.toml files from other PRs. If locking succeeds without this PR, the same lock file is generated with this PR, it just takes longer...

Times for `poetry lock` with a warm cache:

|`pyproject.toml` from ...| time without PR | time with PR |
|---|---|---|
|#3367|0.8 s|2.8 s|
|#4670|1.8 s|4.2 s|
|#4870|71 s| 11800 s (not a typo)|
|#5506|error after 4.5 s|1090 s|
|shootout example|3.9 s|250 s|

Number of overrides:

|`pyproject.toml` from ...| number of overrides without PR | number of overrides with PR |
|---|---|---|
|#3367|4|10|
|#4670|16|19|
|#4870|46|4179|
|#5506|-|288|
|shootout example|0|69|

The data shows that the time seems to correlate with the number of overrides. Thus, I assume a more sophisticated algorithm to reduce the number of overrides or even a complete overhaul of how to handle multiple-constraints dependencies might be necessary. I can imagine to make the `VersionSolver` marker aware so that a version conflict is only a conflict if the intersection of markers is not empty. This way, overrides would not be necessary anymore and everything could be solved at once. However, that's probably a huge task.
