### PR TITLE
feat: cache url dependencies during dependency resolution

### DIFF
--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -80,6 +80,7 @@ class Installer:
             installed = self._get_installed()
 
         self._installed_repository = installed
+        self._disable_cache = disable_cache
 
     @property
     def executor(self) -> Executor:
@@ -209,6 +210,7 @@ class Installer:
             locked_repository.packages,
             locked_repository.packages,
             self._io,
+            self._disable_cache,
         )
 
         # Always re-solve directory dependencies, otherwise we can't determine
@@ -255,6 +257,7 @@ class Installer:
                 self._installed_repository.packages,
                 locked_repository.packages,
                 self._io,
+                self._disable_cache,
             )
 
             with solver.provider.use_source_root(
@@ -327,6 +330,7 @@ class Installer:
             self._installed_repository.packages,
             locked_repository.packages,
             NullIO(),
+            self._disable_cache,
         )
         # Everything is resolved at this point, so we no longer need
         # to load deferred dependencies (i.e. VCS, URL and path dependencies)

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -43,6 +43,7 @@ class Solver:
         installed: list[Package],
         locked: list[Package],
         io: IO,
+        disable_cache: bool = False,
     ) -> None:
         self._package = package
         self._pool = pool
@@ -51,7 +52,12 @@ class Solver:
         self._io = io
 
         self._provider = Provider(
-            self._package, self._pool, self._io, installed=installed, locked=locked
+            self._package,
+            self._pool,
+            self._io,
+            installed=installed,
+            locked=locked,
+            disable_cache=disable_cache,
         )
         self._overrides: list[dict[DependencyPackage, dict[str, Dependency]]] = []
 

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -118,7 +118,7 @@ def test_application_verify_cache_flag_at_install(
 
     tester.execute(command)
 
-    assert spy.call_count == 2
+    assert spy.call_count == 3
     for call in spy.mock_calls:
         (name, args, kwargs) = call
         assert "disable_cache" in kwargs

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -126,7 +126,7 @@ def mock_clone(
     return MockDulwichRepo(dest)
 
 
-def mock_download(url: str, dest: Path) -> None:
+def mock_download(url: str, dest: Path, **kwargs: Any) -> None:
     parts = urllib.parse.urlparse(url)
 
     fixtures = Path(__file__).parent / "fixtures"


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2415

This PR exploits the already existing `Authenticator` object with file-cache functionalities to create a dedicated `url` cache for URL dependencies. Such cache is used at dependency resolution time.

Note how the solution isn't still perfect, as there's an extra file transfer performed by Poetry from the cached file to a temporary directory. Still, by setting an appropriate `chunk_size` the performance improvement is extremely visible even with huge dependencies (dear PyTorch) where the "download' goes from minutes to a few seconds.

Also, there's quite a `disable_cache` forwarding around the codebase to make sure that the Authenticator's cache is disabled upon user request.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code. -> Might need support for it. Also there's currently no tests for URL dependencies in `test_provider.py`, while there are tests for most other kinds (git, file, ..)
- ~[ ] Updated **documentation** for changed code.~ Not needed IMO
