### PR TITLE
wip: use pypa/installer to install wheels

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -305,6 +305,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "installer"
+version = "0.5.1"
+description = "A library for installing Python wheels."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "jaraco.classes"
 version = "3.2.3"
 description = "Utility functions for Python class constructs"
@@ -951,7 +959,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "5f69872916713817bf4617699cc1ed4a0baf50ed78422cc821cc14e43ff2de4b"
+content-hash = "67874e62e9609b8392891aa6a2a7b2342cae46c9248ef45bb59236005c1a8bd1"
 
 [metadata.files]
 attrs = [
@@ -1218,6 +1226,10 @@ importlib-resources = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+installer = [
+    {file = "installer-0.5.1-py3-none-any.whl", hash = "sha256:1d6c8d916ed82771945b9c813699e6f57424ded970c9d8bf16bbc23e1e826ed3"},
+    {file = "installer-0.5.1.tar.gz", hash = "sha256:f970995ec2bb815e2fdaf7977b26b2091e1e386f0f42eafd5ac811953dc5d445"},
 ]
 "jaraco.classes" = [
     {file = "jaraco.classes-3.2.3-py3-none-any.whl", hash = "sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ trove-classifiers = "^2022.5.19"
 virtualenv = "^20.4.3,!=20.4.5,!=20.4.6"
 xattr = { version = "^0.10.0", markers = "sys_platform == 'darwin'" }
 urllib3 = "^1.26.0"
+installer = "^0.5.1"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.6"
@@ -171,6 +172,7 @@ module = [
   'cachy.*',
   'cleo.*',
   'crashtest.*',
+  'installer.*',
   'lockfile.*',
   'pexpect.*',
   'pkginfo.*',

--- a/src/poetry/installation/base_installer.py
+++ b/src/poetry/installation/base_installer.py
@@ -4,10 +4,19 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
+    from cleo.io.io import IO
     from poetry.core.packages.package import Package
+
+    from poetry.repositories.repository_pool import RepositoryPool
+    from poetry.utils.env import Env
 
 
 class BaseInstaller:
+    def __init__(self, env: Env, io: IO, pool: RepositoryPool) -> None:
+        self._env = env
+        self._io = io
+        self._pool = pool
+
     def install(self, package: Package) -> None:
         raise NotImplementedError
 


### PR DESCRIPTION
An initial step towards dropping `pip` to install packages. Once there is a more performant iteration of #5650 we should be able to replace `PipInstaller` with a `NativeInstaller` that uses a combination of `build` (to build wheels from source), `EditableBuilder` to install editable sources and `installer` to install wheels. The editable installs should already be doable.

In the interim, this is an experimentation for early feedback on using `installer` to install already available wheels. The initial results are quite promising. On my development environment, once the cache is populated, the following times were recorded for 10 iterations for the following command and `pyproject.toml`.

```bash
time for i in {1..10}; do rm -rf .venv/; poetry install; done
```

<details>
<summary><b>pyproject.toml</b></summary>
<p>

```toml
[tool.poetry]
name = "foobar"
version = "0.1.0"
description = ""
authors = ["Some One <some.one@somewhere.com>"]
readme = "README.md"

[tool.poetry.dependencies]
python = "^3.10"
aiohttp = "^3.8.3"
poetry-core = "^1.3.2"
tomlkit = "^0.11.6"
httpx = "^0.23.0"

[tool.poetry.group.dev.dependencies]
pytest = "^7.2.0"

[build-system]
requires = ["poetry-core"]
build-backend = "poetry.core.masonry.api"
```

</p>
</details>

#### Without patch
```console
real    0m37.136s
user    2m37.909s
sys     0m13.516s
```

#### With patch
````console
real    0m11.295s
user    0m10.434s
sys     0m2.567s
````

If enabling this we should allow for `experimental` as there could be edge cases around how platform wheels will be installed.
