### PR TITLE
Fix python version parsing for deadsnakes python versions

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -134,9 +134,13 @@ else:
     iver = "0"
     implementation_name = platform.python_implementation().lower()
 
-    
-_pep_440_and_deadsnakes_regex = "^\\d+\\.([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)(\\+([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)?)?$"
-_clean_python_version = re.compile(_pep_440_and_deadsnakes_regex).match(platform.python_version()).group()
+_primary_version_regex = "\\d+\\.([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)"
+_local_segment_regex = "(\\+([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)?)?$"
+_pep_440_and_deadsnakes_regex = f"^{_primary_version_regex}{_local_segment_regex}$"
+match = re.compile(_pep_440_and_deadsnakes_regex).match(platform.python_version())
+if match is None:
+    raise ValueError("Python version must be PEP 440 compatible")
+_clean_python_version = match.group()
 _clean_python_version = _clean_python_version.rstrip("+")
 
 env = {
@@ -1684,8 +1688,15 @@ class SystemEnv(Env):
             iver = "0"
             implementation_name = ""
 
-        pep_440_and_deadsnakes_regex = "^\\d+\\.([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)(\\+([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)?)?$"
-        clean_python_version = re.compile(pep_440_and_deadsnakes_regex).match(platform.python_version()).group()
+        primary_version_regex = "\\d+\\.([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)"
+        local_segment_regex = "(\\+([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)?)?$"
+        pep_440_and_deadsnakes_regex = f"^{primary_version_regex}{local_segment_regex}$"
+        match = re.compile(pep_440_and_deadsnakes_regex).match(
+            platform.python_version()
+        )
+        if match is None:
+            raise ValueError("Python version must be PEP 440 compatible.")
+        clean_python_version = match.group()
         clean_python_version = clean_python_version.rstrip("+")
 
         return {

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -90,6 +90,7 @@ GET_ENVIRONMENT_INFO = """\
 import json
 import os
 import platform
+import re
 import sys
 import sysconfig
 
@@ -133,6 +134,11 @@ else:
     iver = "0"
     implementation_name = platform.python_implementation().lower()
 
+    
+_pep_440_and_deadsnakes_regex = "^\\d+\\.([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)(\\+([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)?)?$"
+_clean_python_version = re.compile(_pep_440_and_deadsnakes_regex).match(platform.python_version()).group()
+_clean_python_version = _clean_python_version.rstrip("+")
+
 env = {
     "implementation_name": implementation_name,
     "implementation_version": iver,
@@ -141,9 +147,9 @@ env = {
     "platform_release": platform.release(),
     "platform_system": platform.system(),
     "platform_version": platform.version(),
-    "python_full_version": platform.python_version(),
+    "python_full_version": _clean_python_version,
     "platform_python_implementation": platform.python_implementation(),
-    "python_version": ".".join(platform.python_version_tuple()[:2]),
+    "python_version": ".".join(_clean_python_version.split('.')[:2]),
     "sys_platform": sys.platform,
     "version_info": tuple(sys.version_info),
     # Extra information
@@ -1678,6 +1684,10 @@ class SystemEnv(Env):
             iver = "0"
             implementation_name = ""
 
+        pep_440_and_deadsnakes_regex = "^\\d+\\.([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)(\\+([a-zA-Z\\d]+(\\.[a-zA-Z\\d]+)*)?)?$"
+        clean_python_version = re.compile(pep_440_and_deadsnakes_regex).match(platform.python_version()).group()
+        clean_python_version = clean_python_version.rstrip("+")
+
         return {
             "implementation_name": implementation_name,
             "implementation_version": iver,
@@ -1686,9 +1696,9 @@ class SystemEnv(Env):
             "platform_release": platform.release(),
             "platform_system": platform.system(),
             "platform_version": platform.version(),
-            "python_full_version": platform.python_version(),
+            "python_full_version": clean_python_version,
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": ".".join(platform.python_version().split(".")[:2]),
+            "python_version": ".".join(clean_python_version.split(".")[:2]),
             "sys_platform": sys.platform,
             "version_info": sys.version_info,
             "interpreter_name": interpreter_name(),

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1617,40 +1617,43 @@ def test_fallback_on_detect_active_python(poetry: Poetry, mocker: MockerFixture)
     assert m.call_count == 1
 
 
-# list taken from https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering
+# list taken from https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering # noqa: E501
 _PEP_440_VERSION_STRINGS = [
-        "1.dev0",
-        "1.0.dev456",
-        "1.0a1",
-        "1.0a2.dev456",
-        "1.0a12.dev456",
-        "1.0a12",
-        "1.0b1.dev456",
-        "1.0b2",
-        "1.0b2.post345.dev456",
-        "1.0b2.post345",
-        "1.0rc1.dev456",
-        "1.0rc1",
-        "1.0",
-        "1.0+abc.5",
-        "1.0+abc.7",
-        "1.0+5",
-        "1.0.post456.dev34",
-        "1.0.post456",
-        "1.0.15",
-        "1.1.dev1",
+    "1.dev0",
+    "1.0.dev456",
+    "1.0a1",
+    "1.0a2.dev456",
+    "1.0a12.dev456",
+    "1.0a12",
+    "1.0b1.dev456",
+    "1.0b2",
+    "1.0b2.post345.dev456",
+    "1.0b2.post345",
+    "1.0rc1.dev456",
+    "1.0rc1",
+    "1.0",
+    "1.0+abc.5",
+    "1.0+abc.7",
+    "1.0+5",
+    "1.0.post456.dev34",
+    "1.0.post456",
+    "1.0.15",
+    "1.1.dev1",
 ]
 
+
 def _get_parsed_version(platform_version: str) -> str:
-    with mock.patch.object(platform, 'python_version') as m:
+    with mock.patch.object(platform, "python_version") as m:
         m.return_value = platform_version
         sys_env = SystemEnv(Path(sys.prefix))
         return sys_env.get_marker_env()["python_full_version"]
-    
+
+
 def test_allows_pep_440_version_strings() -> None:
     for version_string in _PEP_440_VERSION_STRINGS:
         print(version_string)
         assert _get_parsed_version(version_string) == version_string
+
 
 def test_allows_deadsnakes_version_strings() -> None:
     # See https://github.com/python-poetry/poetry/issues/6925
@@ -1658,19 +1661,20 @@ def test_allows_deadsnakes_version_strings() -> None:
         if "+" in version_string:
             continue
         empty_local_version_string = version_string + "+"
-        assert _get_parsed_version(empty_local_version_string) == version_string   
-    
+        assert _get_parsed_version(empty_local_version_string) == version_string
+
     # version "3.11.1+" used to cause an issue.
     assert _get_parsed_version("3.11.1+") == "3.11.1"
 
+
 def _is_version_rejected(platform_version: str) -> bool:
     try:
-        _version = _get_parsed_version(platform_version)
-    except:
+        _get_parsed_version(platform_version)
+    except ValueError:
         return True
-    return False    
+    return False
+
 
 def test_rejects_non_pep_440_or_deadsnakes_version_strings() -> None:
     assert _is_version_rejected("abcd")
     assert _is_version_rejected("3.11.1+foo+bar")
-    


### PR DESCRIPTION
This PR will allows poetry to a single trailing "+" character at the end of a PEP 440 compatible Python version string. This will allow Poetry to handle the nightly builds from CPython.

Note: The version string must be either exactly compatible with PEP 440 or it must be compatible except for a trailing "+" character while also not having a local version segment.

Resolves: #233
