### PR TITLE
Add tests and remove unused params for test_add.py

### DIFF
--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -175,9 +175,7 @@ No changes were applied.
     assert content == pyproject2["tool"]["poetry"]
 
 
-def test_add_equal_constraint(
-    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
-) -> None:
+def test_add_equal_constraint(repo: TestRepository, tester: CommandTester) -> None:
     repo.add_package(get_package("cachy", "0.1.0"))
     repo.add_package(get_package("cachy", "0.2.0"))
 
@@ -200,9 +198,7 @@ Writing lock file
     assert tester.command.installer.executor.installations_count == 1
 
 
-def test_add_greater_constraint(
-    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
-) -> None:
+def test_add_greater_constraint(repo: TestRepository, tester: CommandTester) -> None:
     repo.add_package(get_package("cachy", "0.1.0"))
     repo.add_package(get_package("cachy", "0.2.0"))
 
@@ -227,7 +223,6 @@ Writing lock file
 
 @pytest.mark.parametrize("extra_name", ["msgpack", "MsgPack"])
 def test_add_constraint_with_extras(
-    app: PoetryTestApplication,
     repo: TestRepository,
     tester: CommandTester,
     extra_name: str,
@@ -1002,6 +997,29 @@ cachy = "^0.2.0"
     assert expected in string_content
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cachy --extras security socks",
+    ],
+)
+def test_add_extras_only_accepts_one_value(
+    command: str, tester: CommandTester, repo: TestRepository
+) -> None:
+    """
+    You cannot pass in multiple values to a single --extras flag.\
+    e.g. --extras security socks is not allowed.
+    """
+    repo.add_package(get_package("cachy", "0.1.0"))
+
+    with pytest.raises(ValueError) as e:
+        tester.execute(command)
+        assert (
+            str(e.value)
+            == "You can only specify one package when using the --extras option"
+        )
+
+
 def test_add_to_dev_section_deprecated(
     app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
 ) -> None:
@@ -1122,7 +1140,7 @@ If you prefer to upgrade it to the latest available version,\
 
 
 def test_add_should_fail_circular_dependency(
-    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
+    repo: TestRepository, tester: CommandTester
 ) -> None:
     repo.add_package(get_package("simple-project", "1.1.2"))
     result = tester.execute("simple-project")

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -257,7 +257,7 @@ Writing lock file
 
 
 def test_add_constraint_dependencies(
-    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
+    repo: TestRepository, tester: CommandTester
 ) -> None:
     cachy2 = get_package("cachy", "0.2.0")
     msgpack_dep = get_dependency("msgpack-python", ">=0.5 <0.6")
@@ -327,7 +327,6 @@ Writing lock file
 
 
 def test_add_git_constraint_with_poetry(
-    app: PoetryTestApplication,
     repo: TestRepository,
     tester: CommandTester,
     tmp_venv: VirtualEnv,
@@ -415,9 +414,7 @@ def test_add_git_constraint_with_subdirectory(
     url: str,
     rev: str | None,
     app: PoetryTestApplication,
-    repo: TestRepository,
     tester: CommandTester,
-    env: MockEnv,
 ) -> None:
     tester.execute(url)
 
@@ -586,7 +583,6 @@ def test_add_file_constraint_wheel(
     app: PoetryTestApplication,
     repo: TestRepository,
     tester: CommandTester,
-    poetry: Poetry,
 ) -> None:
     repo.add_package(get_package("pendulum", "1.4.4"))
 
@@ -750,7 +746,6 @@ def test_add_url_constraint_wheel_with_extras(
     repo: TestRepository,
     tester: CommandTester,
     extra_name: str,
-    mocker: MockerFixture,
 ) -> None:
     repo.add_package(get_package("pendulum", "1.4.4"))
     repo.add_package(get_package("cleo", "0.6.5"))
@@ -923,9 +918,7 @@ Writing lock file
     }
 
 
-def test_add_constraint_with_source_that_does_not_exist(
-    app: PoetryTestApplication, tester: CommandTester
-) -> None:
+def test_add_constraint_with_source_that_does_not_exist(tester: CommandTester) -> None:
     with pytest.raises(IndexError) as e:
         tester.execute("foo --source i-dont-exist")
 
@@ -933,7 +926,6 @@ def test_add_constraint_with_source_that_does_not_exist(
 
 
 def test_add_constraint_not_found_with_source(
-    app: PoetryTestApplication,
     poetry: Poetry,
     mocker: MockerFixture,
     tester: CommandTester,
@@ -1224,7 +1216,7 @@ Writing lock file
 
 
 def test_add_chooses_prerelease_if_only_prereleases_are_available(
-    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
+    repo: TestRepository, tester: CommandTester
 ) -> None:
     repo.add_package(get_package("foo", "1.2.3b0"))
     repo.add_package(get_package("foo", "1.2.3b1"))
@@ -1247,7 +1239,7 @@ Writing lock file
 
 
 def test_add_prefers_stable_releases(
-    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
+    repo: TestRepository, tester: CommandTester
 ) -> None:
     repo.add_package(get_package("foo", "1.2.3"))
     repo.add_package(get_package("foo", "1.2.4b1"))

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -1000,7 +1000,7 @@ cachy = "^0.2.0"
 @pytest.mark.parametrize(
     "command",
     [
-        "cachy --extras security socks",
+        "requests --extras security socks",
     ],
 )
 def test_add_extras_only_accepts_one_value(
@@ -1010,7 +1010,7 @@ def test_add_extras_only_accepts_one_value(
     You cannot pass in multiple values to a single --extras flag.\
     e.g. --extras security socks is not allowed.
     """
-    repo.add_package(get_package("cachy", "0.1.0"))
+    repo.add_package(get_package("requests", "2.30.0"))
 
     with pytest.raises(ValueError) as e:
         tester.execute(command)


### PR DESCRIPTION
# Pull Request Check List

Relates-to: #3155

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


This PR removes unused parameters in function signatures and adds two additional tests for the add command, which brings the coverage from 96% to 98%.

Before:

```
/workspaces/poetry/src/poetry/console/commands/add.py                   134      5    96%   121, 133, 149, 185, 188
```

After:
```
workspaces/poetry/src/poetry/console/commands/add.py                   134      3    98%   133, 149, 188
```
