### PR TITLE
fix: fix url dependency caching when special urlencoded chars

### DIFF
--- a/src/poetry/packages/direct_origin.py
+++ b/src/poetry/packages/direct_origin.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import functools
-import os
-import urllib.parse
 
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -77,20 +75,19 @@ class DirectOrigin:
         return PackageInfo.from_directory(path=directory).to_package(root_dir=directory)
 
     def get_package_from_url(self, url: str) -> Package:
-        file_name = os.path.basename(urllib.parse.urlparse(url).path)
         link = Link(url)
         artifact = self._artifact_cache.get_cached_archive_for_link(link, strict=True)
 
         if not artifact:
             artifact = (
-                self._artifact_cache.get_cache_directory_for_link(link) / file_name
+                self._artifact_cache.get_cache_directory_for_link(link) / link.filename
             )
             artifact.parent.mkdir(parents=True, exist_ok=True)
             download_file(url, artifact)
 
         package = self.get_package_from_file(artifact)
         package.files = [
-            {"file": file_name, "hash": "sha256:" + get_file_hash(artifact)}
+            {"file": link.filename, "hash": "sha256:" + get_file_hash(artifact)}
         ]
 
         package._source_type = "url"


### PR DESCRIPTION
Minor fix over https://github.com/python-poetry/poetry/pull/7693, ideally to be included in [1.5.0](https://github.com/python-poetry/poetry/issues/7853) as well.

Noticed that the url dependency caching behaviour was broken when special characters (`+` in the example) are part of the url. Taking the usual PyTorch as example (👀):
- We were storing the wheel on filesystem as `torch-2.0.0%2Bcpu-cp39-cp39-linux_x86_64.whl`
- But we were trying to retrieve from cache `torch-2.0.0+cpu-cp39-cp39-linux_x86_64.whl`

thus rendering the caching mechanism useless.

The fix correctly stores the wheel on filesystem as `torch-2.0.0+cpu-cp39-cp39-linux_x86_64.whl`, making the cache great again.

Didn't mind adding a test as using `Link` should be the general way to go around the codebase instead of using `os` and `urllib` directly.  
