### PR TITLE
executor: update setuptools/wheel first before other (parallel) installs

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -157,9 +157,10 @@ class Executor:
         self._sections = {}
         self._yanked_warnings = []
 
-        # pip has to be installed first without parallelism if we install via pip
+        # pip/setuptools/wheel has to be installed first without parallelism
+        # if we install via pip
         for i, op in enumerate(operations):
-            if op.package.name == "pip":
+            if op.package.name in ("setuptools", "pip", "wheel"):
                 wait([self._executor.submit(self._execute_operation, op)])
                 del operations[i]
                 break


### PR DESCRIPTION
If a package is build from source because no pep517 build system are
indicated in pyproject.toml or the file is missing, pep517 will fallback
to setuptools and wheel installed within the virtualenv to build it.

eg:

https://github.com/pypa/pip/blob/22.3.1/src/pip/_vendor/pep517/wrappers.py#L167
https://github.com/pypa/pip/blob/22.3.1/src/pip/_vendor/pep517/wrappers.py#L220
https://github.com/pypa/pip/blob/22.3.1/src/pip/_vendor/pep517/wrappers.py#L273

Resolves: #7046

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->