### PR TITLE
Console: Add "--top-level" flag to show command.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -484,6 +484,7 @@ required by
 * `--latest (-l)`: Show the latest version.
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.
 * `--all (-a)`: Show all packages (even those not compatible with current system).
+* `--top-level (-T)`: Only show packages **not** required by any other package.
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -64,6 +64,7 @@ class ShowCommand(GroupCommand, EnvCommand):
             "a",
             "Show all packages (even those not compatible with current system).",
         ),
+        option("top-level", "T", "Show only top-level dependencies."),
     ]
 
     help = """The show command displays detailed information about a package, or
@@ -76,6 +77,20 @@ lists all packages available."""
 
         if self.option("tree"):
             self.init_styles(self.io)
+
+        if self.option("top-level"):
+            if self.option("tree"):
+                self.line_error(
+                    "<error>Error: Cannot use --tree and --top-level at the same"
+                    " time.</error>"
+                )
+                return 1
+            if package is not None:
+                self.line_error(
+                    "<error>Error: Cannot use --top-level when displaying a single"
+                    " package.</error>"
+                )
+                return 1
 
         if self.option("why"):
             if self.option("tree") and package is None:
@@ -303,6 +318,10 @@ lists all packages available."""
             color = "cyan"
             name = locked.pretty_name
             install_marker = ""
+
+            if self.option("top-level") and reverse_deps(locked, locked_repository):
+                continue
+
             if locked not in required_locked_packages:
                 if not show_all:
                     continue

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -319,7 +319,9 @@ lists all packages available."""
             name = locked.pretty_name
             install_marker = ""
 
-            if self.option("top-level") and reverse_deps(locked, locked_repository):
+            if self.option("top-level") and not any(
+                locked.is_same_package_as(r) for r in root.all_requires
+            ):
                 continue
 
             if locked not in required_locked_packages:

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -2140,3 +2140,106 @@ def test_url_dependency_is_not_outdated_by_repository_package(
     # version in the repository.
     tester.execute("--outdated")
     assert tester.io.fetch_output() == ""
+
+
+def test_show_top_level(tester: CommandTester, poetry: Poetry, installed: Repository):
+    poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.2.0"))
+
+    cachy2 = get_package("cachy", "0.2.0")
+    cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
+
+    installed.add_package(cachy2)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.2.0",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"msgpack-python": ">=0.5 <0.6"},
+                },
+                {
+                    "name": "msgpack-python",
+                    "version": "0.5.1",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": [], "msgpack-python": []},
+            },
+        }
+    )
+
+    tester.execute("--top-level")
+
+    expected = """cachy              0.2.0 \n"""
+
+    assert tester.io.fetch_output() == expected
+
+
+def test_show_top_level_with_explicitly_defined_depenancy(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+):
+    poetry.package.add_dependency(Factory.create_dependency("a", "^0.1.0"))
+    poetry.package.add_dependency(Factory.create_dependency("b", "^0.2.0"))
+
+    a = get_package("a", "0.1.0")
+    a.add_dependency(Factory.create_dependency("b", "0.2.0"))
+    b = get_package("b", "0.2.0")
+
+    installed.add_package(a)
+    installed.add_package(b)
+
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "a",
+                    "version": "0.1.0",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"b": "0.2.0"},
+                },
+                {
+                    "name": "b",
+                    "version": "0.2.0",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"a": [], "b": []},
+            },
+        }
+    )
+
+    tester.execute("--top-level")
+
+    expected = """a 0.1.0 \n"""
+
+    assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -2240,6 +2240,6 @@ def test_show_top_level_with_explicitly_defined_depenancy(
 
     tester.execute("--top-level")
 
-    expected = """a 0.1.0 \n"""
+    expected = """a 0.1.0 \nb 0.2.0 \n"""
 
     assert tester.io.fetch_output() == expected


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4175 and #1990 (And relates to #4342, #2684)

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

--- 

The above issues all request a way, for various reasons, to view *only* explicitly defined dependencies using the `poetry show` command. This PR adds the `--top-level/-T` flag to display these dependencies. 


# Examples
```
❯ poetry run poetry show --top-level --only=test
cachy           0.3.0  Cachy provides a simple yet effective caching library.
deepdiff        6.2.2  Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other.
httpretty       1.1.4  HTTP client mock for Python
pytest          7.2.0  pytest: simple powerful testing with Python
pytest-cov      4.0.0  Pytest plugin for measuring coverage.
pytest-mock     3.10.0 Thin-wrapper around the mock package for easier use with pytest
pytest-randomly 3.12.0 Pytest plugin to randomly order tests and control random.seed.
```

Show out-of-date top level dependencies:
```
❯ poetry run poetry show --top-level --outdated --only=main
filelock           3.8.2     3.9.0     A platform independent file lock.
importlib-metadata 5.1.0     6.0.0     Read metadata from Python packages
keyring            23.11.0   23.13.1   Store and access your passwords safely.
packaging          22.0      23.0      Core utilities for Python packages
pkginfo            1.9.4     1.9.6     Query metadatdata from sdists / bdists / installed packages.
platformdirs       2.6.0     2.6.2     A small Python package for determining appropriate platform-specific dirs, e.g. a "user data dir".
requests           2.28.1    2.28.2    Python HTTP for Humans.
trove-classifiers  2022.12.1 2023.1.20 Canonical source for classifiers on PyPI (pypi.org).
urllib3            1.26.13   1.26.14   HTTP library with thread-safe connection pooling, file post, and more.
```

It also errors when used with `--tree` and `[package]`
```
❯ poetry run poetry show --top-level --tree                
Error: Cannot use --tree and --top-level at the same time. 

❯ poetry run poetry show --top-level pytest
Error: Cannot use --top-level when displaying a single package.
```
