### PR TITLE
add missing env keyword in Env._run

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1533,6 +1533,7 @@ class Env:
                     stderr=stderr,
                     input=encode(input_),
                     check=True,
+                    env=env,
                     **kwargs,
                 ).stdout
             elif call:


### PR DESCRIPTION
The env keyword contains the modified path (that uses get_temp_environ) so without it, anything using the `input` path here would get the wrong env.

fixes #7623

# Pull Request Check List

Resolves: #7623 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
