### PR TITLE
Use py.exe to find python on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+__pycache__/
 
 # Packages
 *.egg

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -522,12 +522,18 @@ class EnvManager:
         self._io = io or NullIO()
 
     def _full_python_path(self, python: str) -> str:
+        command = [python, "-c", '"import sys; print(sys.executable)"']
+
+        if WINDOWS and python.startswith("python"):
+            command[0] = "py"
+            python_version = python.replace("python", "")  # Could use python.removeprefix in 3.9
+            if python_version:
+                command.insert(1, f"-{python_version}")
+
         try:
             executable = decode(
                 subprocess.check_output(
-                    list_to_shell_command(
-                        [python, "-c", '"import sys; print(sys.executable)"']
-                    ),
+                    list_to_shell_command(command),
                     shell=True,
                 ).strip()
             )

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -11,6 +11,7 @@ import tomlkit
 from poetry.core.constraints.version import Version
 from poetry.core.toml.file import TOMLFile
 
+from poetry.utils._compat import WINDOWS
 from poetry.utils.env import MockEnv
 from tests.console.commands.env.helpers import build_venv
 from tests.console.commands.env.helpers import check_output_wrapper
@@ -68,9 +69,10 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     tester.execute("3.7")
 
     venv_py37 = venv_cache / f"{venv_name}-py3.7"
+    executable = "/usr/bin/py" if WINDOWS else "/usr/bin/python3.7"
     mock_build_env.assert_called_with(
         venv_py37,
-        executable="/usr/bin/python3.7",
+        executable=executable,
         flags={
             "always-copy": False,
             "system-site-packages": False,

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -228,9 +228,10 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
 
     env = manager.activate("python3.7")
 
+    executable = "/usr/bin/py" if WINDOWS else "/usr/bin/python3.7"
     m.assert_called_with(
         Path(tmp_dir) / f"{venv_name}-py3.7",
-        executable="/usr/bin/python3.7",
+        executable=executable,
         flags={
             "always-copy": False,
             "system-site-packages": False,
@@ -364,9 +365,10 @@ def test_activate_activates_different_virtualenv_with_envs_file(
 
     env = manager.activate("python3.6")
 
+    executable = "/usr/bin/py" if WINDOWS else "/usr/bin/python3.6"
     m.assert_called_with(
         Path(tmp_dir) / f"{venv_name}-py3.6",
-        executable="/usr/bin/python3.6",
+        executable=executable,
         flags={
             "always-copy": False,
             "system-site-packages": False,
@@ -428,9 +430,10 @@ def test_activate_activates_recreates_for_different_patch(
 
     env = manager.activate("python3.7")
 
+    executable = "/usr/bin/py" if WINDOWS else "/usr/bin/python3.7"
     build_venv_m.assert_called_with(
         Path(tmp_dir) / f"{venv_name}-py3.7",
-        executable="/usr/bin/python3.7",
+        executable=executable,
         flags={
             "always-copy": False,
             "system-site-packages": False,
@@ -1001,9 +1004,10 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
 
     manager.create_venv()
 
+    executable = "/usr/bin/py" if WINDOWS else "/usr/bin/python3.7"
     m.assert_called_with(
         config_virtualenvs_path / f"{venv_name}-py3.7",
-        executable="/usr/bin/python3",
+        executable=executable,
         flags={
             "always-copy": False,
             "system-site-packages": False,
@@ -1241,9 +1245,10 @@ def test_activate_with_in_project_setting_does_not_fail_if_no_venvs_dir(
 
     manager.activate("python3.7")
 
+    executable = "/usr/bin/py" if WINDOWS else "/usr/bin/python3.7"
     m.assert_called_with(
         poetry.file.parent / ".venv",
-        executable="/usr/bin/python3.7",
+        executable=executable,
         flags={
             "always-copy": False,
             "system-site-packages": False,
@@ -1590,9 +1595,10 @@ def test_create_venv_project_name_empty_sets_correct_prompt(
 
     manager.create_venv()
 
+    executable = "/usr/bin/py" if WINDOWS else "/usr/bin/python3"
     m.assert_called_with(
         config_virtualenvs_path / f"{venv_name}-py3.7",
-        executable="/usr/bin/python3",
+        executable=executable,
         flags={
             "always-copy": False,
             "system-site-packages": False,


### PR DESCRIPTION
On Windows, python installs the py.exe launcher as a reliable way to find a given installed version of python.

This PR adds the possibillity to specify a python version (e.g. `poetry env use 3.10`) on Windows. 