### PR TITLE
Use existing .venv even without explicit in-project

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -626,10 +626,9 @@ class EnvManager:
         patch = python_version.text
 
         create = False
-        is_root_venv = self.use_in_project_venv()
-        # If we are required to create the virtual environment in the root folder,
+        # If we are required to create the virtual environment in the project directory,
         # create or recreate it if needed
-        if is_root_venv:
+        if self.use_in_project_venv():
             create = False
             venv = self.in_project_venv
             if venv.exists():
@@ -893,8 +892,8 @@ class EnvManager:
         if in_project is not None:
             return in_project
 
-        root_venv: Path = self._poetry.file.parent / ".venv"
-        return root_venv.is_dir()
+        venv: Path = self._poetry.file.parent / ".venv"
+        return venv.is_dir()
 
     def create_venv(
         self,
@@ -923,7 +922,7 @@ class EnvManager:
             return env
 
         create_venv = self._poetry.config.get("virtualenvs.create")
-        root_venv = self.use_in_project_venv()
+        in_project_venv = self.use_in_project_venv()
         prefer_active_python = self._poetry.config.get(
             "virtualenvs.prefer-active-python"
         )
@@ -933,7 +932,9 @@ class EnvManager:
             executable = self._detect_active_python()
 
         venv_path = (
-            self.in_project_venv if root_venv else self._poetry.config.virtualenvs_path
+            self.in_project_venv
+            if in_project_venv
+            else self._poetry.config.virtualenvs_path
         )
         if not name:
             name = self._poetry.package.name
@@ -1011,7 +1012,7 @@ class EnvManager:
                     self._poetry.package.python_versions
                 )
 
-        if root_venv:
+        if in_project_venv:
             venv = venv_path
         else:
             name = self.generate_env_name(name, str(cwd))

--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -891,9 +891,7 @@ class EnvManager:
         in_project: bool | None = self._poetry.config.get("virtualenvs.in-project")
         if in_project is not None:
             return in_project
-
-        venv: Path = self._poetry.file.parent / ".venv"
-        return venv.is_dir()
+        return self.in_project_venv.is_dir()
 
     def create_venv(
         self,


### PR DESCRIPTION
When `virtualenvs.in-project` is not set, but a `.venv` directory exists, poetry should use that directory.

That's what the documentation says anyway:

> If not set explicitly, poetry by default will create virtual environment under {cache-dir}/virtualenvs or use the {project-dir}/.venv directory when one is available.

Prior to this fix, if that directory exists but the configuration is not explicitly set then poetry will:
- create a new virtual environment (because the code in `.activate()` only looks at whether the configuration value is truthy - which it's not when not explicitly set)
- but then use `.venv` anyway (because the code in `.get()` works as the documentation describes)