### PR TITLE
atomic downloads

### DIFF
--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -121,7 +121,7 @@ def download_file(
             # but skip the updating
             set_indicator = total_size > 1024 * 1024
 
-        with dest.open("wb") as f:
+        with atomic_open(dest) as f:
             for chunk in response.iter_content(chunk_size=chunk_size):
                 if chunk:
                     f.write(chunk)


### PR DESCRIPTION
sad that this code is so similar to the executor's `_download_archive()`, maybe one day someone will clean this up

meanwhile let's copy the fix from there to here, so as not to leave partially downloaded files lying around