### PR TITLE
don't set shell=True on subprocess calls

### DIFF
--- a/src/poetry/utils/_compat.py
+++ b/src/poetry/utils/_compat.py
@@ -60,19 +60,11 @@ def to_str(string: str) -> str:
     return decode(string)
 
 
-def list_to_shell_command(cmd: list[str]) -> str:
-    return " ".join(
-        f'"{token}"' if " " in token and token[0] not in {"'", '"'} else token
-        for token in cmd
-    )
-
-
 __all__ = [
     "WINDOWS",
     "cached_property",
     "decode",
     "encode",
-    "list_to_shell_command",
     "metadata",
     "to_str",
     "tomllib",

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -10,8 +10,6 @@ from poetry.core.constraints.version import Version
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from poetry.core.version.pep440.version import PEP440Version
-
 VERSION_3_7_1 = Version.parse("3.7.1")
 
 
@@ -20,16 +18,19 @@ def build_venv(path: Path | str, **_: Any) -> None:
 
 
 def check_output_wrapper(
-    version: PEP440Version = VERSION_3_7_1,
-) -> Callable[[str, Any, Any], str]:
-    def check_output(cmd: str, *_: Any, **__: Any) -> str:
-        if "sys.version_info[:3]" in cmd:
+    version: Version = VERSION_3_7_1,
+) -> Callable[[list[str], Any, Any], str]:
+    def check_output(cmd: list[str], *args: Any, **kwargs: Any) -> str:
+        # cmd is a list, like ["python", "-c", "do stuff"]
+        python_cmd = cmd[2]
+        if "sys.version_info[:3]" in python_cmd:
             return version.text
-        elif "sys.version_info[:2]" in cmd:
+        elif "sys.version_info[:2]" in python_cmd:
             return f"{version.major}.{version.minor}"
-        elif '-c "import sys; print(sys.executable)"' in cmd:
-            return f"/usr/bin/{cmd.split()[0]}"
+        elif "import sys; print(sys.executable)" in python_cmd:
+            return f"/usr/bin/{cmd[0]}"
         else:
+            assert "import sys; print(sys.prefix)" in python_cmd
             return str(Path("/prefix"))
 
     return check_output


### PR DESCRIPTION
When poetry executes subprocesses, it sets `shell=True`, concatenates the list of command elements into a single string, and makes an unconvincing try at escaping the components.  See eg #6848.

I don't know what the point is in any of this.  Surely it's simpler not to create a shell, and to let `subprocess` take care of arguments.

On the other hand I'm ony testing on Linux, and - I'm not sure - it may be that the unit tests mock this part sufficiently thoroughly that making them pass doesn't reveal very much about the real-life behaviour. 

So I thought I'd see if either the pipeline or a reviewer can tell me why this doesn't work.