### PR TITLE
handle distutils deprecation

### DIFF
--- a/tests/fixtures/extended_with_no_setup/build.py
+++ b/tests/fixtures/extended_with_no_setup/build.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import os
 import shutil
 
-from distutils.command.build_ext import build_ext
-from distutils.core import Distribution
-from distutils.core import Extension
+from setuptools import Distribution
+from setuptools import Extension
+from setuptools.command.build_ext import build_ext
 
 
 extensions = [Extension("extended.extended", ["extended/extended.c"])]
@@ -13,7 +13,7 @@ extensions = [Extension("extended.extended", ["extended/extended.c"])]
 
 def build():
     distribution = Distribution({"name": "extended", "ext_modules": extensions})
-    distribution.package_dir = "extended"
+    distribution.package_dir = {"extended": "extended"}
 
     cmd = build_ext(distribution)
     cmd.ensure_finalized()

--- a/tests/fixtures/extended_with_no_setup/pyproject.toml
+++ b/tests/fixtures/extended_with_no_setup/pyproject.toml
@@ -22,5 +22,5 @@ script = "build.py"
 generate-setup-file = false
 
 [build-system]
-requires = ["poetry-core>=1.5.0"]
+requires = ["poetry-core>=1.5.0", "setuptools>=67.6.1"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
`distutils` is going away in python 3.12.

I don't find this comment very clear
```
# We can't use sysconfig.get_paths() because
# on some distributions it does not return the proper paths
# (those used by pip for instance).
```
but it was written three years ago now, we can always hope that things have moved on far enough to make it no longer a thing that needs to be worried about.

Well anyway let's start by seeing how the pipelines like it if we don't use `distutils`...