### PR TITLE
Removing tmp_dir test fixture in favor of pytest's tmp_path.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,6 @@ from poetry.repositories import RepositoryPool
 from poetry.utils.env import EnvManager
 from poetry.utils.env import SystemEnv
 from poetry.utils.env import VirtualEnv
-from poetry.utils.helpers import remove_directory
 from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import TestLocker
 from tests.helpers import TestRepository
@@ -166,8 +165,8 @@ def with_chained_null_keyring(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
-def config_cache_dir(tmp_dir: str) -> Path:
-    path = Path(tmp_dir) / ".cache" / "pypoetry"
+def config_cache_dir(tmp_path: Path) -> Path:
+    path = tmp_path / ".cache" / "pypoetry"
     path.mkdir(parents=True)
     return path
 
@@ -216,8 +215,8 @@ def config(
 
 
 @pytest.fixture()
-def config_dir(tmp_dir: str) -> Path:
-    return Path(tempfile.mkdtemp(prefix="poetry_config_", dir=tmp_dir))
+def config_dir(tmp_path: Path) -> Path:
+    return Path(tempfile.mkdtemp(prefix="poetry_config_", dir=str(tmp_path)))
 
 
 @pytest.fixture(autouse=True)
@@ -293,15 +292,6 @@ def fixture_dir(fixture_base: Path) -> FixtureDirGetter:
 
 
 @pytest.fixture
-def tmp_dir() -> Iterator[str]:
-    dir_ = tempfile.mkdtemp(prefix="poetry_")
-
-    yield Path(dir_).resolve().as_posix()
-
-    remove_directory(dir_, force=True)
-
-
-@pytest.fixture
 def mocked_open_files(mocker: MockerFixture) -> list:
     files = []
     original = Path.open
@@ -317,8 +307,8 @@ def mocked_open_files(mocker: MockerFixture) -> list:
 
 
 @pytest.fixture
-def tmp_venv(tmp_dir: str) -> Iterator[VirtualEnv]:
-    venv_path = Path(tmp_dir) / "venv"
+def tmp_venv(tmp_path: Path) -> Iterator[VirtualEnv]:
+    venv_path = tmp_path / "venv"
 
     EnvManager.build_venv(str(venv_path))
 
@@ -359,14 +349,14 @@ def repo(http: type[httpretty.httpretty]) -> TestRepository:
 
 @pytest.fixture
 def project_factory(
-    tmp_dir: str,
+    tmp_path: Path,
     config: Config,
     repo: TestRepository,
     installed: Repository,
     default_python: str,
     load_required_fixtures: None,
 ) -> ProjectFactory:
-    workspace = Path(tmp_dir)
+    workspace = tmp_path
 
     def _factory(
         name: str | None = None,
@@ -453,10 +443,10 @@ def set_simple_log_formatter() -> None:
 
 
 @pytest.fixture
-def fixture_copier(fixture_base: Path, tmp_dir: str) -> FixtureCopier:
+def fixture_copier(fixture_base: Path, tmp_path: Path) -> FixtureCopier:
     def _copy(relative_path: str, target: Path | None = None) -> Path:
         path = fixture_base.joinpath(relative_path)
-        target = target or Path(tmp_dir, relative_path)
+        target = target or Path(tmp_path, relative_path)
         target.parent.mkdir(parents=True, exist_ok=True)
 
         if target.exists():

--- a/tests/console/commands/env/conftest.py
+++ b/tests/console/commands/env/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,6 +11,7 @@ from poetry.utils.env import EnvManager
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
     from tests.helpers import PoetryTestApplication
 
@@ -25,8 +25,8 @@ def venv_name(app: PoetryTestApplication) -> str:
 
 
 @pytest.fixture
-def venv_cache(tmp_dir: str) -> Path:
-    return Path(tmp_dir)
+def venv_cache(tmp_path: Path) -> Path:
+    return tmp_path
 
 
 @pytest.fixture(scope="module")

--- a/tests/console/commands/self/test_show_plugins.py
+++ b/tests/console/commands/self/test_show_plugins.py
@@ -64,7 +64,7 @@ def plugin_package(plugin_package_requires_dist: list[str]) -> Package:
 
 
 @pytest.fixture()
-def plugin_distro(plugin_package: Package, tmp_dir: str) -> metadata.Distribution:
+def plugin_distro(plugin_package: Package, tmp_path: Path) -> metadata.Distribution:
     class MockDistribution(metadata.Distribution):
         def read_text(self, filename: str) -> str | None:
             if filename == "METADATA":
@@ -81,7 +81,7 @@ def plugin_distro(plugin_package: Package, tmp_dir: str) -> metadata.Distributio
             return None
 
         def locate_file(self, path: PathLike[str]) -> PathLike[str]:
-            return Path(tmp_dir, path)
+            return Path(tmp_path, path)
 
     return MockDistribution()
 

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -149,18 +149,20 @@ def test_command_new(
     package_path: str,
     include_from: str | None,
     tester: CommandTester,
-    tmp_dir: str,
+    tmp_path: Path,
 ):
-    path = Path(tmp_dir) / directory
+    path = tmp_path / directory
     options.append(path.as_posix())
     tester.execute(" ".join(options))
     verify_project_directory(path, package_name, package_path, include_from)
 
 
 @pytest.mark.parametrize(("fmt",), [(None,), ("md",), ("rst",), ("adoc",), ("creole",)])
-def test_command_new_with_readme(fmt: str | None, tester: CommandTester, tmp_dir: str):
+def test_command_new_with_readme(
+    fmt: str | None, tester: CommandTester, tmp_path: Path
+):
     package = "package"
-    path = Path(tmp_dir) / package
+    path = tmp_path / package
     options = [path.as_posix()]
 
     if fmt:

--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -40,8 +40,8 @@ def installer() -> NoopInstaller:
 
 
 @pytest.fixture
-def env(tmp_dir: str) -> MockEnv:
-    path = Path(tmp_dir) / ".venv"
+def env(tmp_path: Path) -> MockEnv:
+    path = tmp_path / ".venv"
     path.mkdir(parents=True)
     return MockEnv(path=path, is_venv=True)
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -38,8 +38,8 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def env(tmp_dir: str) -> MockEnv:
-    path = Path(tmp_dir) / ".venv"
+def env(tmp_path: Path) -> MockEnv:
+    path = tmp_path / ".venv"
     path.mkdir(parents=True)
 
     return MockEnv(path=path, is_venv=True)
@@ -104,13 +104,13 @@ def test_execute_executes_a_batch_of_operations(
     config: Config,
     pool: RepositoryPool,
     io: BufferedIO,
-    tmp_dir: str,
+    tmp_path: Path,
     mock_file_downloads: None,
     env: MockEnv,
 ):
     pip_install = mocker.patch("poetry.installation.executor.pip_install")
 
-    config.merge({"cache-dir": tmp_dir})
+    config.merge({"cache-dir": str(tmp_path)})
 
     executor = Executor(env, pool, config, io)
 
@@ -205,13 +205,13 @@ def test_execute_prints_warning_for_yanked_package(
     config: Config,
     pool: RepositoryPool,
     io: BufferedIO,
-    tmp_dir: str,
+    tmp_path: Path,
     mock_file_downloads: None,
     env: MockEnv,
     operations: list[Operation],
     has_warning: bool,
 ):
-    config.merge({"cache-dir": tmp_dir})
+    config.merge({"cache-dir": str(tmp_path)})
 
     executor = Executor(env, pool, config, io)
 
@@ -293,11 +293,11 @@ def test_execute_works_with_ansi_output(
     config: Config,
     pool: RepositoryPool,
     io_decorated: BufferedIO,
-    tmp_dir: str,
+    tmp_path: Path,
     mock_file_downloads: None,
     env: MockEnv,
 ):
-    config.merge({"cache-dir": tmp_dir})
+    config.merge({"cache-dir": str(tmp_path)})
 
     executor = Executor(env, pool, config, io_decorated)
 
@@ -335,11 +335,11 @@ def test_execute_works_with_no_ansi_output(
     config: Config,
     pool: RepositoryPool,
     io_not_decorated: BufferedIO,
-    tmp_dir: str,
+    tmp_path: Path,
     mock_file_downloads: None,
     env: MockEnv,
 ):
-    config.merge({"cache-dir": tmp_dir})
+    config.merge({"cache-dir": str(tmp_path)})
 
     executor = Executor(env, pool, config, io_not_decorated)
 
@@ -424,7 +424,7 @@ Package operations: 1 install, 0 updates, 0 removals
 def test_executor_should_delete_incomplete_downloads(
     config: Config,
     io: BufferedIO,
-    tmp_dir: str,
+    tmp_path: Path,
     mocker: MockerFixture,
     pool: RepositoryPool,
     mock_file_downloads: None,
@@ -433,7 +433,7 @@ def test_executor_should_delete_incomplete_downloads(
     fixture = Path(__file__).parent.parent.joinpath(
         "fixtures/distributions/demo-0.1.0-py2.py3-none-any.whl"
     )
-    destination_fixture = Path(tmp_dir) / "tomlkit-0.5.3-py2.py3-none-any.whl"
+    destination_fixture = tmp_path / "tomlkit-0.5.3-py2.py3-none-any.whl"
     shutil.copyfile(str(fixture), str(destination_fixture))
     mocker.patch(
         "poetry.installation.executor.Executor._download_archive",
@@ -445,10 +445,10 @@ def test_executor_should_delete_incomplete_downloads(
     )
     mocker.patch(
         "poetry.installation.chef.Chef.get_cache_directory_for_link",
-        return_value=Path(tmp_dir),
+        return_value=tmp_path,
     )
 
-    config.merge({"cache-dir": tmp_dir})
+    config.merge({"cache-dir": str(tmp_path)})
 
     executor = Executor(env, pool, config, io)
 
@@ -727,7 +727,7 @@ def test_executer_fallback_on_poetry_create_error(
     config: Config,
     pool: RepositoryPool,
     io: BufferedIO,
-    tmp_dir: str,
+    tmp_path: Path,
     mock_file_downloads: None,
     env: MockEnv,
 ):
@@ -740,7 +740,7 @@ def test_executer_fallback_on_poetry_create_error(
         "poetry.factory.Factory.create_poetry", side_effect=RuntimeError
     )
 
-    config.merge({"cache-dir": tmp_dir})
+    config.merge({"cache-dir": str(tmp_path)})
 
     executor = Executor(env, pool, config, io)
 

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -74,8 +74,8 @@ def env_manager(simple_poetry: Poetry) -> EnvManager:
 
 
 @pytest.fixture
-def tmp_venv(tmp_dir: str, env_manager: EnvManager) -> VirtualEnv:
-    venv_path = Path(tmp_dir) / "venv"
+def tmp_venv(tmp_path: Path, env_manager: EnvManager) -> VirtualEnv:
+    venv_path = tmp_path / "venv"
 
     env_manager.build_venv(str(venv_path))
 
@@ -213,10 +213,10 @@ if __name__ == '__main__':
 
 
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(
-    mocker: MockerFixture, extended_poetry: Poetry, tmp_dir: str
+    mocker: MockerFixture, extended_poetry: Poetry, tmp_path: Path
 ):
     pip_install = mocker.patch("poetry.masonry.builders.editable.pip_install")
-    env = MockEnv(path=Path(tmp_dir) / "foo")
+    env = MockEnv(path=tmp_path / "foo")
     builder = EditableBuilder(extended_poetry, env, NullIO())
 
     builder.build()
@@ -226,10 +226,10 @@ def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(
     assert [] == env.executed
 
 
-def test_builder_setup_generation_runs_with_pip_editable(tmp_dir: str) -> None:
+def test_builder_setup_generation_runs_with_pip_editable(tmp_path: Path) -> None:
     # create an isolated copy of the project
     fixture = Path(__file__).parent.parent.parent / "fixtures" / "extended_project"
-    extended_project = Path(tmp_dir) / "extended_project"
+    extended_project = tmp_path / "extended_project"
 
     shutil.copytree(fixture, extended_project)
     assert extended_project.exists()

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -47,7 +47,7 @@ class InvalidPlugin:
 
 
 @pytest.fixture()
-def poetry(tmp_dir: str, config: Config) -> Poetry:
+def poetry(config: Config) -> Poetry:
     poetry = Poetry(
         CWD / "pyproject.toml",
         {},

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -108,9 +108,9 @@ def test_load_successful(repository: InstalledRepository):
 
 
 def test_load_successful_with_invalid_distribution(
-    caplog: LogCaptureFixture, mocker: MockerFixture, env: MockEnv, tmp_dir: str
+    caplog: LogCaptureFixture, mocker: MockerFixture, env: MockEnv, tmp_path: Path
 ) -> None:
-    invalid_dist_info = Path(tmp_dir) / "site-packages" / "invalid-0.1.0.dist-info"
+    invalid_dist_info = tmp_path / "site-packages" / "invalid-0.1.0.dist-info"
     invalid_dist_info.mkdir(parents=True)
     mocker.patch(
         "poetry.utils._compat.metadata.Distribution.discover",

--- a/tests/utils/test_env_site.py
+++ b/tests/utils/test_env_site.py
@@ -13,12 +13,12 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-def test_env_site_simple(tmp_dir: str, mocker: MockerFixture):
+def test_env_site_simple(tmp_path: Path, mocker: MockerFixture):
     # emulate permission error when creating directory
     mocker.patch("pathlib.Path.mkdir", side_effect=OSError())
-    site_packages = SitePackages(Path("/non-existent"), fallbacks=[Path(tmp_dir)])
+    site_packages = SitePackages(Path("/non-existent"), fallbacks=[tmp_path])
     candidates = site_packages.make_candidates(Path("hello.txt"), writable_only=True)
-    hello = Path(tmp_dir) / "hello.txt"
+    hello = tmp_path / "hello.txt"
 
     assert len(candidates) == 1
     assert candidates[0].as_posix() == hello.as_posix()
@@ -31,8 +31,8 @@ def test_env_site_simple(tmp_dir: str, mocker: MockerFixture):
     assert not (site_packages.path / "hello.txt").exists()
 
 
-def test_env_site_select_first(tmp_dir: str):
-    path = Path(tmp_dir)
+def test_env_site_select_first(tmp_path: Path):
+    path = tmp_path
     fallback = path / "fallback"
     fallback.mkdir(parents=True)
 

--- a/tests/utils/test_pip.py
+++ b/tests/utils/test_pip.py
@@ -16,9 +16,7 @@ if TYPE_CHECKING:
     from tests.types import FixtureDirGetter
 
 
-def test_pip_install_successful(
-    tmp_dir: str, tmp_venv: VirtualEnv, fixture_dir: FixtureDirGetter
-):
+def test_pip_install_successful(tmp_venv: VirtualEnv, fixture_dir: FixtureDirGetter):
     file_path = fixture_dir("distributions/demo-0.1.0-py2.py3-none-any.whl")
     result = pip_install(file_path, tmp_venv)
 
@@ -26,7 +24,6 @@ def test_pip_install_successful(
 
 
 def test_pip_install_with_keyboard_interrupt(
-    tmp_dir: str,
     tmp_venv: VirtualEnv,
     fixture_dir: FixtureDirGetter,
     mocker: MockerFixture,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6934

These changes remove the custom `tmp_dir` test fixture in favor of pytest's built-in `tmp_path` fixture for creating temporary directories. Only test code has been updated, so there was no need to add additional tests or documentation.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
