### PR TITLE
fix: fix `poetry shell` for nushell

### DIFF
--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -104,13 +104,14 @@ class Shell:
 
         if self._name in ["zsh", "nu"]:
             c.setecho(False)
-            if self._name == "zsh":
-                # Under ZSH the source command should be invoked in zsh's bash emulator
-                c.sendline(f"emulate bash -c '. {shlex.quote(str(activate_path))}'")
+
+        if self._name == "zsh":
+            # Under ZSH the source command should be invoked in zsh's bash emulator
+            c.sendline(f"emulate bash -c '. {shlex.quote(str(activate_path))}'")
         else:
             cmd = f"{self._get_source_command()} {shlex.quote(str(activate_path))}"
-            if self._name == "fish":
-                # Under fish "\r" should be sent explicitly
+            if self._name in ["fish", "nu"]:
+                # Under fish and nu "\r" should be sent explicitly
                 cmd += "\r"
             c.sendline(cmd)
 
@@ -143,8 +144,10 @@ class Shell:
         return "activate" + suffix
 
     def _get_source_command(self) -> str:
-        if self._name in ("fish", "csh", "tcsh", "nu"):
+        if self._name in ("fish", "csh", "tcsh"):
             return "source"
+        elif self._name == "nu":
+            return "overlay use"
         return "."
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Here are two fixes to `poetry shell` under nushell:

1. the virtualenv activation command was not actually being sent. The commit 28d0175 accidentally removed the sendline command for nu, and nu also requires an explicit `\r` like fish.
2. the correct activation command is `overlay use`, not `source`. For reference, see the header comment in virtualenv's [`activate.nu`](https://github.com/pypa/virtualenv/blob/64bec9be8d412d7e7439987f565f7070e66cdf5a/src/virtualenv/activation/nushell/activate.nu#L2).

Tested manually with nushell 0.78.0. There do not seem to be any unit tests for the shell activation logic, so I didn't add any new ones.

# Pull Request Check List

Resolves: #7228

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
