### PR TITLE
Fix: Misconfiguration in ask dependency interactive

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -292,6 +292,11 @@ You can specify a package in the following forms:
             )
             question.set_validator(self._validate_package)
 
+            follow_up_question = self.create_question(
+                "\nAdd a package (leave blank to skip):"
+            )
+            follow_up_question.set_validator(self._validate_package)
+
             package = self.ask(question)
             while package:
                 constraint = self._parse_requirements([package])[0]
@@ -303,9 +308,7 @@ You can specify a package in the following forms:
                 ):
                     self.line(f"Adding <info>{package}</info>")
                     result.append(constraint)
-
-                    self.line("")
-                    package = self.ask(question)
+                    package = self.ask(follow_up_question)
                     continue
 
                 canonicalized_name = canonicalize_name(constraint["name"])
@@ -373,8 +376,7 @@ You can specify a package in the following forms:
                     result.append(constraint)
 
                 if self.io.is_interactive():
-                    self.line("")
-                    package = self.ask(question)
+                    package = self.ask(follow_up_question)
 
             return result
 

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -303,7 +303,9 @@ You can specify a package in the following forms:
                 ):
                     self.line(f"Adding <info>{package}</info>")
                     result.append(constraint)
-                    package = self.ask("\nAdd a package (leave blank to skip):")
+
+                    self.line("")
+                    package = self.ask(question)
                     continue
 
                 canonicalized_name = canonicalize_name(constraint["name"])
@@ -371,7 +373,8 @@ You can specify a package in the following forms:
                     result.append(constraint)
 
                 if self.io.is_interactive():
-                    package = self.ask("\nAdd a package (leave blank to skip):")
+                    self.line("")
+                    package = self.ask(question)
 
             return result
 

--- a/src/poetry/utils/dependency_specification.py
+++ b/src/poetry/utils/dependency_specification.py
@@ -114,7 +114,7 @@ def _parse_dependency_specification_simple(
     require: DependencySpec = {}
 
     if " " in pair:
-        name, version = pair.split(" ", 2)
+        name, version = pair.split(" ", 1)
         extras_m = re.search(r"\[([\w\d,-_]+)\]$", name)
         if extras_m:
             extras = [e.strip() for e in extras_m.group(1).split(",")]

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -595,9 +595,6 @@ pytest = "^3.6.0"
 def test_interactive_with_wrong_dependency_inputs(
     tester: CommandTester, repo: TestRepository
 ):
-    repo.add_package(get_package("pendulum", "2.0.0"))
-    repo.add_package(get_package("pytest", "3.6.0"))
-
     inputs = [
         "my-package",  # Package name
         "1.2.3",  # Version
@@ -608,9 +605,6 @@ def test_interactive_with_wrong_dependency_inputs(
         "",  # Interactive packages
         "foo 1.19.2",
         "pendulum 2.0.0 foo",  # Package name and constraint (invalid)
-        "pendulum 2.0.0",  # Package name and constraint (invalid)
-        "pendulum 2.0.0",  # Package name and constraint (invalid)
-        "pendulum 2.0.0",  # Package name and constraint (invalid)
         "pendulum@^2.0.0",  # Package name and constraint (valid)
         "",  # End package selection
         "",  # Interactive dev packages

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -606,6 +606,7 @@ def test_interactive_with_wrong_dependency_inputs(
         "MIT",  # License
         "^3.8",  # Python
         "",  # Interactive packages
+        "foo 1.19.2",
         "pendulum 2.0.0 foo",  # Package name and constraint (invalid)
         "pendulum 2.0.0",  # Package name and constraint (invalid)
         "pendulum 2.0.0",  # Package name and constraint (invalid)
@@ -633,6 +634,7 @@ packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
+foo = "1.19.2"
 pendulum = "^2.0.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Fixing a misunderstand of buitin str function: [maxsplit can return maxsplit+1 items](https://docs.python.org/3.8/library/stdtypes.html#str.split)

Resolves: #7567

---

Although, this alteration resolves the broken message reported, we'd be better to treat the string using regex and validating the received result.
