### PR TITLE
tests: ensure forward compatibility with python-poetry/poetry-core#402

### DIFF
--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -99,7 +99,7 @@ if TYPE_CHECKING:
                 {
                     "name": "requests",
                     "markers": 'python_version < "2.7"',
-                    "version": ">=2.8.1,!=2.8.*",
+                    "version": ">=2.8.1,==2.8.*",
                     "extras": ["security", "tests"],
                 },
             ),

--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -20,54 +20,73 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize(
-    ("requirement", "specification"),
+    ("requirement", "expected_variants"),
     [
         (
             "git+https://github.com/demo/demo.git",
-            {"git": "https://github.com/demo/demo.git", "name": "demo"},
+            ({"git": "https://github.com/demo/demo.git", "name": "demo"},),
         ),
         (
             "git+ssh://github.com/demo/demo.git",
-            {"git": "ssh://github.com/demo/demo.git", "name": "demo"},
+            ({"git": "ssh://github.com/demo/demo.git", "name": "demo"},),
         ),
         (
             "git+https://github.com/demo/demo.git#main",
-            {"git": "https://github.com/demo/demo.git", "name": "demo", "rev": "main"},
+            (
+                {
+                    "git": "https://github.com/demo/demo.git",
+                    "name": "demo",
+                    "rev": "main",
+                },
+            ),
         ),
         (
             "git+https://github.com/demo/demo.git@main",
-            {"git": "https://github.com/demo/demo.git", "name": "demo", "rev": "main"},
+            (
+                {
+                    "git": "https://github.com/demo/demo.git",
+                    "name": "demo",
+                    "rev": "main",
+                },
+            ),
         ),
         (
             "git+https://github.com/demo/subdirectories.git@main#subdirectory=two",
-            {
-                "git": "https://github.com/demo/subdirectories.git",
-                "name": "two",
-                "rev": "main",
-                "subdirectory": "two",
-            },
+            (
+                {
+                    "git": "https://github.com/demo/subdirectories.git",
+                    "name": "two",
+                    "rev": "main",
+                    "subdirectory": "two",
+                },
+            ),
         ),
-        ("demo", {"name": "demo"}),
-        ("demo@1.0.0", {"name": "demo", "version": "1.0.0"}),
-        ("demo@^1.0.0", {"name": "demo", "version": "^1.0.0"}),
-        ("demo@==1.0.0", {"name": "demo", "version": "==1.0.0"}),
-        ("demo@!=1.0.0", {"name": "demo", "version": "!=1.0.0"}),
-        ("demo@~1.0.0", {"name": "demo", "version": "~1.0.0"}),
-        ("demo[a,b]@1.0.0", {"name": "demo", "version": "1.0.0", "extras": ["a", "b"]}),
-        ("demo[a,b]", {"name": "demo", "extras": ["a", "b"]}),
-        ("../demo", {"name": "demo", "path": "../demo"}),
-        ("../demo/demo.whl", {"name": "demo", "path": "../demo/demo.whl"}),
+        ("demo", ({"name": "demo"},)),
+        ("demo@1.0.0", ({"name": "demo", "version": "1.0.0"},)),
+        ("demo@^1.0.0", ({"name": "demo", "version": "^1.0.0"},)),
+        ("demo@==1.0.0", ({"name": "demo", "version": "==1.0.0"},)),
+        ("demo@!=1.0.0", ({"name": "demo", "version": "!=1.0.0"},)),
+        ("demo@~1.0.0", ({"name": "demo", "version": "~1.0.0"},)),
+        (
+            "demo[a,b]@1.0.0",
+            ({"name": "demo", "version": "1.0.0", "extras": ["a", "b"]},),
+        ),
+        ("demo[a,b]", ({"name": "demo", "extras": ["a", "b"]},)),
+        ("../demo", ({"name": "demo", "path": "../demo"},)),
+        ("../demo/demo.whl", ({"name": "demo", "path": "../demo/demo.whl"},)),
         (
             "https://example.com/distributions/demo-0.1.0.tar.gz",
-            {
-                "name": "demo",
-                "url": "https://example.com/distributions/demo-0.1.0.tar.gz",
-            },
+            (
+                {
+                    "name": "demo",
+                    "url": "https://example.com/distributions/demo-0.1.0.tar.gz",
+                },
+            ),
         ),
         # PEP 508 inputs
         (
             "poetry-core (>=1.0.7,<1.1.0)",
-            {"name": "poetry-core", "version": ">=1.0.7,<1.1.0"},
+            ({"name": "poetry-core", "version": ">=1.0.7,<1.1.0"},),
         ),
         (
             'requests [security,tests] >= 2.8.1, == 2.8.* ; python_version < "2.7"',
@@ -104,37 +123,41 @@ if TYPE_CHECKING:
                 },
             ),
         ),
-        ("name (>=3,<4)", {"name": "name", "version": ">=3,<4"}),
+        ("name (>=3,<4)", ({"name": "name", "version": ">=3,<4"},)),
         (
             "name@http://foo.com",
-            {"name": "name", "url": "http://foo.com"},
+            ({"name": "name", "url": "http://foo.com"},),
         ),
         (
             "name [fred,bar] @ http://foo.com ; python_version=='2.7'",
-            {
-                "name": "name",
-                "markers": 'python_version == "2.7"',
-                "url": "http://foo.com",
-                "extras": ["fred", "bar"],
-            },
+            (
+                {
+                    "name": "name",
+                    "markers": 'python_version == "2.7"',
+                    "url": "http://foo.com",
+                    "extras": ["fred", "bar"],
+                },
+            ),
         ),
         (
             (
                 'cachecontrol[filecache] (>=0.12.9,<0.13.0); python_version >= "3.6"'
                 ' and python_version < "4.0"'
             ),
-            {
-                "version": ">=0.12.9,<0.13.0",
-                "markers": 'python_version >= "3.6" and python_version < "4.0"',
-                "extras": ["filecache"],
-                "name": "cachecontrol",
-            },
+            (
+                {
+                    "version": ">=0.12.9,<0.13.0",
+                    "markers": 'python_version >= "3.6" and python_version < "4.0"',
+                    "extras": ["filecache"],
+                    "name": "cachecontrol",
+                },
+            ),
         ),
     ],
 )
 def test_parse_dependency_specification(
     requirement: str,
-    specification: DependencySpec | Collection[DependencySpec],
+    expected_variants: Collection[DependencySpec],
     mocker: MockerFixture,
     artifact_cache: ArtifactCache,
 ) -> None:
@@ -147,13 +170,11 @@ def test_parse_dependency_specification(
 
     mocker.patch("pathlib.Path.exists", _mock)
 
-    if isinstance(specification, dict):
-        specification = [specification]
     assert any(
         not DeepDiff(
             RequirementsParser(artifact_cache=artifact_cache).parse(requirement),
-            spec,
+            specification,
             ignore_order=True,
         )
-        for spec in specification
+        for specification in expected_variants
     )


### PR DESCRIPTION
With python-poetry/poetry-core#402 the constraint `">= 2.8.1, == 2.8.*"` is parsed to `">=2.8.1,<2.9.dev0"` instead of `">=2.8.1,<2.9.0"`.

All three are equivalent according to PEP 440.

I added some more options (considering zero padding) to make the test more robust to possible future changes.