### PR TITLE
Error when invalid groups are referenced

### DIFF
--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -162,14 +162,6 @@ the `--only` option.
 poetry install --only docs
 ```
 
-{{% warning %}}
-
-Groups provided to `--with`, `--without`, and `--only` should at least be declared in `pyproject.toml`.
-Poetry will raise an **Error** if a group that is not declared is used, letting the user know of a
-potential mistake.
-
-{{% /warning %}}
-
 {{% note %}}
 If you only want to install the project's runtime dependencies, you can do so with the
 `--only main` notation:

--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -165,7 +165,7 @@ poetry install --only docs
 {{% warning %}}
 
 Groups provided to `--with`, `--without`, and `--only` should at least be declared in `pyproject.toml`.
-Poetry will display a **Warning** if a group that is not declared is used, letting the user know of a
+Poetry will raise an **Error** if a group that is not declared is used, letting the user know of a
 potential mistake.
 
 {{% /warning %}}

--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -162,8 +162,16 @@ the `--only` option.
 poetry install --only docs
 ```
 
+{{% warning %}}
+
+Groups provided to `--with`, `--without`, and `--only` should at least be declared in `pyproject.toml`.
+Poetry will display a **Warning** if a group that is not declared is used, letting the user know of a
+potential mistake.
+
+{{% /warning %}}
+
 {{% note %}}
-If you only want to install the project's runtime dependencies, you can do so  with the
+If you only want to install the project's runtime dependencies, you can do so with the
 `--only main` notation:
 
 ```bash

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -120,9 +120,7 @@ class GroupCommand(Command):
         invalid_options = defaultdict(set)
         for opt, groups in group_options.items():
             for group in groups:
-                try:
-                    self.poetry.package.dependency_group(group)
-                except ValueError:
+                if not self.poetry.package.has_dependency_group(group):
                     invalid_options[opt].add(group)
         if invalid_options:
             line_err = (

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -111,7 +111,7 @@ class GroupCommand(Command):
             list(self.activated_groups), only=True
         )
 
-    def _validate_group_options(self, group_options: dict[str, set[str]]) -> bool:
+    def _validate_group_options(self, group_options: dict[str, set[str]]) -> None:
         """
         Raises en error if it detects that a group is not part of pyproject.toml
         """
@@ -121,14 +121,12 @@ class GroupCommand(Command):
                 if not self.poetry.package.has_dependency_group(group):
                     invalid_options[group].add(opt)
         if invalid_options:
-            invalid_groups = sorted(invalid_options.keys())
-            error_msg = "Group(s) not found:"
-            for group in invalid_groups:
+            message_parts = []
+            for group in sorted(invalid_options):
                 opts = ", ".join(
                     f"<fg=yellow;options=bold>--{opt}</>"
                     for opt in sorted(invalid_options[group])
                 )
-                error_msg += f" {group} (via {opts}),"
-            error_msg = error_msg.rstrip(",")
-            raise GroupNotFound(error_msg)
+                message_parts.append(f"{group} (via {opts})")
+            raise GroupNotFound(f"Group(s) not found: {', '.join(message_parts)}")
         return len(invalid_options) == 0

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -129,4 +129,3 @@ class GroupCommand(Command):
                 )
                 message_parts.append(f"{group} (via {opts})")
             raise GroupNotFound(f"Group(s) not found: {', '.join(message_parts)}")
-        return len(invalid_options) == 0

--- a/src/poetry/console/exceptions.py
+++ b/src/poetry/console/exceptions.py
@@ -5,3 +5,7 @@ from cleo.exceptions import CleoError
 
 class PoetryConsoleError(CleoError):
     pass
+
+
+class GroupNotFound(PoetryConsoleError):
+    pass

--- a/src/poetry/exceptions.py
+++ b/src/poetry/exceptions.py
@@ -7,3 +7,7 @@ class PoetryException(Exception):
 
 class InvalidProjectFile(PoetryException):
     pass
+
+
+class GroupNotFound(PoetryException):
+    pass

--- a/src/poetry/exceptions.py
+++ b/src/poetry/exceptions.py
@@ -7,7 +7,3 @@ class PoetryException(Exception):
 
 class InvalidProjectFile(PoetryException):
     pass
-
-
-class GroupNotFound(PoetryException):
-    pass

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -257,6 +257,42 @@ def test_only_root_conflicts_with_without_only(
     )
 
 
+@pytest.mark.parametrize(
+    ("options", "valid_groups"),
+    [
+        ({"--with": MAIN_GROUP}, {MAIN_GROUP}),
+        ({"--with": "spam"}, set()),
+        ({"--with": "spam,foo"}, {"foo"}),
+        ({"--without": "spam"}, set()),
+        ({"--without": "spam,bar"}, {"bar"}),
+        ({"--with": "eggs,ham", "--without": "spam"}, set()),
+        ({"--with": "eggs,ham", "--without": "spam,baz"}, {"baz"}),
+        ({"--only": "spam"}, set()),
+        ({"--only": "bim"}, {"bim"}),
+        ({"--only": MAIN_GROUP}, {MAIN_GROUP}),
+    ],
+)
+def test_invalid_groups_with_without_only(
+    tester: CommandTester,
+    mocker: MockerFixture,
+    options: dict[str, str],
+    valid_groups: set[str],
+):
+    mocker.patch.object(tester.command.installer, "run", return_value=0)
+
+    cmd_args = " ".join(f"{flag} {groups}" for (flag, groups) in options.items())
+    tester.execute(cmd_args)
+
+    assert tester.status_code == 0
+
+    io_error = tester.io.fetch_error()
+    for opt, groups in options.items():
+        group_list = groups.split(",")
+        invalid_groups = ",".join(sorted(set(group_list) - valid_groups))
+        if invalid_groups:
+            assert f"Invalid {invalid_groups} provided to {opt}." in io_error
+
+
 def test_remove_untracked_outputs_deprecation_warning(
     tester: CommandTester,
     mocker: MockerFixture,

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -289,19 +291,15 @@ def test_invalid_groups_with_without_only(
         tester.execute(cmd_args)
         assert tester.status_code == 0
     else:
-        with pytest.raises(
-            GroupNotFound, match=r"^Group\(s\) \[.*] were not found."
-        ) as e:
+        with pytest.raises(GroupNotFound, match=r"^Group\(s\) not found:") as e:
             tester.execute(cmd_args)
         assert tester.status_code is None
         for opt, groups in options.items():
             group_list = groups.split(",")
-            invalid_groups = ", ".join(sorted(set(group_list) - valid_groups))
-            if invalid_groups:
+            invalid_groups = sorted(set(group_list) - valid_groups)
+            for group in invalid_groups:
                 assert (
-                    f"Invalid [{invalid_groups}] provided to"
-                    f" <fg=yellow;options=bold>{opt}</>."
-                    in str(e.value)
+                    re.search(rf"{group} \(via .*{opt}.*\)", str(e.value)) is not None
                 )
 
 

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -7,7 +7,7 @@ import pytest
 from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
 from poetry.core.packages.dependency_group import MAIN_GROUP
 
-from poetry.exceptions import GroupNotFound
+from poetry.console.exceptions import GroupNotFound
 
 
 if TYPE_CHECKING:
@@ -289,16 +289,20 @@ def test_invalid_groups_with_without_only(
         tester.execute(cmd_args)
         assert tester.status_code == 0
     else:
-        with pytest.raises(GroupNotFound, match=r"^Group\(s\) \[.*] were not found"):
+        with pytest.raises(
+            GroupNotFound, match=r"^Group\(s\) \[.*] were not found."
+        ) as e:
             tester.execute(cmd_args)
         assert tester.status_code is None
-
-    io_error = tester.io.fetch_error()
-    for opt, groups in options.items():
-        group_list = groups.split(",")
-        invalid_groups = ", ".join(sorted(set(group_list) - valid_groups))
-        if invalid_groups:
-            assert f"Invalid [{invalid_groups}] provided to {opt}." in io_error
+        for opt, groups in options.items():
+            group_list = groups.split(",")
+            invalid_groups = ", ".join(sorted(set(group_list) - valid_groups))
+            if invalid_groups:
+                assert (
+                    f"Invalid [{invalid_groups}] provided to"
+                    f" <fg=yellow;options=bold>{opt}</>."
+                    in str(e.value)
+                )
 
 
 def test_remove_untracked_outputs_deprecation_warning(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7303

**Edit (Apr 3rd 2023)**: Changed implementation from warning to an error.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This PR raises a new `GroupNotFound` error when groups that do not exist in `pyproject.toml` are used with `--with`, `--without`, and `--only` flags as indicated in #7303 to help the user encounter mistakes related to this early on (instead of silently proceeding as it does now).

**Edit (Apr 4th 2023)**: Latest Output Below

![latest_output](https://user-images.githubusercontent.com/3933065/229842581-d946feb2-745a-4756-9633-85b22591a124.png)
