### PR TITLE
fix: subprocess doesn't allow Path on windows, 3.7

### DIFF
--- a/src/poetry/utils/env.py
+++ b/src/poetry/utils/env.py
@@ -544,7 +544,7 @@ class EnvManager:
             if executable:
                 python_patch = decode(
                     subprocess.check_output(
-                        [executable, "-c", GET_PYTHON_VERSION_ONELINER],
+                        [str(executable), "-c", GET_PYTHON_VERSION_ONELINER],
                     ).strip()
                 )
 
@@ -579,7 +579,7 @@ class EnvManager:
         try:
             python_version_string = decode(
                 subprocess.check_output(
-                    [python_path, "-c", GET_PYTHON_VERSION_ONELINER],
+                    [str(python_path), "-c", GET_PYTHON_VERSION_ONELINER],
                 )
             )
         except CalledProcessError as e:
@@ -906,7 +906,7 @@ class EnvManager:
         if executable:
             python_patch = decode(
                 subprocess.check_output(
-                    [executable, "-c", GET_PYTHON_VERSION_ONELINER],
+                    [str(executable), "-c", GET_PYTHON_VERSION_ONELINER],
                 ).strip()
             )
             python_minor = ".".join(python_patch.split(".")[:2])
@@ -954,7 +954,7 @@ class EnvManager:
                 try:
                     python_patch = decode(
                         subprocess.check_output(
-                            [python, "-c", GET_PYTHON_VERSION_ONELINER],
+                            [str(python), "-c", GET_PYTHON_VERSION_ONELINER],
                             stderr=subprocess.STDOUT,
                         ).strip()
                     )

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -192,6 +192,7 @@ def check_output_wrapper(
 ) -> Callable[[list[str], Any, Any], str]:
     def check_output(cmd: list[str], *args: Any, **kwargs: Any) -> str:
         # cmd is a list, like ["python", "-c", "do stuff"]
+        assert all(isinstance(arg, str) for arg in cmd)
         python_cmd = cmd[2]
         if "sys.version_info[:3]" in python_cmd:
             return version.text


### PR DESCRIPTION
# Pull Request Check List

Due to https://bugs.python.org/issue31961, `subprocess.run` on Python 3.7 + Windows does not accept a `Path` as an argument.

Discovered from https://github.com/python-poetry/install.python-poetry.org/pull/90, where our installer smoke test fails: [`argument of type 'WindowsPath' is not iterable`](https://github.com/python-poetry/install.python-poetry.org/actions/runs/4973814297/jobs/8899895899?pr=90#step:8:111). Our existing tests here didn't catch this since `subprocess.run` is mocked
