### PR TITLE
repository: PEP 440 pre-release handling

### DIFF
--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -50,9 +50,7 @@ class Repository(AbstractRepository):
                 and not allow_prereleases
                 and not package.is_direct_origin()
             ):
-                if constraint.is_any():
-                    # we need this when all versions of the package are pre-releases
-                    ignored_pre_release_packages.append(package)
+                ignored_pre_release_packages.append(package)
                 continue
 
             packages.append(package)

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -213,7 +213,7 @@ def test_find_packages_no_prereleases() -> None:
 
 
 @pytest.mark.parametrize(
-    ["constraint", "count"], [("*", 1), (">=1", 0), (">=19.0.0a0", 1)]
+    ["constraint", "count"], [("*", 1), (">=1", 1), ("<=18", 0), (">=19.0.0a0", 1)]
 )
 def test_find_packages_only_prereleases(constraint: str, count: int) -> None:
     repo = MockRepository()
@@ -226,13 +226,6 @@ def test_find_packages_only_prereleases(constraint: str, count: int) -> None:
             assert package.source_type == "legacy"
             assert package.source_reference == repo.name
             assert package.source_url == repo.url
-
-
-def test_find_packages_only_prereleases_empty_when_not_any() -> None:
-    repo = MockRepository()
-    packages = repo.find_packages(Factory.create_dependency("black", ">=1"))
-
-    assert len(packages) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -87,7 +87,7 @@ def test_find_packages_does_not_select_prereleases_if_not_allowed() -> None:
 
 
 @pytest.mark.parametrize(
-    ["constraint", "count"], [("*", 1), (">=1", 0), (">=19.0.0a0", 1)]
+    ["constraint", "count"], [("*", 1), (">=1", 1), ("<=18", 0), (">=19.0.0a0", 1)]
 )
 def test_find_packages_only_prereleases(constraint: str, count: int) -> None:
     repo = MockRepository()


### PR DESCRIPTION
# Pull Request Check List

PEP 440 says:

> Pre-releases of any kind, including developmental releases, are implicitly excluded from all version specifiers, unless they are already present on the system, explicitly requested by the user, or if the only available version that satisfies the version specifier is a pre-release.

IIUC, we should allow pre-releases if the only available version that satisfies the version specifier is a pre-release. Nothing special about "*" (`AnyConstraint`).

This is also a prerequisite for python-poetry/poetry-core#402.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
