### PR TITLE
check for circular self-dependency

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -126,6 +126,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
         # dictionary.
         content: dict[str, Any] = self.poetry.file.read()
         poetry_content = content["tool"]["poetry"]
+        project_name = canonicalize_name(poetry_content["name"])
 
         if group == MAIN_GROUP:
             if "dependencies" not in poetry_content:
@@ -222,6 +223,14 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
             assert isinstance(constraint_name, str)
 
             canonical_constraint_name = canonicalize_name(constraint_name)
+
+            if canonical_constraint_name == project_name:
+                self.line_error(
+                    f"<error>Cannot add dependency on <c1>{_constraint['name']}</c1> to"
+                    " project with the same name."
+                )
+                self.line_error("\nNo changes were applied.")
+                return 1
 
             for key in section:
                 if canonicalize_name(key) == canonical_constraint_name:

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -226,7 +226,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
 
             if canonical_constraint_name == project_name:
                 self.line_error(
-                    f"<error>Cannot add dependency on <c1>{_constraint['name']}</c1> to"
+                    f"<error>Cannot add dependency on <c1>{constraint_name}</c1> to"
                     " project with the same name."
                 )
                 self.line_error("\nNo changes were applied.")

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -1073,6 +1073,18 @@ If you prefer to upgrade it to the latest available version,\
     assert expected in tester.io.fetch_output()
 
 
+def test_add_should_fail_circular_dependency(
+    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
+) -> None:
+    repo.add_package(get_package("simple-project", "1.1.2"))
+    result = tester.execute("simple-project")
+
+    assert result == 1
+
+    expected = "Cannot add dependency on simple-project to project with the same name."
+    assert expected in tester.io.fetch_error()
+
+
 def test_add_latest_should_not_create_duplicate_keys(
     project_factory: ProjectFactory,
     repo: TestRepository,

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -43,6 +43,7 @@ def test_check_invalid(
 
     expected = """\
 Error: 'description' is a required property
+Error: Project name (invalid) is same as one of its dependencies
 Error: Unrecognized classifiers: ['Intended Audience :: Clowns'].
 Warning: A wildcard Python dependency is ambiguous.\
  Consider specifying a more explicit one.

--- a/tests/fixtures/invalid_pyproject/pyproject.toml
+++ b/tests/fixtures/invalid_pyproject/pyproject.toml
@@ -15,3 +15,4 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "*"
 pendulum = {"version" = "^2.0.5", allows-prereleases = true}
+invalid = "1.0"

--- a/tests/fixtures/sample_project/pyproject.toml
+++ b/tests/fixtures/sample_project/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "my-package"
+name = "sample-project"
 version = "1.2.3"
 description = "Some description."
 authors = [
@@ -51,7 +51,7 @@ pytest = "~3.4"
 
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = "sample_project:main"
 
 
 [tool.poetry.plugins."blogtool.parsers"]

--- a/tests/fixtures/with_default_source/pyproject.toml
+++ b/tests/fixtures/with_default_source/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "my-package"
+name = "with-default-source"
 version = "1.2.3"
 description = "Some description."
 authors = [
@@ -48,7 +48,7 @@ pytest = "~3.4"
 
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = "with_default_source:main"
 
 
 [tool.poetry.plugins."blogtool.parsers"]

--- a/tests/fixtures/with_default_source_legacy/pyproject.toml
+++ b/tests/fixtures/with_default_source_legacy/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "my-package"
+name = "default-source-legacy"
 version = "1.2.3"
 description = "Some description."
 authors = [
@@ -48,7 +48,7 @@ pytest = "~3.4"
 
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = "default_source_legacy:main"
 
 
 [tool.poetry.plugins."blogtool.parsers"]

--- a/tests/fixtures/with_explicit_source/pyproject.toml
+++ b/tests/fixtures/with_explicit_source/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "my-package"
+name = "with-explicit-source"
 version = "1.2.3"
 description = "Some description."
 authors = [

--- a/tests/fixtures/with_local_config/pyproject.toml
+++ b/tests/fixtures/with_local_config/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "my-package"
+name = "local-config"
 version = "1.2.3"
 description = "Some description."
 authors = [
@@ -48,7 +48,7 @@ pytest = "~3.4"
 
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = "local_config:main"
 
 
 [tool.poetry.plugins."blogtool.parsers"]

--- a/tests/fixtures/with_two_default_sources/pyproject.toml
+++ b/tests/fixtures/with_two_default_sources/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "my-package"
+name = "two-default-sources"
 version = "1.2.3"
 description = "Some description."
 authors = [
@@ -48,7 +48,7 @@ pytest = "~3.4"
 
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = "two_default_sources:main"
 
 
 [tool.poetry.plugins."blogtool.parsers"]

--- a/tests/fixtures/with_two_default_sources_legacy/pyproject.toml
+++ b/tests/fixtures/with_two_default_sources_legacy/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "my-package"
+name = "two-default-sources-legacy"
 version = "1.2.3"
 description = "Some description."
 authors = [
@@ -48,7 +48,7 @@ pytest = "~3.4"
 
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = "two_default_sources_legacy:main"
 
 
 [tool.poetry.plugins."blogtool.parsers"]

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -9,9 +9,9 @@ import pytest
 
 from cleo.io.buffered_io import BufferedIO
 from cleo.io.null_io import NullIO
+from packaging.utils import canonicalize_name
 
 from poetry.factory import Factory
-from packaging.utils import canonicalize_name
 from poetry.publishing.publisher import Publisher
 
 

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -11,6 +11,7 @@ from cleo.io.buffered_io import BufferedIO
 from cleo.io.null_io import NullIO
 
 from poetry.factory import Factory
+from packaging.utils import canonicalize_name
 from poetry.publishing.publisher import Publisher
 
 
@@ -72,7 +73,8 @@ def test_publish_can_publish_to_given_repository(
         ("http://foo.bar",),
         {"cert": True, "client_cert": None, "dry_run": False, "skip_existing": False},
     ] == uploader_upload.call_args
-    assert "Publishing my-package (1.2.3) to foo" in io.fetch_output()
+    project_name = canonicalize_name(fixture_name)
+    assert f"Publishing {project_name} (1.2.3) to foo" in io.fetch_output()
 
 
 def test_publish_raises_error_for_undefined_repository(

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -37,7 +37,7 @@ def test_create_poetry(fixture_dir: FixtureDirGetter) -> None:
 
     package = poetry.package
 
-    assert package.name == "my-package"
+    assert package.name == "sample-project"
     assert package.version.text == "1.2.3"
     assert package.description == "Some description."
     assert package.authors == ["Sébastien Eustace <sebastien@eustace.io>"]
@@ -418,6 +418,7 @@ def test_create_poetry_fails_on_invalid_configuration(
     expected = """\
 The Poetry configuration is invalid:
   - 'description' is a required property
+  - Project name (invalid) is same as one of its dependencies
 """
     assert str(e.value) == expected
 


### PR DESCRIPTION
since as long ago as #236 this popular error has resulted in obscure assertions, and though at least one try has been made at improving this it continues to be an issue as recently as #7501

- have `Factory.validate()` check for circular self-dependencies
- reject `poetry add` when it would create such a self-dependency
