### PR TITLE
make keyring fallback optional

### DIFF
--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -245,6 +245,8 @@ To remove a repository (repo is a short alias for repositories):
             if self.option("unset"):
                 if m.group(1) == "http-basic":
                     password_manager.delete_http_password(m.group(2))
+                if m.group(1) == "http-fallback":
+                    password_manager.delete_http_fallback(m.group(2))
                 elif m.group(1) == "pypi-token":
                     password_manager.delete_pypi_token(m.group(2))
 
@@ -265,6 +267,12 @@ To remove a repository (repo is a short alias for repositories):
                     password = values[1]
 
                 password_manager.set_http_password(m.group(2), username, password)
+
+            if m.group(1) == "http-fallback":
+                if len(values) != 0:
+                    raise ValueError("Expected no arguments", f"Got {len(values)}")
+                password_manager.set_http_fallback(m.group(2))
+
             elif m.group(1) == "pypi-token":
                 if len(values) != 1:
                     raise ValueError(

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -105,7 +105,9 @@ class AuthenticatorRepositoryConfig:
         default_auth = password_manager.get_http_auth(self.name)
         if default_auth.password is None:
             netloc_auth = password_manager.get_http_auth(self.netloc.replace(".", "-"))
-        return netloc_auth if netloc_auth.password is not None else default_auth
+            if netloc_auth.password is not None:
+                return netloc_auth 
+        return default_auth
 
 
 class Authenticator:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -104,7 +104,7 @@ class AuthenticatorRepositoryConfig:
     ) -> HTTPAuthCredential:
         default_auth = password_manager.get_http_auth(self.name)
         if default_auth.password is None:
-            netloc_auth =  password_manager.get_http_auth(self.netloc.replace(".", "-"))
+            netloc_auth = password_manager.get_http_auth(self.netloc.replace(".", "-"))
         return netloc_auth if netloc_auth.password is not None else default_auth
 
 

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -102,12 +102,12 @@ class AuthenticatorRepositoryConfig:
     def get_http_credentials(
         self, password_manager: PasswordManager, username: str | None = None
     ) -> HTTPAuthCredential:
-        default_auth = password_manager.get_http_auth(self.name)
-        if default_auth.password is None:
-            netloc_auth = password_manager.get_http_auth(self.netloc.replace(".", "-"))
-            if netloc_auth.password is not None:
-                return netloc_auth
-        return default_auth
+        if password_manager.is_http_fallback(self.name):
+            return password_manager.get_http_auth_from_fallback(
+                url=self.url, netloc=self.netloc, username=username
+            )
+        else:
+            return password_manager.get_http_auth(self.name)
 
 
 class Authenticator:

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -106,7 +106,7 @@ class AuthenticatorRepositoryConfig:
         if default_auth.password is None:
             netloc_auth = password_manager.get_http_auth(self.netloc.replace(".", "-"))
             if netloc_auth.password is not None:
-                return netloc_auth 
+                return netloc_auth
         return default_auth
 
 

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -203,7 +203,6 @@ class PasswordManager:
                 password = self._keyring.get_password(name, username)
 
         return HTTPAuthCredential(username=username, password=password)
-    
 
     def set_http_password(self, name: str, username: str, password: str) -> None:
         auth = {"username": username}

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 
 from contextlib import suppress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 
 if TYPE_CHECKING:
@@ -192,8 +192,8 @@ class PasswordManager:
 
         self._keyring.delete_password(name, "__token__")
 
-    def get_http_auth(self, name: str) -> HTTPAuthCredential | None:
-        auth: Config = self._config.get(f"http-basic.{name}")
+    def get_http_auth(self, name: str) -> HTTPAuthCredential:
+        auth: Optional[Config] = self._config.get(f"http-basic.{name}")
         if not auth:
             username = self._config.get(f"http-basic.{name}.username")
             password = self._config.get(f"http-basic.{name}.password")
@@ -217,8 +217,6 @@ class PasswordManager:
 
     def delete_http_password(self, name: str) -> None:
         auth = self.get_http_auth(name)
-        if not auth:
-            return
 
         username = auth.username
         if username is None:

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -59,10 +59,8 @@ def test_run_has_helpful_error_when_command_not_found(
         # The expected string in this assertion assumes Command Prompt (cmd.exe) is the
         # shell used.
         assert capfd.readouterr().err.splitlines() == [
-            (
-                "'nonexistent-command' is not recognized as an internal or external"
-                " command,"
-            ),
+            "'nonexistent-command' is not recognized as an internal or external"
+            " command,",
             "operable program or batch file.",
         ]
     else:

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -159,12 +159,11 @@ def test_authenticator_falls_back_to_keyring_url(
     config.merge(
         {
             "repositories": repo,
+            "http-basic": {"foo": {"username": None, "password": None}},
         }
     )
 
-    dummy_keyring.set_password(
-        "https://foo.bar/simple/", None, SimpleCredential(None, "bar")
-    )
+    dummy_keyring.set_password("poetry-repository-foo", None, "bar")
 
     authenticator = Authenticator(config, NullIO())
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
@@ -185,10 +184,12 @@ def test_authenticator_falls_back_to_keyring_netloc(
     config.merge(
         {
             "repositories": repo,
+            "http-basic": {"foo-bar": {"username": None, "password": None}},
         }
     )
 
-    dummy_keyring.set_password("foo.bar", None, SimpleCredential(None, "bar"))
+    dummy_keyring.set_password("poetry-repository-foo-bar", None, "bar")
+
 
     authenticator = Authenticator(config, NullIO())
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
@@ -416,15 +417,20 @@ def test_authenticator_falls_back_to_keyring_url_matched_by_path(
             "repositories": {
                 "foo-alpha": {"url": "https://foo.bar/alpha/files/simple/"},
                 "foo-beta": {"url": "https://foo.bar/beta/files/simple/"},
-            }
+            },
+            "http-basic": {
+                "foo-alpha": {"username": None, "password": None},
+                "foo-beta": {"username": None, "password": None}
+            },
+
         }
     )
 
     dummy_keyring.set_password(
-        "https://foo.bar/alpha/files/simple/", None, SimpleCredential(None, "bar")
+        "poetry-repository-foo-alpha", None,  "bar"
     )
     dummy_keyring.set_password(
-        "https://foo.bar/beta/files/simple/", None, SimpleCredential(None, "baz")
+        "poetry-repository-foo-beta", None, "baz"
     )
 
     authenticator = Authenticator(config, NullIO())

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -159,11 +159,13 @@ def test_authenticator_falls_back_to_keyring_url(
     config.merge(
         {
             "repositories": repo,
-            "http-basic": {"foo": {"username": None, "password": None}},
+            "http-fallback": {"foo": True},
         }
     )
 
-    dummy_keyring.set_password("poetry-repository-foo", None, "bar")
+    dummy_keyring.set_password(
+        "https://foo.bar/simple/", None, SimpleCredential(None, "bar")
+    )
 
     authenticator = Authenticator(config, NullIO())
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
@@ -184,11 +186,10 @@ def test_authenticator_falls_back_to_keyring_netloc(
     config.merge(
         {
             "repositories": repo,
-            "http-basic": {"foo-bar": {"username": None, "password": None}},
+            "http-fallback": {"foo": True},
         }
     )
-
-    dummy_keyring.set_password("poetry-repository-foo-bar", None, "bar")
+    dummy_keyring.set_password("foo.bar", None, SimpleCredential(None, "bar"))
 
     authenticator = Authenticator(config, NullIO())
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
@@ -417,15 +418,19 @@ def test_authenticator_falls_back_to_keyring_url_matched_by_path(
                 "foo-alpha": {"url": "https://foo.bar/alpha/files/simple/"},
                 "foo-beta": {"url": "https://foo.bar/beta/files/simple/"},
             },
-            "http-basic": {
-                "foo-alpha": {"username": None, "password": None},
-                "foo-beta": {"username": None, "password": None},
+            "http-fallback": {
+                "foo-alpha": True,
+                "foo-beta": True,
             },
         }
     )
 
-    dummy_keyring.set_password("poetry-repository-foo-alpha", None, "bar")
-    dummy_keyring.set_password("poetry-repository-foo-beta", None, "baz")
+    dummy_keyring.set_password(
+        "https://foo.bar/alpha/files/simple/", None, SimpleCredential(None, "bar")
+    )
+    dummy_keyring.set_password(
+        "https://foo.bar/beta/files/simple/", None, SimpleCredential(None, "baz")
+    )
 
     authenticator = Authenticator(config, NullIO())
 

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -190,7 +190,6 @@ def test_authenticator_falls_back_to_keyring_netloc(
 
     dummy_keyring.set_password("poetry-repository-foo-bar", None, "bar")
 
-
     authenticator = Authenticator(config, NullIO())
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
@@ -420,18 +419,13 @@ def test_authenticator_falls_back_to_keyring_url_matched_by_path(
             },
             "http-basic": {
                 "foo-alpha": {"username": None, "password": None},
-                "foo-beta": {"username": None, "password": None}
+                "foo-beta": {"username": None, "password": None},
             },
-
         }
     )
 
-    dummy_keyring.set_password(
-        "poetry-repository-foo-alpha", None,  "bar"
-    )
-    dummy_keyring.set_password(
-        "poetry-repository-foo-beta", None, "baz"
-    )
+    dummy_keyring.set_password("poetry-repository-foo-alpha", None, "bar")
+    dummy_keyring.set_password("poetry-repository-foo-beta", None, "baz")
 
     authenticator = Authenticator(config, NullIO())
 

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -23,7 +23,7 @@ def test_set_http_password(
 ):
     manager = PasswordManager(config)
 
-    assert manager.keyring.is_available()
+    assert manager._keyring.is_available()
     manager.set_http_password("foo", "bar", "baz")
 
     assert dummy_keyring.get_password("poetry-repository-foo", "bar") == "baz"
@@ -40,11 +40,11 @@ def test_get_http_auth(
     config.auth_config_source.add_property("http-basic.foo", {"username": "bar"})
     manager = PasswordManager(config)
 
-    assert manager.keyring.is_available()
+    assert manager._keyring.is_available()
     auth = manager.get_http_auth("foo")
 
-    assert auth["username"] == "bar"
-    assert auth["password"] == "baz"
+    assert auth.username== "bar"
+    assert auth.password == "baz"
 
 
 def test_delete_http_password(
@@ -54,7 +54,7 @@ def test_delete_http_password(
     config.auth_config_source.add_property("http-basic.foo", {"username": "bar"})
     manager = PasswordManager(config)
 
-    assert manager.keyring.is_available()
+    assert manager._keyring.is_available()
     manager.delete_http_password("foo")
 
     assert dummy_keyring.get_password("poetry-repository-foo", "bar") is None
@@ -66,7 +66,7 @@ def test_set_pypi_token(
 ):
     manager = PasswordManager(config)
 
-    assert manager.keyring.is_available()
+    assert manager._keyring.is_available()
     manager.set_pypi_token("foo", "baz")
 
     assert config.get("pypi-token.foo") is None
@@ -80,7 +80,7 @@ def test_get_pypi_token(
     dummy_keyring.set_password("poetry-repository-foo", "__token__", "baz")
     manager = PasswordManager(config)
 
-    assert manager.keyring.is_available()
+    assert manager._keyring.is_available()
     assert manager.get_pypi_token("foo") == "baz"
 
 
@@ -90,7 +90,7 @@ def test_delete_pypi_token(
     dummy_keyring.set_password("poetry-repository-foo", "__token__", "baz")
     manager = PasswordManager(config)
 
-    assert manager.keyring.is_available()
+    assert manager._keyring.is_available()
     manager.delete_pypi_token("foo")
 
     assert dummy_keyring.get_password("poetry-repository-foo", "__token__") is None
@@ -101,7 +101,7 @@ def test_set_http_password_with_unavailable_backend(
 ):
     manager = PasswordManager(config)
 
-    assert not manager.keyring.is_available()
+    assert not manager._keyring.is_available()
     manager.set_http_password("foo", "bar", "baz")
 
     auth = config.get("http-basic.foo")
@@ -117,11 +117,11 @@ def test_get_http_auth_with_unavailable_backend(
     )
     manager = PasswordManager(config)
 
-    assert not manager.keyring.is_available()
+    assert not manager._keyring.is_available()
     auth = manager.get_http_auth("foo")
 
-    assert auth["username"] == "bar"
-    assert auth["password"] == "baz"
+    assert auth.username == "bar"
+    assert auth.password == "baz"
 
 
 def test_delete_http_password_with_unavailable_backend(
@@ -132,7 +132,7 @@ def test_delete_http_password_with_unavailable_backend(
     )
     manager = PasswordManager(config)
 
-    assert not manager.keyring.is_available()
+    assert not manager._keyring.is_available()
     manager.delete_http_password("foo")
 
     assert config.get("http-basic.foo") is None
@@ -143,7 +143,7 @@ def test_set_pypi_token_with_unavailable_backend(
 ):
     manager = PasswordManager(config)
 
-    assert not manager.keyring.is_available()
+    assert not manager._keyring.is_available()
     manager.set_pypi_token("foo", "baz")
 
     assert config.get("pypi-token.foo") == "baz"
@@ -155,7 +155,7 @@ def test_get_pypi_token_with_unavailable_backend(
     config.auth_config_source.add_property("pypi-token.foo", "baz")
     manager = PasswordManager(config)
 
-    assert not manager.keyring.is_available()
+    assert not manager._keyring.is_available()
     assert manager.get_pypi_token("foo") == "baz"
 
 
@@ -165,7 +165,7 @@ def test_delete_pypi_token_with_unavailable_backend(
     config.auth_config_source.add_property("pypi-token.foo", "baz")
     manager = PasswordManager(config)
 
-    assert not manager.keyring.is_available()
+    assert not manager._keyring.is_available()
     manager.delete_pypi_token("foo")
 
     assert config.get("pypi-token.foo") is None
@@ -229,8 +229,8 @@ def test_get_http_auth_from_environment_variables(
 
     auth = manager.get_http_auth("foo")
 
-    assert auth["username"] == "bar"
-    assert auth["password"] == "baz"
+    assert auth.username == "bar"
+    assert auth.password == "baz"
 
 
 def test_get_pypi_token_with_env_var_positive(

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -43,7 +43,7 @@ def test_get_http_auth(
     assert manager._keyring.is_available()
     auth = manager.get_http_auth("foo")
 
-    assert auth.username== "bar"
+    assert auth.username == "bar"
     assert auth.password == "baz"
 
 


### PR DESCRIPTION
Fixes #1917 - the root cause of this issue seems to be that any request made by poetry tries to get auth information from the keyring even if the config of the PasswordManager has no indication that the requets needs auth in the first place. This is also the reason why any operation that does any kind of requests fails, with the keyring errors.
This was caused by some code that was bypassing the normal keyring opreations, which i removed.

I updated the test so that they still pass using the normal poetry keyring repo. I also made the keyring protected so access to it is discouraged.


# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


