### PR TITLE
fix: make git ref resolution less greedy for HEAD

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -134,7 +134,9 @@ class GitRefSpec:
 
     @property
     def is_ref(self) -> bool:
-        return self.branch is not None and self.branch.startswith("refs/")
+        return self.branch is not None and (
+            self.branch.startswith("refs/") or self.branch == "HEAD"
+        )
 
     @property
     def is_sha_short(self) -> bool:

--- a/tests/integration/test_utils_vcs_git.py
+++ b/tests/integration/test_utils_vcs_git.py
@@ -8,6 +8,7 @@ from hashlib import sha1
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Iterator
+from typing import TypedDict
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
@@ -37,6 +38,15 @@ if TYPE_CHECKING:
 # these tests are integration as they rely on an external repository
 # see `source_url` fixture
 pytestmark = pytest.mark.integration
+
+
+class GitCloneKwargs(TypedDict):
+    name: str | None
+    branch: str | None
+    tag: str | None
+    revision: str | None
+    source_root: Path | None
+    clean: bool
 
 
 @pytest.fixture(autouse=True)
@@ -133,7 +143,11 @@ def test_git_local_info(
         assert info.revision == remote_refs.refs[remote_default_ref].decode("utf-8")
 
 
+@pytest.mark.parametrize(
+    "specification", [{}, {"revision": "HEAD"}, {"branch": "HEAD"}]
+)
 def test_git_clone_default_branch_head(
+    specification: GitCloneKwargs,
     source_url: str,
     remote_refs: FetchPackResult,
     remote_default_ref: bytes,
@@ -142,7 +156,7 @@ def test_git_clone_default_branch_head(
     spy = mocker.spy(Git, "_clone")
     spy_legacy = mocker.spy(Git, "_clone_legacy")
 
-    with Git.clone(url=source_url) as repo:
+    with Git.clone(url=source_url, **specification) as repo:
         assert remote_refs.refs[remote_default_ref] == repo.head()
 
     spy_legacy.assert_not_called()


### PR DESCRIPTION
This change ensures that when ref `HEAD` is specified, it is not incorrectly resolved to `refs/head/HEAD`. `HEAD` is not treated as a branch, and correctly resolved from the ref spec.

Resolves: #7024
Closes: #6874