### PR TITLE
debug ci test failures

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -623,7 +623,7 @@ def get_pep517_metadata(path: Path) -> PackageInfo:
                 info = PackageInfo.from_metadata(path)
             except EnvCommandError as fbe:
                 raise PackageInfoError(
-                    path, "Fallback egg_info generation failed.", fbe
+                    path, e, "Fallback egg_info generation failed.", fbe
                 )
             finally:
                 os.chdir(cwd)

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -250,12 +250,8 @@ def test_info_setup_missing_mandatory_should_trigger_pep517(
     setup_py.write_text(decode(setup))
 
     spy = mocker.spy(VirtualEnv, "run")
-    try:
-        PackageInfo.from_directory(source_dir)
-    except PackageInfoError:
-        assert spy.call_count == 3
-    else:
-        assert spy.call_count == 1
+    _ = PackageInfo.from_directory(source_dir)
+    assert spy.call_count == 1
 
 
 def test_info_prefer_poetry_config_over_egg_info():


### PR DESCRIPTION
So I've seen the changed testcase failing, rarely, in CI.  

It's a bit of a curious testcase because so far as I can see it should only ever go through the branch that I've retained - as previously structured the output was quite unhelpful on failure (`venv.run()` gets called two times, instead of three, in the examples I recall).

So I've rearranged that, and also included information from the original exception in the `PackageInfoError` which - I think - must be the one that is being hit.  The hope being that next time the test fails, we'll get to see what the problem was.

I speculate that this _might_ be #7611 being hit in poetry's own CI pipelines all along.

However obviously now that I want the test script to fail, it is passing reliably, I've tried a few times and not hit problems...

Might just as well merge this though I think - it improves the clarity of the scripts anyway, and probably sooner or later it will pay off and reveal something.