### PR TITLE
test: remove cachy dependency and cache compatiblity tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -62,22 +62,6 @@ filecache = ["lockfile (>=0.9)"]
 redis = ["redis (>=2.10.5)"]
 
 [[package]]
-name = "cachy"
-version = "0.3.0"
-description = "Cachy provides a simple yet effective caching library."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "cachy-0.3.0-py2.py3-none-any.whl", hash = "sha256:338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7"},
-    {file = "cachy-0.3.0.tar.gz", hash = "sha256:186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1"},
-]
-
-[package.extras]
-memcached = ["python-memcached (>=1.59,<2.0)"]
-msgpack = ["msgpack-python (>=0.5,<0.6)"]
-redis = ["redis (>=3.3.6,<4.0.0)"]
-
-[[package]]
 name = "certifi"
 version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1688,4 +1672,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "2a028eba8da6043cb897458153fc28cadc9a7b9184fe8edaee48e3e5a8468f06"
+content-hash = "fab5b1b0800c476f29b2f064c2c664cde4bcf7b8fbe98c58feb529d0935f98fb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,6 @@ warn_unused_ignores = false
 [[tool.mypy.overrides]]
 module = [
     'cachecontrol.*',
-    'cachy.*',
     'deepdiff.*',
     'httpretty.*',
     'keyring.*',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,6 @@ urllib3 = "^1.26.0"
 pre-commit = "^2.6"
 
 [tool.poetry.group.test.dependencies]
-# Cachy frozen to test backwards compatibility for `poetry.utils.cache`.
-cachy = "0.3.0"
 deepdiff = "^6.3"
 httpretty = "^1.0"
 pytest = "^7.1"

--- a/src/poetry/utils/cache.py
+++ b/src/poetry/utils/cache.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from poetry.utils.env import Env
 
 
-# Used by Cachy for items that do not expire.
+# Used by FileCache for items that do not expire.
 MAX_DATE = 9999999999
 T = TypeVar("T")
 

--- a/tests/console/commands/cache/conftest.py
+++ b/tests/console/commands/cache/conftest.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from cachy import CacheManager
+from poetry.utils.cache import FileCache
 
 
 if TYPE_CHECKING:
@@ -47,19 +47,11 @@ def cache(
     repository_cache_dir: Path,
     repository_one: str,
     mock_caches: None,
-) -> CacheManager:
-    cache = CacheManager(
-        {
-            "default": repository_one,
-            "serializer": "json",
-            "stores": {
-                repository_one: {
-                    "driver": "file",
-                    "path": str(repository_cache_dir / repository_one),
-                }
-            },
-        }
+) -> FileCache:
+    cache = FileCache(path=repository_cache_dir / repository_one)
+
+    cache.remember(
+        "cachy:0.1", lambda: {"name": "cachy", "version": "0.1"}, minutes=None
     )
-    cache.remember_forever("cachy:0.1", lambda: {"name": "cachy", "version": "0.1"})
-    cache.remember_forever("cleo:0.2", lambda: {"name": "cleo", "version": "0.2"})
+    cache.remember("cleo:0.2", lambda: {"name": "cleo", "version": "0.2"}, minutes=None)
     return cache

--- a/tests/console/commands/cache/conftest.py
+++ b/tests/console/commands/cache/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 
 from typing import TYPE_CHECKING
+from typing import TypeVar
 
 import pytest
 
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
 
     from tests.conftest import Config
+
+T = TypeVar("T")
 
 
 @pytest.fixture
@@ -47,8 +50,10 @@ def cache(
     repository_cache_dir: Path,
     repository_one: str,
     mock_caches: None,
-) -> FileCache:
-    cache = FileCache(path=repository_cache_dir / repository_one)
+) -> FileCache[dict[str, str]]:
+    cache: FileCache[dict[str, str]] = FileCache(
+        path=repository_cache_dir / repository_one
+    )
 
     cache.remember(
         "cachy:0.1", lambda: {"name": "cachy", "version": "0.1"}, minutes=None

--- a/tests/console/commands/cache/test_clear.py
+++ b/tests/console/commands/cache/test_clear.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import TypeVar
 
 import pytest
 
@@ -13,6 +14,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from poetry.utils.cache import FileCache
+
+T = TypeVar("T")
 
 
 @pytest.fixture
@@ -27,7 +30,7 @@ def test_cache_clear_all(
     tester: ApplicationTester,
     repository_one: str,
     repository_cache_dir: Path,
-    cache: FileCache,
+    cache: FileCache[T],
 ) -> None:
     exit_code = tester.execute(f"cache clear {repository_one} --all", inputs="yes")
     repository_one_dir = repository_cache_dir / repository_one
@@ -44,7 +47,7 @@ def test_cache_clear_all_no(
     tester: ApplicationTester,
     repository_one: str,
     repository_cache_dir: Path,
-    cache: FileCache,
+    cache: FileCache[T],
 ) -> None:
     exit_code = tester.execute(f"cache clear {repository_one} --all", inputs="no")
 
@@ -60,7 +63,7 @@ def test_cache_clear_all_no(
 def test_cache_clear_pkg(
     tester: ApplicationTester,
     repository_one: str,
-    cache: FileCache,
+    cache: FileCache[T],
     package_name: str,
 ) -> None:
     exit_code = tester.execute(
@@ -76,7 +79,7 @@ def test_cache_clear_pkg(
 def test_cache_clear_pkg_no(
     tester: ApplicationTester,
     repository_one: str,
-    cache: FileCache,
+    cache: FileCache[T],
 ) -> None:
     exit_code = tester.execute(f"cache clear {repository_one}:cachy:0.1", inputs="no")
 

--- a/tests/console/commands/cache/test_clear.py
+++ b/tests/console/commands/cache/test_clear.py
@@ -12,7 +12,7 @@ from poetry.console.application import Application
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from cachy import CacheManager
+    from poetry.utils.cache import FileCache
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def test_cache_clear_all(
     tester: ApplicationTester,
     repository_one: str,
     repository_cache_dir: Path,
-    cache: CacheManager,
+    cache: FileCache,
 ) -> None:
     exit_code = tester.execute(f"cache clear {repository_one} --all", inputs="yes")
     repository_one_dir = repository_cache_dir / repository_one
@@ -44,7 +44,7 @@ def test_cache_clear_all_no(
     tester: ApplicationTester,
     repository_one: str,
     repository_cache_dir: Path,
-    cache: CacheManager,
+    cache: FileCache,
 ) -> None:
     exit_code = tester.execute(f"cache clear {repository_one} --all", inputs="no")
 
@@ -60,7 +60,7 @@ def test_cache_clear_all_no(
 def test_cache_clear_pkg(
     tester: ApplicationTester,
     repository_one: str,
-    cache: CacheManager,
+    cache: FileCache,
     package_name: str,
 ) -> None:
     exit_code = tester.execute(
@@ -76,7 +76,7 @@ def test_cache_clear_pkg(
 def test_cache_clear_pkg_no(
     tester: ApplicationTester,
     repository_one: str,
-    cache: CacheManager,
+    cache: FileCache,
 ) -> None:
     exit_code = tester.execute(f"cache clear {repository_one}:cachy:0.1", inputs="no")
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -17,6 +17,8 @@ from poetry.utils.env import MockEnv
 
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from pytest_mock import MockerFixture
 
     from tests.conftest import Config
@@ -32,7 +34,7 @@ def repository_cache_dir(config: Config) -> Path:
 
 
 @pytest.fixture
-def poetry_file_cache(repository_cache_dir: Path) -> FileCache[T]:
+def poetry_file_cache(repository_cache_dir: Path) -> FileCache[Any]:
     return FileCache(repository_cache_dir / "cache")
 
 
@@ -43,7 +45,7 @@ def test_cache_validates(repository_cache_dir: Path) -> None:
 
 
 def test_cache_get_put_has(repository_cache_dir: Path) -> None:
-    cache = FileCache(repository_cache_dir / "cache")
+    cache: FileCache[Any] = FileCache(repository_cache_dir / "cache")
     cache.put("key1", "value")
     cache.put("key2", {"a": ["json-encoded", "value"]})
 
@@ -55,7 +57,7 @@ def test_cache_get_put_has(repository_cache_dir: Path) -> None:
 
 
 def test_cache_forget(repository_cache_dir: Path) -> None:
-    cache = FileCache(repository_cache_dir / "cache")
+    cache: FileCache[Any] = FileCache(repository_cache_dir / "cache")
     cache.put("key1", "value")
     cache.put("key2", "value")
 
@@ -69,7 +71,7 @@ def test_cache_forget(repository_cache_dir: Path) -> None:
 
 
 def test_cache_flush(repository_cache_dir: Path) -> None:
-    cache = FileCache(repository_cache_dir / "cache")
+    cache: FileCache[Any] = FileCache(repository_cache_dir / "cache")
     cache.put("key1", "value")
     cache.put("key2", "value")
 
@@ -83,7 +85,7 @@ def test_cache_flush(repository_cache_dir: Path) -> None:
 
 
 def test_cache_remember(repository_cache_dir: Path, mocker: MockerFixture) -> None:
-    cache = FileCache(repository_cache_dir / "cache")
+    cache: FileCache[Any] = FileCache(repository_cache_dir / "cache")
 
     method = mocker.Mock(return_value="value2")
     cache.put("key1", "value1")
@@ -97,7 +99,7 @@ def test_cache_remember(repository_cache_dir: Path, mocker: MockerFixture) -> No
 def test_cache_get_limited_minutes(
     repository_cache_dir: Path, mocker: MockerFixture
 ) -> None:
-    cache = FileCache(repository_cache_dir / "cache")
+    cache: FileCache[Any] = FileCache(repository_cache_dir / "cache")
 
     start_time = 1111111111
 
@@ -114,7 +116,7 @@ def test_cache_get_limited_minutes(
     assert cache.get("key2") is None
 
 
-def test_missing_cache_file(poetry_file_cache: FileCache[T]) -> None:
+def test_missing_cache_file(poetry_file_cache: FileCache[Any]) -> None:
     poetry_file_cache.put("key1", "value")
 
     key1_path = (
@@ -127,7 +129,7 @@ def test_missing_cache_file(poetry_file_cache: FileCache[T]) -> None:
     assert poetry_file_cache.get("key1") is None
 
 
-def test_missing_cache_path(poetry_file_cache: FileCache[T]) -> None:
+def test_missing_cache_path(poetry_file_cache: FileCache[Any]) -> None:
     poetry_file_cache.put("key1", "value")
 
     key1_partial_path = poetry_file_cache.path / "81/74/09/96/87/a2/"
@@ -151,7 +153,7 @@ def test_missing_cache_path(poetry_file_cache: FileCache[T]) -> None:
     ],
 )
 def test_detect_corrupted_cache_key_file(
-    corrupt_payload: str | bytes, poetry_file_cache: FileCache[T]
+    corrupt_payload: str | bytes, poetry_file_cache: FileCache[Any]
 ) -> None:
     poetry_file_cache.put("key1", "value")
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -4,14 +4,10 @@ import shutil
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import TypeVar
-from typing import Union
-from unittest.mock import Mock
 
 import pytest
 
-from cachy import CacheManager
 from packaging.tags import Tag
 from poetry.core.packages.utils.link import Link
 
@@ -21,74 +17,23 @@ from poetry.utils.env import MockEnv
 
 
 if TYPE_CHECKING:
-    from _pytest.monkeypatch import MonkeyPatch
-    from pytest import FixtureRequest
     from pytest_mock import MockerFixture
 
     from tests.conftest import Config
     from tests.types import FixtureDirGetter
 
 
-FILE_CACHE = Union[FileCache, CacheManager]
 T = TypeVar("T")
 
 
 @pytest.fixture
-def repository_cache_dir(monkeypatch: MonkeyPatch, config: Config) -> Path:
+def repository_cache_dir(config: Config) -> Path:
     return config.repository_cache_directory
-
-
-def patch_cachy(cache: CacheManager) -> CacheManager:
-    old_put = cache.put
-    old_remember = cache.remember
-
-    def new_put(key: str, value: Any, minutes: int | None = None) -> Any:
-        if minutes is not None:
-            return old_put(key, value, minutes=minutes)
-        else:
-            return cache.forever(key, value)
-
-    cache.put = new_put
-
-    def new_remember(key: str, value: Any, minutes: int | None = None) -> Any:
-        if minutes is not None:
-            return old_remember(key, value, minutes=minutes)
-        else:
-            return cache.remember_forever(key, value)
-
-    cache.remember = new_remember
-    return cache
-
-
-@pytest.fixture
-def cachy_file_cache(repository_cache_dir: Path) -> CacheManager:
-    cache = CacheManager(
-        {
-            "default": "cache",
-            "serializer": "json",
-            "stores": {
-                "cache": {"driver": "file", "path": str(repository_cache_dir / "cache")}
-            },
-        }
-    )
-    return patch_cachy(cache)
 
 
 @pytest.fixture
 def poetry_file_cache(repository_cache_dir: Path) -> FileCache[T]:
     return FileCache(repository_cache_dir / "cache")
-
-
-@pytest.fixture
-def cachy_dict_cache() -> CacheManager:
-    cache = CacheManager(
-        {
-            "default": "cache",
-            "serializer": "json",
-            "stores": {"cache": {"driver": "dict"}},
-        }
-    )
-    return patch_cachy(cache)
 
 
 def test_cache_validates(repository_cache_dir: Path) -> None:
@@ -97,9 +42,8 @@ def test_cache_validates(repository_cache_dir: Path) -> None:
     assert str(e.value) == "FileCache.hash_type is unknown value: 'unknown'."
 
 
-@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
-def test_cache_get_put_has(cache_name: str, request: FixtureRequest) -> None:
-    cache = request.getfixturevalue(cache_name)
+def test_cache_get_put_has(repository_cache_dir: Path) -> None:
+    cache = FileCache(repository_cache_dir / "cache")
     cache.put("key1", "value")
     cache.put("key2", {"a": ["json-encoded", "value"]})
 
@@ -110,9 +54,8 @@ def test_cache_get_put_has(cache_name: str, request: FixtureRequest) -> None:
     assert not cache.has("key3")
 
 
-@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
-def test_cache_forget(cache_name: str, request: FixtureRequest) -> None:
-    cache = request.getfixturevalue(cache_name)
+def test_cache_forget(repository_cache_dir: Path) -> None:
+    cache = FileCache(repository_cache_dir / "cache")
     cache.put("key1", "value")
     cache.put("key2", "value")
 
@@ -125,9 +68,8 @@ def test_cache_forget(cache_name: str, request: FixtureRequest) -> None:
     assert cache.has("key2")
 
 
-@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
-def test_cache_flush(cache_name: str, request: FixtureRequest) -> None:
-    cache = request.getfixturevalue(cache_name)
+def test_cache_flush(repository_cache_dir: Path) -> None:
+    cache = FileCache(repository_cache_dir / "cache")
     cache.put("key1", "value")
     cache.put("key2", "value")
 
@@ -140,13 +82,10 @@ def test_cache_flush(cache_name: str, request: FixtureRequest) -> None:
     assert not cache.has("key2")
 
 
-@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
-def test_cache_remember(
-    cache_name: str, request: FixtureRequest, mocker: MockerFixture
-) -> None:
-    cache = request.getfixturevalue(cache_name)
+def test_cache_remember(repository_cache_dir: Path, mocker: MockerFixture) -> None:
+    cache = FileCache(repository_cache_dir / "cache")
 
-    method = Mock(return_value="value2")
+    method = mocker.Mock(return_value="value2")
     cache.put("key1", "value1")
     assert cache.remember("key1", method) == "value1"
     method.assert_not_called()
@@ -155,15 +94,11 @@ def test_cache_remember(
     method.assert_called()
 
 
-@pytest.mark.parametrize("cache_name", ["cachy_file_cache", "poetry_file_cache"])
 def test_cache_get_limited_minutes(
-    mocker: MockerFixture,
-    cache_name: str,
-    request: FixtureRequest,
+    repository_cache_dir: Path, mocker: MockerFixture
 ) -> None:
-    cache = request.getfixturevalue(cache_name)
+    cache = FileCache(repository_cache_dir / "cache")
 
-    # needs to be 10 digits because cachy assumes it's a 10-digit int.
     start_time = 1111111111
 
     mocker.patch("time.time", return_value=start_time)
@@ -177,27 +112,6 @@ def test_cache_get_limited_minutes(
     # check to make sure that the cache deletes for has() and get()
     assert not cache.has("key1")
     assert cache.get("key2") is None
-
-
-def test_cachy_compatibility(
-    cachy_file_cache: CacheManager, poetry_file_cache: FileCache[T]
-) -> None:
-    """
-    The new file cache should be able to support reading legacy caches.
-    """
-    test_str = "value"
-    test_obj = {"a": ["json", "object"]}
-    cachy_file_cache.put("key1", test_str)
-    cachy_file_cache.put("key2", test_obj)
-
-    assert poetry_file_cache.get("key1") == test_str
-    assert poetry_file_cache.get("key2") == test_obj
-
-    poetry_file_cache.put("key3", test_str)
-    poetry_file_cache.put("key4", test_obj)
-
-    assert cachy_file_cache.get("key3") == test_str
-    assert cachy_file_cache.get("key4") == test_obj
 
 
 def test_missing_cache_file(poetry_file_cache: FileCache[T]) -> None:


### PR DESCRIPTION
# Pull Request Check List

Resolves: kind of related to #5720

Followup of https://github.com/python-poetry/poetry/pull/5868 by chadac which I am happy for. This PR removes `cachy` dependency and compatibility tests that were put in place for the transition from old `cachy.CacheManager` to the new `utils.cache.FileCache` and . Cachy is an abandoned package.

- [ ] ~Added **tests** for changed code.~
- [ ] ~Updated **documentation** for changed code.~
