### PR TITLE
feat: do not call keyring when user in config and password in environment variables

### DIFF
--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -193,16 +193,13 @@ class PasswordManager:
         self.keyring.delete_password(name, "__token__")
 
     def get_http_auth(self, name: str) -> dict[str, str | None] | None:
-        auth = self._config.get(f"http-basic.{name}")
-        if not auth:
-            username = self._config.get(f"http-basic.{name}.username")
-            password = self._config.get(f"http-basic.{name}.password")
-            if not username and not password:
-                return None
-        else:
-            username, password = auth["username"], auth.get("password")
-            if password is None:
-                password = self.keyring.get_password(name, username)
+        username = self._config.get(f"http-basic.{name}.username")
+        password = self._config.get(f"http-basic.{name}.password")
+        if not username and not password:
+            return None
+
+        if not password:
+            password = self.keyring.get_password(name, username)
 
         return {
             "username": username,


### PR DESCRIPTION
# Pull Request Check List

Improvement for: https://github.com/python-poetry/poetry/issues/1917

Keyring is not currently invoked when both http username and password are found in the config. It is however invoked when username is in config but password is in environment variables, completely ignoring the password passed through environment variables. This PR fixes this second behaviour and introduces two tests to assert that the keyring is not invoked in both situations. 

- [x] Added **tests** for changed code.
- ~[ ] Updated **documentation** for changed code.~
