### PR TITLE
env: installing into `MockEnv` should not have side effects on another env

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -2039,6 +2039,17 @@ class MockEnv(NullEnv):
 
         return self._sys_path
 
+    @property
+    def paths(self) -> dict[str, str]:
+        if self._paths is None:
+            self._paths = self.get_paths()
+            self._paths["platlib"] = str(self._path / "platlib")
+            self._paths["purelib"] = str(self._path / "purelib")
+            self._paths["scripts"] = str(self._path / "scripts")
+            self._paths["data"] = str(self._path / "data")
+
+        return self._paths
+
     def get_marker_env(self) -> dict[str, Any]:
         if self._mock_marker_env is not None:
             return self._mock_marker_env

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -291,16 +291,6 @@ def test_builder_should_execute_build_scripts(
     mocker: MockerFixture, extended_without_setup_poetry: Poetry, tmp_path: Path
 ):
     env = MockEnv(path=tmp_path / "foo")
-    site_packages_dir = tmp_path / "site-packages"
-    site_packages_dir.mkdir(parents=True, exist_ok=True)
-    mocker.patch.object(
-        env,
-        "get_paths",
-        return_value={
-            "purelib": str(site_packages_dir),
-            "platlib": str(site_packages_dir),
-        },
-    )
     mocker.patch(
         "poetry.masonry.builders.editable.build_environment"
     ).return_value.__enter__.return_value = env


### PR DESCRIPTION
As noticed in https://github.com/python-poetry/poetry/pull/6205#issuecomment-1304544519, when using the new installer, tests will pollute poetry's own virtualenv. We've even had a problem like that without the new installer in one test case in editable_builder.py. This issue has been fixed for this specific test case in #6929. Especially with regard to #6205, I think we should take a more general approach: Installing into a `MockEnv` should not have any side effects on other environments. I don't think it makes sense to imitate a specific installation scheme, so I just use distinct, clearly named paths. 