### PR TITLE
Add lockfile as an explicit dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1828,4 +1828,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "c1c21f02e493ffbfd622bec8546c83edad08325b957851dd3f9a287867ce24a4"
+content-hash = "7b52d7192276e1e1ab4667723a0911fbecd54bbf3ed1cd2621a654bb121eb49f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ poetry-core = "1.4.0"
 poetry-plugin-export = "^1.2.0"
 "backports.cached-property" = { version = "^1.0.2", python = "<3.8" }
 cachecontrol = { version = "^0.12.9", extras = ["filecache"] }
-lockfile = "^0.12.2"
 cleo = "^2.0.0"
 crashtest = "^0.4.1"
 dulwich = "^0.20.46"
@@ -60,6 +59,7 @@ html5lib = "^1.0"
 importlib-metadata = { version = "^4.4", python = "<3.10" }
 jsonschema = "^4.10.0"
 keyring = "^23.9.0"
+lockfile = "^0.12.2"
 # packaging uses calver, so version is unclamped
 packaging = ">=20.4"
 pexpect = "^4.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ poetry-core = "1.4.0"
 poetry-plugin-export = "^1.2.0"
 "backports.cached-property" = { version = "^1.0.2", python = "<3.8" }
 cachecontrol = { version = "^0.12.9", extras = ["filecache"] }
+lockfile = "^0.12.2"
 cleo = "^2.0.0"
 crashtest = "^0.4.1"
 dulwich = "^0.20.46"


### PR DESCRIPTION
Resolves #7171

Whilst exploring why https://github.com/Homebrew/homebrew-core/pull/117779 is failing, I saw the following traceback:

```
  File "/usr/local/Cellar/poetry/1.3.0/libexec/lib/python3.11/site-packages/poetry/puzzle/provider.py", line 37, in <module>
    from poetry.vcs.git import Git
  File "/usr/local/Cellar/poetry/1.3.0/libexec/lib/python3.11/site-packages/poetry/vcs/git/__init__.py", line 3, in <module>
    from poetry.vcs.git.backend import Git
  File "/usr/local/Cellar/poetry/1.3.0/libexec/lib/python3.11/site-packages/poetry/vcs/git/backend.py", line 21, in <module>
    from poetry.utils.authenticator import get_default_authenticator
  File "/usr/local/Cellar/poetry/1.3.0/libexec/lib/python3.11/site-packages/poetry/utils/authenticator.py", line 15, in <module>
    import lockfile
ModuleNotFoundError: No module named 'lockfile'
```

The `lockfile` module was missing from the resources block when it should have been present. However, Poetry is using the `lockfile` package directly despite it being brought in via an transient dependency:

https://github.com/python-poetry/poetry/blob/aa48815d2253e318d6e70c9a15fc4def0b48c870/src/poetry/utils/authenticator.py#L15

This MR adds it as a direct dependency.
