### PR TITLE
don't set package pretty_version

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -119,7 +119,6 @@ class Locker:
             package = Package(
                 name,
                 info["version"],
-                info["version"],
                 source_type=source_type,
                 source_url=url,
                 source_reference=source.get("reference"),


### PR DESCRIPTION
The pretty_version on the Package is pointless, it can always just be taken from the regular version's `.text`.

This is the only place in the codebase that sets it; and clearly it's not doing anything useful.

This is a prelude to corresponding tidying in poetry-core