### PR TITLE
Cache git dependencies as wheels

### DIFF
--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -94,8 +94,8 @@ class Chef:
             return archive
 
         if archive.is_dir():
-            tmp_dir = tempfile.mkdtemp(prefix="poetry-chef-")
-            return self._prepare(archive, Path(tmp_dir), editable=editable)
+            destination = output_dir or Path(tempfile.mkdtemp(prefix="poetry-chef-"))
+            return self._prepare(archive, destination=destination, editable=editable)
 
         return self._prepare_sdist(archive, destination=output_dir)
 

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -653,7 +653,8 @@ class Executor:
             )
 
         archive = self._prepare_archive(operation, output_dir=output_dir)
-        package._source_url = original_url
+        if not package.develop:
+            package._source_url = original_url
 
         if output_dir is not None and output_dir.is_dir():
             # Mark directories with cached git packages, to distinguish from
@@ -893,12 +894,12 @@ class Executor:
 
         url_reference: dict[str, Any] | None = None
 
-        if package.source_type == "git":
+        if package.source_type == "git" and not package.develop:
             url_reference = self._create_git_url_reference(package)
+        elif package.source_type in ("directory", "git"):
+            url_reference = self._create_directory_url_reference(package)
         elif package.source_type == "url":
             url_reference = self._create_url_url_reference(package)
-        elif package.source_type == "directory":
-            url_reference = self._create_directory_url_reference(package)
         elif package.source_type == "file":
             url_reference = self._create_file_url_reference(package)
 

--- a/src/poetry/utils/cache.py
+++ b/src/poetry/utils/cache.py
@@ -231,6 +231,9 @@ class ArtifactCache:
         if link.subdirectory_fragment:
             key_parts["subdirectory"] = link.subdirectory_fragment
 
+        return self._get_directory_from_hash(key_parts)
+
+    def _get_directory_from_hash(self, key_parts: object) -> Path:
         key = hashlib.sha256(
             json.dumps(
                 key_parts, sort_keys=True, separators=(",", ":"), ensure_ascii=True
@@ -238,8 +241,16 @@ class ArtifactCache:
         ).hexdigest()
 
         split_key = [key[:2], key[2:4], key[4:6], key[6:]]
-
         return self._cache_dir.joinpath(*split_key)
+
+    def get_cache_directory_for_git(
+        self, url: str, ref: str, subdirectory: str | None
+    ) -> Path:
+        key_parts = {"url": url, "ref": ref}
+        if subdirectory:
+            key_parts["subdirectory"] = subdirectory
+
+        return self._get_directory_from_hash(key_parts)
 
     def get_cached_archive_for_link(
         self,
@@ -248,18 +259,42 @@ class ArtifactCache:
         strict: bool,
         env: Env | None = None,
     ) -> Path | None:
-        assert strict or env is not None
+        cache_dir = self.get_cache_directory_for_link(link)
 
-        archives = self._get_cached_archives_for_link(link)
+        return self._get_cached_archive(
+            cache_dir, strict=strict, filename=link.filename, env=env
+        )
+
+    def get_cached_archive_for_git(
+        self, url: str, reference: str, subdirectory: str | None, env: Env
+    ) -> Path | None:
+        cache_dir = self.get_cache_directory_for_git(url, reference, subdirectory)
+
+        return self._get_cached_archive(cache_dir, strict=False, env=env)
+
+    def _get_cached_archive(
+        self,
+        cache_dir: Path,
+        *,
+        strict: bool,
+        filename: str | None = None,
+        env: Env | None = None,
+    ) -> Path | None:
+        assert strict or env is not None
+        # implication "strict -> filename should not be None"
+        assert not strict or filename is not None
+
+        archives = self._get_cached_archives(cache_dir)
         if not archives:
             return None
 
         candidates: list[tuple[float | None, Path]] = []
+
         for archive in archives:
             if strict:
                 # in strict mode return the original cached archive instead of the
                 # prioritized archive type.
-                if link.filename == archive.name:
+                if filename == archive.name:
                     return archive
                 continue
 
@@ -286,9 +321,7 @@ class ArtifactCache:
 
         return min(candidates)[1]
 
-    def _get_cached_archives_for_link(self, link: Link) -> list[Path]:
-        cache_dir = self.get_cache_directory_for_link(link)
-
+    def _get_cached_archives(self, cache_dir: Path) -> list[Path]:
         archive_types = ["whl", "tar.gz", "tar.bz2", "bz2", "zip"]
         paths: list[Path] = []
         for archive_type in archive_types:

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1058,12 +1058,8 @@ def test_executor_should_write_pep610_url_references_for_editable_git(
         tmp_venv,
         package,
         {
-            "vcs_info": {
-                "vcs": "git",
-                "requested_revision": "master",
-                "commit_id": "123456",
-            },
-            "url": package.source_url,
+            "dir_info": {"editable": True},
+            "url": Path(package.source_url).as_uri(),
         },
     )
 


### PR DESCRIPTION
Currently, poetry install will clone, build and install every git dependency when it's not present in the environment. This is OK for developer's machines, but not OK for CI - there environment is always fresh, and installing git dependencies takes significant time on each CI run, especially if the dependency has C extensions that need to be built.

This commit builds a wheel for every git dependency that has precise reference hash in lock file and is not required to be in editable mode, stores that wheel in a cache dir and will install from it instead of cloning the repository again.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This is a copy of #6896, which got automatically closed when `feature/wheel-installer-and-builder` branch was merged and deleted.

@neersighted @radoering may I ping you about this feature? 🙏 

If it's OK, I'll try to write a test.