### PR TITLE
send \r to fish when using poetry shell to execute source command

### DIFF
--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -107,12 +107,13 @@ class Shell:
             if self._name == "zsh":
                 # Under ZSH the source command should be invoked in zsh's bash emulator
                 c.sendline(f"emulate bash -c '. {shlex.quote(str(activate_path))}'")
-        elif self._name == "fish":
-            # Under fish "\r" should be sent explicitly
-            c.sendline(f"source {shlex.quote(str(activate_path))}\r")
         else:
+            cmd = f"{self._get_source_command()} {shlex.quote(str(activate_path))}"
+            if self._name == "fish":
+                # Under fish "\r" should be sent explicitly
+                cmd += "\r"
             c.sendline(
-                f"{self._get_source_command()} {shlex.quote(str(activate_path))}"
+                cmd
             )
 
         def resize(sig: Any, data: Any) -> None:

--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -112,9 +112,7 @@ class Shell:
             if self._name == "fish":
                 # Under fish "\r" should be sent explicitly
                 cmd += "\r"
-            c.sendline(
-                cmd
-            )
+            c.sendline(cmd)
 
         def resize(sig: Any, data: Any) -> None:
             terminal = shutil.get_terminal_size()

--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -107,6 +107,9 @@ class Shell:
             if self._name == "zsh":
                 # Under ZSH the source command should be invoked in zsh's bash emulator
                 c.sendline(f"emulate bash -c '. {shlex.quote(str(activate_path))}'")
+        elif self._name == "fish":
+            # Under fish "\r" should be sent explicitly
+            c.sendline(f"source {shlex.quote(str(activate_path))}\r")
         else:
             c.sendline(
                 f"{self._get_source_command()} {shlex.quote(str(activate_path))}"
@@ -141,7 +144,7 @@ class Shell:
         return "activate" + suffix
 
     def _get_source_command(self) -> str:
-        if self._name in ("fish", "csh", "tcsh", "nu"):
+        if self._name in ("csh", "tcsh", "nu"):
             return "source"
         return "."
 

--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -145,7 +145,7 @@ class Shell:
         return "activate" + suffix
 
     def _get_source_command(self) -> str:
-        if self._name in ("csh", "tcsh", "nu"):
+        if self._name in ("fish", "csh", "tcsh", "nu"):
             return "source"
         return "."
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7883

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

The fix to issue #7883 is to send "\r" explicitly. Compare [here](https://github.com/pexpect/pexpect/issues/755#issuecomment-1536157035). I don't think a documentation update is necessary. I did not add a test, because the change is small and I could not find an existing test for the poetry shell module.