### PR TITLE
Only write lock file when installation is success

### DIFF
--- a/tests/console/commands/self/test_add_plugins.py
+++ b/tests/console/commands/self/test_add_plugins.py
@@ -49,11 +49,11 @@ Using version ^0.1.0 for poetry-plugin
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing poetry-plugin (0.1.0)
+
+Writing lock file
 """
     assert_plugin_add_result(tester, expected, "^0.1.0")
 
@@ -71,11 +71,11 @@ def test_add_with_constraint(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing poetry-plugin (0.2.0)
+
+Writing lock file
 """
 
     assert_plugin_add_result(tester, expected, "^0.2.0")
@@ -93,12 +93,12 @@ def test_add_with_git_constraint(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (2.0.5)
   • Installing poetry-plugin (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert_plugin_add_result(
@@ -119,13 +119,13 @@ def test_add_with_git_constraint_with_extras(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 3 installs, 0 updates, 0 removals
 
   • Installing pendulum (2.0.5)
   • Installing tomlkit (0.7.0)
   • Installing poetry-plugin (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert_plugin_add_result(
@@ -162,12 +162,12 @@ def test_add_with_git_constraint_with_subdirectory(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (2.0.5)
   • Installing poetry-plugin (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     constraint = {
@@ -262,11 +262,11 @@ Using version ^2.3.4 for poetry-plugin
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 0 installs, 1 update, 0 removals
 
   • Updating poetry-plugin (1.2.3 -> 2.3.4)
+
+Writing lock file
 """
 
     assert_plugin_add_result(tester, expected, "^2.3.4")
@@ -298,12 +298,12 @@ Using version ^1.2.3 for poetry-plugin
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 1 update, 0 removals
 
   • Updating tomlkit (0.7.1 -> 0.7.2)
   • Installing poetry-plugin (1.2.3)
+
+Writing lock file
 """
 
     assert_plugin_add_result(tester, expected, "^1.2.3")

--- a/tests/console/commands/self/test_remove_plugins.py
+++ b/tests/console/commands/self/test_remove_plugins.py
@@ -73,11 +73,11 @@ def test_remove_installed_package(tester: CommandTester):
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 0 installs, 0 updates, 1 removal
 
   • Removing poetry-plugin (1.2.3)
+
+Writing lock file
 """
     assert tester.io.fetch_output() == expected
 

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -71,12 +71,12 @@ Using version ^{new_version} for poetry
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 0 installs, 2 updates, 0 removals
 
   • Updating cleo (0.8.2 -> 1.0.0)
   • Updating poetry ({__version__} -> {new_version})
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected_output

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -2233,7 +2233,6 @@ Resolving dependencies...
 
   BuildError
 
-Writing lock file
 """
 
     assert poetry_with_up_to_date_lockfile.file.read() == original_pyproject_content

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -2159,7 +2159,8 @@ def test_add_keyboard_interrupt_restore_content(
     tester = command_tester_factory("add", poetry=poetry_with_up_to_date_lockfile)
 
     mocker.patch(
-        "poetry.installation.installer.Installer.run", side_effect=KeyboardInterrupt()
+        "poetry.installation.installer.Installer._execute",
+        side_effect=KeyboardInterrupt(),
     )
     original_pyproject_content = poetry_with_up_to_date_lockfile.file.read()
     original_lockfile_content = poetry_with_up_to_date_lockfile._locker.lock_data

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -72,11 +72,11 @@ Using version ^0.2.0 for cachy
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -102,11 +102,11 @@ Using version ^0.2.0 for cachy
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
     assert tester.io.fetch_output() == expected
     assert tester.command.installer.executor.installations_count == 1
@@ -121,11 +121,11 @@ Package operations: 1 install, 0 updates, 0 removals
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.1.0)
+
+Writing lock file
 """
     assert tester.io.fetch_output() == expected
 
@@ -169,11 +169,11 @@ def test_add_equal_constraint(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.1.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -193,11 +193,11 @@ def test_add_greater_constraint(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -227,12 +227,12 @@ def test_add_constraint_with_extras(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing msgpack-python (0.5.3)
   • Installing cachy (0.1.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -257,12 +257,12 @@ def test_add_constraint_dependencies(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing msgpack-python (0.5.3)
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -287,12 +287,12 @@ def test_add_git_constraint(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
   • Installing demo (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -323,12 +323,12 @@ def test_add_git_constraint_with_poetry(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
   • Installing demo (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -356,14 +356,14 @@ def test_add_git_constraint_with_extras(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 4 installs, 0 updates, 0 removals
 
   • Installing cleo (0.6.5)
   • Installing pendulum (1.4.4)
   • Installing tomlkit (0.5.5)
   • Installing demo (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output().strip() == expected.strip()
@@ -402,11 +402,11 @@ def test_add_git_constraint_with_subdirectory(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing two (2.0.0 9cf87a2)
+
+Writing lock file
 """
     assert tester.io.fetch_output().strip() == expected.strip()
     assert tester.command.installer.executor.installations_count == 1
@@ -446,12 +446,12 @@ def test_add_git_ssh_constraint(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
   • Installing demo (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -493,12 +493,12 @@ def test_add_directory_constraint(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
   • Installing demo (0.1.2 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -534,12 +534,12 @@ def test_add_directory_with_poetry(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
   • Installing demo (0.1.2 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -566,12 +566,12 @@ def test_add_file_constraint_wheel(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
   • Installing demo (0.1.0 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -602,12 +602,12 @@ def test_add_file_constraint_sdist(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
   • Installing demo (0.1.0 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -642,12 +642,12 @@ def test_add_constraint_with_extras_option(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing msgpack-python (0.5.3)
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -682,13 +682,13 @@ def test_add_url_constraint_wheel(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   • Installing pendulum (1.4.4)
   • Installing demo\
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -724,8 +724,6 @@ def test_add_url_constraint_wheel_with_extras(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 4 installs, 0 updates, 0 removals
 
   • Installing cleo (0.6.5)
@@ -733,6 +731,8 @@ Package operations: 4 installs, 0 updates, 0 removals
   • Installing tomlkit (0.5.5)
   • Installing demo\
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+
+Writing lock file
 """
     # Order might be different, split into lines and compare the overall output.
     expected = set(expected.splitlines())
@@ -766,11 +766,11 @@ def test_add_constraint_with_python(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -804,11 +804,11 @@ def test_add_constraint_with_platform(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -855,11 +855,11 @@ def test_add_constraint_with_source(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -917,11 +917,11 @@ Using version ^0.2.0 for cachy
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -964,11 +964,11 @@ Using version ^0.2.0 for cachy
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert tester.io.fetch_error() == warning
@@ -995,11 +995,11 @@ Using version ^3.13 for pyyaml
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing pyyaml (3.13)
+
+Writing lock file
 """
 
     assert tester.io.fetch_output() == expected
@@ -1114,11 +1114,11 @@ Using version ^1.1.2 for foo
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing foo (1.1.2)
+
+Writing lock file
 """
 
     assert expected in tester.io.fetch_output()
@@ -1143,11 +1143,11 @@ Using version ^1.2.3b1 for foo
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing foo (1.2.3b1)
+
+Writing lock file
 """
     assert expected in tester.io.fetch_output()
 
@@ -1166,11 +1166,11 @@ Using version ^1.2.3 for foo
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   • Installing foo (1.2.3)
+
+Writing lock file
 """
 
     assert expected in tester.io.fetch_output()
@@ -1214,11 +1214,11 @@ Using version ^0.2.0 for cachy
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1247,11 +1247,11 @@ def test_add_equal_constraint_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.1.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1275,11 +1275,11 @@ def test_add_greater_constraint_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1311,12 +1311,12 @@ def test_add_constraint_with_extras_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing msgpack-python (0.5.3)
   - Installing cachy (0.1.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1345,12 +1345,12 @@ def test_add_constraint_dependencies_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing msgpack-python (0.5.3)
   - Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1374,12 +1374,12 @@ def test_add_git_constraint_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1409,12 +1409,12 @@ def test_add_git_constraint_with_poetry_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1441,14 +1441,14 @@ def test_add_git_constraint_with_extras_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 4 installs, 0 updates, 0 removals
 
   - Installing cleo (0.6.5)
   - Installing pendulum (1.4.4)
   - Installing tomlkit (0.5.5)
   - Installing demo (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1480,12 +1480,12 @@ def test_add_git_ssh_constraint_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 9cf87a2)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1522,12 +1522,12 @@ def test_add_directory_constraint_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1560,12 +1560,12 @@ def test_add_directory_with_poetry_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1593,12 +1593,12 @@ def test_add_file_constraint_wheel_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.0 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1631,12 +1631,12 @@ def test_add_file_constraint_sdist_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.0 {app.poetry.file.parent.joinpath(path).resolve().as_posix()})
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1673,12 +1673,12 @@ def test_add_constraint_with_extras_option_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing msgpack-python (0.5.3)
   - Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1715,13 +1715,13 @@ def test_add_url_constraint_wheel_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo\
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1758,8 +1758,6 @@ def test_add_url_constraint_wheel_with_extras_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 4 installs, 0 updates, 0 removals
 
   - Installing cleo (0.6.5)
@@ -1767,6 +1765,8 @@ Package operations: 4 installs, 0 updates, 0 removals
   - Installing tomlkit (0.5.5)
   - Installing demo\
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1802,11 +1802,11 @@ def test_add_constraint_with_python_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1842,11 +1842,11 @@ def test_add_constraint_with_platform_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1895,11 +1895,11 @@ def test_add_constraint_with_source_old_installer(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1961,11 +1961,11 @@ Using version ^0.2.0 for cachy
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.2.0)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -1995,11 +1995,11 @@ Using version ^3.13 for pyyaml
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing pyyaml (3.13)
+
+Writing lock file
 """
 
     assert old_tester.io.fetch_output() == expected
@@ -2060,11 +2060,11 @@ Using version ^1.1.2 for foo
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing foo (1.1.2)
+
+Writing lock file
 """
 
     assert expected in old_tester.io.fetch_output()
@@ -2092,11 +2092,11 @@ Using version ^1.2.3b1 for foo
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing foo (1.2.3b1)
+
+Writing lock file
 """
     assert expected in old_tester.io.fetch_output()
 
@@ -2118,11 +2118,11 @@ Using version ^1.2.3 for foo
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
-
 Package operations: 1 install, 0 updates, 0 removals
 
   - Installing foo (1.2.3)
+
+Writing lock file
 """
 
     assert expected in old_tester.io.fetch_output()

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -105,6 +105,7 @@ class Locker(BaseLocker):
         self._lock = lock_path / "poetry.lock"
         self._written_data = None
         self._locked = False
+        self._lock_data = None
         self._content_hash = self._get_content_hash()
 
     @property

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -2416,6 +2416,28 @@ def test_installer_can_handle_old_lock_files(
     assert installer.executor.installations_count == 8
 
 
+def test_installer_does_not_write_lock_file_when_installation_fails(
+    installer: Installer,
+    locker: Locker,
+    repo: Repository,
+    package: ProjectPackage,
+    mocker: MockerFixture,
+):
+    repo.add_package(get_package("A", "1.0"))
+    package.add_dependency(Factory.create_dependency("A", "~1.0"))
+
+    locker.locked(False)
+
+    mocker.patch("poetry.installation.installer.Installer._execute", return_value=1)
+    installer.run()
+
+    assert locker._lock_data is None
+
+    assert installer.executor.installations_count == 0
+    assert installer.executor.updates_count == 0
+    assert installer.executor.removals_count == 0
+
+
 @pytest.mark.parametrize("quiet", [True, False])
 def test_run_with_dependencies_quiet(
     installer: Installer,

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -2429,7 +2429,8 @@ def test_installer_does_not_write_lock_file_when_installation_fails(
     locker.locked(False)
 
     mocker.patch("poetry.installation.installer.Installer._execute", return_value=1)
-    installer.run()
+    result = installer.run()
+    assert result == 1  # error
 
     assert locker._lock_data is None
 

--- a/tests/installation/test_installer_old.py
+++ b/tests/installation/test_installer_old.py
@@ -62,6 +62,7 @@ class Locker(BaseLocker):
         self._lock = lock_path / "poetry.lock"
         self._written_data = None
         self._locked = False
+        self._lock_data = None
         self._content_hash = self._get_content_hash()
 
     @property


### PR DESCRIPTION
# Pull Request Check List

Resolves: #395 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## How it appear to users

The user experience is almost the same, but "Writing lock file" only appears in the end of the process, and only if the installation process succeeds.

### On success ("Writing lock file" displays after installation)
```console
$ poetry add jinja2      
Using version ^3.1.2 for jinja2

Updating dependencies
Resolving dependencies... (0.1s)

Package operations: 2 installs, 0 updates, 0 removals

  • Installing markupsafe (2.1.2)
  • Installing jinja2 (3.1.2)

Writing lock file
```

### On failure ("Writing lock file" is not displayed)
```console
$ poetry add pyaudio
Using version ^0.2.13 for pyaudio

Updating dependencies
Resolving dependencies... (0.1s)

Package operations: 1 install, 0 updates, 0 removals

  • Installing pyaudio (0.2.13): Failed

  ChefBuildError

  Backend subprocess exited when trying to invoke build_wheel

  ...bdist logs omitted for brevity...

Note: This error originates from the build backend, and is likely not a problem with poetry but with pyaudio (0.2.13) not supporting PEP 517 builds. You can verify this by running 'pip wheel --use-pep517 "pyaudio (==0.2.13)"'.

```