### PR TITLE
Fix certain hash miss matches in case of non weel installations

### DIFF
--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -154,8 +154,6 @@ class Chef:
             return path
 
     def _prepare_sdist(self, archive: Path, destination: Path) -> Path:
-        from poetry.core.packages.utils.link import Link
-
         suffix = archive.suffix
         context: Callable[
             [str], AbstractContextManager[zipfile.ZipFile | tarfile.TarFile]

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -86,8 +86,6 @@ class IsolatedEnv(BaseIsolatedEnv):
 
 
 class Chef:
-    tmp_dir_prefix = "poetry-chef-"
-
     def __init__(self, config: Config, env: Env, pool: RepositoryPool) -> None:
         self._env = env
         self._pool = pool
@@ -102,7 +100,7 @@ class Chef:
             return archive
 
         if archive.is_dir():
-            tmp_dir = tempfile.mkdtemp(prefix=self.tmp_dir_prefix)
+            tmp_dir = tempfile.mkdtemp(prefix="poetry-chef-")
             return self._prepare(archive, Path(tmp_dir), editable=editable)
 
         return self._prepare_sdist(archive, destination=output_dir)

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -199,7 +199,7 @@ class Chef:
     def _is_wheel(cls, archive: Path) -> bool:
         return archive.suffix == ".whl"
 
-    def get_cached_archive_for_link(self, link: Link, strict: bool) -> Path | None:
+    def get_cached_archive_for_link(self, link: Link, *, strict: bool) -> Path | None:
         archives = self.get_cached_archives_for_link(link)
         if not archives:
             return None

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -95,15 +95,17 @@ class Chef:
             Path(config.get("cache-dir")).expanduser().joinpath("artifacts")
         )
 
-    def prepare(self, archive: Path, *, editable: bool = False) -> Path:
+    def prepare(
+        self, archive: Path, output_dir: Path | None = None, *, editable: bool = False
+    ) -> Path:
         if not self._should_prepare(archive):
             return archive
 
-        tmp_dir = tempfile.mkdtemp(prefix=self.tmp_dir_prefix)
         if archive.is_dir():
+            tmp_dir = tempfile.mkdtemp(prefix=self.tmp_dir_prefix)
             return self._prepare(archive, Path(tmp_dir), editable=editable)
 
-        return self._prepare_sdist(archive, destination=Path(tmp_dir))
+        return self._prepare_sdist(archive, destination=output_dir)
 
     def _prepare(
         self, directory: Path, destination: Path, *, editable: bool = False
@@ -153,7 +155,9 @@ class Chef:
 
             return path
 
-    def _prepare_sdist(self, archive: Path, destination: Path) -> Path:
+    def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
+        from poetry.core.packages.utils.link import Link
+
         suffix = archive.suffix
         context: Callable[
             [str], AbstractContextManager[zipfile.ZipFile | tarfile.TarFile]
@@ -177,6 +181,9 @@ class Chef:
                 sdist_dir = archive_dir / archive.name.rstrip(suffix)
                 if not sdist_dir.is_dir():
                     sdist_dir = archive_dir
+
+            if destination is None:
+                destination = self.get_cache_directory_for_link(Link(archive.as_uri()))
 
             destination.mkdir(parents=True, exist_ok=True)
 

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -209,8 +209,7 @@ class Chef:
                 # prioritized archive type.
                 if link.filename == archive.name:
                     return archive
-                else:
-                    continue
+                continue
             if archive.suffix != ".whl":
                 candidates.append((float("inf"), archive))
                 continue

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -199,13 +199,20 @@ class Chef:
     def _is_wheel(cls, archive: Path) -> bool:
         return archive.suffix == ".whl"
 
-    def get_cached_archive_for_link(self, link: Link) -> Path | None:
+    def get_cached_archive_for_link(self, link: Link, strict: bool) -> Path | None:
         archives = self.get_cached_archives_for_link(link)
         if not archives:
             return None
 
         candidates: list[tuple[float | None, Path]] = []
         for archive in archives:
+            if strict:
+                # in strict mode return the original cached archive instead of the
+                # prioritized archive type.
+                if link.filename == archive.name:
+                    return archive
+                else:
+                    continue
             if archive.suffix != ".whl":
                 candidates.append((float("inf"), archive))
                 continue

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -740,7 +740,7 @@ class Executor:
         archive_hash: str = "sha256:" + get_file_hash(archive)
         known_hashes = {f["hash"] for f in package.files if f["file"] == archive.name}
 
-        if known_hashes and archive_hash not in known_hashes:
+        if archive_hash not in known_hashes:
             raise RuntimeError(
                 f"Hash for {package} from archive {archive.name} not found in"
                 f" known hashes (was: {archive_hash})"

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -697,7 +697,6 @@ class Executor:
     def _download_link(self, operation: Install | Update, link: Link) -> Path:
         package = operation.package
 
-        output_dir = self._chef.get_cache_directory_for_link(link)
         archive = self._chef.get_cached_archive_for_link(link)
         if archive is None:
             # No cached distributions was found, so we download and prepare it

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -729,14 +729,9 @@ class Executor:
 
         return archive
 
-    def _populate_hashes_dict(
-        self, archive: Path, package: Package, validate=True
-    ) -> None:
+    def _populate_hashes_dict(self, archive: Path, package: Package) -> None:
         if package.files and archive.name in {f["file"] for f in package.files}:
-            if validate:
-                archive_hash = self._validate_archive_hash(archive, package)
-            else:
-                archive_hash: str = "sha256:" + get_file_hash(archive)
+            archive_hash = self._validate_archive_hash(archive, package)
             self._hashes[package.name] = archive_hash
 
     @staticmethod

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -5,7 +5,6 @@ import csv
 import itertools
 import json
 import os
-import tempfile
 import threading
 
 from concurrent.futures import ThreadPoolExecutor
@@ -514,10 +513,6 @@ class Executor:
             archive = self._download_link(operation, Link(package.source_url))
         else:
             archive = self._download(operation)
-
-        tmp_path_prefix = str(Path(tempfile.gettempdir(), self._chef.tmp_dir_prefix))
-        if str(archive).startswith(tmp_path_prefix):
-            cleanup_archive = True
 
         operation_message = self.get_operation_message(operation)
         message = (

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -716,7 +716,7 @@ class Executor:
         # validate the original (downloaded or cached) archive only if we can. e.g. if
         # we use the cached wheel or the actual downloaded archive
         if package.files and link.filename == archive.name:
-            self._validate_archive_hash(archive, package)
+            self._populate_hashes_dict(archive, package)
 
         if archive.suffix != ".whl":
             message = (
@@ -726,11 +726,6 @@ class Executor:
             self._write(operation, message)
 
             archive = self._chef.prepare(archive, output_dir=output_dir)
-
-        elif link.is_wheel:
-            self._populate_hashes_dict(
-                archive, package, validate=False
-            )  # already validated
 
         return archive
 

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import tempfile
-
 from pathlib import Path
 from typing import TYPE_CHECKING
 from zipfile import ZipFile
@@ -142,10 +140,7 @@ def test_prepare_sdist(config: Config, config_cache_dir: Path) -> None:
 
     wheel = chef.prepare(archive)
 
-    assert wheel.parent != destination
-
-    tmp_file_prefix = str(Path(tempfile.gettempdir(), chef.tmp_dir_prefix))
-    assert str(wheel.parent).startswith(tmp_file_prefix)
+    assert wheel.parent == destination
     assert wheel.name == "demo-0.1.0-py3-none-any.whl"
 
 

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 from zipfile import ZipFile
@@ -140,7 +141,10 @@ def test_prepare_sdist(config: Config, config_cache_dir: Path) -> None:
 
     wheel = chef.prepare(archive)
 
-    assert wheel.parent == destination
+    assert wheel.parent != destination
+
+    tmp_file_prefix = str(Path(tempfile.gettempdir(), chef.tmp_dir_prefix))
+    assert str(wheel.parent).startswith(tmp_file_prefix)
     assert wheel.name == "demo-0.1.0-py3-none-any.whl"
 
 

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tempfile
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 from zipfile import ZipFile

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import tempfile
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 from zipfile import ZipFile
@@ -213,6 +216,10 @@ def test_prepare_directory(config: Config, config_cache_dir: Path):
 
     assert wheel.name == "simple_project-1.2.3-py2.py3-none-any.whl"
 
+    assert wheel.parent.parent == Path(tempfile.gettempdir())
+    # cleanup generated tmp dir artifact
+    os.unlink(wheel)
+
 
 def test_prepare_directory_with_extensions(
     config: Config, config_cache_dir: Path
@@ -228,7 +235,11 @@ def test_prepare_directory_with_extensions(
 
     wheel = chef.prepare(archive)
 
+    assert wheel.parent.parent == Path(tempfile.gettempdir())
     assert wheel.name == f"extended-0.1-{env.supported_tags[0]}.whl"
+
+    # cleanup generated tmp dir artifact
+    os.unlink(wheel)
 
 
 def test_prepare_directory_editable(config: Config, config_cache_dir: Path):
@@ -238,7 +249,11 @@ def test_prepare_directory_editable(config: Config, config_cache_dir: Path):
 
     wheel = chef.prepare(archive, editable=True)
 
+    assert wheel.parent.parent == Path(tempfile.gettempdir())
     assert wheel.name == "simple_project-1.2.3-py2.py3-none-any.whl"
 
     with ZipFile(wheel) as z:
         assert "simple_project.pth" in z.namelist()
+
+    # cleanup generated tmp dir artifact
+    os.unlink(wheel)

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -85,7 +85,7 @@ def test_get_not_found_cached_archive_for_link(
 
     archive = chef.get_cached_archive_for_link(Link(link), strict=strict)
 
-    assert None is archive
+    assert archive is None
 
 
 @pytest.mark.parametrize(

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -38,20 +38,80 @@ def setup(mocker: MockerFixture, pool: RepositoryPool) -> None:
 
 
 @pytest.mark.parametrize(
-    ("link", "cached"),
+    ("link", "strict", "available_packages"),
+    [
+        (
+            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            True,
+            [
+                Path("/cache/demo-0.1.0-py2.py3-none-any"),
+                Path("/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl"),
+                Path("/cache/demo-0.1.0-cp37-cp37-macosx_10_15_x86_64.whl"),
+            ],
+        ),
+        (
+            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            False,
+            [],
+        ),
+    ],
+)
+def test_get_not_found_cached_archive_for_link(
+    config: Config,
+    mocker: MockerFixture,
+    link: str,
+    strict: bool,
+    available_packages: list[Path],
+):
+    chef = Chef(
+        config,
+        MockEnv(
+            version_info=(3, 8, 3),
+            marker_env={"interpreter_name": "cpython", "interpreter_version": "3.8.3"},
+            supported_tags=[
+                Tag("cp38", "cp38", "macosx_10_15_x86_64"),
+                Tag("py3", "none", "any"),
+            ],
+        ),
+        Factory.create_pool(config),
+    )
+
+    mocker.patch.object(
+        chef, "get_cached_archives_for_link", return_value=available_packages
+    )
+
+    archive = chef.get_cached_archive_for_link(Link(link), strict=strict)
+
+    assert None is archive
+
+
+@pytest.mark.parametrize(
+    ("link", "cached", "strict"),
     [
         (
             "https://files.python-poetry.org/demo-0.1.0.tar.gz",
             "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            False,
         ),
         (
             "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
             "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            False,
+        ),
+        (
+            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            "/cache/demo-0.1.0.tar.gz",
+            True,
+        ),
+        (
+            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            True,
         ),
     ],
 )
-def test_get_cached_archive_for_link(
-    config: Config, mocker: MockerFixture, link: str, cached: str
+def test_get_found_cached_archive_for_link(
+    config: Config, mocker: MockerFixture, link: str, cached: str, strict: bool
 ):
     chef = Chef(
         config,
@@ -77,7 +137,7 @@ def test_get_cached_archive_for_link(
         ],
     )
 
-    archive = chef.get_cached_archive_for_link(Link(link))
+    archive = chef.get_cached_archive_for_link(Link(link), strict=strict)
 
     assert Path(cached) == archive
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -22,6 +22,7 @@ from cleo.io.buffered_io import BufferedIO
 from cleo.io.outputs.output import Verbosity
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
+from typing_extensions import Self
 
 from poetry.factory import Factory
 from poetry.installation.chef import Chef as BaseChef
@@ -801,7 +802,7 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
         link_cached = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
         original_func = Chef.get_cached_archive_for_link
 
-        def mock_get_cached_archive_for_link(self, link: Link, strict: bool):
+        def mock_get_cached_archive_for_link(self: Self, link: Link, strict: bool):
             if link.filename == "demo-0.1.0.tar.gz":
                 return link_cached
             else:
@@ -837,8 +838,6 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
         },
         "url": package.source_url,
     }
-    print(io.fetch_output())
-    print(io.fetch_error())
     verify_installed_distribution(tmp_venv, package, expected_url_reference)
 
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -840,18 +840,11 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
         cached_wheel = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
 
         def mock_get_cached_archive_for_link_func(_: Link, strict: bool):
-            if strict:
-                if is_sdist_artifact_cached:
-                    return cached_sdist
-                else:
-                    return None
-            else:
-                if is_wheel_cached:
-                    return cached_wheel
-                elif is_sdist_artifact_cached:
-                    return cached_sdist
-                else:
-                    return None
+            if is_wheel_cached and not strict:
+                return cached_wheel
+            if is_sdist_cached:
+                return cached_sdist
+            return None
 
         mocker.patch(
             "poetry.installation.chef.Chef.get_cached_archive_for_link",

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -803,7 +803,7 @@ def test_executor_should_write_pep610_url_references_for_wheel_urls(
 
 @pytest.mark.parametrize(
     (
-        "is_sdist_artifact_cached",
+        "is_sdist_cached",
         "is_wheel_cached",
         "expect_artifact_building",
         "expect_artifact_download",
@@ -823,7 +823,7 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
     mock_file_downloads: None,
     mocker: MockerFixture,
     fixture_dir: FixtureDirGetter,
-    is_sdist_artifact_cached: bool,
+    is_sdist_cached: bool,
     is_wheel_cached: bool,
     expect_artifact_building: bool,
     expect_artifact_download: bool,
@@ -835,7 +835,7 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
     )
     download_spy = mocker.spy(Executor, "_download_archive")
 
-    if is_sdist_artifact_cached | is_wheel_cached:
+    if is_sdist_cached | is_wheel_cached:
         cached_sdist = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
         cached_wheel = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -63,7 +63,7 @@ class Chef(BaseChef):
 
         self._sdist_wheels = wheels
 
-    def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
+    def _prepare_sdist(self, archive: Path, destination: Path) -> Path:
         if self._sdist_wheels is not None:
             wheel = self._sdist_wheels.pop(0)
             self._sdist_wheels.append(wheel)

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -651,13 +651,11 @@ def test_executor_should_write_pep610_url_references_for_wheel_files(
 
 
 def test_executor_should_write_pep610_url_references_for_non_wheel_files(
-        tmp_venv: VirtualEnv, pool: RepositoryPool, config: Config, io: BufferedIO
+    tmp_venv: VirtualEnv, pool: RepositoryPool, config: Config, io: BufferedIO
 ):
     url = (
         Path(__file__)
-        .parent.parent.joinpath(
-            "fixtures/distributions/demo-0.1.0.tar.gz"
-        )
+        .parent.parent.joinpath("fixtures/distributions/demo-0.1.0.tar.gz")
         .resolve()
     )
     package = Package("demo", "0.1.0", source_type="file", source_url=url.as_posix())
@@ -779,11 +777,11 @@ def test_executor_should_write_pep610_url_references_for_wheel_urls(
 
 
 def test_executor_should_not_write_pep610_url_references_for_non_wheel_urls(
-        tmp_venv: VirtualEnv,
-        pool: RepositoryPool,
-        config: Config,
-        io: BufferedIO,
-        mock_file_downloads: None,
+    tmp_venv: VirtualEnv,
+    pool: RepositoryPool,
+    config: Config,
+    io: BufferedIO,
+    mock_file_downloads: None,
 ):
     package = Package(
         "demo",

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -538,7 +538,7 @@ def test_executor_should_delete_incomplete_downloads(
     )
     mocker.patch(
         "poetry.installation.chef.Chef.get_cached_archive_for_link",
-        side_effect=lambda link: None,
+        side_effect=lambda link, strict: None,
     )
     mocker.patch(
         "poetry.installation.chef.Chef.get_cache_directory_for_link",
@@ -740,13 +740,23 @@ def test_executor_should_write_pep610_url_references_for_editable_directories(
     )
 
 
+@pytest.mark.parametrize("cached", [False, True])
 def test_executor_should_write_pep610_url_references_for_wheel_urls(
     tmp_venv: VirtualEnv,
     pool: RepositoryPool,
     config: Config,
     io: BufferedIO,
     mock_file_downloads: None,
+    mocker: MockerFixture,
+    fixture_dir: FixtureDirGetter,
+    cached: bool,
 ):
+    if cached:
+        link_cached = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
+        mocker.patch(
+            "poetry.installation.chef.Chef.get_cached_archive_for_link",
+            return_value=link_cached,
+        )
     package = Package(
         "demo",
         "0.1.0",
@@ -776,13 +786,23 @@ def test_executor_should_write_pep610_url_references_for_wheel_urls(
     verify_installed_distribution(tmp_venv, package, expected_url_reference)
 
 
-def test_executor_should_not_write_pep610_url_references_for_non_wheel_urls(
+@pytest.mark.parametrize("cached", [False, True])
+def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
     tmp_venv: VirtualEnv,
     pool: RepositoryPool,
     config: Config,
     io: BufferedIO,
     mock_file_downloads: None,
+    mocker: MockerFixture,
+    fixture_dir: FixtureDirGetter,
+    cached: bool,
 ):
+    if cached:
+        link_cached = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
+        mocker.patch(
+            "poetry.installation.chef.Chef.get_cached_archive_for_link",
+            return_value=link_cached,
+        )
     package = Package(
         "demo",
         "0.1.0",

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -22,7 +22,6 @@ from cleo.io.buffered_io import BufferedIO
 from cleo.io.outputs.output import Verbosity
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
-from typing_extensions import Self
 
 from poetry.factory import Factory
 from poetry.installation.chef import Chef as BaseChef
@@ -41,6 +40,7 @@ if TYPE_CHECKING:
 
     from httpretty.core import HTTPrettyRequest
     from pytest_mock import MockerFixture
+    from typing_extensions import Self
 
     from poetry.config.config import Config
     from poetry.installation.operations.operation import Operation

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -799,9 +799,17 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
 ):
     if cached:
         link_cached = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
+        original_func = Chef.get_cached_archive_for_link
+
+        def mock_get_cached_archive_for_link(self, link: Link, strict: bool):
+            if link.filename == "demo-0.1.0.tar.gz":
+                return link_cached
+            else:
+                return original_func(self, link, strict)
+
         mocker.patch(
             "poetry.installation.chef.Chef.get_cached_archive_for_link",
-            return_value=link_cached,
+            new=mock_get_cached_archive_for_link,
         )
     package = Package(
         "demo",
@@ -829,6 +837,8 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
         },
         "url": package.source_url,
     }
+    print(io.fetch_output())
+    print(io.fetch_error())
     verify_installed_distribution(tmp_venv, package, expected_url_reference)
 
 


### PR DESCRIPTION
## Addressed Issue:

1. Have a a package which provides both wheel and non wheel archives (like a `tar.gz`)
2. Force the use of the non wheel archive during installation:
```bash
export POETRY_INSTALLER_NO_BINARY=dagster-docker; poetry install dagster-docker
```
3. Get error like this:
```bash
 RuntimeError

  Hash for dagster-docker (0.17.20) from archive dagster_docker-0.17.20-py3-none-any.whl not found in known hashes (was: sha256:f0369c37d4328bd140c727494f65b88c49df0999c1981912bc68274e8412d793)
```

~~This is due to the original wheel archive from the registry being overwritten in the poetry artifact cache by the newly created wheel archive from the sdist `tar.gz` archive. The new wheel archive though has minimal changes (bdist version etc.) and causes the sha265 hash miss match.~~ (Overwrite does not happen but the wrong hash is checked. See [comment](https://github.com/python-poetry/poetry/pull/7594#issuecomment-1454792582) )

## Changes to fix the issue:

- ~~Adjusted Chef.prepare() to always write to a temporary directory. Otherwise we would overwrite an already existing cached wheel. This could then make the installation fail due to miss matched hashes.~~
- ~~Changed Executor._download_link() to validate package hashes via _populate_hashes_dict before building a new wheel in case we use a non wheel archive.~~

~~This eliminates the caching of the built wheel for non wheel archives but i did not see an easy way to keep this caching and fix the issue.  Do you think this will impact performance in a meaningfull way ?~~

## Pull Request Check List

Resolves: Unclear - I have not created a specific issue for my problem but it could address some issues related to hash miss matches.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
