### PR TITLE
Make test locale independent

### DIFF
--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -65,26 +65,23 @@ def test_run_keeps_options_passed_before_command(
 def test_run_has_helpful_error_when_command_not_found(
     app_tester: ApplicationTester, env: MockEnv, capfd: pytest.CaptureFixture[str]
 ):
+    nonexistent_command = "nonexistent-command"
     env._execute = True
-    app_tester.execute("run nonexistent-command")
+    app_tester.execute(f"run {nonexistent_command}")
 
-    assert env.executed == [["nonexistent-command"]]
+    assert env.executed == [[nonexistent_command]]
     assert app_tester.status_code == 1
     if WINDOWS:
         # On Windows we use a shell to run commands which provides its own error
         # message when a command is not found that is not captured by the
         # ApplicationTester but is captured by pytest, and we can access it via capfd.
-        # The expected string in this assertion assumes Command Prompt (cmd.exe) is the
-        # shell used.
-        assert capfd.readouterr().err.splitlines() == [
-            (
-                "'nonexistent-command' is not recognized as an internal or external"
-                " command,"
-            ),
-            "operable program or batch file.",
-        ]
+        # The exact error message depends on the system language. Thus, we check only
+        # for the name of the command.
+        assert nonexistent_command in capfd.readouterr().err
     else:
-        assert app_tester.io.fetch_error() == "Command not found: nonexistent-command\n"
+        assert (
+            app_tester.io.fetch_error() == f"Command not found: {nonexistent_command}\n"
+        )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Resolves: #7408 

Just test that the command name is in the output. THis should be sufficient as we already tested the command result code.