### PR TITLE
fix: fix exception on invalid url dependency for current env

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -780,9 +780,15 @@ class Executor:
             strict=False,
             env=self._env,
         )
-        # 'archive' can at this point never be None. Since we previously downloaded
-        # an archive, we now should have something cached that we can use here
-        assert archive is not None
+        if archive is None:
+            # Since we previously downloaded an archive, we now should have
+            # something cached that we can use here. The only case in which
+            # archive is None is if the original archive is not valid for the
+            # current environment.
+            raise RuntimeError(
+                f"Package {link.url} cannot be installed in the current environment"
+                f" {self._env.marker_env}"
+            )
 
         if archive.suffix != ".whl":
             message = (


### PR DESCRIPTION
The `Executor` first downloads and caches the original artifact, then tries to fetch a higher priority cached artifact (i.e. a wheel instead of a sdist) to speed up the installation, falling back on the previously downloaded original artifact. Therefore it was assumed that whatever cached artifact gets returned, it will not be None.

The assumption however is wrong since the cached artifact search is filtered for the given environment, i.e. if even the original artifact is invalid for the current environment than `artifact` will actually be None, raising a quite mysterious exception. This can happen for instance in this case:
```toml
[tool.poetry.dependencies]
python = "~3.9"

# Requesting a Python 3.10 wheel on a Python 3.9 environment
torch = { url = "https://download.pytorch.org/whl/torch-1.13.1-cp310-cp310-manylinux2014_aarch64.whl" }
```

The fix simply transforms that mysterious exception into a more self-explanatory one.