### PR TITLE
Add poetry version used to generate lock file

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -25,6 +25,7 @@ from tomlkit import document
 from tomlkit import inline_table
 from tomlkit import table
 
+from poetry.__version__ import __version__
 from poetry.utils._compat import tomllib
 
 
@@ -40,8 +41,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 _GENERATED_IDENTIFIER = "@" + "generated"
 GENERATED_COMMENT = (
-    f"This file is automatically {_GENERATED_IDENTIFIER} by Poetry and should not be"
-    " changed by hand."
+    f"This file is automatically {_GENERATED_IDENTIFIER} by Poetry"
+    f" {__version__} and should not be changed by hand."
 )
 
 

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-import tomlkit
 
 from poetry.core.constraints.version import Version
 from poetry.core.packages.package import Package
@@ -231,9 +230,8 @@ python-versions = "~2.7 || ^3.4"
 content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77"
 """  # noqa: E800
 
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     packages = locker.locked_repository().packages
 
@@ -296,9 +294,8 @@ lock-version = "2.0"
 content-hash = "123456789"
 """  # noqa: E800
 
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     repository = locker.locked_repository()
     assert len(repository.packages) == 3
@@ -363,9 +360,8 @@ lock-version = "2.0"
 content-hash = "123456789"
 """  # noqa: E800
 
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     repository = locker.locked_repository()
     assert len(repository.packages) == 2
@@ -405,9 +401,8 @@ lock-version = "2.0"
 python-versions = "*"
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
 """
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     repository = locker.locked_repository()
     assert len(repository.packages) == 1
@@ -503,9 +498,8 @@ demo = [
     {file = "demo-1.0-py3-none-any.whl", hash = "sha256"},
 ]
 """
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     repository = locker.locked_repository()
     assert len(repository.packages) == 5
@@ -697,9 +691,8 @@ content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77
 """
     caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
 
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     _ = locker.lock_data
 
@@ -729,9 +722,8 @@ content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77
 """  # noqa: E800
     caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
 
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     with pytest.raises(RuntimeError, match="^The lock file is not compatible"):
         _ = locker.lock_data
@@ -824,9 +816,8 @@ content-hash = "c3d07fca33fba542ef2b2a4d75bf5b48d892d21a830e2ad9c952ba5123a52f77
 """
     caplog.set_level(logging.WARNING, logger="poetry.packages.locker")
 
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     _ = locker.lock_data
 
@@ -1031,9 +1022,8 @@ python-versions = "*"
 content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
 """  # noqa: E800
 
-    data = tomlkit.parse(content)
     with open(locker.lock, "w", encoding="utf-8") as f:
-        f.write(data.as_string())
+        f.write(content)
 
     create_dependency_patch = mocker.patch(
         "poetry.factory.Factory.create_dependency", autospec=True


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/pull/2773#issuecomment-1353657313

Like in this comment, we would like to ensure the committed lock file has been generated with a specific version.

Following #2773 This PR simply add the poetry version used to generate the lock file (with the same fingerprint than `poetry --version`)

From
```
# This file is automatically @generated by Poetry and should not be changed by hand.
```
To
```
# This file is automatically @generated by Poetry (version 1.3.1) and should not be changed by hand.
```

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
