### PR TITLE
poetry run: deprecate uninstalled entry points

### DIFF
--- a/src/poetry/console/commands/run.py
+++ b/src/poetry/console/commands/run.py
@@ -63,6 +63,9 @@ class RunCommand(EnvCommand):
             if script_path.exists():
                 args = [str(script_path), *args[1:]]
                 break
+        else:
+            # If reach this point, the script is not installed
+            self._warning_not_installed_script(args[0])
 
         if isinstance(script, dict):
             script = script["callable"]
@@ -81,3 +84,27 @@ class RunCommand(EnvCommand):
         ]
 
         return self.env.execute(*cmd)
+
+    def _warning_not_installed_script(self, script: str) -> None:
+        self.line_error(
+            (
+                f"Warning: '{script}' is an entry point defined in pyproject.toml,"
+                " but it's not installed as a script."
+                " You may get improper `sys.argv[0]`."
+            ),
+            style="warning",
+        )
+        self.line_error("")
+        self.line_error(
+            (
+                "The support to run uninstalled scripts "
+                "will be removed in a future release."
+            ),
+            style="warning",
+        )
+        self.line_error("")
+        self.line_error(
+            "Run `poetry install` to resolve and get rid of this message.",
+            style="warning",
+        )
+        self.line_error("")

--- a/src/poetry/console/commands/run.py
+++ b/src/poetry/console/commands/run.py
@@ -64,7 +64,7 @@ class RunCommand(EnvCommand):
                 args = [str(script_path), *args[1:]]
                 break
         else:
-            # If reach this point, the script is not installed
+            # If we reach this point, the script is not installed
             self._warning_not_installed_script(args[0])
 
         if isinstance(script, dict):

--- a/src/poetry/console/commands/run.py
+++ b/src/poetry/console/commands/run.py
@@ -86,25 +86,12 @@ class RunCommand(EnvCommand):
         return self.env.execute(*cmd)
 
     def _warning_not_installed_script(self, script: str) -> None:
-        self.line_error(
-            (
-                f"Warning: '{script}' is an entry point defined in pyproject.toml,"
-                " but it's not installed as a script."
-                " You may get improper `sys.argv[0]`."
-            ),
-            style="warning",
-        )
-        self.line_error("")
-        self.line_error(
-            (
-                "The support to run uninstalled scripts "
-                "will be removed in a future release."
-            ),
-            style="warning",
-        )
-        self.line_error("")
-        self.line_error(
-            "Run `poetry install` to resolve and get rid of this message.",
-            style="warning",
-        )
-        self.line_error("")
+        message = f"""\
+Warning: '{script}' is an entry point defined in pyproject.toml, but it's not \
+installed as a script. You may get improper `sys.argv[0]`.
+
+The support to run uninstalled scripts will be removed in a future release.
+
+Run `poetry install` to resolve and get rid of this message.
+"""
+        self.line_error(message, style="warning")

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -171,12 +171,15 @@ def test_run_script_sys_argv0(
         environment=tmp_venv,
     )
     assert install_tester.execute() == 0
-    if not installed_script:
-        for path in tmp_venv.script_dirs[0].glob("check-argv0*"):
+
+    script = "check-argv0"
+    if installed_script:
+        script = tmp_venv.script_dirs[0] / script
+    else:
+        for path in tmp_venv.script_dirs[0].glob(script + "*"):
             path.unlink()
 
     tester = command_tester_factory(
         "run", poetry=poetry_with_scripts, environment=tmp_venv
     )
-    argv1 = "absolute" if installed_script else "relative"
-    assert tester.execute(f"check-argv0 {argv1}") == 0
+    assert tester.execute(f"check-argv0 {script}") == 0

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -183,3 +183,15 @@ def test_run_script_sys_argv0(
         "run", poetry=poetry_with_scripts, environment=tmp_venv
     )
     assert tester.execute(f"check-argv0 {script}") == 0
+
+    if not installed_script:
+        expected_message = """\
+Warning: 'check-argv0' is an entry point defined in pyproject.toml, but it's not \
+installed as a script. You may get improper `sys.argv[0]`.
+
+The support to run uninstalled scripts will be removed in a future release.
+
+Run `poetry install` to resolve and get rid of this message.
+
+"""
+        assert tester.io.fetch_error() == expected_message

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -181,7 +181,9 @@ def test_run_script_sys_argv0(
     argv1 = "absolute" if installed_script else "relative"
     assert tester.execute(f"check-argv0 {argv1}") == 0
 
-    if not installed_script:
+    if installed_script:
+        expected_message = ""
+    else:
         expected_message = """\
 Warning: 'check-argv0' is an entry point defined in pyproject.toml, but it's not \
 installed as a script. You may get improper `sys.argv[0]`.
@@ -191,4 +193,4 @@ The support to run uninstalled scripts will be removed in a future release.
 Run `poetry install` to resolve and get rid of this message.
 
 """
-        assert tester.io.fetch_error() == expected_message
+    assert tester.io.fetch_error() == expected_message

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -171,18 +171,15 @@ def test_run_script_sys_argv0(
         environment=tmp_venv,
     )
     assert install_tester.execute() == 0
-
-    script = "check-argv0"
-    if installed_script:
-        script = tmp_venv.script_dirs[0] / script
-    else:
-        for path in tmp_venv.script_dirs[0].glob(script + "*"):
+    if not installed_script:
+        for path in tmp_venv.script_dirs[0].glob("check-argv0*"):
             path.unlink()
 
     tester = command_tester_factory(
         "run", poetry=poetry_with_scripts, environment=tmp_venv
     )
-    assert tester.execute(f"check-argv0 {script}") == 0
+    argv1 = "absolute" if installed_script else "relative"
+    assert tester.execute(f"check-argv0 {argv1}") == 0
 
     if not installed_script:
         expected_message = """\

--- a/tests/fixtures/scripts/scripts/check_argv0.py
+++ b/tests/fixtures/scripts/scripts/check_argv0.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 def main() -> int:
     path = Path(sys.argv[0])
-    if sys.argv[0] == sys.argv[1]:
-        if path.is_absolute() and not path.exists():
+    if sys.argv[1] == "absolute":
+        if not path.is_absolute():
+            raise RuntimeError(f"sys.argv[0] is not an absolute path: {path}")
+        if not path.exists():
             raise RuntimeError(f"sys.argv[0] does not exist: {path}")
     else:
-        raise RuntimeError(
-            f"unexpected sys.argv[0]: '{sys.argv[0]}', should be '{sys.argv[1]}'"
-        )
+        if path.is_absolute():
+            raise RuntimeError(f"sys.argv[0] is an absolute path: {path}")
 
     return 0
 

--- a/tests/fixtures/scripts/scripts/check_argv0.py
+++ b/tests/fixtures/scripts/scripts/check_argv0.py
@@ -7,14 +7,13 @@ from pathlib import Path
 
 def main() -> int:
     path = Path(sys.argv[0])
-    if sys.argv[1] == "absolute":
-        if not path.is_absolute():
-            raise RuntimeError(f"sys.argv[0] is not an absolute path: {path}")
-        if not path.exists():
+    if sys.argv[0] == sys.argv[1]:
+        if path.is_absolute() and not path.exists():
             raise RuntimeError(f"sys.argv[0] does not exist: {path}")
     else:
-        if path.is_absolute():
-            raise RuntimeError(f"sys.argv[0] is an absolute path: {path}")
+        raise RuntimeError(
+            f"unexpected sys.argv[0]: '{sys.argv[0]}', should be '{sys.argv[1]}'"
+        )
 
     return 0
 


### PR DESCRIPTION
# Pull Request Check List
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Deprecating `poetry run` to execute uninstalled entry points.

Say I have the following entry point:
```toml
[tool.poetry.scripts]
dev = "my_package.main:run"
```

If I run `poetry run dev`, the `sys.argv[0]` is unpredictable and is confusing users:
- `sys.argv = ['dev']` if script is not installed.
- `sys.argv = ['/home/wagner/.cache/pypoetry/virtualenvs/my_package-Iqs9p7vq-py3.7/bin/dev']` if script is installed.

Refer to discussion #7599, to understand more of why this deprecation is important.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

### Sample output

![image](https://user-images.githubusercontent.com/428341/222963168-21e5726b-08ca-4e00-aca6-a76e5146aecf.png)
