### PR TITLE
Change my-token to <my-token> in documentation.

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -342,7 +342,7 @@ when uploading packages to PyPI.
 Once you have created a new token, you can tell Poetry to use it:
 
 ```bash
-poetry config pypi-token.pypi my-token
+poetry config pypi-token.pypi <my-token>
 ```
 
 If you still want to use your username and password, you can do so with the following


### PR DESCRIPTION
Change my-token to &lt;my-token>, to be coherent with &lt;username> and &lt;password >. (At first glance, I thought my-token was a token name, not the token content, and that the token itself should be put elsewhere... Using &lt;my-token> make it much more clear I think.)

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
