### PR TITLE
console: Fix typo in docs for `self add`

### DIFF
--- a/src/poetry/console/commands/self/add.py
+++ b/src/poetry/console/commands/self/add.py
@@ -16,7 +16,7 @@ class SelfAddCommand(SelfCommand, AddCommand):
         if o.name in {"editable", "extras", "source", "dry-run", "allow-prereleases"}
     ]
     help = f"""\
-The <c1>self add</c1> command installs additional package's to Poetry's runtime \
+The <c1>self add</c1> command installs additional packages to Poetry's runtime \
 environment.
 
 This is managed in the <comment>{SelfCommand.get_default_system_pyproject_file()}</> \


### PR DESCRIPTION
The apostrophe in "package's" is erroneous.

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
