### PR TITLE
refactor: extract cache utilities

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -213,6 +213,10 @@ class Config:
         return Path(self.get("cache-dir")) / "cache" / "repositories"
 
     @property
+    def artifacts_cache_directory(self) -> Path:
+        return Path(self.get("cache-dir")) / "artifacts"
+
+    @property
     def virtualenvs_path(self) -> Path:
         path = self.get("virtualenvs.path")
         if path is None:

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -210,11 +210,11 @@ class Config:
 
     @property
     def repository_cache_directory(self) -> Path:
-        return Path(self.get("cache-dir")) / "cache" / "repositories"
+        return Path(self.get("cache-dir")).expanduser() / "cache" / "repositories"
 
     @property
     def artifacts_cache_directory(self) -> Path:
-        return Path(self.get("cache-dir")) / "artifacts"
+        return Path(self.get("cache-dir")).expanduser() / "artifacts"
 
     @property
     def virtualenvs_path(self) -> Path:

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 import tarfile
 import tempfile
 import zipfile
@@ -19,15 +17,12 @@ from build.env import IsolatedEnv as BaseIsolatedEnv
 from poetry.core.utils.helpers import temporary_directory
 from pyproject_hooks import quiet_subprocess_runner  # type: ignore[import]
 
-from poetry.installation.chooser import InvalidWheelName
-from poetry.installation.chooser import Wheel
+from poetry.utils.cache import get_cache_directory_for_link
 from poetry.utils.env import ephemeral_environment
 
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
-
-    from poetry.core.packages.utils.link import Link
 
     from poetry.config.config import Config
     from poetry.repositories import RepositoryPool
@@ -89,9 +84,7 @@ class Chef:
     def __init__(self, config: Config, env: Env, pool: RepositoryPool) -> None:
         self._env = env
         self._pool = pool
-        self._cache_dir = (
-            Path(config.get("cache-dir")).expanduser().joinpath("artifacts")
-        )
+        self._cache_dir = config.artifacts_cache_directory
 
     def prepare(
         self, archive: Path, output_dir: Path | None = None, *, editable: bool = False
@@ -181,7 +174,9 @@ class Chef:
                     sdist_dir = archive_dir
 
             if destination is None:
-                destination = self.get_cache_directory_for_link(Link(archive.as_uri()))
+                destination = get_cache_directory_for_link(
+                    self._cache_dir, Link(archive.as_uri())
+                )
 
             destination.mkdir(parents=True, exist_ok=True)
 
@@ -196,72 +191,3 @@ class Chef:
     @classmethod
     def _is_wheel(cls, archive: Path) -> bool:
         return archive.suffix == ".whl"
-
-    def get_cached_archive_for_link(self, link: Link, *, strict: bool) -> Path | None:
-        archives = self.get_cached_archives_for_link(link)
-        if not archives:
-            return None
-
-        candidates: list[tuple[float | None, Path]] = []
-        for archive in archives:
-            if strict:
-                # in strict mode return the original cached archive instead of the
-                # prioritized archive type.
-                if link.filename == archive.name:
-                    return archive
-                continue
-            if archive.suffix != ".whl":
-                candidates.append((float("inf"), archive))
-                continue
-
-            try:
-                wheel = Wheel(archive.name)
-            except InvalidWheelName:
-                continue
-
-            if not wheel.is_supported_by_environment(self._env):
-                continue
-
-            candidates.append(
-                (wheel.get_minimum_supported_index(self._env.supported_tags), archive),
-            )
-
-        if not candidates:
-            return None
-
-        return min(candidates)[1]
-
-    def get_cached_archives_for_link(self, link: Link) -> list[Path]:
-        cache_dir = self.get_cache_directory_for_link(link)
-
-        archive_types = ["whl", "tar.gz", "tar.bz2", "bz2", "zip"]
-        paths = []
-        for archive_type in archive_types:
-            for archive in cache_dir.glob(f"*.{archive_type}"):
-                paths.append(Path(archive))
-
-        return paths
-
-    def get_cache_directory_for_link(self, link: Link) -> Path:
-        key_parts = {"url": link.url_without_fragment}
-
-        if link.hash_name is not None and link.hash is not None:
-            key_parts[link.hash_name] = link.hash
-
-        if link.subdirectory_fragment:
-            key_parts["subdirectory"] = link.subdirectory_fragment
-
-        key_parts["interpreter_name"] = self._env.marker_env["interpreter_name"]
-        key_parts["interpreter_version"] = "".join(
-            self._env.marker_env["interpreter_version"].split(".")[:2]
-        )
-
-        key = hashlib.sha256(
-            json.dumps(
-                key_parts, sort_keys=True, separators=(",", ":"), ensure_ascii=True
-            ).encode("ascii")
-        ).hexdigest()
-
-        split_key = [key[:2], key[2:4], key[4:6], key[6:]]
-
-        return self._cache_dir.joinpath(*split_key)

--- a/src/poetry/installation/chooser.py
+++ b/src/poetry/installation/chooser.py
@@ -6,11 +6,9 @@ import re
 from typing import TYPE_CHECKING
 from typing import Any
 
-from packaging.tags import Tag
-
 from poetry.config.config import Config
 from poetry.config.config import PackageFilterPolicy
-from poetry.utils.patterns import wheel_file_re
+from poetry.utils.wheel import Wheel
 
 
 if TYPE_CHECKING:
@@ -23,37 +21,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-class InvalidWheelName(Exception):
-    pass
-
-
-class Wheel:
-    def __init__(self, filename: str) -> None:
-        wheel_info = wheel_file_re.match(filename)
-        if not wheel_info:
-            raise InvalidWheelName(f"{filename} is not a valid wheel filename.")
-
-        self.filename = filename
-        self.name = wheel_info.group("name").replace("_", "-")
-        self.version = wheel_info.group("ver").replace("_", "-")
-        self.build_tag = wheel_info.group("build")
-        self.pyversions = wheel_info.group("pyver").split(".")
-        self.abis = wheel_info.group("abi").split(".")
-        self.plats = wheel_info.group("plat").split(".")
-
-        self.tags = {
-            Tag(x, y, z) for x in self.pyversions for y in self.abis for z in self.plats
-        }
-
-    def get_minimum_supported_index(self, tags: list[Tag]) -> int | None:
-        indexes = [tags.index(t) for t in self.tags if t in tags]
-
-        return min(indexes) if indexes else None
-
-    def is_supported_by_environment(self, env: Env) -> bool:
-        return bool(set(env.supported_tags).intersection(self.tags))
 
 
 class Chooser:

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -27,8 +27,7 @@ from poetry.installation.wheel_installer import WheelInstaller
 from poetry.puzzle.exceptions import SolverProblemError
 from poetry.utils._compat import decode
 from poetry.utils.authenticator import Authenticator
-from poetry.utils.cache import get_cache_directory_for_link
-from poetry.utils.cache import get_cached_archive_for_link
+from poetry.utils.cache import ArtifactCache
 from poetry.utils.env import EnvCommandError
 from poetry.utils.helpers import atomic_open
 from poetry.utils.helpers import get_file_hash
@@ -79,12 +78,12 @@ class Executor:
         else:
             self._max_workers = 1
 
+        self._artifact_cache = ArtifactCache(cache_dir=config.artifacts_cache_directory)
         self._authenticator = Authenticator(
             config, self._io, disable_cache=disable_cache, pool_size=self._max_workers
         )
-        self._chef = Chef(config, self._env, pool)
+        self._chef = Chef(self._artifact_cache, self._env, pool)
         self._chooser = Chooser(pool, self._env, config)
-        self._artifacts_cache_dir = config.artifacts_cache_directory
 
         self._executor = ThreadPoolExecutor(max_workers=self._max_workers)
         self._total_operations = 0
@@ -712,18 +711,18 @@ class Executor:
     def _download_link(self, operation: Install | Update, link: Link) -> Path:
         package = operation.package
 
-        output_dir = get_cache_directory_for_link(self._artifacts_cache_dir, link)
+        output_dir = self._artifact_cache.get_cache_directory_for_link(link)
         # Try to get cached original package for the link provided
-        original_archive = get_cached_archive_for_link(
-            self._env, self._artifacts_cache_dir, link, strict=True
+        original_archive = self._artifact_cache.get_cached_archive_for_link(
+            link, strict=True
         )
         if original_archive is None:
             # No cached original distributions was found, so we download and prepare it
             try:
                 original_archive = self._download_archive(operation, link)
             except BaseException:
-                cache_directory = get_cache_directory_for_link(
-                    self._artifacts_cache_dir, link
+                cache_directory = self._artifact_cache.get_cache_directory_for_link(
+                    link
                 )
                 cached_file = cache_directory.joinpath(link.filename)
                 # We can't use unlink(missing_ok=True) because it's not available
@@ -735,8 +734,10 @@ class Executor:
 
         # Get potential higher prioritized cached archive, otherwise it will fall back
         # to the original archive.
-        archive = get_cached_archive_for_link(
-            self._env, self._artifacts_cache_dir, link, strict=False
+        archive = self._artifact_cache.get_cached_archive_for_link(
+            link,
+            strict=False,
+            env=self._env,
         )
         # 'archive' can at this point never be None. Since we previously downloaded
         # an archive, we now should have something cached that we can use here
@@ -802,8 +803,7 @@ class Executor:
 
         done = 0
         archive = (
-            get_cache_directory_for_link(self._artifacts_cache_dir, link)
-            / link.filename
+            self._artifact_cache.get_cache_directory_for_link(link) / link.filename
         )
         archive.parent.mkdir(parents=True, exist_ok=True)
         with atomic_open(archive) as f:

--- a/src/poetry/utils/wheel.py
+++ b/src/poetry/utils/wheel.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+
+from typing import TYPE_CHECKING
+
+from packaging.tags import Tag
+
+from poetry.utils.patterns import wheel_file_re
+
+
+if TYPE_CHECKING:
+    from poetry.utils.env import Env
+
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidWheelName(Exception):
+    pass
+
+
+class Wheel:
+    def __init__(self, filename: str) -> None:
+        wheel_info = wheel_file_re.match(filename)
+        if not wheel_info:
+            raise InvalidWheelName(f"{filename} is not a valid wheel filename.")
+
+        self.filename = filename
+        self.name = wheel_info.group("name").replace("_", "-")
+        self.version = wheel_info.group("ver").replace("_", "-")
+        self.build_tag = wheel_info.group("build")
+        self.pyversions = wheel_info.group("pyver").split(".")
+        self.abis = wheel_info.group("abi").split(".")
+        self.plats = wheel_info.group("plat").split(".")
+
+        self.tags = {
+            Tag(x, y, z) for x in self.pyversions for y in self.abis for z in self.plats
+        }
+
+    def get_minimum_supported_index(self, tags: list[Tag]) -> int | None:
+        indexes = [tags.index(t) for t in self.tags if t in tags]
+
+        return min(indexes) if indexes else None
+
+    def is_supported_by_environment(self, env: Env) -> bool:
+        return bool(set(env.supported_tags).intersection(self.tags))

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -40,7 +40,7 @@ def setup(mocker: MockerFixture, pool: RepositoryPool) -> None:
     mocker.patch.object(Factory, "create_pool", return_value=pool)
 
 
-@pytest.fixture()
+@pytest.fixture
 def artifact_cache(config: Config) -> ArtifactCache:
     return ArtifactCache(cache_dir=config.artifacts_cache_directory)
 

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -9,14 +9,13 @@ from zipfile import ZipFile
 
 import pytest
 
-from packaging.tags import Tag
 from poetry.core.packages.utils.link import Link
 
 from poetry.factory import Factory
 from poetry.installation.chef import Chef
 from poetry.repositories import RepositoryPool
+from poetry.utils.cache import get_cache_directory_for_link
 from poetry.utils.env import EnvManager
-from poetry.utils.env import MockEnv
 from tests.repositories.test_pypi_repository import MockRepository
 
 
@@ -40,156 +39,6 @@ def setup(mocker: MockerFixture, pool: RepositoryPool) -> None:
     mocker.patch.object(Factory, "create_pool", return_value=pool)
 
 
-@pytest.mark.parametrize(
-    ("link", "strict", "available_packages"),
-    [
-        (
-            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
-            True,
-            [
-                Path("/cache/demo-0.1.0-py2.py3-none-any"),
-                Path("/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl"),
-                Path("/cache/demo-0.1.0-cp37-cp37-macosx_10_15_x86_64.whl"),
-            ],
-        ),
-        (
-            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
-            False,
-            [],
-        ),
-    ],
-)
-def test_get_not_found_cached_archive_for_link(
-    config: Config,
-    mocker: MockerFixture,
-    link: str,
-    strict: bool,
-    available_packages: list[Path],
-):
-    chef = Chef(
-        config,
-        MockEnv(
-            version_info=(3, 8, 3),
-            marker_env={"interpreter_name": "cpython", "interpreter_version": "3.8.3"},
-            supported_tags=[
-                Tag("cp38", "cp38", "macosx_10_15_x86_64"),
-                Tag("py3", "none", "any"),
-            ],
-        ),
-        Factory.create_pool(config),
-    )
-
-    mocker.patch.object(
-        chef, "get_cached_archives_for_link", return_value=available_packages
-    )
-
-    archive = chef.get_cached_archive_for_link(Link(link), strict=strict)
-
-    assert archive is None
-
-
-@pytest.mark.parametrize(
-    ("link", "cached", "strict"),
-    [
-        (
-            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
-            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
-            False,
-        ),
-        (
-            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
-            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
-            False,
-        ),
-        (
-            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
-            "/cache/demo-0.1.0.tar.gz",
-            True,
-        ),
-        (
-            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
-            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
-            True,
-        ),
-    ],
-)
-def test_get_found_cached_archive_for_link(
-    config: Config, mocker: MockerFixture, link: str, cached: str, strict: bool
-):
-    chef = Chef(
-        config,
-        MockEnv(
-            version_info=(3, 8, 3),
-            marker_env={"interpreter_name": "cpython", "interpreter_version": "3.8.3"},
-            supported_tags=[
-                Tag("cp38", "cp38", "macosx_10_15_x86_64"),
-                Tag("py3", "none", "any"),
-            ],
-        ),
-        Factory.create_pool(config),
-    )
-
-    mocker.patch.object(
-        chef,
-        "get_cached_archives_for_link",
-        return_value=[
-            Path("/cache/demo-0.1.0-py2.py3-none-any"),
-            Path("/cache/demo-0.1.0.tar.gz"),
-            Path("/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl"),
-            Path("/cache/demo-0.1.0-cp37-cp37-macosx_10_15_x86_64.whl"),
-        ],
-    )
-
-    archive = chef.get_cached_archive_for_link(Link(link), strict=strict)
-
-    assert Path(cached) == archive
-
-
-def test_get_cached_archives_for_link(config: Config, mocker: MockerFixture):
-    chef = Chef(
-        config,
-        MockEnv(
-            marker_env={"interpreter_name": "cpython", "interpreter_version": "3.8.3"}
-        ),
-        Factory.create_pool(config),
-    )
-
-    distributions = Path(__file__).parent.parent.joinpath("fixtures/distributions")
-    mocker.patch.object(
-        chef,
-        "get_cache_directory_for_link",
-        return_value=distributions,
-    )
-
-    archives = chef.get_cached_archives_for_link(
-        Link("https://files.python-poetry.org/demo-0.1.0.tar.gz")
-    )
-
-    assert archives
-    assert set(archives) == set(distributions.glob("demo-0.1.*"))
-
-
-def test_get_cache_directory_for_link(config: Config, config_cache_dir: Path):
-    chef = Chef(
-        config,
-        MockEnv(
-            marker_env={"interpreter_name": "cpython", "interpreter_version": "3.8.3"}
-        ),
-        Factory.create_pool(config),
-    )
-
-    directory = chef.get_cache_directory_for_link(
-        Link("https://files.python-poetry.org/poetry-1.1.0.tar.gz")
-    )
-
-    expected = Path(
-        f"{config_cache_dir.as_posix()}/artifacts/ba/63/13/"
-        "283a3b3b7f95f05e9e6f84182d276f7bb0951d5b0cc24422b33f7a4648"
-    )
-
-    assert directory == expected
-
-
 def test_prepare_sdist(config: Config, config_cache_dir: Path) -> None:
     chef = Chef(config, EnvManager.get_system_env(), Factory.create_pool(config))
 
@@ -199,7 +48,7 @@ def test_prepare_sdist(config: Config, config_cache_dir: Path) -> None:
         .resolve()
     )
 
-    destination = chef.get_cache_directory_for_link(Link(archive.as_uri()))
+    destination = get_cache_directory_for_link(chef._cache_dir, Link(archive.as_uri()))
 
     wheel = chef.prepare(archive)
 

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from tests.conftest import Config
+    from tests.types import FixtureDirGetter
 
 
 @pytest.fixture()
@@ -45,18 +46,15 @@ def artifact_cache(config: Config) -> ArtifactCache:
 
 
 def test_prepare_sdist(
-    config: Config, config_cache_dir: Path, artifact_cache: ArtifactCache
+    config: Config,
+    config_cache_dir: Path,
+    artifact_cache: ArtifactCache,
+    fixture_dir: FixtureDirGetter,
 ) -> None:
     chef = Chef(
         artifact_cache, EnvManager.get_system_env(), Factory.create_pool(config)
     )
-
-    archive = (
-        Path(__file__)
-        .parent.parent.joinpath("fixtures/distributions/demo-0.1.0.tar.gz")
-        .resolve()
-    )
-
+    archive = (fixture_dir("distributions") / "demo-0.1.0.tar.gz").resolve()
     destination = artifact_cache.get_cache_directory_for_link(Link(archive.as_uri()))
 
     wheel = chef.prepare(archive)
@@ -66,13 +64,15 @@ def test_prepare_sdist(
 
 
 def test_prepare_directory(
-    config: Config, config_cache_dir: Path, artifact_cache: ArtifactCache
+    config: Config,
+    config_cache_dir: Path,
+    artifact_cache: ArtifactCache,
+    fixture_dir: FixtureDirGetter,
 ):
     chef = Chef(
         artifact_cache, EnvManager.get_system_env(), Factory.create_pool(config)
     )
-
-    archive = Path(__file__).parent.parent.joinpath("fixtures/simple_project").resolve()
+    archive = fixture_dir("simple_project").resolve()
 
     wheel = chef.prepare(archive)
 
@@ -84,16 +84,14 @@ def test_prepare_directory(
 
 
 def test_prepare_directory_with_extensions(
-    config: Config, config_cache_dir: Path, artifact_cache: ArtifactCache
+    config: Config,
+    config_cache_dir: Path,
+    artifact_cache: ArtifactCache,
+    fixture_dir: FixtureDirGetter,
 ) -> None:
     env = EnvManager.get_system_env()
     chef = Chef(artifact_cache, env, Factory.create_pool(config))
-
-    archive = (
-        Path(__file__)
-        .parent.parent.joinpath("fixtures/extended_with_no_setup")
-        .resolve()
-    )
+    archive = fixture_dir("extended_with_no_setup").resolve()
 
     wheel = chef.prepare(archive)
 
@@ -105,13 +103,15 @@ def test_prepare_directory_with_extensions(
 
 
 def test_prepare_directory_editable(
-    config: Config, config_cache_dir: Path, artifact_cache: ArtifactCache
+    config: Config,
+    config_cache_dir: Path,
+    artifact_cache: ArtifactCache,
+    fixture_dir: FixtureDirGetter,
 ):
     chef = Chef(
         artifact_cache, EnvManager.get_system_env(), Factory.create_pool(config)
     )
-
-    archive = Path(__file__).parent.parent.joinpath("fixtures/simple_project").resolve()
+    archive = fixture_dir("simple_project").resolve()
 
     wheel = chef.prepare(archive, editable=True)
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -20,6 +20,7 @@ from build import ProjectBuilder
 from cleo.formatters.style import Style
 from cleo.io.buffered_io import BufferedIO
 from cleo.io.outputs.output import Verbosity
+from packaging.tags import Tag
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.packages.utils.utils import path_to_url
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
 
     from poetry.config.config import Config
     from poetry.installation.operations.operation import Operation
+    from poetry.utils.env import Env
     from poetry.utils.env import VirtualEnv
     from tests.types import FixtureDirGetter
 
@@ -538,11 +540,11 @@ def test_executor_should_delete_incomplete_downloads(
         side_effect=Exception("Download error"),
     )
     mocker.patch(
-        "poetry.installation.chef.Chef.get_cached_archive_for_link",
-        side_effect=lambda link, strict: None,
+        "poetry.installation.executor.Executor._get_cached_archive_for_link",
+        return_value=None,
     )
     mocker.patch(
-        "poetry.installation.chef.Chef.get_cache_directory_for_link",
+        "poetry.installation.executor.get_cache_directory_for_link",
         return_value=Path(tmp_dir),
     )
 
@@ -761,7 +763,7 @@ def test_executor_should_write_pep610_url_references_for_wheel_urls(
     if is_artifact_cached:
         link_cached = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
         mocker.patch(
-            "poetry.installation.chef.Chef.get_cached_archive_for_link",
+            "poetry.installation.executor.Executor._get_cached_archive_for_link",
             return_value=link_cached,
         )
     download_spy = mocker.spy(Executor, "_download_archive")
@@ -840,7 +842,9 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
         cached_sdist = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
         cached_wheel = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
 
-        def mock_get_cached_archive_for_link_func(_: Link, strict: bool):
+        def mock_get_cached_archive_for_link_func(
+            _: Env, __: Path, ___: Link, strict: bool
+        ):
             if is_wheel_cached and not strict:
                 return cached_wheel
             if is_sdist_cached:
@@ -848,7 +852,7 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
             return None
 
         mocker.patch(
-            "poetry.installation.chef.Chef.get_cached_archive_for_link",
+            "poetry.installation.executor.Executor._get_cached_archive_for_link",
             side_effect=mock_get_cached_archive_for_link_func,
         )
 
@@ -1218,3 +1222,106 @@ Package operations: 1 install, 0 updates, 0 removals
     output = io.fetch_output().strip()
     assert output.startswith(expected_start)
     assert output.endswith(expected_end)
+
+
+@pytest.mark.parametrize(
+    ("link", "strict", "available_packages"),
+    [
+        (
+            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            True,
+            [
+                Path("/cache/demo-0.1.0-py2.py3-none-any"),
+                Path("/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl"),
+                Path("/cache/demo-0.1.0-cp37-cp37-macosx_10_15_x86_64.whl"),
+            ],
+        ),
+        (
+            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            False,
+            [],
+        ),
+    ],
+)
+def test_get_not_found_cached_archive_for_link(
+    mocker: MockerFixture,
+    link: str,
+    strict: bool,
+    available_packages: list[Path],
+) -> None:
+    env = MockEnv(
+        version_info=(3, 8, 3),
+        marker_env={"interpreter_name": "cpython", "interpreter_version": "3.8.3"},
+        supported_tags=[
+            Tag("cp38", "cp38", "macosx_10_15_x86_64"),
+            Tag("py3", "none", "any"),
+        ],
+    )
+
+    mocker.patch(
+        "poetry.installation.executor.get_cached_archives_for_link",
+        return_value=available_packages,
+    )
+
+    archive = Executor._get_cached_archive_for_link(
+        env, Path(), Link(link), strict=strict
+    )
+
+    assert archive is None
+
+
+@pytest.mark.parametrize(
+    ("link", "cached", "strict"),
+    [
+        (
+            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            False,
+        ),
+        (
+            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            False,
+        ),
+        (
+            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            "/cache/demo-0.1.0.tar.gz",
+            True,
+        ),
+        (
+            "https://example.com/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            True,
+        ),
+    ],
+)
+def test_get_found_cached_archive_for_link(
+    mocker: MockerFixture,
+    link: str,
+    cached: str,
+    strict: bool,
+) -> None:
+    env = MockEnv(
+        version_info=(3, 8, 3),
+        marker_env={"interpreter_name": "cpython", "interpreter_version": "3.8.3"},
+        supported_tags=[
+            Tag("cp38", "cp38", "macosx_10_15_x86_64"),
+            Tag("py3", "none", "any"),
+        ],
+    )
+
+    mocker.patch(
+        "poetry.installation.executor.get_cached_archives_for_link",
+        return_value=[
+            Path("/cache/demo-0.1.0-py2.py3-none-any"),
+            Path("/cache/demo-0.1.0.tar.gz"),
+            Path("/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl"),
+            Path("/cache/demo-0.1.0-cp37-cp37-macosx_10_15_x86_64.whl"),
+        ],
+    )
+
+    archive = Executor._get_cached_archive_for_link(
+        env, Path(), Link(link), strict=strict
+    )
+
+    assert Path(cached) == archive

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
 
     from poetry.config.config import Config
     from poetry.installation.operations.operation import Operation
-    from poetry.utils.env import Env
     from poetry.utils.env import VirtualEnv
     from tests.types import FixtureDirGetter
 
@@ -539,11 +538,11 @@ def test_executor_should_delete_incomplete_downloads(
         side_effect=Exception("Download error"),
     )
     mocker.patch(
-        "poetry.installation.executor.get_cached_archive_for_link",
+        "poetry.installation.executor.ArtifactCache.get_cached_archive_for_link",
         return_value=None,
     )
     mocker.patch(
-        "poetry.installation.executor.get_cache_directory_for_link",
+        "poetry.installation.executor.ArtifactCache.get_cache_directory_for_link",
         return_value=Path(tmp_dir),
     )
 
@@ -762,7 +761,7 @@ def test_executor_should_write_pep610_url_references_for_wheel_urls(
     if is_artifact_cached:
         link_cached = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
         mocker.patch(
-            "poetry.installation.executor.get_cached_archive_for_link",
+            "poetry.installation.executor.ArtifactCache.get_cached_archive_for_link",
             return_value=link_cached,
         )
     download_spy = mocker.spy(Executor, "_download_archive")
@@ -841,9 +840,7 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
         cached_sdist = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
         cached_wheel = fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
 
-        def mock_get_cached_archive_for_link_func(
-            _: Env, __: Path, ___: Link, strict: bool
-        ):
+        def mock_get_cached_archive_for_link_func(_: Link, *, strict: bool, **__: Any):
             if is_wheel_cached and not strict:
                 return cached_wheel
             if is_sdist_cached:
@@ -851,7 +848,7 @@ def test_executor_should_write_pep610_url_references_for_non_wheel_urls(
             return None
 
         mocker.patch(
-            "poetry.installation.executor.get_cached_archive_for_link",
+            "poetry.installation.executor.ArtifactCache.get_cached_archive_for_link",
             side_effect=mock_get_cached_archive_for_link_func,
         )
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from tests.conftest import Config
+    from tests.types import FixtureDirGetter
 
 
 FILE_CACHE = Union[FileCache, CacheManager]
@@ -211,8 +212,10 @@ def test_get_cache_directory_for_link(tmp_path: Path) -> None:
     assert directory == expected
 
 
-def test_get_cached_archives_for_link(mocker: MockerFixture) -> None:
-    distributions = Path(__file__).parent.parent.joinpath("fixtures/distributions")
+def test_get_cached_archives_for_link(
+    fixture_dir: FixtureDirGetter, mocker: MockerFixture
+) -> None:
+    distributions = fixture_dir("distributions")
     cache = ArtifactCache(cache_dir=Path())
 
     mocker.patch.object(

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -197,6 +197,20 @@ def test_cachy_compatibility(
     assert cachy_file_cache.get("key4") == test_obj
 
 
+def test_get_cache_directory_for_link(tmp_path: Path) -> None:
+    cache = ArtifactCache(cache_dir=tmp_path)
+    directory = cache.get_cache_directory_for_link(
+        Link("https://files.python-poetry.org/poetry-1.1.0.tar.gz")
+    )
+
+    expected = Path(
+        f"{tmp_path.as_posix()}/11/4f/a8/"
+        "1c89d75547e4967082d30a28360401c82c83b964ddacee292201bf85f2"
+    )
+
+    assert directory == expected
+
+
 def test_get_cached_archives_for_link(mocker: MockerFixture) -> None:
     distributions = Path(__file__).parent.parent.joinpath("fixtures/distributions")
     cache = ArtifactCache(cache_dir=Path())
@@ -315,17 +329,3 @@ def test_get_found_cached_archive_for_link(
     archive = cache.get_cached_archive_for_link(Link(link), strict=strict, env=env)
 
     assert Path(cached) == archive
-
-
-def test_get_cache_directory_for_link(tmp_path: Path) -> None:
-    cache = ArtifactCache(cache_dir=tmp_path)
-    directory = cache.get_cache_directory_for_link(
-        Link("https://files.python-poetry.org/poetry-1.1.0.tar.gz")
-    )
-
-    expected = Path(
-        f"{tmp_path.as_posix()}/11/4f/a8/"
-        "1c89d75547e4967082d30a28360401c82c83b964ddacee292201bf85f2"
-    )
-
-    assert directory == expected


### PR DESCRIPTION
# Pull Request Check List

As discuss with @radoering in https://github.com/python-poetry/poetry/pull/7595, this is a first refactor PR that tries to extract cache utilities outside of Chef. The end goal is to resolve finally https://github.com/python-poetry/poetry/issues/2415.

- Added an `artifacts_cache_directory` property to config.py analoguous to `repository_cache_directory`
- Made `get_cached_archives_for_link()` independent from interpreter_name and interpreter_version
- Moved `get_cached_archives_for_link` and `get_cache_directory_for_link` from `chef.py` to `utils/cache.py`

I ended up moving the recently touched `get_cached_archive_for_link` too, although it looks to me that it's not such a generic utility, but it's mostly related to the installation step. The fact that I had to refactor a bit the `installer` package to avoid circular imports makes this evident. Still, I believed `chef.py` wasn't the best place to keep that function since the other ones have been moved. I'm happy to receive feedback on this and other possible solutions. Most likely I would put  `get_cached_archive_for_link` directly inside `Executor`( which is the only user of that function), but I wanted to get your feedback first.

- [x] Added **tests** for changed code.
- ~[ ] Updated **documentation** for changed code.~
