### PR TITLE
docs:mention enabled venv in virtualenvs.create configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -280,8 +280,8 @@ Use parallel execution when using the new (`>=1.1.0`) installer.
 Create a new virtual environment if one doesn't already exist.
 
 If set to `false`, Poetry will not create a new virtual environment. If it detects a virtual environment
-in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` it will install dependencies into them, otherwise it will install
-dependencies into the systems python environment.
+in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` or in `VIRTUAL_ENV` it will install dependencies
+into them, otherwise it will install dependencies into the systems python environment.
 
 {{% note %}}
 If Poetry detects it's running within an activated virtual environment, it will never create a new virtual environment,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,8 +279,8 @@ Use parallel execution when using the new (`>=1.1.0`) installer.
 
 Create a new virtual environment if one doesn't already exist.
 
-If set to `false`, Poetry will not create a new virtual environment. If it detects already enabled virtual 
-environment or existing one in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` it will 
+If set to `false`, Poetry will not create a new virtual environment. If it detects already enabled virtual
+environment or existing one in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` it will
 install dependencies into them, otherwise it will install dependencies into the systems python environment.
 
 {{% note %}}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -280,7 +280,7 @@ Use parallel execution when using the new (`>=1.1.0`) installer.
 Create a new virtual environment if one doesn't already exist.
 
 If set to `false`, Poetry will not create a new virtual environment. If it detects already enabled virtual
-environment or existing one in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` it will
+environment or an existing one in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` it will
 install dependencies into them, otherwise it will install dependencies into the systems python environment.
 
 {{% note %}}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,9 +279,9 @@ Use parallel execution when using the new (`>=1.1.0`) installer.
 
 Create a new virtual environment if one doesn't already exist.
 
-If set to `false`, Poetry will not create a new virtual environment. If it detects a virtual environment
-in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` or in `VIRTUAL_ENV` it will install dependencies
-into them, otherwise it will install dependencies into the systems python environment.
+If set to `false`, Poetry will not create a new virtual environment. If it detects already enabled virtual 
+environment or existing one in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` it will 
+install dependencies into them, otherwise it will install dependencies into the systems python environment.
 
 {{% note %}}
 If Poetry detects it's running within an activated virtual environment, it will never create a new virtual environment,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,7 +279,7 @@ Use parallel execution when using the new (`>=1.1.0`) installer.
 
 Create a new virtual environment if one doesn't already exist.
 
-If set to `false`, Poetry will not create a new virtual environment. If it detects already enabled virtual
+If set to `false`, Poetry will not create a new virtual environment. If it detects an already enabled virtual
 environment or an existing one in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` it will
 install dependencies into them, otherwise it will install dependencies into the systems python environment.
 


### PR DESCRIPTION
## Issue
[Docs](https://python-poetry.org/docs/configuration/#virtualenvscreate) do not mention that if you have `VIRTUAL_ENV` set with path to venv created inside (if path does not have venv direcotries there poetry simply ignores that variable), poetry will install packages into it. Documentation only mentions that it will detect venvs found in `{cache-dir}/virtualenvs` or `{project-dir}/.venv` and then fallback to systems python environment . Change that detects venv by variable is mentioned in [0.12.4](https://github.com/python-poetry/poetry/releases/tag/0.12.4) - 2018-10-21. 

Reason to mention that is to be aware that it is possible to install all packages in custom directory using environment variable. I use it myself to install dependencies in one stage of docker build and then copy them to another stage. 

### Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
