### PR TITLE
feat: Support "automated install" usage via `make`

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -241,10 +241,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
                 )
             )
 
-        # Refresh the locker
-        self.poetry.set_locker(
-            self.poetry.locker.__class__(self.poetry.locker.lock, poetry_content)
-        )
+        self.poetry.locker.refresh(poetry_content)
         self.installer.set_locker(self.poetry.locker)
 
         # Cosmetic new line
@@ -264,6 +261,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
         if status == 0 and not self.option("dry-run"):
             assert isinstance(content, TOMLDocument)
             self.poetry.file.write(content)
+            self.installer.touch_lockfile()
 
         return status
 

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -105,10 +105,7 @@ list of installed packages
                 "The following packages were not found: " + ", ".join(sorted(not_found))
             )
 
-        # Refresh the locker
-        self.poetry.set_locker(
-            self.poetry.locker.__class__(self.poetry.locker.lock, poetry_content)
-        )
+        self.poetry.locker.refresh(poetry_content)
         self.installer.set_locker(self.poetry.locker)
 
         self.installer.set_package(self.poetry.package)
@@ -122,6 +119,7 @@ list of installed packages
         if not self.option("dry-run") and status == 0:
             assert isinstance(content, TOMLDocument)
             self.poetry.file.write(content)
+            self.installer.touch_lockfile()
 
         return status
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -158,6 +158,9 @@ class Installer:
 
         return self
 
+    def touch_lockfile(self) -> None:
+        self._locker.lock.touch()
+
     def is_updating(self) -> bool:
         return self._update
 

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import TypeVar
 from typing import cast
 
 from packaging.utils import canonicalize_name
@@ -34,9 +35,12 @@ if TYPE_CHECKING:
     from poetry.core.packages.file_dependency import FileDependency
     from poetry.core.packages.url_dependency import URLDependency
     from poetry.core.packages.vcs_dependency import VCSDependency
+    from tomlkit.container import Container
     from tomlkit.toml_document import TOMLDocument
 
     from poetry.repositories.lockfile_repository import LockfileRepository
+
+    Self = TypeVar("Self", bound="Locker")
 
 logger = logging.getLogger(__name__)
 _GENERATED_IDENTIFIER = "@" + "generated"
@@ -89,6 +93,17 @@ class Locker:
             return fresh
 
         return False
+
+    def refresh(
+        self: Self, new_config: dict[str, Any] | Container | None = None
+    ) -> Self:
+        """
+        Refreshes the locker using new_config (or existing config, if not provided).
+        """
+        self._local_config = self._local_config if new_config is None else new_config
+        self._lock_data = None
+        self._content_hash = self._get_content_hash()
+        return self
 
     def locked_repository(self) -> LockfileRepository:
         """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -96,6 +96,10 @@ def copy_or_symlink(source: Path, dest: Path) -> None:
         os.symlink(str(source), str(dest))
 
 
+def modtime(path: str | Path | TOMLFile) -> float:
+    return os.path.getmtime(str(path))
+
+
 class MockDulwichRepo:
     def __init__(self, root: Path | str, **__: Any) -> None:
         self.path = str(root)


### PR DESCRIPTION
A common annoyance when managing deps is having long sessions of
repeated iteration loops of `add`, `remove`, tweaking `pyproject.toml` +
`lock --no-update` + `install --sync`, re-running tests, trying to find
a configuration that works.

GNU `make` can implement "automated install" behavior, simplifying the
loop to: "save any change, `make`, repeat if needed". Consider:

```make
VENV := .venv
PYTHON_VERSION := $(shell cat .python-version)

PYTHON_VERSIONS_PATH ?= ~/.pyenv/versions
PYTHON_INSTALL_CMD ?= pyenv install

.PHONY: test
test: $(VENV)/install.sentinel  # tests depend on venv state
	poetry run pytest

$(VENV)/install.sentinel: poetry.lock $(VENV)/bin/python  # venv state depends on poetry.lock and venv
	poetry install --sync
	@ touch $@

.poetry.lock: pyproject.toml  # poetry.lock depends on pyproject.toml
	poetry lock --check && touch poetry.lock || poetry lock --no-update

$(VENV)/bin/python: $(PYTHON_VERSIONS_PATH)/$(PYTHON_VERSION)/bin/python
	@ [[ "$(shell python --version)" = "Python $(PYTHON_VERSION)" ]] || { \
		echo 'Expected Python $(PYTHON_VERSION) in $$PATH' >& 2; \
		exit 1; \
	}
	poetry env use python

$(PYTHON_VERSIONS_PATH)/$(PYTHON_VERSION)/bin/python:
	$(PYTHON_INSTALL_CMD) $(PYTHON_VERSION)
```

This greatly simplifies handling many workflow states. In all cases:

 * The lockfile changed and venv needs to sync
 * I just freshly downloaded the project
 * The required Python version isn't installed
 * I want to run tests
 * I changed pyproject.toml

Just run `make`.

These changes to `add` and `remove` speed up the "dep search iteration
loop" by avoiding unnecessary `lock --check` and `lock --no-update`
calls after changing `pyproject.toml`

Resolves: #7392

# Pull Request Check List

Resolves: #7392

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->