### PR TITLE
repositories: deprecate `default` option and introduce possibility to disable PyPI explicitly

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -774,7 +774,7 @@ You cannot use the name `pypi` as it is reserved for use by the default PyPI sou
 
 #### Options
 
-* `--default`: Set this source as the [default]({{< relref "repositories#disabling-the-pypi-repository" >}}) (disable PyPI).
+* `--default`: Set this source as the default (**Deprecated**, use `poetry source default --disable-pypi` to disable PyPI).
 * `--secondary`: Set this source as a [secondary]({{< relref "repositories#install-dependencies-from-a-private-repository" >}}) source.
 
 {{% note %}}
@@ -806,6 +806,19 @@ The `source remove` command removes a configured source from your `pyproject.tom
 ```bash
 poetry source remove pypi-test
 ```
+
+### source default
+
+The `source default` command enables or disables the implicit default source PyPI for the project.
+
+```bash
+poetry source default --disable-pypi
+```
+
+#### Options
+
+* `--disable-pypi`: Disable PyPI as implicit default source.
+* `--enable-pypi`: Enable PyPI as implicit default source.
 
 ## about
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -120,7 +120,6 @@ This will generate the following configuration snippet in your
 [[tool.poetry.source]]
 name = "foo"
 url = "https://foo.bar/simple/"
-default = false
 secondary = false
 ```
 
@@ -129,7 +128,9 @@ Any package source not marked as `secondary` will take precedence over [PyPI](ht
 
 {{% note %}}
 
-If you prefer to disable [PyPI](https://pypi.org) completely, you may choose to set one of your package sources to be the [default](#default-package-source).
+If you prefer to disable [PyPI](https://pypi.org) completely,
+you can run `poetry source default --disable-pypi`.
+If you disable PyPI, you have to configure at least one other source.
 
 If you prefer to specify a package source for a specific dependency, see [Secondary Package Sources](#secondary-package-sources).
 
@@ -146,18 +147,39 @@ you must declare **all** package sources to be [secondary](#secondary-package-so
 
 #### Default Package Source
 
-By default, Poetry configures [PyPI](https://pypi.org) as the default package source for your
-project. You can alter this behaviour and exclusively look up packages only from the configured
-package sources by adding a **single** source with `default = true`.
+By default, Poetry configures [PyPI](https://pypi.org) as the default package source for
+your project. If you configure additional sources, these are preferred to PyPI unless
+they are configured as secondary. Nevertheless, packages are looked up on PyPI.
+
+If you want to exclusively look up packages only from the configured package sources,
+you can disable the implicit default source PyPI:
 
 ```bash
-poetry source add --default foo https://foo.bar/simple/
+poetry source default --disable-pypi
+```
+
+This will generate the following entry in your `pyproject.toml` file:
+
+```toml
+[tool.poetry]
+...
+default-source-pypi = false
 ```
 
 {{% warning %}}
 
-Configuring a custom package source as default, will effectively disable [PyPI](https://pypi.org)
-as a package source for your project.
+Configuring a custom package source as default (`default = true`, **deprecated**),
+will effectively disable [PyPI](https://pypi.org) as a package source for your project.
+Whereas the implicit default source PyPI is looked up before secondary but after other
+repositories, an explicit default source will be looked up before all other repositories.
+
+{{% /warning %}}
+
+{{% warning %}}
+
+Strictly speaking, PyPI is only configured as default package source if there is at
+least one other non-secondary source. Otherwise PyPI is configured as last secondary
+source.
 
 {{% /warning %}}
 
@@ -229,10 +251,12 @@ This will generate the following configuration snippet in your `pyproject.toml` 
 httpx = {version = "^0.22.0", source = "pypi"}
 ```
 
+If you want to disable PyPI completely, see [Default Package Source](#default-package-source).
+
 {{% warning %}}
 
-If any source within a project is configured with `default = true`, The implicit `pypi` source will
-be disabled and not used for any packages.
+If any source within a project is configured with `default = true` (**deprecated**),
+the implicit `pypi` source will be disabled and not used for any packages.
 
 {{% /warning %}}
 

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -88,6 +88,7 @@ COMMANDS = [
     "self show plugins",
     # Source commands
     "source add",
+    "source default",
     "source remove",
     "source show",
 ]

--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from cleo.helpers import argument
 from cleo.helpers import option
-from cleo.io.null_io import NullIO
 from tomlkit.items import AoT
 
 from poetry.config.source import Source
@@ -85,7 +84,7 @@ class SourceAddCommand(Command):
 
         # ensure new source is valid. eg: invalid name etc.
         try:
-            pool = Factory.create_pool(self.poetry.config, sources, NullIO())
+            pool = Factory.create_pool(self.poetry.config, sources, self._io)
             pool.repository(name)
         except ValueError as e:
             self.line_error(

--- a/src/poetry/console/commands/source/default.py
+++ b/src/poetry/console/commands/source/default.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from cleo.helpers import option
+
+from poetry.console.commands.command import Command
+
+
+class SourceDefaultCommand(Command):
+    name = "source default"
+    description = "Enable or disable the implicit default source PyPI for the project."
+
+    options = [
+        option("enable-pypi", None, "Enable PyPI as implicit default source."),
+        option("disable-pypi", None, "Disable PyPI as implicit default source."),
+    ]
+
+    def handle(self) -> int:
+        enable_pypi = self.option("enable-pypi")
+        disable_pypi = self.option("disable-pypi")
+
+        if enable_pypi and disable_pypi:
+            self.line_error("Cannot enable and disable PyPI.")
+            return 1
+
+        if enable_pypi or disable_pypi:
+            self.poetry.pyproject.poetry_config["default-source-pypi"] = enable_pypi
+            self.poetry.pyproject.save()
+
+        else:
+            state = (
+                "enabled"
+                if self.poetry.pyproject.poetry_config.get("default-source-pypi", True)
+                else "disabled"
+            )
+            self.line(f"PyPI is {state} as implicit default source.")
+
+        return 0

--- a/src/poetry/console/commands/source/show.py
+++ b/src/poetry/console/commands/source/show.py
@@ -61,5 +61,12 @@ class SourceShowCommand(Command):
             table.add_rows(rows)
             table.render()
             self.line("")
+        if not names:
+            state = (
+                "enabled"
+                if self.poetry.pyproject.poetry_config.get("default-source-pypi", True)
+                else "disabled"
+            )
+            self.line(f"PyPI is {state} as implicit default source.")
 
         return 0

--- a/src/poetry/json/schemas/poetry.json
+++ b/src/poetry/json/schemas/poetry.json
@@ -4,6 +4,10 @@
   "type": "object",
   "required": [],
   "properties": {
+    "default-source-pypi": {
+      "type": "boolean",
+      "description": "Whether PyPI is implicitly used to search for packages."
+    },
     "source": {
       "type": "array",
       "description": "A set of additional repositories where packages can be found.",

--- a/src/poetry/utils/source.py
+++ b/src/poetry/utils/source.py
@@ -15,6 +15,9 @@ def source_to_table(source: Source) -> Table:
 
     source_table: Table = table()
     for key, value in source.to_dict().items():
+        if key == "default" and not value:
+            # default is deprecated, so we don't add it if it is not set
+            continue
         source_table.add(key, value)
     source_table.add(nl())
     return source_table

--- a/tests/console/commands/self/conftest.py
+++ b/tests/console/commands/self/conftest.py
@@ -47,12 +47,14 @@ def pool(repo: TestRepository) -> RepositoryPool:
 
 def create_pool_factory(
     repo: Repository,
-) -> Callable[[Config, Iterable[dict[str, Any]], IO, bool], RepositoryPool]:
+) -> Callable[[Config, Iterable[dict[str, Any]], IO, bool, bool], RepositoryPool]:
     def _create_pool(
         config: Config,
         sources: Iterable[dict[str, Any]] = (),
         io: IO | None = None,
         disable_cache: bool = False,
+        *,
+        default_source_pypi: bool = True,
     ) -> RepositoryPool:
         pool = RepositoryPool()
         pool.add_repository(repo)

--- a/tests/console/commands/source/test_add.py
+++ b/tests/console/commands/source/test_add.py
@@ -33,6 +33,9 @@ def assert_source_added(
         == f"Adding source with name {source_added.name}."
     )
     poetry.pyproject.reload()
+    for source_table in poetry.pyproject.poetry_config["source"]:
+        # "default" is deprecated and should only be written if set to True
+        assert "default" not in source_table or source_table["default"] is True
     sources = poetry.get_sources()
     assert sources == [source_existing, source_added]
     assert tester.status_code == 0
@@ -55,6 +58,7 @@ def test_source_add_default(
     poetry_with_source: Poetry,
 ):
     tester.execute(f"--default {source_default.name} {source_default.url}")
+    assert "deprecated" in tester.io.fetch_error()
     assert_source_added(tester, poetry_with_source, source_existing, source_default)
 
 
@@ -95,6 +99,7 @@ def test_source_add_existing(
         tester.io.fetch_output().strip()
         == f"Source with name {source_existing.name} already exists. Updating."
     )
+    assert "deprecated" in tester.io.fetch_error()
 
     poetry_with_source.pyproject.reload()
     sources = poetry_with_source.get_sources()

--- a/tests/console/commands/source/test_default.py
+++ b/tests/console/commands/source/test_default.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from poetry.config.source import Source
+    from poetry.poetry import Poetry
+    from tests.types import CommandTesterFactory
+
+
+@pytest.fixture
+def tester(
+    command_tester_factory: CommandTesterFactory, poetry_with_source: Poetry
+) -> CommandTester:
+    return command_tester_factory("source default", poetry=poetry_with_source)
+
+
+def test_source_default_enabled_by_default(
+    tester: CommandTester,
+    source_existing: Source,
+    source_default: Source,
+    poetry_with_source: Poetry,
+) -> None:
+    tester.execute("")
+    assert "enabled" in tester.io.fetch_output()
+    poetry_with_source.pyproject.reload()
+    assert "default-source-pypi" not in poetry_with_source.pyproject.poetry_config
+
+
+@pytest.mark.parametrize("enable", [True, False])
+def test_source_default_disable(
+    tester: CommandTester,
+    source_existing: Source,
+    source_default: Source,
+    poetry_with_source: Poetry,
+    enable: bool,
+) -> None:
+    tester.execute("--enable-pypi" if enable else "--disable-pypi")
+    poetry_with_source.pyproject.reload()
+    assert poetry_with_source.pyproject.poetry_config["default-source-pypi"] is enable
+
+    tester.execute("")
+    output = tester.io.fetch_output()
+    assert ("enabled" in output) is enable
+    assert ("disabled" in output) is not enable
+    poetry_with_source.pyproject.reload()
+    assert poetry_with_source.pyproject.poetry_config["default-source-pypi"] is enable

--- a/tests/console/commands/source/test_show.py
+++ b/tests/console/commands/source/test_show.py
@@ -40,6 +40,32 @@ name       : two
 url        : https://two.com
 default    : no
 secondary  : no
+
+PyPI is enabled as implicit default source.
+""".splitlines()
+    assert [
+        line.strip() for line in tester.io.fetch_output().strip().splitlines()
+    ] == expected
+    assert tester.status_code == 0
+
+
+def test_source_show_default_pypi_disabled(
+    command_tester_factory: CommandTesterFactory,
+    poetry_with_source: Poetry,
+) -> None:
+    tester = command_tester_factory("source default", poetry=poetry_with_source)
+    tester.execute("--disable-pypi")
+
+    tester = command_tester_factory("source show", poetry=poetry_with_source)
+    tester.execute("")
+
+    expected = """\
+name       : existing
+url        : https://existing.com
+default    : no
+secondary  : no
+
+PyPI is disabled as implicit default source.
 """.splitlines()
     assert [
         line.strip() for line in tester.io.fetch_output().strip().splitlines()

--- a/tests/fixtures/with_no_explicit_source_pypi_disabled/pyproject.toml
+++ b/tests/fixtures/with_no_explicit_source_pypi_disabled/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "Some description."
+authors = [
+    "Your Name <you@example.com>"
+]
+license = "MIT"
+default-source-pypi = false
+
+# Requirements
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+
+[tool.poetry.dev-dependencies]

--- a/tests/fixtures/with_non_default_source_pypi_disabled/pyproject.toml
+++ b/tests/fixtures/with_non_default_source_pypi_disabled/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "Some description."
+authors = [
+    "Your Name <you@example.com>"
+]
+license = "MIT"
+default-source-pypi = false
+
+# Requirements
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+
+[tool.poetry.dev-dependencies]
+
+[[tool.poetry.source]]
+name = "foo"
+url = "https://foo.bar/simple/"

--- a/tests/utils/test_source.py
+++ b/tests/utils/test_source.py
@@ -16,7 +16,6 @@ from poetry.utils.source import source_to_table
         (
             Source("foo", "https://example.com"),
             {
-                "default": False,
                 "name": "foo",
                 "secondary": False,
                 "url": "https://example.com",


### PR DESCRIPTION
Related-to: #6713

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

### Motivation

While reviewing #6879, I figured out that there is a huge inconsistence between the implementation and the documentation of the `default` source (originally posted in https://github.com/python-poetry/poetry/pull/6879#pullrequestreview-1273887207):

|implementation|documentation|
|---|---|
|If there is no explicit `default`, **PyPI is only the `default` if there is no `primary`**, otherwise it's `secondary`. **`default` is the highest priority.** In other words, implicit PyPI always comes after `primary` but is not always the `default`.|It's a bit difficult to find but it says that primary sources take precedence over PyPI and that the default source takes precedence over `secondary` sources. It does not clearly say but implies that **if there is no explicit `default`, PyPI always is the `default`**. If you combine everything, it seems **`primary` sources should take precedence over the `default` source** (even if it's not PyPI).|

In my opinion, the documentation makes more sense, but changing the implementation to match the documentation is a breaking change because it puts the explicit `default` source from highest priority to lower than all primary sources.

Thinking a bit about the problem, I came to the conclusion that we do not really need to explicitly specify a `default` source if we had another option to disable PyPI. Currently, specifying a `default` source has two effects:
1. It disables PyPI.
2. It defines the source with the highest priority.

The second effect is not really required because you can achieve the same result by making the source the first one in pyroject.toml.

The first effect is kind of implicit and from an UI perspective probably shouldn't be coupled to a specific repository. That's why I think we should deprecate configuring sources as `default` and introduce an option to disable PyPI.

### Implementation details

* Deprecate `default=true` for sources
* Introduce new command `poetry source default`:
  * Options: `--enable-pypi`, `--disable-pypi`
  * When executed without an option it shows the current state (enabled/disabled).

pyproject.toml:

```toml
[tool.poetry]
...
default-source-pypi = false
```