### PR TITLE
Shell clear

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -613,6 +613,8 @@ according to the `$SHELL` environment variable,
 within the virtual environment.
 If one doesn't exist yet, it will be created.
 
+If `$POETRY_SHELL_CLEAR` is set, all previous terminal output will be cleared.
+
 ```bash
 poetry shell
 ```

--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -112,7 +112,7 @@ class Shell:
                 f"{self._get_source_command()} {shlex.quote(str(activate_path))}"
             )
 
-        if os.environ.get("POETRY_CLEAR_SHELL"):
+        if os.environ.get("POETRY_SHELL_CLEAR"):
             c.sendline("clear")
 
         def resize(sig: Any, data: Any) -> None:

--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -111,6 +111,9 @@ class Shell:
             c.sendline(
                 f"{self._get_source_command()} {shlex.quote(str(activate_path))}"
             )
+        
+        if os.environ.get("POETRY_CLEAR_SHELL"):
+            c.sendline("clear")
 
         def resize(sig: Any, data: Any) -> None:
             terminal = shutil.get_terminal_size()

--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -111,7 +111,7 @@ class Shell:
             c.sendline(
                 f"{self._get_source_command()} {shlex.quote(str(activate_path))}"
             )
-        
+
         if os.environ.get("POETRY_CLEAR_SHELL"):
             c.sendline("clear")
 

--- a/tests/console/commands/test_shell.py
+++ b/tests/console/commands/test_shell.py
@@ -10,6 +10,7 @@ import pytest
 
 if TYPE_CHECKING:
     from cleo.testers.command_tester import CommandTester
+    from pytest import Fixture
     from pytest_mock import MockerFixture
 
     from tests.types import CommandTesterFactory
@@ -30,6 +31,19 @@ def test_shell(tester: CommandTester, mocker: MockerFixture):
     shell_activate.assert_called_once_with(tester.command.env)
     assert tester.io.fetch_output() == expected_output
     assert tester.status_code == 0
+
+
+def test_shell_clear(tester: CommandTester, mocker: MockerFixture, capfd: Fixture):
+    os.environ["POETRY_SHELL_CLEAR"] = "1"
+    shell_activate = mocker.patch("poetry.utils.shell.Shell.activate")
+
+    tester.execute()
+    out, err = capfd.readouterr()
+
+    shell_activate.assert_called_once_with(tester.command.env)
+    assert tester.status_code == 0
+    assert out == ""
+    assert err == ""
 
 
 def test_shell_already_active(tester: CommandTester, mocker: MockerFixture):

--- a/tests/console/commands/test_shell.py
+++ b/tests/console/commands/test_shell.py
@@ -38,12 +38,12 @@ def test_shell_clear(tester: CommandTester, mocker: MockerFixture, capfd: Fixtur
     shell_activate = mocker.patch("poetry.utils.shell.Shell.activate")
 
     tester.execute()
-    out, err = capfd.readouterr()
+
+    expected_output = f"Spawning shell within {tester.command.env.path}\n"
 
     shell_activate.assert_called_once_with(tester.command.env)
+    assert tester.io.fetch_output() == expected_output
     assert tester.status_code == 0
-    assert out == ""
-    assert err == ""
 
 
 def test_shell_already_active(tester: CommandTester, mocker: MockerFixture):


### PR DESCRIPTION
Resolves: NA

- [✔] Added **tests** for changed code.
- [✔] Updated **documentation** for changed code.

Typically, `poetry shell` leaves lines of output that are redundant in typical use. There should be an option to have `poetry shell` drop the user into a clean shell (i.e. no previous output). This is a feature that I have been missing in my daily workflow with Poetry.

I have elected to do this via an environment variable, `$POETRY_SHELL_CLEAR`. The advantage of this approach is that this is the simplest to implement; only two lines of code have been added in addition to small testing and documentation changes.

An alternative would be to add a config option, such as `virtualenv.clear-upon-activation`, which I would be willing to implement if that is preferred.
