### PR TITLE
remove empty vendor directory

### DIFF
--- a/src/poetry/_vendor/.gitignore
+++ b/src/poetry/_vendor/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Looks like this is a relic of stuff that now happens in poetry-core.  Maybe the pipeline will show that I'm wrong.