### PR TITLE
ci: update skip job for 3.11 GA

### DIFF
--- a/.github/workflows/skip.yml
+++ b/.github/workflows/skip.yml
@@ -28,6 +28,6 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - run: exit 0


### PR DESCRIPTION
This is needed for docs PRs on master/1.3.
