### PR TITLE
Make run_script args[0] the absolute path to the script being called

### DIFF
--- a/src/poetry/console/commands/run.py
+++ b/src/poetry/console/commands/run.py
@@ -47,10 +47,7 @@ class RunCommand(EnvCommand):
 
     def run_script(self, script: str | dict[str, str], args: list[str]) -> int:
         env = EnvManager(self.poetry).get()
-        if env.platform == "win32":
-            args[0] = rf"{env.path}\Scripts\{args[0]}"
-        else:
-            args[0] = f"{env.path}/bin/{args[0]}"
+        args[0] = rf"{env.script_dirs[0]}/{args[0]}"
 
         if isinstance(script, dict):
             script = script["callable"]

--- a/src/poetry/console/commands/run.py
+++ b/src/poetry/console/commands/run.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from cleo.helpers import argument
 
 from poetry.console.commands.env_command import EnvCommand
+from poetry.utils.env import EnvManager
 
 
 if TYPE_CHECKING:
@@ -44,7 +45,13 @@ class RunCommand(EnvCommand):
 
         return module
 
-    def run_script(self, script: str | dict[str, str], args: str) -> int:
+    def run_script(self, script: str | dict[str, str], args: list[str]) -> int:
+        env = EnvManager(self.poetry).get()
+        if env.platform == "win32":
+            args[0] = rf"{env.path}\Scripts\{args[0]}"
+        else:
+            args[0] = f"{env.path}/bin/{args[0]}"
+
         if isinstance(script, dict):
             script = script["callable"]
 

--- a/src/poetry/console/commands/run.py
+++ b/src/poetry/console/commands/run.py
@@ -47,7 +47,10 @@ class RunCommand(EnvCommand):
 
     def run_script(self, script: str | dict[str, str], args: list[str]) -> int:
         env = EnvManager(self.poetry).get()
-        args[0] = rf"{env.script_dirs[0]}/{args[0]}"
+        if env.platform == "win32":
+            args[0] = rf"{env.path}\Scripts\{args[0]}"
+        else:
+            args[0] = f"{env.path}/bin/{args[0]}"
 
         if isinstance(script, dict):
             script = script["callable"]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2435

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [] Added **tests** for changed code. 
- [x] Updated **documentation** for changed code <- This would not produce a change in the documentation as it is not altering the core way the `run` command functions only deal with edge cases of its use. 

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

When a poetry user wants to run tools with auto-reload such as the kind found in Django's `runserver` through the `poetry run` functionality the auto-reload will collect the original command again in our case it works as `poetry run script` will look up in the config where the script is to be run from however when called again will produce an error as found in #2435. This PR aims to resolve that issue. 
