### PR TITLE
fix(dependencies): remove upper boundary for importlib-metadata

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1781,4 +1781,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "39120ecbb0a8005ab2bab602a5f36ca178588521343d56c87ea2596f14c1c88a"
+content-hash = "c1c3d959c9e5ede769d788c0fe4767bdc9a444aabb9ebfcb47c3a393d8a5ef2d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ crashtest = "^0.4.1"
 dulwich = "^0.21.2"
 filelock = "^3.8.0"
 html5lib = "^1.0"
-importlib-metadata = { version = ">=4.4,<6", python = "<3.10" }
+importlib-metadata = { version = ">=4.4", python = "<3.10" }
 jsonschema = "^4.10.0"
 keyring = "^23.9.0"
 lockfile = "^0.12.2"


### PR DESCRIPTION
`importlib-metada` doesn't follow SemVer. New major versions are usually released if features of new Python versions are included.

Resolves problems like in https://github.com/enpaul/tox-poetry-installer/pull/80
