### PR TITLE
perf: use cached file for wheel inspection

### DIFF
--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import functools
 import hashlib
-import os
-import urllib
-import urllib.parse
 
 from collections import defaultdict
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Iterator
 
 import requests
 
@@ -75,39 +74,28 @@ class HTTPRepository(CachedRepository):
     def _download(self, url: str, dest: Path) -> None:
         return download_file(url, dest, session=self.session)
 
+    @contextmanager
+    def _cached_or_downloaded_file(self, link: Link) -> Iterator[Path]:
+        filepath = self._authenticator.get_cached_file_for_url(link.url)
+        if filepath:
+            yield filepath
+        else:
+            self._log(f"Downloading: {link.url}", level="debug")
+            with temporary_directory() as temp_dir:
+                filepath = Path(temp_dir) / link.filename
+                self._download(link.url, filepath)
+                yield filepath
+
     def _get_info_from_wheel(self, url: str) -> PackageInfo:
         from poetry.inspection.info import PackageInfo
 
-        wheel_name = urllib.parse.urlparse(url).path.rsplit("/")[-1]
-
-        filepath = self._authenticator.get_cached_file_for_url(url)
-        if filepath:
-            return PackageInfo.from_wheel(filepath)
-
-        self._log(f"Downloading wheel: {wheel_name}", level="debug")
-        filename = os.path.basename(wheel_name)
-        with temporary_directory() as temp_dir:
-            filepath = Path(temp_dir) / filename
-            self._download(url, filepath)
-
+        with self._cached_or_downloaded_file(Link(url)) as filepath:
             return PackageInfo.from_wheel(filepath)
 
     def _get_info_from_sdist(self, url: str) -> PackageInfo:
         from poetry.inspection.info import PackageInfo
 
-        sdist_name = urllib.parse.urlparse(url).path
-        sdist_name_log = sdist_name.rsplit("/")[-1]
-
-        filepath = self._authenticator.get_cached_file_for_url(url)
-        if filepath:
-            return PackageInfo.from_wheel(filepath)
-
-        self._log(f"Downloading sdist: {sdist_name_log}", level="debug")
-        filename = os.path.basename(sdist_name)
-        with temporary_directory() as temp_dir:
-            filepath = Path(temp_dir) / filename
-            self._download(url, filepath)
-
+        with self._cached_or_downloaded_file(Link(url)) as filepath:
             return PackageInfo.from_sdist(filepath)
 
     def _get_info_from_urls(self, urls: dict[str, list[str]]) -> PackageInfo:
@@ -242,12 +230,7 @@ class HTTPRepository(CachedRepository):
                 and link.hash_name not in ("sha256", "sha384", "sha512")
                 and hasattr(hashlib, link.hash_name)
             ):
-                with temporary_directory() as temp_dir:
-                    filepath = self._authenticator.get_cached_file_for_url(link.url)
-                    if not filepath:
-                        filepath = Path(temp_dir) / link.filename
-                        self._download(link.url, filepath)
-
+                with self._cached_or_downloaded_file(link) as filepath:
                     known_hash = (
                         getattr(hashlib, link.hash_name)() if link.hash_name else None
                     )

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -19,6 +19,7 @@ import requests.exceptions
 
 from cachecontrol import CacheControlAdapter
 from cachecontrol.caches import FileCache
+from cachecontrol.caches.file_cache import url_to_file_path
 from filelock import FileLock
 
 from poetry.config.config import Config
@@ -462,6 +463,13 @@ class Authenticator:
         if selected:
             return selected.certs(config=self._config)
         return RepositoryCertificateConfig()
+
+    def get_cached_file_for_url(self, url: str) -> Path | None:
+        if self._cache_control is None:
+            return None
+
+        path = Path(url_to_file_path(url, self._cache_control))
+        return path if path.exists() else None
 
 
 _authenticator: Authenticator | None = None

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -627,6 +627,22 @@ def test_authenticator_git_repositories(
     assert not three.password
 
 
+def test_authenticator_get_cached_file_for_url__cache_miss(config: Config) -> None:
+    authenticator = Authenticator(config, NullIO())
+    assert (
+        authenticator.get_cached_file_for_url("https://foo.bar/cache/miss.whl") is None
+    )
+
+
+def test_authenticator_get_cached_file_for_url__cache_hit(config: Config) -> None:
+    authenticator = Authenticator(config, NullIO())
+    url = "https://foo.bar/files/foo-0.1.0.tar.gz"
+
+    authenticator._cache_control.set(url, b"hello")
+
+    assert authenticator.get_cached_file_for_url(url)
+
+
 @pytest.mark.parametrize(
     ("ca_cert", "client_cert", "result"),
     [


### PR DESCRIPTION
Another PR that goes in the way of improving the Poetry experience when dealing with huge wheels (did anyone say PyTorch? 👀 #6409 )

I'm hosting huge wheels on a repository that is not PEP 658 compliant. What happens is that Poetry will rightfully want to [get package metadata from the first wheel](https://github.com/python-poetry/poetry/blob/3bed8d67cb16f6e016e8cac0905bb7a4677868c6/src/poetry/repositories/http_repository.py#L210). The package is correctly cached on filesystem in the repository cache (the whole `Authenticator` + `FileCache` flow) so that future downloads are not needed again.

However, when a wheel is already cached on filesystem the inspection code performs an unnecessary data transfer operation from the cache location to a temporary directory. As the speed of this operation is controlled by the low `chunk_size: int = 1024` value, we spend a gigantic amount of time waiting for something that we already have. Console logs also incorrectly show that a package is being downloaded, while in reality no network operation is happening.

This PR fixes this behaviour by accessing the cached file directly, and relying on the download to temporary file only if the file is not cached (or the cache is disabled). In order to do so it exploits the public `url_to_file_path` utility from `cachecontrol`. I thought it was best leaving any direct `cachecontrol` dependency inside the `Authenticator`, which is the reason why I'm touching two classes.

- [x] Added **tests** for changed code.
- ~[ ] Updated **documentation** for changed code.~
