### PR TITLE
fix: check for mutually exclusive markers

### DIFF
--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -43,7 +43,8 @@ def test_check_invalid(
 
     expected = """\
 Error: 'description' is a required property
-Error: Project name (invalid) is same as one of its dependencies
+Error: Project name (invalid) is same as one of its dependencies.
+Error: Dependency pillow does not have mutually exclusive markers.
 Error: Unrecognized classifiers: ['Intended Audience :: Clowns'].
 Warning: A wildcard Python dependency is ambiguous.\
  Consider specifying a more explicit one.

--- a/tests/fixtures/invalid_pyproject/pyproject.toml
+++ b/tests/fixtures/invalid_pyproject/pyproject.toml
@@ -1,18 +1,20 @@
 [tool.poetry]
-name = "invalid"
-version = "1.0.0"
-authors = [
-    "Foo <foo@bar.com>"
-]
-license = "INVALID"
+authors = ["Foo <foo@bar.com>"]
 classifiers = [
     "Environment :: Console",
     "Intended Audience :: Clowns",
     "Natural Language :: Ukranian",
     "Topic :: Communications :: Chat :: AOL Instant Messenger",
 ]
+license = "INVALID"
+name = "invalid"
+version = "1.0.0"
 
 [tool.poetry.dependencies]
-python = "*"
-pendulum = {"version" = "^2.0.5", allows-prereleases = true}
 invalid = "1.0"
+pendulum = { "version" = "^2.0.5", allows-prereleases = true }
+pillow = [
+    { version = "^9", python = "^3.9" },
+    { version = "^7", python = "^3.7" },
+]
+python = "*"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -518,7 +518,8 @@ def test_create_poetry_fails_on_invalid_configuration(
     expected = """\
 The Poetry configuration is invalid:
   - 'description' is a required property
-  - Project name (invalid) is same as one of its dependencies
+  - Project name (invalid) is same as one of its dependencies.
+  - Dependency pillow does not have mutually exclusive markers.
 """
     assert str(e.value) == expected
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/5066

I might be mistaken, but I don't see cases where one wants to specify multiple constraints for the same dependency where markers have an intersection.

- [x] Added **tests** for changed code.

