### PR TITLE
parse extras correctly at 'poetry add'

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -192,7 +192,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
                 for extra in self.option("extras"):
                     extras += extra.split()
 
-                constraint["extras"] = self.option("extras")
+                constraint["extras"] = extras
 
             if self.option("editable"):
                 if "git" in _constraint or "path" in _constraint:


### PR DESCRIPTION
The code was carefully parsing the extras to allow multiple to be named in single whitespace-separated string (just as for `poetry install`).  But then it was throwing away the answer.

Splitting on commas would seem considerably more conventional than splitting on whitespace, but unless you also are willing to change `poetry install` the inconsistency would be even worse.