### PR TITLE
Don't uninstall packages that should be kept

### DIFF
--- a/tests/puzzle/test_transaction.py
+++ b/tests/puzzle/test_transaction.py
@@ -121,6 +121,31 @@ def test_it_should_remove_installed_packages_if_required():
     )
 
 
+def test_it_should_not_remove_installed_packages_that_are_in_result():
+    transaction = Transaction(
+        [],
+        [
+            (Package("a", "1.0.0"), 1),
+            (Package("b", "2.0.0"), 2),
+            (Package("c", "3.0.0"), 0),
+        ],
+        installed_packages=[
+            Package("a", "1.0.0"),
+            Package("b", "2.0.0"),
+            Package("c", "3.0.0"),
+        ],
+    )
+
+    check_operations(
+        transaction.calculate_operations(synchronize=True),
+        [
+            {"job": "install", "package": Package("a", "1.0.0"), "skipped": True},
+            {"job": "install", "package": Package("b", "2.0.0"), "skipped": True},
+            {"job": "install", "package": Package("c", "3.0.0"), "skipped": True},
+        ],
+    )
+
+
 def test_it_should_update_installed_packages_if_sources_are_different():
     transaction = Transaction(
         [Package("a", "1.0.0")],


### PR DESCRIPTION
Resolves: #4465

When deciding what to uninstall at `--sync`, poetry was checking whether the installed packages appeared in the `_current_packages`, which is to say: it was checking whether the installed packages were wanted by the _previous_ lock file (if any).

#4465 shows the most extreme way in which this is wrong: if you delete the old lock file then poetry concludes that nothing that is installed can be wanted, and removes everything.

The correct check is to ask whether the installed packages are wanted by the result of the locking that has just been done.