### PR TITLE
chore: remove unused duplicated default values for config settings

### DIFF
--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -16,7 +16,6 @@ from poetry.config.config import boolean_normalizer
 from poetry.config.config import boolean_validator
 from poetry.config.config import int_normalizer
 from poetry.console.commands.command import Command
-from poetry.locations import DEFAULT_CACHE_DIR
 
 
 if TYPE_CHECKING:
@@ -52,74 +51,31 @@ To remove a repository (repo is a short alias for repositories):
     LIST_PROHIBITED_SETTINGS = {"http-basic", "pypi-token"}
 
     @property
-    def unique_config_values(self) -> dict[str, tuple[Any, Any, Any]]:
+    def unique_config_values(self) -> dict[str, tuple[Any, Any]]:
         unique_config_values = {
-            "cache-dir": (
-                str,
-                lambda val: str(Path(val)),
-                str(DEFAULT_CACHE_DIR / "virtualenvs"),
-            ),
-            "virtualenvs.create": (boolean_validator, boolean_normalizer, True),
-            "virtualenvs.in-project": (boolean_validator, boolean_normalizer, False),
-            "virtualenvs.options.always-copy": (
-                boolean_validator,
-                boolean_normalizer,
-                False,
-            ),
+            "cache-dir": (str, lambda val: str(Path(val))),
+            "virtualenvs.create": (boolean_validator, boolean_normalizer),
+            "virtualenvs.in-project": (boolean_validator, boolean_normalizer),
+            "virtualenvs.options.always-copy": (boolean_validator, boolean_normalizer),
             "virtualenvs.options.system-site-packages": (
                 boolean_validator,
                 boolean_normalizer,
-                False,
             ),
-            "virtualenvs.options.no-pip": (
-                boolean_validator,
-                boolean_normalizer,
-                False,
-            ),
+            "virtualenvs.options.no-pip": (boolean_validator, boolean_normalizer),
             "virtualenvs.options.no-setuptools": (
                 boolean_validator,
                 boolean_normalizer,
-                False,
             ),
-            "virtualenvs.path": (
-                str,
-                lambda val: str(Path(val)),
-                str(DEFAULT_CACHE_DIR / "virtualenvs"),
-            ),
-            "virtualenvs.prefer-active-python": (
-                boolean_validator,
-                boolean_normalizer,
-                False,
-            ),
-            "experimental.new-installer": (
-                boolean_validator,
-                boolean_normalizer,
-                True,
-            ),
-            "experimental.system-git-client": (
-                boolean_validator,
-                boolean_normalizer,
-                False,
-            ),
-            "installer.parallel": (
-                boolean_validator,
-                boolean_normalizer,
-                True,
-            ),
-            "installer.max-workers": (
-                lambda val: int(val) > 0,
-                int_normalizer,
-                None,
-            ),
-            "virtualenvs.prompt": (
-                str,
-                lambda val: str(val),
-                "{project_name}-py{python_version}",
-            ),
+            "virtualenvs.path": (str, lambda val: str(Path(val))),
+            "virtualenvs.prefer-active-python": (boolean_validator, boolean_normalizer),
+            "experimental.new-installer": (boolean_validator, boolean_normalizer),
+            "experimental.system-git-client": (boolean_validator, boolean_normalizer),
+            "installer.parallel": (boolean_validator, boolean_normalizer),
+            "installer.max-workers": (lambda val: int(val) > 0, int_normalizer),
+            "virtualenvs.prompt": (str, lambda val: str(val)),
             "installer.no-binary": (
                 PackageFilterPolicy.validator,
                 PackageFilterPolicy.normalize,
-                None,
             ),
         }
 
@@ -196,8 +152,7 @@ To remove a repository (repo is a short alias for repositories):
 
         values: list[str] = self.argument("value")
 
-        unique_config_values = self.unique_config_values
-        if setting_key in unique_config_values:
+        if setting_key in self.unique_config_values:
             if self.option("unset"):
                 config.config_source.remove_property(setting_key)
                 return 0
@@ -205,7 +160,7 @@ To remove a repository (repo is a short alias for repositories):
             return self._handle_single_value(
                 config.config_source,
                 setting_key,
-                unique_config_values[setting_key],
+                self.unique_config_values[setting_key],
                 values,
             )
 
@@ -310,10 +265,10 @@ To remove a repository (repo is a short alias for repositories):
         self,
         source: ConfigSource,
         key: str,
-        callbacks: tuple[Any, Any, Any],
+        callbacks: tuple[Any, Any],
         values: list[Any],
     ) -> int:
-        validator, normalizer, _ = callbacks
+        validator, normalizer = callbacks
 
         if len(values) > 1:
             raise RuntimeError("You can only pass one value.")


### PR DESCRIPTION
Default values in the config command were not used. The actual default values for config settings can be found in https://github.com/python-poetry/poetry/blob/master/src/poetry/config/config.py#L108.