### PR TITLE
feat: skip python-incompatible wheels inspection and locking

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -483,6 +483,7 @@ class Provider:
                     self._pool.package(
                         package.pretty_name,
                         package.version,
+                        python_constraint=self._python_constraint,
                         extras=list(dependency.extras),
                         repository_name=dependency.source_name,
                     ),

--- a/src/poetry/repositories/abstract_repository.py
+++ b/src/poetry/repositories/abstract_repository.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from poetry.core.constraints.version import Version
+    from poetry.core.constraints.version import VersionConstraint
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
 
@@ -32,6 +33,7 @@ class AbstractRepository(ABC):
         self,
         name: str,
         version: Version,
+        python_constraint: VersionConstraint,
         extras: list[str] | None = None,
     ) -> Package:
         ...

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -46,7 +46,11 @@ class LegacyRepository(HTTPRepository):
         return []
 
     def package(
-        self, name: str, version: Version, extras: list[str] | None = None
+        self,
+        name: str,
+        version: Version,
+        python_constraint: VersionConstraint,
+        extras: list[str] | None = None,
     ) -> Package:
         """
         Retrieve the release information.
@@ -64,7 +68,7 @@ class LegacyRepository(HTTPRepository):
 
             return self._packages[index]
         except ValueError:
-            package = super().package(name, version, extras)
+            package = super().package(name, version, python_constraint, extras)
             package._source_type = "legacy"
             package._source_url = self._url
             package._source_reference = self.name
@@ -110,7 +114,10 @@ class LegacyRepository(HTTPRepository):
         ]
 
     def _get_release_info(
-        self, name: NormalizedName, version: Version
+        self,
+        name: NormalizedName,
+        version: Version,
+        python_constraint: VersionConstraint,
     ) -> dict[str, Any]:
         page = self.get_page(name)
 
@@ -129,6 +136,7 @@ class LegacyRepository(HTTPRepository):
                 yanked=yanked,
                 cache_version=str(self.CACHE_VERSION),
             ),
+            python_constraint,
         )
 
     def _get_page(self, name: NormalizedName) -> SimpleRepositoryPage:

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -146,7 +146,10 @@ class PyPiRepository(HTTPRepository):
         return links
 
     def _get_release_info(
-        self, name: NormalizedName, version: Version
+        self,
+        name: NormalizedName,
+        version: Version,
+        python_constraint: VersionConstraint,
     ) -> dict[str, Any]:
         from poetry.inspection.info import PackageInfo
 

--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -110,7 +110,11 @@ class Repository(AbstractRepository):
         return []
 
     def package(
-        self, name: str, version: Version, extras: list[str] | None = None
+        self,
+        name: str,
+        version: Version,
+        python_version: VersionConstraint,
+        extras: list[str] | None = None,
     ) -> Package:
         canonicalized_name = canonicalize_name(name)
         for package in self.packages:

--- a/src/poetry/repositories/repository_pool.py
+++ b/src/poetry/repositories/repository_pool.py
@@ -16,6 +16,7 @@ from poetry.utils.cache import ArtifactCache
 
 if TYPE_CHECKING:
     from poetry.core.constraints.version import Version
+    from poetry.core.constraints.version import VersionConstraint
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
 
@@ -165,17 +166,18 @@ class RepositoryPool(AbstractRepository):
         self,
         name: str,
         version: Version,
+        python_constraint: VersionConstraint,
         extras: list[str] | None = None,
         repository_name: str | None = None,
     ) -> Package:
         if repository_name and not self._ignore_repository_names:
             return self.repository(repository_name).package(
-                name, version, extras=extras
+                name, version, python_constraint, extras=extras
             )
 
         for repo in self.repositories:
             try:
-                return repo.package(name, version, extras=extras)
+                return repo.package(name, version, python_constraint, extras=extras)
             except PackageNotFound:
                 continue
         raise PackageNotFound(f"Package {name} ({version}) not found.")

--- a/tests/utils/test_wheel.py
+++ b/tests/utils/test_wheel.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pytest
+
+from poetry.core.constraints.version import Version
+from poetry.core.constraints.version import VersionConstraint
+from poetry.core.constraints.version import VersionRange
+
+from poetry.utils.wheel import Wheel
+
+
+@pytest.mark.parametrize(
+    "pyversion, min_version, max_version",
+    [
+        ("cp39", "3.9.0", "3.10.0"),
+        ("cp310", "3.10.0", "3.11.0"),
+        ("py2", "2.0.0", "3.0.0"),
+        ("py3", "3.0.0", "4.0.0"),
+        ("py30", "3.0.0", "3.1.0"),
+    ],
+)
+def test_pyversion_to_constraint(
+    pyversion: str, min_version: str, max_version: str
+) -> None:
+    assert Wheel._pyversion_to_constraint(pyversion) == VersionRange(
+        min=Version.parse(min_version),
+        max=Version.parse(max_version),
+        include_min=True,
+        include_max=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "wheel_name, python_constraint, expected",
+    [
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.8.0"), max=Version.parse("3.9.0")),
+            True,
+        ),
+        (
+            "foo-0.1.0-cp38-none-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.8.0"), max=Version.parse("3.9.0")),
+            True,
+        ),
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.8.0"), max=Version.parse("4.0.0")),
+            True,
+        ),
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.8.2"), max=Version.parse("3.8.5")),
+            True,
+        ),
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            Version.parse("3.8.0"),
+            True,
+        ),
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            Version.parse("3.8.15"),
+            True,
+        ),
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.8.0"), max=None),
+            True,
+        ),
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.7.0"), max=Version.parse("3.9.0")),
+            True,
+        ),
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.9.0"), max=Version.parse("3.10.0")),
+            False,
+        ),
+        (
+            "foo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
+            Version.parse("3.9.15"),
+            False,
+        ),
+        (
+            "foo-0.1.0-py3-none-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.9.0"), max=Version.parse("3.10.0")),
+            True,
+        ),
+        (
+            "foo-0.1.0-py2-none-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.0.0"), max=None),
+            False,
+        ),
+        (
+            "foo-0.1.0-py3-none-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("3.0.0"), max=None),
+            True,
+        ),
+        (
+            "foo-0.1.0-py2.py3-none-macosx_10_15_x86_64.whl",
+            VersionRange(min=Version.parse("2.0.0"), max=Version.parse("2.7.0")),
+            True,
+        ),
+    ],
+)
+def test_is_compatible_with_python(
+    wheel_name: str, python_constraint: VersionConstraint, expected: bool
+) -> None:
+    wheel = Wheel(wheel_name)
+    assert wheel.is_compatible_with_python(python_constraint) is expected


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7935

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [ ] Cache is invalidated on `poetry lock` and `poetry lock --no-update`
- [ ] Applies to PyPI too

Would love some preliminary feedback on this 🙏 
