### PR TITLE
fix: log config file warning as string not tuple

### DIFF
--- a/src/poetry/locations.py
+++ b/src/poetry/locations.py
@@ -36,12 +36,10 @@ if sys.platform == "darwin":
     if any(file.exists() for file in (auth_toml, config_toml)):
         logger.warning(
             (
-                (
-                    "Configuration file exists at %s, reusing this"
-                    " directory.\n\nConsider moving TOML configuration files to %s, as"
-                    " support for the legacy directory will be removed in an upcoming"
-                    " release."
-                ),
+                "Configuration file exists at %s, reusing this"
+                " directory.\n\nConsider moving TOML configuration files to %s, as"
+                " support for the legacy directory will be removed in an upcoming"
+                " release."
             ),
             _LEGACY_CONFIG_DIR,
             CONFIG_DIR,


### PR DESCRIPTION
Fixes a regression from #7140
