### PR TITLE
tighten up some unused typechecking ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,6 @@ enable_error_code = [
 # warning.
 [[tool.mypy.overrides]]
 module = [
-    'poetry.console.commands.self.show.plugins',
     'poetry.plugins.plugin_manager',
     'poetry.repositories.installed_repository',
     'poetry.utils.env',

--- a/src/poetry/console/commands/self/show/plugins.py
+++ b/src/poetry/console/commands/self/show/plugins.py
@@ -25,14 +25,14 @@ class PluginPackage:
         from poetry.plugins.application_plugin import ApplicationPlugin
         from poetry.plugins.plugin import Plugin
 
-        group = entry_point.group  # type: ignore[attr-defined]
+        group = entry_point.group
 
         if group == ApplicationPlugin.group:
             self.application_plugins.append(entry_point)
         elif group == Plugin.group:
             self.plugins.append(entry_point)
         else:
-            name = entry_point.name  # type: ignore[attr-defined]
+            name = entry_point.name
             raise ValueError(f"Unknown plugin group ({group}) for {name}")
 
 

--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -71,7 +71,7 @@ class PluginManager:
             plugin.activate(*args, **kwargs)
 
     def _load_plugin_entry_point(self, ep: metadata.EntryPoint) -> None:
-        logger.debug("Loading the %s plugin", ep.name)  # type: ignore[attr-defined]
+        logger.debug("Loading the %s plugin", ep.name)
 
         plugin = ep.load()  # type: ignore[no-untyped-call]
 


### PR DESCRIPTION
we'll see whether the pipeline agrees, but I think that most of the `# type: ignore` markers relating to importlib-metadata are unnecessary