### PR TITLE
drop flatdict dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -490,17 +490,6 @@ docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.1
 testing = ["covdefaults (>=2.2.2)", "coverage (>=6.5)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "flatdict"
-version = "4.0.1"
-description = "Python module for interacting with nested dicts as a single level dict with delimited keys."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "flatdict-4.0.1.tar.gz", hash = "sha256:cd32f08fd31ed21eb09ebc76f06b6bd12046a24f77beb1fd0281917e47f26742"},
-]
-
-[[package]]
 name = "html5lib"
 version = "1.1"
 description = "HTML parser based on the WHATWG HTML specification"
@@ -1792,4 +1781,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "0ec7c852f1ac947add292b5e4d33f8d7ad79358ca6da3661480c94608fd4c4a6"
+content-hash = "39120ecbb0a8005ab2bab602a5f36ca178588521343d56c87ea2596f14c1c88a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ pre-commit = "^2.6"
 # Cachy frozen to test backwards compatibility for `poetry.utils.cache`.
 cachy = "0.3.0"
 deepdiff = "^6.2"
-flatdict = "^4.0.1"
 httpretty = "^1.0"
 pytest = "^7.1"
 pytest-cov = "^4.0"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -8,11 +8,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from flatdict import FlatDict
-
 from poetry.config.config import Config
 from poetry.config.config import boolean_normalizer
 from poetry.config.config import int_normalizer
+from tests.helpers import flatten_dict
 
 
 if TYPE_CHECKING:
@@ -21,7 +20,7 @@ if TYPE_CHECKING:
 
 
 def get_options_based_on_normalizer(normalizer: Callable) -> str:
-    flattened_config = FlatDict(Config.default_config, delimiter=".")
+    flattened_config = flatten_dict(obj=Config.default_config, delimiter=".")
 
     for k in flattened_config:
         if Config._get_normalizer(k) == normalizer:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,6 @@ import urllib.parse
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Any
 
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
@@ -28,6 +27,8 @@ from poetry.utils._compat import metadata
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from typing import Any
+    from typing import Mapping
 
     from poetry.core.constraints.version import Version
     from poetry.core.packages.dependency import Dependency
@@ -284,3 +285,33 @@ def mock_metadata_entry_points(
         "entry_points",
         return_value=[make_entry_point_from_plugin(name, cls, dist)],
     )
+
+
+def flatten_dict(obj: Mapping[str, Any], delimiter: str = ".") -> Mapping[str, Any]:
+    """
+    Flatten a nested dict.
+
+    A flatdict replacement.
+
+    :param obj: A nested dict to be flattened
+    :delimiter str: A delimiter used in the key path
+    :return: Flattened dict
+    """
+
+    def recurse_keys(obj: Mapping[str, Any]) -> Iterator[tuple[list[str], Any]]:
+        """
+        A recursive generator to yield key paths and their values
+
+        :param obj: A nested dict to be flattened
+        :return:  dict
+        """
+        if isinstance(obj, dict):
+            for key in obj.keys():
+                for leaf in recurse_keys(obj[key]):
+                    leaf_path, leaf_value = leaf
+                    leaf_path.insert(0, key)
+                    yield (leaf_path, leaf_value)
+        else:
+            yield ([], obj)
+
+    return {delimiter.join(path): value for path, value in recurse_keys(obj)}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from tests.helpers import flatten_dict
+
+
+def test_flatten_dict() -> None:
+    orig_dict = {
+        "a": 1,
+        "b": 2,
+        "c": {
+            "x": 8,
+            "y": 9,
+        },
+    }
+
+    flattened_dict = {
+        "a": 1,
+        "b": 2,
+        "c:x": 8,
+        "c:y": 9,
+    }
+
+    assert flattened_dict == flatten_dict(orig_dict, delimiter=":")


### PR DESCRIPTION
# Pull Request Check List

In the spirit of dependency cleanup #5720 this PR replaces the `flatdict` dependency with a new function. Flatdict doesn't appear to be maintained and was used only once (in a test). I also believe poetry being a package manager should have as little dependencies as possible.
I am trying to get poetry included in the package repository of Gentoo Linux, and not having to include the `flatdict` dependency would be really nice.

- [x] Added **tests** for changed code.
- [ ] ~~Updated **documentation** for changed code.~~