### PR TITLE
Add tests and remove unused params for test_config.py

### DIFF
--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -213,6 +213,19 @@ def test_unset_nonempty_repositories_section(
     assert str(e.value) == expected
 
 
+def test_set_malformed_repositories_setting(
+    tester: CommandTester,
+) -> None:
+    with pytest.raises(ValueError) as e:
+        tester.execute("repositories.foo bar baz")
+
+    assert (
+        str(e.value)
+        == "You must pass the url. Example: poetry config repositories.foo"
+        " https://bar.com"
+    )
+
+
 @pytest.mark.parametrize(
     ("setting", "expected"),
     [

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -273,6 +273,21 @@ def test_set_cert(
     assert auth_config_source.config["certificates"]["foo"]["cert"] == result
 
 
+def test_unset_cert(
+    tester: CommandTester,
+    auth_config_source: DictConfigSource,
+    mocker: MockerFixture,
+) -> None:
+    mocker.spy(ConfigSource, "__init__")
+
+    tester.execute("certificates.foo.cert path/to/ca.pem")
+
+    assert "cert" in auth_config_source.config["certificates"]["foo"]
+
+    tester.execute("certificates.foo.cert --unset")
+    assert "cert" not in auth_config_source.config["certificates"]["foo"]
+
+
 def test_config_installer_parallel(
     tester: CommandTester, command_tester_factory: CommandTesterFactory
 ) -> None:

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -151,6 +151,13 @@ virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
     assert tester.io.fetch_output() == expected
 
 
+def test_unset_value_not_exists(tester: CommandTester) -> None:
+    with pytest.raises(ValueError) as e:
+        tester.execute("foobar --unset")
+
+    assert str(e.value) == "Setting foobar does not exist"
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -181,6 +181,20 @@ def test_display_single_local_setting(
     assert tester.io.fetch_output() == expected
 
 
+def test_display_empty_repositories_key(
+    command_tester_factory: CommandTesterFactory, fixture_dir: FixtureDirGetter
+) -> None:
+    tester = command_tester_factory(
+        "config",
+        poetry=Factory().create_poetry(fixture_dir("with_empty_repositories_key")),
+    )
+    tester.execute("repositories")
+
+    expected = """{}
+"""
+    assert tester.io.fetch_output() == expected
+
+
 def test_list_displays_set_get_local_setting(
     tester: CommandTester, config: Config, config_cache_dir: Path
 ) -> None:

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -109,6 +109,13 @@ def test_cannot_set_with_multiple_values(tester: CommandTester) -> None:
     assert str(e.value) == "You can only pass one value."
 
 
+def test_cannot_set_invalid_value(tester: CommandTester) -> None:
+    with pytest.raises(RuntimeError) as e:
+        tester.execute("virtualenvs.create foo")
+
+    assert str(e.value) == '"foo" is an invalid value for virtualenvs.create'
+
+
 def test_cannot_unset_with_value(tester: CommandTester) -> None:
     with pytest.raises(RuntimeError) as e:
         tester.execute("virtualenvs.create false --unset")

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -123,7 +123,35 @@ def test_cannot_unset_with_value(tester: CommandTester) -> None:
     assert str(e.value) == "You can not combine a setting value with --unset"
 
 
-def test_unset_value_successfully(
+def test_unset_setting(
+    tester: CommandTester, config: Config, config_cache_dir: Path
+) -> None:
+    tester.execute("virtualenvs.path /some/path")
+    tester.execute("virtualenvs.path --unset")
+    tester.execute("--list")
+    cache_dir = json.dumps(str(config_cache_dir))
+    venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
+    expected = f"""cache-dir = {cache_dir}
+experimental.system-git-client = false
+installer.max-workers = null
+installer.modern-installation = true
+installer.no-binary = null
+installer.parallel = true
+virtualenvs.create = true
+virtualenvs.in-project = null
+virtualenvs.options.always-copy = false
+virtualenvs.options.no-pip = false
+virtualenvs.options.no-setuptools = false
+virtualenvs.options.system-site-packages = false
+virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
+virtualenvs.prefer-active-python = false
+virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+"""
+    assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
+    assert tester.io.fetch_output() == expected
+
+
+def test_unset_repo_setting(
     tester: CommandTester, config: Config, config_cache_dir: Path
 ) -> None:
     tester.execute("repositories.foo.url https://bar.com/simple/")

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -102,6 +102,13 @@ virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
     assert tester.io.fetch_output() == expected
 
 
+def test_cannot_set_with_multiple_values(tester: CommandTester) -> None:
+    with pytest.raises(RuntimeError) as e:
+        tester.execute("virtualenvs.create false true")
+
+    assert str(e.value) == "You can only pass one value."
+
+
 def test_cannot_unset_with_value(tester: CommandTester) -> None:
     with pytest.raises(RuntimeError) as e:
         tester.execute("virtualenvs.create false --unset")

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -330,6 +330,15 @@ def test_unset_http_basic(
     assert "foo" not in auth_config_source.config["http-basic"]
 
 
+def test_set_http_basic_unsuccessful_multiple_values(
+    tester: CommandTester,
+) -> None:
+    with pytest.raises(ValueError) as e:
+        tester.execute("http-basic.foo username password password")
+
+    assert str(e.value) == "Expected one or two arguments (username, password), got 3"
+
+
 def test_set_pypi_token(
     tester: CommandTester, auth_config_source: DictConfigSource
 ) -> None:
@@ -347,6 +356,15 @@ def test_unset_pypi_token(
     tester.execute("--list")
 
     assert "pypi" not in auth_config_source.config["pypi-token"]
+
+
+def test_set_pypi_token_unsuccessful_multiple_values(
+    tester: CommandTester,
+) -> None:
+    with pytest.raises(ValueError) as e:
+        tester.execute("pypi-token.pypi mytoken mytoken")
+
+    assert str(e.value) == "Expected only one argument (token), got 2"
 
 
 def test_set_client_cert(

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -308,6 +308,28 @@ virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
     assert tester.io.fetch_output() == expected
 
 
+def test_set_http_basic(
+    tester: CommandTester, auth_config_source: DictConfigSource
+) -> None:
+    tester.execute("http-basic.foo username password")
+    tester.execute("--list")
+
+    assert auth_config_source.config["http-basic"]["foo"] == {
+        "username": "username",
+        "password": "password",
+    }
+
+
+def test_unset_http_basic(
+    tester: CommandTester, auth_config_source: DictConfigSource
+) -> None:
+    tester.execute("http-basic.foo username password")
+    tester.execute("http-basic.foo --unset")
+    tester.execute("--list")
+
+    assert "foo" not in auth_config_source.config["http-basic"]
+
+
 def test_set_pypi_token(
     tester: CommandTester, auth_config_source: DictConfigSource
 ) -> None:
@@ -315,6 +337,16 @@ def test_set_pypi_token(
     tester.execute("--list")
 
     assert auth_config_source.config["pypi-token"]["pypi"] == "mytoken"
+
+
+def test_unset_pypi_token(
+    tester: CommandTester, auth_config_source: DictConfigSource
+) -> None:
+    tester.execute("pypi-token.pypi mytoken")
+    tester.execute("pypi-token.pypi --unset")
+    tester.execute("--list")
+
+    assert "pypi" not in auth_config_source.config["pypi-token"]
 
 
 def test_set_client_cert(

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -181,7 +181,7 @@ def test_display_single_local_setting(
     assert tester.io.fetch_output() == expected
 
 
-def test_display_empty_repositories_key(
+def test_display_empty_repositories_setting(
     command_tester_factory: CommandTesterFactory, fixture_dir: FixtureDirGetter
 ) -> None:
     tester = command_tester_factory(
@@ -193,6 +193,20 @@ def test_display_empty_repositories_key(
     expected = """{}
 """
     assert tester.io.fetch_output() == expected
+
+
+def test_display_undefined_repository_setting(
+    command_tester_factory: CommandTesterFactory, fixture_dir: FixtureDirGetter
+) -> None:
+    tester = command_tester_factory(
+        "config",
+        poetry=Factory().create_poetry(fixture_dir("with_undefined_repository_key")),
+    )
+
+    with pytest.raises(ValueError) as e:
+        tester.execute("repositories.foo")
+
+    assert str(e.value) == "There is no foo repository defined"
 
 
 def test_list_displays_set_get_local_setting(

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -151,11 +151,18 @@ virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
     assert tester.io.fetch_output() == expected
 
 
-def test_display_single_setting(tester: CommandTester) -> None:
-    tester.execute("virtualenvs.create")
-
-    expected = """true
-"""
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("virtualenvs.create", "true\n"),
+        ("repositories.foo.url", "{'url': 'https://bar.com/simple/'}\n"),
+    ],
+)
+def test_display_single_setting(
+    tester: CommandTester, value: str, expected: str | bool
+) -> None:
+    tester.execute("repositories.foo.url https://bar.com/simple/")
+    tester.execute(value)
 
     assert tester.io.fetch_output() == expected
 

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -195,18 +195,20 @@ def test_display_empty_repositories_setting(
     assert tester.io.fetch_output() == expected
 
 
-def test_display_undefined_repository_setting(
-    command_tester_factory: CommandTesterFactory, fixture_dir: FixtureDirGetter
+@pytest.mark.parametrize(
+    ("setting", "expected_output"),
+    [
+        ("repositories.foo", "There is no foo repository defined"),
+        ("foo", "There is no foo setting."),
+    ],
+)
+def test_display_undefined_setting(
+    tester: CommandTester, setting: str, expected_output: str
 ) -> None:
-    tester = command_tester_factory(
-        "config",
-        poetry=Factory().create_poetry(fixture_dir("with_undefined_repository_key")),
-    )
-
     with pytest.raises(ValueError) as e:
-        tester.execute("repositories.foo")
+        tester.execute(setting)
 
-    assert str(e.value) == "There is no foo repository defined"
+    assert str(e.value) == expected_output
 
 
 def test_list_displays_set_get_local_setting(

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -194,7 +194,6 @@ def test_list_must_not_display_sources_from_pyproject_toml(
     project_factory: ProjectFactory,
     fixture_dir: FixtureDirGetter,
     command_tester_factory: CommandTesterFactory,
-    config: Config,
     config_cache_dir: Path,
 ) -> None:
     source = fixture_dir("with_non_default_source_implicit")
@@ -249,6 +248,18 @@ def test_set_client_cert(
         auth_config_source.config["certificates"]["foo"]["client-cert"]
         == "path/to/cert.pem"
     )
+
+
+def test_set_client_cert_unsuccessful_multiple_values(
+    tester: CommandTester,
+    mocker: MockerFixture,
+) -> None:
+    mocker.spy(ConfigSource, "__init__")
+
+    with pytest.raises(ValueError) as e:
+        tester.execute("certificates.foo.client-cert path/to/cert.pem path/to/cert.pem")
+
+    assert str(e.value) == "You must pass exactly 1 value"
 
 
 @pytest.mark.parametrize(

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -196,19 +196,37 @@ def test_display_empty_repositories_setting(
 
 
 @pytest.mark.parametrize(
-    ("setting", "expected_output"),
+    ("setting", "expected"),
+    [
+        ("repositories", "You cannot remove the [repositories] section"),
+        ("repositories.test", "There is no test repository defined"),
+    ],
+)
+def test_unset_nonempty_repositories_section(
+    tester: CommandTester, setting: str, expected: str
+) -> None:
+    tester.execute("repositories.foo.url https://bar.com/simple/")
+
+    with pytest.raises(ValueError) as e:
+        tester.execute(f"{setting} --unset")
+
+    assert str(e.value) == expected
+
+
+@pytest.mark.parametrize(
+    ("setting", "expected"),
     [
         ("repositories.foo", "There is no foo repository defined"),
         ("foo", "There is no foo setting."),
     ],
 )
 def test_display_undefined_setting(
-    tester: CommandTester, setting: str, expected_output: str
+    tester: CommandTester, setting: str, expected: str
 ) -> None:
     with pytest.raises(ValueError) as e:
         tester.execute(setting)
 
-    assert str(e.value) == expected_output
+    assert str(e.value) == expected
 
 
 def test_list_displays_set_get_local_setting(


### PR DESCRIPTION
# Pull Request Check List

Relates-to: #3155

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This PR removes unused parameters in function signatures and adds additional tests for the config command, which brings the coverage from 69% to 95%.

Before:
```
src/poetry/console/commands/config.py       166     52    69%   22, 101-102, 121, 128-139, 142, 157-158, 170-189, 201-206, 209-223, 226, 243-247, 259, 263, 275, 279, 303-306
```

After:
```
src/poetry/console/commands/config.py       166      8    95%   22, 101-102, 210-213, 303-306
```