### PR TITLE
inspection.info: simplify get_pep517_metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ module = [
     'cachecontrol.*',
     'lockfile.*',
     'pexpect.*',
+    'pyproject_hooks.*',
     'requests_toolbelt.*',
     'shellingham.*',
     'virtualenv.*',

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -15,7 +15,7 @@ from build import BuildBackendException
 from build import ProjectBuilder
 from build.env import IsolatedEnv as BaseIsolatedEnv
 from poetry.core.utils.helpers import temporary_directory
-from pyproject_hooks import quiet_subprocess_runner  # type: ignore[import]
+from pyproject_hooks import quiet_subprocess_runner
 
 from poetry.utils.env import ephemeral_environment
 

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -1516,6 +1516,15 @@ class Env:
             **kwargs,
         )
 
+    def run_pip_install(self, *packages: str) -> int | str:
+        return self.run_pip(
+            "install",
+            "--disable-pip-version-check",
+            "--ignore-installed",
+            "--no-input",
+            *packages,
+        )
+
     def _run(self, cmd: list[str], **kwargs: Any) -> int | str:
         """
         Run a command inside the Python environment.


### PR DESCRIPTION
Resolves: #6154, #7702

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This patch simplifies `get_pep517_metadata`, makes it more efficient, and make sure we handle the build dependencies corrently on legacy (`setup.py`) projects.