### PR TITLE
use shutil.which() to detect the active python

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -9,6 +9,7 @@ import os
 import platform
 import plistlib
 import re
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -472,6 +473,11 @@ class EnvCommandError(EnvError):
         super().__init__("\n\n".join(message_parts))
 
 
+class PythonVersionNotFound(EnvError):
+    def __init__(self, expected: str) -> None:
+        super().__init__(f"Could not find the python executable {expected}")
+
+
 class NoCompatiblePythonVersionFound(EnvError):
     def __init__(self, expected: str, given: str | None = None) -> None:
         if given:
@@ -517,34 +523,39 @@ class EnvManager:
         self._io = io or NullIO()
 
     @staticmethod
-    def _full_python_path(python: str) -> Path:
+    def _full_python_path(python: str) -> Path | None:
+        # eg first find pythonXY.bat on windows.
+        path_python = shutil.which(python)
+        if path_python is None:
+            return None
+
         try:
             executable = decode(
                 subprocess.check_output(
-                    [python, "-c", "import sys; print(sys.executable)"],
+                    [path_python, "-c", "import sys; print(sys.executable)"],
                 ).strip()
             )
-        except CalledProcessError as e:
-            raise EnvCommandError(e)
+            return Path(executable)
 
-        return Path(executable)
+        except CalledProcessError:
+            return None
 
     @staticmethod
     def _detect_active_python(io: None | IO = None) -> Path | None:
         io = io or NullIO()
-        executable = None
+        io.write_error_line(
+            (
+                "Trying to detect current active python executable as specified in"
+                " the config."
+            ),
+            verbosity=Verbosity.VERBOSE,
+        )
 
-        try:
-            io.write_error_line(
-                (
-                    "Trying to detect current active python executable as specified in"
-                    " the config."
-                ),
-                verbosity=Verbosity.VERBOSE,
-            )
-            executable = EnvManager._full_python_path("python")
+        executable = EnvManager._full_python_path("python")
+
+        if executable is not None:
             io.write_error_line(f"Found: {executable}", verbosity=Verbosity.VERBOSE)
-        except EnvCommandError:
+        else:
             io.write_error_line(
                 (
                     "Unable to detect the current active python executable. Falling"
@@ -552,6 +563,7 @@ class EnvManager:
                 ),
                 verbosity=Verbosity.VERBOSE,
             )
+
         return executable
 
     @staticmethod
@@ -592,6 +604,8 @@ class EnvManager:
             pass
 
         python_path = self._full_python_path(python)
+        if python_path is None:
+            raise PythonVersionNotFound(python)
 
         try:
             python_version_string = decode(
@@ -949,25 +963,26 @@ class EnvManager:
                 "Trying to find and use a compatible version.</warning> "
             )
 
-            for python_to_try in sorted(
+            for suffix in sorted(
                 self._poetry.package.AVAILABLE_PYTHONS,
                 key=lambda v: (v.startswith("3"), -len(v), v),
                 reverse=True,
             ):
-                if len(python_to_try) == 1:
-                    if not parse_constraint(f"^{python_to_try}.0").allows_any(
+                if len(suffix) == 1:
+                    if not parse_constraint(f"^{suffix}.0").allows_any(
                         supported_python
                     ):
                         continue
-                elif not supported_python.allows_any(
-                    parse_constraint(python_to_try + ".*")
-                ):
+                elif not supported_python.allows_any(parse_constraint(suffix + ".*")):
                     continue
 
-                python = "python" + python_to_try
-
+                python_name = f"python{suffix}"
                 if self._io.is_debug():
-                    self._io.write_error_line(f"<debug>Trying {python}</debug>")
+                    self._io.write_error_line(f"<debug>Trying {python_name}</debug>")
+
+                python = self._full_python_path(python_name)
+                if python is None:
+                    continue
 
                 try:
                     python_patch = decode(
@@ -979,14 +994,11 @@ class EnvManager:
                 except CalledProcessError:
                     continue
 
-                if not python_patch:
-                    continue
-
                 if supported_python.allows(Version.parse(python_patch)):
                     self._io.write_error_line(
-                        f"Using <c1>{python}</c1> ({python_patch})"
+                        f"Using <c1>{python_name}</c1> ({python_patch})"
                     )
-                    executable = self._full_python_path(python)
+                    executable = python
                     python_minor = ".".join(python_patch.split(".")[:2])
                     break
 

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -28,9 +30,11 @@ def check_output_wrapper(
         elif "sys.version_info[:2]" in python_cmd:
             return f"{version.major}.{version.minor}"
         elif "import sys; print(sys.executable)" in python_cmd:
-            return f"/usr/bin/{cmd[0]}"
+            executable = cmd[0]
+            basename = os.path.basename(executable)
+            return f"/usr/bin/{basename}"
         else:
             assert "import sys; print(sys.prefix)" in python_cmd
-            return str(Path("/prefix"))
+            return "/prefix"
 
     return check_output

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -56,6 +56,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
     venv_name: str,
     venvs_in_cache_config: None,
 ) -> None:
+    mocker.patch("shutil.which", side_effect=lambda py: f"/usr/bin/{py}")
     mocker.patch(
         "subprocess.check_output",
         side_effect=check_output_wrapper(),
@@ -94,6 +95,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
 
 
 def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
+    mocker: MockerFixture,
     tester: CommandTester,
     current_python: tuple[int, int, int],
     venv_cache: Path,
@@ -111,6 +113,8 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     doc = tomlkit.document()
     doc[venv_name] = {"minor": python_minor, "patch": python_patch}
     envs_file.write(doc)
+
+    mocker.patch("shutil.which", side_effect=lambda py: f"/usr/bin/{py}")
 
     tester.execute(python_minor)
 
@@ -134,6 +138,7 @@ def test_get_prefers_explicitly_activated_non_existing_virtualenvs_over_env_var(
     python_minor = ".".join(str(v) for v in current_python[:2])
     venv_dir = venv_cache / f"{venv_name}-py{python_minor}"
 
+    mocker.patch("shutil.which", side_effect=lambda py: f"/usr/bin/{py}")
     mocker.patch(
         "poetry.utils.env.EnvManager._env",
         new_callable=mocker.PropertyMock,

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1765,3 +1765,17 @@ def test_fallback_on_detect_active_python(
 
     assert active_python is None
     assert m.call_count == 1
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+def test_detect_active_python_with_bat(poetry: Poetry, tmp_path: Path) -> None:
+    """On Windows pyenv uses batch files for python management."""
+    python_wrapper = tmp_path / "python.bat"
+    wrapped_python = Path(r"C:\SpecialPython\python.exe")
+    with python_wrapper.open("w") as f:
+        f.write(f"@echo {wrapped_python}")
+    os.environ["PATH"] = str(python_wrapper.parent) + os.pathsep + os.environ["PATH"]
+
+    active_python = EnvManager(poetry)._detect_active_python()
+
+    assert active_python == wrapped_python


### PR DESCRIPTION
Resolves: #7772

https://github.com/python-poetry/poetry/issues/7075#issuecomment-1497136923 says that `subprocess.call("python")` on windows doesn't give the same answer as calling `python` from the command line does (in particular, since dropping `shell=True` on the `subprocess` call).

dropping `shell=True` still seems to me to be highly desirable, so this MR uses `shutil.which("python")` to figure out which python would have been found by typing `python` directly.

I'm not working on windows so can't readily verify that this works and it's not clear to me how to write a test script either.  Such things certainly seem desirable, but it might need someone else to pick up the baton...