### PR TITLE
fix(env): get full python path for appropriate executable

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -995,7 +995,7 @@ class EnvManager:
                     self._io.write_error_line(
                         f"Using <c1>{python}</c1> ({python_patch})"
                     )
-                    executable = python
+                    executable = self._full_python_path(python)
                     python_minor = ".".join(python_patch.split(".")[:2])
                     break
 

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -551,7 +551,7 @@ class EnvManager:
             self._io.write_error_line(
                 f"Found: {executable}", verbosity=Verbosity.VERBOSE
             )
-        except CalledProcessError:
+        except EnvCommandError:
             self._io.write_error_line(
                 (
                     "Unable to detect the current active python executable. Falling"

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1601,3 +1601,15 @@ def test_create_venv_project_name_empty_sets_correct_prompt(
         },
         prompt="virtualenv-py3.7",
     )
+
+
+def test_fallback_on_detect_active_python(poetry: Poetry, mocker: MockerFixture):
+    m = mocker.patch(
+        "subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "some command"),
+    )
+    env_manager = EnvManager(poetry)
+    active_python = env_manager._detect_active_python()
+
+    assert active_python is None
+    assert m.call_count == 1

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -18,6 +18,7 @@ from poetry.factory import Factory
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.utils._compat import WINDOWS
 from poetry.utils.env import GET_BASE_PREFIX
+from poetry.utils.env import GET_PYTHON_VERSION_ONELINER
 from poetry.utils.env import EnvCommandError
 from poetry.utils.env import EnvManager
 from poetry.utils.env import GenericEnv
@@ -1002,7 +1003,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
 
     m.assert_called_with(
         config_virtualenvs_path / f"{venv_name}-py3.7",
-        executable="python3",
+        executable="/usr/bin/python3",
         flags={
             "always-copy": False,
             "system-site-packages": False,
@@ -1027,7 +1028,9 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     poetry.package.python_versions = "^3.6"
 
     mocker.patch("sys.version_info", (2, 7, 16))
-    mocker.patch("subprocess.check_output", side_effect=["3.5.3", "3.9.0"])
+    mocker.patch(
+        "subprocess.check_output", side_effect=["3.5.3", "3.9.0", "/usr/bin/python3.9"]
+    )
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
     )
@@ -1036,7 +1039,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
 
     m.assert_called_with(
         config_virtualenvs_path / f"{venv_name}-py3.9",
-        executable="python3.9",
+        executable="/usr/bin/python3.9",
         flags={
             "always-copy": False,
             "system-site-packages": False,
@@ -1459,11 +1462,18 @@ def test_create_venv_accepts_fallback_version_w_nonzero_patchlevel(
 
     poetry.package.python_versions = "~3.5.1"
 
+    def mock_check_output(cmd: str, *args: Any, **kwargs: Any) -> str:
+        if GET_PYTHON_VERSION_ONELINER in cmd:
+            if "python3.5" in cmd:
+                return "3.5.12"
+            else:
+                return "3.7.1"
+        else:
+            return "/usr/bin/python3.5"
+
     check_output = mocker.patch(
         "subprocess.check_output",
-        side_effect=lambda cmd, *args, **kwargs: str(
-            "3.5.12" if "python3.5" in cmd else "3.7.1"
-        ),
+        side_effect=mock_check_output,
     )
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
@@ -1474,7 +1484,7 @@ def test_create_venv_accepts_fallback_version_w_nonzero_patchlevel(
     assert check_output.called
     m.assert_called_with(
         config_virtualenvs_path / f"{venv_name}-py3.5",
-        executable="python3.5",
+        executable="/usr/bin/python3.5",
         flags={
             "always-copy": False,
             "system-site-packages": False,
@@ -1582,7 +1592,7 @@ def test_create_venv_project_name_empty_sets_correct_prompt(
 
     m.assert_called_with(
         config_virtualenvs_path / f"{venv_name}-py3.7",
-        executable="python3",
+        executable="/usr/bin/python3",
         flags={
             "always-copy": False,
             "system-site-packages": False,


### PR DESCRIPTION
Passing `python3` to `virtualenv` will result in a wrong Python version, if `virtualenv` is installed in a venv with a different Python Version associated with the `python3` command. So it is necessary to get the full python path for the executable before passing it to `virtualenv`.

During the investigation of this bug I recognize that `_detect_active_python` catches a wrong Exception. I fixed this in this PR as well.

# Pull Request Check List

Resolves:  #7158

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
