### PR TITLE
Docs: whitelist_externals was replaced by allowlist_externals

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,7 +81,7 @@ Thus, dependencies are resolved by `pip`.
 isolated_build = true
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands_pre =
     poetry install --no-root --sync
 commands =
@@ -99,7 +99,7 @@ isolated_build = true
 
 [testenv]
 skip_install = true
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands_pre =
     poetry install
 commands =


### PR DESCRIPTION
tox replaced `whitelist_externals` with `allowlist_externals` and removed `whitelist_externals`.

This PR fixes the docs so that it uses the new option.

See also: https://tox.wiki/en/3.18.1/changelog.html#v3-18-0-2020-07-23
