### PR TITLE
fix: in-project venv not recognized when not requested

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -734,7 +734,7 @@ class EnvManager:
 
         venv = self._poetry.file.parent / ".venv"
         if (
-            self._poetry.config.get("virtualenvs.in-project")
+            self._poetry.config.get("virtualenvs.in-project") is not False
             and venv.exists()
             and venv.is_dir()
         ):

--- a/tests/console/commands/env/conftest.py
+++ b/tests/console/commands/env/conftest.py
@@ -66,3 +66,29 @@ def venvs_in_project_dir(app: PoetryTestApplication) -> Iterator[Path]:
         yield venv_dir
     finally:
         venv_dir.rmdir()
+
+
+@pytest.fixture
+def venvs_in_project_dir_none(app: PoetryTestApplication) -> Iterator[Path]:
+    os.environ.pop("VIRTUAL_ENV", None)
+    venv_dir = app.poetry.file.parent.joinpath(".venv")
+    venv_dir.mkdir(exist_ok=True)
+    app.poetry.config.merge({"virtualenvs": {"in-project": None}})
+
+    try:
+        yield venv_dir
+    finally:
+        venv_dir.rmdir()
+
+
+@pytest.fixture
+def venvs_in_project_dir_false(app: PoetryTestApplication) -> Iterator[Path]:
+    os.environ.pop("VIRTUAL_ENV", None)
+    venv_dir = app.poetry.file.parent.joinpath(".venv")
+    venv_dir.mkdir(exist_ok=True)
+    app.poetry.config.merge({"virtualenvs": {"in-project": False}})
+
+    try:
+        yield venv_dir
+    finally:
+        venv_dir.rmdir()

--- a/tests/console/commands/env/test_list.py
+++ b/tests/console/commands/env/test_list.py
@@ -60,3 +60,19 @@ def test_in_project_venv(tester: CommandTester, venvs_in_project_dir: list[str])
     tester.execute()
     expected = ".venv (Activated)\n"
     assert tester.io.fetch_output() == expected
+
+
+def test_in_project_venv_no_explicit_config(
+    tester: CommandTester, venvs_in_project_dir_none: list[str]
+):
+    tester.execute()
+    expected = ".venv (Activated)\n"
+    assert tester.io.fetch_output() == expected
+
+
+def test_in_project_venv_is_false(
+    tester: CommandTester, venvs_in_project_dir_false: list[str]
+):
+    tester.execute()
+    expected = ""
+    assert tester.io.fetch_output() == expected


### PR DESCRIPTION
If a `.venv` folder exists within the project Poetry uses this if `virtualenv.in-project` is not explicit set to `false`. This PR fixes an issue where a in-project folder wasn't listed, if `virtualenv.in-project` hasn't any explicit value.


# Pull Request Check List

Resolves: #3939

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
