### PR TITLE
deprecate `poetry self` commands

### DIFF
--- a/src/poetry/console/commands/self/self_command.py
+++ b/src/poetry/console/commands/self/self_command.py
@@ -124,6 +124,10 @@ class SelfCommand(InstallerCommand):
         #
         # This method **should not** be overridden in child classes as it may have
         # unexpected consequences.
+        self.line_error(
+            "<warning>`poetry self` commands are deprecated and will be removed in a"
+            " future release</>"
+        )
 
         self.reset()
 


### PR DESCRIPTION
Of course I am not expecting this to be merged without some discussion!  But I think it's a discussion that's worth having, so let's create a space in which to have it.

A thing that sometimes happens on this issue tracker is putting right users who have installed poetry itself in the project under management.  Of course that goes wrong: among other things, running `poetry update` (or whatever) can cause packages to be updated while poetry itself is actively using them; if you get unlucky then poetry just won't work any more.

But so far as I can see `poetry self` commands all are built on this exact mistake: the `poetry` binary is managing its own environment.  And indeed there are reports from people who do things like `poetry self update` and see just the same sort of problem: #7610, #7819

I don't understand how this can be expected to work, and I have no idea how it can be fixed.  

What's more - perhaps this wasn't true a few years back - there are fine alternatives available, most obviously `pipx` based installations.

I also think in general that `poetry` has a larger surface area than is good for the health of the project - see the state of the issue backlog - and that `poetry self` is a relatively bug-rich part of the codebase, certainly compared to the value that it brings.  So to my mind it's a great candidate for establishing that it is possible to remove code that is more burden than help.

Opinions welcome...