### PR TITLE
chore: bump version to 1.4.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry"
-version = "1.3.0"
+version = "1.4.0.dev0"
 description = "Python dependency management and packaging made easy."
 authors = [
     "Sébastien Eustace <sebastien@eustace.io>",


### PR DESCRIPTION
I thought a bit if we want to unpin poetry-core again. I don't think that's necessary because we'll pin it for a release and if we want to update it in master we have to re-lock anyway. So I think we can just keep it pinned.