### PR TITLE
pkginfo has published types, fix resulting errors

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -909,14 +909,14 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "pkginfo"
-version = "1.9.2"
+version = "1.9.4"
 description = "Query metadatdata from sdists / bdists / installed packages."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "pkginfo-1.9.2-py3-none-any.whl", hash = "sha256:d580059503f2f4549ad6e4c106d7437356dbd430e2c7df99ee1efe03d75f691e"},
-    {file = "pkginfo-1.9.2.tar.gz", hash = "sha256:ac03e37e4d601aaee40f8087f63fc4a2a6c9814dda2c8fa6aab1b1829653bdfa"},
+    {file = "pkginfo-1.9.4-py3-none-any.whl", hash = "sha256:7fc056f8e6b93355925083373b0f6bfbabe84ee3f29854fd155c9d6a4211267d"},
+    {file = "pkginfo-1.9.4.tar.gz", hash = "sha256:e769fd353593d43e0c9f47e17e25f09a8efcddcdf9a71674ea3ba444ff31bb44"},
 ]
 
 [package.extras]
@@ -1455,14 +1455,14 @@ testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (
 
 [[package]]
 name = "shellingham"
-version = "1.5.0"
+version = "1.5.0.post1"
 description = "Tool to Detect Surrounding Shell"
 category = "main"
 optional = false
-python-versions = ">=3.4"
+python-versions = ">=3.7"
 files = [
-    {file = "shellingham-1.5.0-py2.py3-none-any.whl", hash = "sha256:a8f02ba61b69baaa13facdba62908ca8690a94b8119b69f5ec5873ea85f7391b"},
-    {file = "shellingham-1.5.0.tar.gz", hash = "sha256:72fb7f5c63103ca2cb91b23dee0c71fe8ad6fbfd46418ef17dbe40db51592dad"},
+    {file = "shellingham-1.5.0.post1-py2.py3-none-any.whl", hash = "sha256:368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744"},
+    {file = "shellingham-1.5.0.post1.tar.gz", hash = "sha256:823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28"},
 ]
 
 [[package]]
@@ -1798,4 +1798,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "c9064502080fd8c4c3195efac3b59202d51d7ca3498a4c92e9e7173fbc46480a"
+content-hash = "bbc71952916c7ee1c404e4a85e611189347955d63d5560b5bdb23073a07afde6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ lockfile = "^0.12.2"
 # packaging uses calver, so version is unclamped
 packaging = ">=20.4"
 pexpect = "^4.7.0"
-pkginfo = "^1.5"
+pkginfo = "^1.9.4"
 platformdirs = "^2.5.2"
 requests = "^2.18"
 requests-toolbelt = ">=0.9.1,<0.11.0"
@@ -174,7 +174,6 @@ module = [
   'cachecontrol.*',
   'lockfile.*',
   'pexpect.*',
-  'pkginfo.*',
   'requests_toolbelt.*',
   'shellingham.*',
   'virtualenv.*',

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -74,7 +74,6 @@ class PackageInfo:
         name: str | None = None,
         version: str | None = None,
         summary: str | None = None,
-        platform: str | None = None,
         requires_dist: list[str] | None = None,
         requires_python: str | None = None,
         files: list[dict[str, str]] | None = None,
@@ -84,7 +83,6 @@ class PackageInfo:
         self.name = name
         self.version = version
         self.summary = summary
-        self.platform = platform
         self.requires_dist = requires_dist
         self.requires_python = requires_python
         self.files = files or []
@@ -102,7 +100,6 @@ class PackageInfo:
         self.name = other.name or self.name
         self.version = other.version or self.version
         self.summary = other.summary or self.summary
-        self.platform = other.platform or self.platform
         self.requires_dist = other.requires_dist or self.requires_dist
         self.requires_python = other.requires_python or self.requires_python
         self.files = other.files or self.files
@@ -117,7 +114,6 @@ class PackageInfo:
             "name": self.name,
             "version": self.version,
             "summary": self.summary,
-            "platform": self.platform,
             "requires_dist": self.requires_dist,
             "requires_python": self.requires_python,
             "files": self.files,
@@ -262,7 +258,6 @@ class PackageInfo:
             name=dist.name,
             version=dist.version,
             summary=dist.summary,
-            platform=dist.supported_platforms,
             requires_dist=requirements,
             requires_python=dist.requires_python,
         )
@@ -423,6 +418,7 @@ class PackageInfo:
         else:
             directories = list(cls._find_dist_info(path=path))
 
+        dist: pkginfo.BDist | pkginfo.SDist | pkginfo.Wheel
         for directory in directories:
             try:
                 if directory.suffix == ".egg-info":
@@ -460,7 +456,6 @@ class PackageInfo:
             name=package.name,
             version=str(package.version),
             summary=package.description,
-            platform=package.platform,
             requires_dist=list(requires),
             requires_python=package.python_versions,
             files=package.files,

--- a/src/poetry/repositories/cached_repository.py
+++ b/src/poetry/repositories/cached_repository.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 
 class CachedRepository(Repository, ABC):
-    CACHE_VERSION = parse_constraint("1.1.0")
+    CACHE_VERSION = parse_constraint("2.0.0")
 
     def __init__(
         self, name: str, disable_cache: bool = False, config: Config | None = None

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -123,7 +123,6 @@ class LegacyRepository(HTTPRepository):
                 name=name,
                 version=version.text,
                 summary="",
-                platform=None,
                 requires_dist=[],
                 requires_python=None,
                 files=[],

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -162,7 +162,6 @@ class PyPiRepository(HTTPRepository):
             name=info["name"],
             version=info["version"],
             summary=info["summary"],
-            platform=info["platform"],
             requires_dist=info["requires_dist"],
             requires_python=info["requires_python"],
             files=info.get("files", []),


### PR DESCRIPTION
The latest version of pkginfo includes type stubs

This reveals that the `platform` on poetry's `PackageInfo` was mis-typed: sometimes it's a `str | None`, but when set via information from `pkginfo` it's actually a `Sequence[str]`

This has caused no real problems because the field isn't used anywhere... so I've just removed the dead code.

In re-locking I've also taken a shellingham post-release: regular 1.5.0 is yanked.