### PR TITLE
ci: check lock file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,9 @@ jobs:
           # Using `timeout` is a safeguard against the Poetry command hanging for some reason.
           timeout 10s poetry run pip --version || rm -rf .venv
 
+      - name: Check lock file
+        run: poetry lock --check
+
       - name: Install dependencies
         run: poetry install --with github-actions
 


### PR DESCRIPTION
Closes #6507 (or is closed by it)

Compared to #6507:

pro: simplicity, maintainability
contra: efficiency (runs always and on each platform and for each python version)