### PR TITLE
remove strange VENDORS handling in installed repository

### DIFF
--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -20,15 +20,6 @@ if TYPE_CHECKING:
     from poetry.utils.env import Env
 
 
-_VENDORS = Path(__file__).parent.parent.joinpath("_vendor")
-
-
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = OSError
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -281,13 +272,6 @@ class InstalledRepository(Repository):
                     continue
 
                 if name in seen:
-                    continue
-
-                try:
-                    path.relative_to(_VENDORS)
-                except ValueError:
-                    pass
-                else:
                     continue
 
                 package = cls.create_package_from_distribution(distribution, env)

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -22,14 +22,12 @@ ENV_DIR = (FIXTURES_DIR / "installed").resolve()
 SITE_PURELIB = ENV_DIR / "lib" / "python3.7" / "site-packages"
 SITE_PLATLIB = ENV_DIR / "lib64" / "python3.7" / "site-packages"
 SRC = ENV_DIR / "src"
-VENDOR_DIR = ENV_DIR / "vendor" / "py3.7"
 INSTALLED_RESULTS = [
     metadata.PathDistribution(SITE_PURELIB / "cleo-0.7.6.dist-info"),
     metadata.PathDistribution(SRC / "pendulum" / "pendulum.egg-info"),
     metadata.PathDistribution(
         zipfile.Path(str(SITE_PURELIB / "foo-0.1.0-py3.8.egg"), "EGG-INFO")
     ),
-    metadata.PathDistribution(VENDOR_DIR / "attrs-19.3.0.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "standard-1.2.3.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "editable-2.3.4.dist-info"),
     metadata.PathDistribution(SITE_PURELIB / "editable-with-import-2.3.4.dist-info"),
@@ -80,11 +78,6 @@ def mock_git_info(mocker: MockerFixture) -> None:
     )
 
 
-@pytest.fixture(autouse=True)
-def mock_installed_repository_vendors(mocker: MockerFixture) -> None:
-    mocker.patch("poetry.repositories.installed_repository._VENDORS", str(VENDOR_DIR))
-
-
 @pytest.fixture
 def repository(mocker: MockerFixture, env: MockEnv) -> InstalledRepository:
     mocker.patch(
@@ -104,7 +97,7 @@ def get_package_from_repository(
 
 
 def test_load_successful(repository: InstalledRepository):
-    assert len(repository.packages) == len(INSTALLED_RESULTS) - 1
+    assert len(repository.packages) == len(INSTALLED_RESULTS)
 
 
 def test_load_successful_with_invalid_distribution(
@@ -118,9 +111,7 @@ def test_load_successful_with_invalid_distribution(
     )
     repository_with_invalid_distribution = InstalledRepository.load(env)
 
-    assert (
-        len(repository_with_invalid_distribution.packages) == len(INSTALLED_RESULTS) - 1
-    )
+    assert len(repository_with_invalid_distribution.packages) == len(INSTALLED_RESULTS)
     assert len(caplog.messages) == 1
 
     message = caplog.messages[0]


### PR DESCRIPTION
#7386 caused me to look harder, and not for the first time I find myself confused about what some code is trying to do...

So far as I can see, the code that I have removed hardcodes knowledge of poetry's own source code into its search for installed packages - regardless of the environment in which it is actually running.  And then the unit test patches that `_VENDORS` in a way that can't possibly happen outside of the unit test, allowing it to find the attrs package in the `installed` fixture's vendors directory.

I'm very open to having it explained to me that I have completely the wrong end of the stick.  But this seems to be really quite peculiar.