### PR TITLE
feat: let Provider use ArtifactCache

### DIFF
--- a/src/poetry/console/commands/debug/resolve.py
+++ b/src/poetry/console/commands/debug/resolve.py
@@ -113,7 +113,7 @@ class DebugResolveCommand(InitCommand):
 
         if self.option("install"):
             env = EnvManager(self.poetry).get()
-            pool = RepositoryPool()
+            pool = RepositoryPool(config=self.poetry.config)
             locked_repository = Repository("poetry-locked")
             for op in ops:
                 locked_repository.add_package(op.package)

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -434,11 +434,15 @@ You can specify a package in the following forms:
 
         try:
             cwd = self.poetry.file.parent
+            artifact_cache = self.poetry.pool.artifact_cache
         except (PyProjectException, RuntimeError):
             cwd = Path.cwd()
+            artifact_cache = self._get_pool().artifact_cache
 
         parser = RequirementsParser(
-            self.env if isinstance(self, EnvCommand) else None, cwd
+            artifact_cache=artifact_cache,
+            env=self.env if isinstance(self, EnvCommand) else None,
+            cwd=cwd,
         )
         return [parser.parse(requirement) for requirement in requirements]
 

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -13,7 +13,7 @@ from tomlkit import inline_table
 
 from poetry.console.commands.command import Command
 from poetry.console.commands.env_command import EnvCommand
-from poetry.utils.dependency_specification import parse_dependency_specification
+from poetry.utils.dependency_specification import RequirementsParser
 
 
 if TYPE_CHECKING:
@@ -437,14 +437,10 @@ You can specify a package in the following forms:
         except (PyProjectException, RuntimeError):
             cwd = Path.cwd()
 
-        return [
-            parse_dependency_specification(
-                requirement=requirement,
-                env=self.env if isinstance(self, EnvCommand) else None,
-                cwd=cwd,
-            )
-            for requirement in requirements
-        ]
+        parser = RequirementsParser(
+            self.env if isinstance(self, EnvCommand) else None, cwd
+        )
+        return [parser.parse(requirement) for requirement in requirements]
 
     def _format_requirements(self, requirements: list[dict[str, str]]) -> Requirements:
         requires: Requirements = {}

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -213,7 +213,7 @@ lists all packages available."""
         from poetry.utils.helpers import get_package_version_display_string
 
         locked_packages = locked_repository.packages
-        pool = RepositoryPool(ignore_repository_names=True)
+        pool = RepositoryPool(ignore_repository_names=True, config=self.poetry.config)
         pool.add_repository(locked_repository)
         solver = Solver(
             root,

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -119,7 +119,7 @@ class Factory(BaseFactory):
     @classmethod
     def create_pool(
         cls,
-        auth_config: Config,
+        config: Config,
         sources: Iterable[dict[str, Any]] = (),
         io: IO | None = None,
         disable_cache: bool = False,
@@ -133,12 +133,12 @@ class Factory(BaseFactory):
         if disable_cache:
             logger.debug("Disabling source caches")
 
-        pool = RepositoryPool()
+        pool = RepositoryPool(config=config)
 
         explicit_pypi = False
         for source in sources:
             repository = cls.create_package_source(
-                source, auth_config, disable_cache=disable_cache
+                source, config, disable_cache=disable_cache
             )
             priority = Priority[source.get("priority", Priority.PRIMARY.name).upper()]
             if "default" in source or "secondary" in source:
@@ -207,7 +207,7 @@ class Factory(BaseFactory):
 
     @classmethod
     def create_package_source(
-        cls, source: dict[str, str], auth_config: Config, disable_cache: bool = False
+        cls, source: dict[str, str], config: Config, disable_cache: bool = False
     ) -> HTTPRepository:
         from poetry.repositories.exceptions import InvalidSourceError
         from poetry.repositories.legacy_repository import LegacyRepository
@@ -239,7 +239,7 @@ class Factory(BaseFactory):
         return repository_class(
             name,
             url,
-            config=auth_config,
+            config=config,
             disable_cache=disable_cache,
         )
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -47,6 +47,7 @@ class Installer:
         self._package = package
         self._locker = locker
         self._pool = pool
+        self._config = config
 
         self._dry_run = False
         self._requires_synchronization = False
@@ -290,7 +291,7 @@ class Installer:
             )
 
         # We resolve again by only using the lock file
-        pool = RepositoryPool(ignore_repository_names=True)
+        pool = RepositoryPool(ignore_repository_names=True, config=self._config)
 
         # Making a new repo containing the packages
         # newly resolved and the ones from the current lock file

--- a/src/poetry/packages/direct_origin.py
+++ b/src/poetry/packages/direct_origin.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import functools
+import os
+import tempfile
+import urllib.parse
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from poetry.inspection.info import PackageInfo
+from poetry.inspection.info import PackageInfoError
+from poetry.utils.helpers import download_file
+from poetry.utils.helpers import get_file_hash
+from poetry.vcs.git import Git
+
+
+if TYPE_CHECKING:
+    from poetry.core.packages.package import Package
+
+
+@functools.lru_cache(maxsize=None)
+def _get_package_from_git(
+    url: str,
+    branch: str | None = None,
+    tag: str | None = None,
+    rev: str | None = None,
+    subdirectory: str | None = None,
+    source_root: Path | None = None,
+) -> Package:
+    source = Git.clone(
+        url=url,
+        source_root=source_root,
+        branch=branch,
+        tag=tag,
+        revision=rev,
+        clean=False,
+    )
+    revision = Git.get_revision(source)
+
+    path = Path(source.path)
+    if subdirectory:
+        path = path.joinpath(subdirectory)
+
+    package = DirectOrigin.get_package_from_directory(path)
+    package._source_type = "git"
+    package._source_url = url
+    package._source_reference = rev or tag or branch or "HEAD"
+    package._source_resolved_reference = revision
+    package._source_subdirectory = subdirectory
+
+    return package
+
+
+class DirectOrigin:
+    @classmethod
+    def get_package_from_file(cls, file_path: Path) -> Package:
+        try:
+            package = PackageInfo.from_path(path=file_path).to_package(
+                root_dir=file_path
+            )
+        except PackageInfoError:
+            raise RuntimeError(
+                f"Unable to determine package info from path: {file_path}"
+            )
+
+        return package
+
+    @classmethod
+    def get_package_from_directory(cls, directory: Path) -> Package:
+        return PackageInfo.from_directory(path=directory).to_package(root_dir=directory)
+
+    @classmethod
+    def get_package_from_url(cls, url: str) -> Package:
+        file_name = os.path.basename(urllib.parse.urlparse(url).path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest = Path(temp_dir) / file_name
+            download_file(url, dest)
+            package = cls.get_package_from_file(dest)
+
+            package.files = [
+                {"file": file_name, "hash": "sha256:" + get_file_hash(dest)}
+            ]
+
+        package._source_type = "url"
+        package._source_url = url
+
+        return package
+
+    @staticmethod
+    def get_package_from_vcs(
+        vcs: str,
+        url: str,
+        branch: str | None = None,
+        tag: str | None = None,
+        rev: str | None = None,
+        subdirectory: str | None = None,
+        source_root: Path | None = None,
+    ) -> Package:
+        if vcs != "git":
+            raise ValueError(f"Unsupported VCS dependency {vcs}")
+
+        return _get_package_from_git(
+            url=url,
+            branch=branch,
+            tag=tag,
+            rev=rev,
+            subdirectory=subdirectory,
+            source_root=source_root,
+        )

--- a/src/poetry/poetry.py
+++ b/src/poetry/poetry.py
@@ -49,7 +49,7 @@ class Poetry(BasePoetry):
 
         self._locker = locker
         self._config = config
-        self._pool = RepositoryPool()
+        self._pool = RepositoryPool(config=config)
         self._plugin_manager: PluginManager | None = None
         self._disable_cache = disable_cache
 

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -107,6 +107,7 @@ class Provider:
     ) -> None:
         self._package = package
         self._pool = pool
+        self._direct_origin = DirectOrigin(self._pool.artifact_cache)
         self._io = io
         self._env: Env | None = None
         self._python_constraint = package.python_constraint
@@ -311,7 +312,7 @@ class Provider:
         Basically, we clone the repository in a temporary directory
         and get the information we need by checking out the specified reference.
         """
-        package = DirectOrigin.get_package_from_vcs(
+        package = self._direct_origin.get_package_from_vcs(
             dependency.vcs,
             dependency.source,
             branch=dependency.branch,
@@ -330,7 +331,7 @@ class Provider:
 
     def _search_for_file(self, dependency: FileDependency) -> Package:
         dependency.validate(raise_error=True)
-        package = DirectOrigin.get_package_from_file(dependency.full_path)
+        package = self._direct_origin.get_package_from_file(dependency.full_path)
 
         self.validate_package_for_dependency(dependency=dependency, package=package)
 
@@ -348,7 +349,7 @@ class Provider:
 
     def _search_for_directory(self, dependency: DirectoryDependency) -> Package:
         dependency.validate(raise_error=True)
-        package = DirectOrigin.get_package_from_directory(dependency.full_path)
+        package = self._direct_origin.get_package_from_directory(dependency.full_path)
 
         self.validate_package_for_dependency(dependency=dependency, package=package)
 
@@ -360,7 +361,7 @@ class Provider:
         return package
 
     def _search_for_url(self, dependency: URLDependency) -> Package:
-        package = DirectOrigin.get_package_from_url(dependency.url)
+        package = self._direct_origin.get_package_from_url(dependency.url)
 
         self.validate_package_for_dependency(dependency=dependency, package=package)
 

--- a/src/poetry/utils/dependency_specification.py
+++ b/src/poetry/utils/dependency_specification.py
@@ -16,7 +16,7 @@ from typing import cast
 from poetry.core.packages.dependency import Dependency
 from tomlkit.items import InlineTable
 
-from poetry.puzzle.provider import Provider
+from poetry.packages.direct_origin import DirectOrigin
 
 
 if TYPE_CHECKING:
@@ -120,7 +120,7 @@ class RequirementsParser:
             pair["subdirectory"] = parsed.subdirectory
 
         source_root = self._env.path.joinpath("src") if self._env else None
-        package = Provider.get_package_from_vcs(
+        package = DirectOrigin.get_package_from_vcs(
             "git",
             url=url.url,
             rev=pair.get("rev"),
@@ -139,7 +139,7 @@ class RequirementsParser:
             return self._parse_git_url(requirement)
 
         if url_parsed.scheme in ["http", "https"]:
-            package = Provider.get_package_from_url(requirement)
+            package = DirectOrigin.get_package_from_url(requirement)
             assert package.source_url is not None
             return {"name": package.name, "url": package.source_url}
 
@@ -158,9 +158,9 @@ class RequirementsParser:
                 path = self._cwd.joinpath(requirement)
 
             if path.is_file():
-                package = Provider.get_package_from_file(path.resolve())
+                package = DirectOrigin.get_package_from_file(path.resolve())
             else:
-                package = Provider.get_package_from_directory(path.resolve())
+                package = DirectOrigin.get_package_from_directory(path.resolve())
 
             return {
                 "name": package.name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from poetry.inspection.info import PackageInfoError
 from poetry.layouts import layout
 from poetry.repositories import Repository
 from poetry.repositories import RepositoryPool
+from poetry.utils.cache import ArtifactCache
 from poetry.utils.env import EnvManager
 from poetry.utils.env import SystemEnv
 from poetry.utils.env import VirtualEnv
@@ -220,6 +221,11 @@ def config(
     mocker.patch("poetry.config.config.Config.set_config_source")
 
     return c
+
+
+@pytest.fixture
+def artifact_cache(config: Config) -> ArtifactCache:
+    return ArtifactCache(cache_dir=config.artifacts_cache_directory)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,7 +239,7 @@ def mock_user_config_dir(mocker: MockerFixture, config_dir: Path) -> None:
 def download_mock(mocker: MockerFixture) -> None:
     # Patch download to not download anything but to just copy from fixtures
     mocker.patch("poetry.utils.helpers.download_file", new=mock_download)
-    mocker.patch("poetry.puzzle.provider.download_file", new=mock_download)
+    mocker.patch("poetry.packages.direct_origin.download_file", new=mock_download)
     mocker.patch("poetry.repositories.http_repository.download_file", new=mock_download)
 
 

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -14,7 +14,6 @@ from poetry.core.packages.utils.link import Link
 from poetry.factory import Factory
 from poetry.installation.chef import Chef
 from poetry.repositories import RepositoryPool
-from poetry.utils.cache import ArtifactCache
 from poetry.utils.env import EnvManager
 from tests.repositories.test_pypi_repository import MockRepository
 
@@ -22,6 +21,7 @@ from tests.repositories.test_pypi_repository import MockRepository
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
+    from poetry.utils.cache import ArtifactCache
     from tests.conftest import Config
     from tests.types import FixtureDirGetter
 
@@ -38,11 +38,6 @@ def pool() -> RepositoryPool:
 @pytest.fixture(autouse=True)
 def setup(mocker: MockerFixture, pool: RepositoryPool) -> None:
     mocker.patch.object(Factory, "create_pool", return_value=pool)
-
-
-@pytest.fixture
-def artifact_cache(config: Config) -> ArtifactCache:
-    return ArtifactCache(cache_dir=config.artifacts_cache_directory)
 
 
 def test_prepare_sdist(

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -136,11 +136,6 @@ def pool() -> RepositoryPool:
 
 
 @pytest.fixture
-def artifact_cache(config: Config) -> ArtifactCache:
-    return ArtifactCache(cache_dir=config.artifacts_cache_directory)
-
-
-@pytest.fixture
 def mock_file_downloads(
     http: type[httpretty.httpretty], fixture_dir: FixtureDirGetter
 ) -> None:

--- a/tests/packages/test_direct_origin.py
+++ b/tests/packages/test_direct_origin.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from poetry.core.packages.utils.link import Link
+
+from poetry.packages.direct_origin import DirectOrigin
+from poetry.utils.cache import ArtifactCache
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+    from tests.types import FixtureDirGetter
+
+
+def test_direct_origin_get_package_from_file(fixture_dir: FixtureDirGetter) -> None:
+    wheel_path = fixture_dir("distributions") / "demo-0.1.2-py2.py3-none-any.whl"
+    package = DirectOrigin.get_package_from_file(wheel_path)
+    assert package.name == "demo"
+
+
+def test_direct_origin_caches_url_dependency(tmp_path: Path) -> None:
+    artifact_cache = ArtifactCache(cache_dir=tmp_path)
+    direct_origin = DirectOrigin(artifact_cache)
+    url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+
+    package = direct_origin.get_package_from_url(url)
+
+    assert package.name == "demo"
+    assert artifact_cache.get_cached_archive_for_link(Link(url), strict=True)
+
+
+def test_direct_origin_does_not_download_url_dependency_when_cached(
+    fixture_dir: FixtureDirGetter, mocker: MockerFixture
+) -> None:
+    artifact_cache = MagicMock()
+    artifact_cache.get_cached_archive_for_link = MagicMock(
+        return_value=fixture_dir("distributions") / "demo-0.1.2-py2.py3-none-any.whl"
+    )
+    direct_origin = DirectOrigin(artifact_cache)
+    url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    mocker.patch(
+        "poetry.packages.direct_origin.download_file",
+        side_effect=Exception("download_file should not be called"),
+    )
+
+    package = direct_origin.get_package_from_url(url)
+
+    assert package.name == "demo"
+    artifact_cache.get_cached_archive_for_link.assert_called_once_with(
+        Link(url), strict=True
+    )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -543,7 +543,7 @@ def test_create_package_source_invalid(
     fixture_dir: FixtureDirGetter,
 ) -> None:
     with pytest.raises(InvalidSourceError) as e:
-        Factory.create_package_source(source, auth_config=config)
+        Factory.create_package_source(source, config=config)
         Factory().create_poetry(fixture_dir("with_source_pypi_url"))
 
     assert str(e.value) == expected

--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -13,6 +13,7 @@ from poetry.utils.dependency_specification import RequirementsParser
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
+    from poetry.utils.cache import ArtifactCache
     from poetry.utils.dependency_specification import DependencySpec
 
 
@@ -104,7 +105,10 @@ if TYPE_CHECKING:
     ],
 )
 def test_parse_dependency_specification(
-    requirement: str, specification: DependencySpec, mocker: MockerFixture
+    requirement: str,
+    specification: DependencySpec,
+    mocker: MockerFixture,
+    artifact_cache: ArtifactCache,
 ) -> None:
     original = Path.exists
 
@@ -116,5 +120,7 @@ def test_parse_dependency_specification(
     mocker.patch("pathlib.Path.exists", _mock)
 
     assert not DeepDiff(
-        RequirementsParser().parse(requirement), specification, ignore_order=True
+        RequirementsParser(artifact_cache=artifact_cache).parse(requirement),
+        specification,
+        ignore_order=True,
     )

--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -7,7 +7,7 @@ import pytest
 
 from deepdiff import DeepDiff
 
-from poetry.utils.dependency_specification import parse_dependency_specification
+from poetry.utils.dependency_specification import RequirementsParser
 
 
 if TYPE_CHECKING:
@@ -116,5 +116,5 @@ def test_parse_dependency_specification(
     mocker.patch("pathlib.Path.exists", _mock)
 
     assert not DeepDiff(
-        parse_dependency_specification(requirement), specification, ignore_order=True
+        RequirementsParser().parse(requirement), specification, ignore_order=True
     )


### PR DESCRIPTION
# Pull Request Check List

Follow-up of https://github.com/python-poetry/poetry/pull/7621. Closes https://github.com/python-poetry/poetry/issues/2415

@radoering most of the PR is about initializing the `ArtifactCache` and passing it around the codebase whenever it's needed. Let me know if you prefer a different approach. For instance I saw usages of `Config.create()` around the codebase (such as in `CachedRepository`) that would simplify the changes a lot, as one would simply need to create an `ArtifactCache` right inside `get_package_from_url`. On the other side I like the DI approach as it allows for better modularity and testability, as the cost of more verbose code. I'll not fight this one though, I'll gladly go for the option you recommend ;) 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code. -> I'll do it as soon as we agree on the best way to refactor the code
- ~[ ] Updated **documentation** for changed code.~ Don't think it's needed

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
