### PR TITLE
clarify use of subprocess.call()

### DIFF
--- a/src/poetry/utils/pip.py
+++ b/src/poetry/utils/pip.py
@@ -18,7 +18,7 @@ def pip_install(
     editable: bool = False,
     deps: bool = False,
     upgrade: bool = False,
-) -> int | str:
+) -> str:
     is_wheel = path.suffix == ".whl"
 
     # We disable version check here as we are already pinning to version available in

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -36,7 +36,7 @@ SOME_URL = "https://example.com/path.tar.gz"
 
 
 class MockEnv(BaseMockEnv):
-    def run(self, bin: str, *args: str, **kwargs: Any) -> str | int:
+    def run(self, bin: str, *args: str, **kwargs: Any) -> str:
         raise EnvCommandError(CalledProcessError(1, "python", output=""))
 
 

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -966,11 +966,11 @@ def test_call_with_input_and_keyboard_interrupt(
 def test_call_no_input_with_keyboard_interrupt(
     tmp_path: Path, tmp_venv: VirtualEnv, mocker: MockerFixture
 ) -> None:
-    mocker.patch("subprocess.call", side_effect=KeyboardInterrupt())
+    mocker.patch("subprocess.check_call", side_effect=KeyboardInterrupt())
     kwargs = {"call": True}
     with pytest.raises(KeyboardInterrupt):
         tmp_venv.run("python", "-", **kwargs)
-    subprocess.call.assert_called_once()
+    subprocess.check_call.assert_called_once()
 
 
 def test_run_with_called_process_error(
@@ -1010,7 +1010,7 @@ def test_call_no_input_with_called_process_error(
     tmp_path: Path, tmp_venv: VirtualEnv, mocker: MockerFixture
 ) -> None:
     mocker.patch(
-        "subprocess.call",
+        "subprocess.check_call",
         side_effect=subprocess.CalledProcessError(
             42, "some_command", "some output", "some error"
         ),
@@ -1018,7 +1018,7 @@ def test_call_no_input_with_called_process_error(
     kwargs = {"call": True}
     with pytest.raises(EnvCommandError) as error:
         tmp_venv.run("python", "-", **kwargs)
-    subprocess.call.assert_called_once()
+    subprocess.check_call.assert_called_once()
     assert "some output" in str(error.value)
     assert "some error" in str(error.value)
 
@@ -1054,9 +1054,10 @@ for i in range(10000):
     )
 
     def target(result: list[int]) -> None:
-        result.append(tmp_venv.run("python", str(script), call=True))
+        tmp_venv.run("python", str(script), call=True)
+        result.append(0)
 
-    results = []
+    results: list[int] = []
     # use a separate thread, so that the test does not block in case of error
     thread = Thread(target=target, args=(results,))
     thread.start()


### PR DESCRIPTION
The mixing of `env.run(..., call=True)` (having no interest in the output, returning an int) and other variants (returning the output as a string) has always been kind of icky.

On closer inspection it turns out [there's exactly one place that sets `call=True`](https://github.com/python-poetry/poetry/blob/a4c95359d7be30c8305bbc5189532845bfaf0fcf/src/poetry/masonry/builders/editable.py#L88), and it doesn't check the return code anyway, and that's a bug: #3717 and duplicate #6182.

So I've arranged that:

- in this branch `env.run()` just returns an empty string, no-one cared about the return value anyway
- but also use `subprocess.check_call()` instead of `subprocess.call()`, so that an exception is thrown in case of error - consistent with the other two branches

There are already testcases for `subprocess.call()` throwing an exception here: it's just that it never actually does so.

Fixes #3717 and duplicate #6182