### PR TITLE
fix: as_uri() can only be applied to an absolute path

### DIFF
--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -249,7 +249,7 @@ class EditableBuilder(Builder):
             json.dumps(
                 {
                     "dir_info": {"editable": True},
-                    "url": self._poetry.file.path.parent.as_uri(),
+                    "url": self._poetry.file.path.parent.absolute().as_uri(),
                 }
             )
         )


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7261

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
