### PR TITLE
respect build requirements at poetry install

### DIFF
--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -9,7 +9,6 @@ from base64 import urlsafe_b64encode
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from poetry.core.constraints.version import Version
 from poetry.core.masonry.builders.builder import Builder
 from poetry.core.masonry.builders.sdist import SdistBuilder
 from poetry.core.masonry.utils.package_include import PackageInclude
@@ -101,16 +100,7 @@ class EditableBuilder(Builder):
                 f.write(decode(builder.build_setup()))
 
         try:
-            if self._env.pip_version < Version.from_parts(19, 0):
-                pip_install(self._path, self._env, upgrade=True, editable=True)
-            else:
-                # Temporarily rename pyproject.toml
-                renamed_pyproject = self._poetry.file.path.with_suffix(".tmp")
-                self._poetry.file.path.rename(renamed_pyproject)
-                try:
-                    pip_install(self._path, self._env, upgrade=True, editable=True)
-                finally:
-                    renamed_pyproject.rename(self._poetry.file.path)
+            pip_install(self._path, self._env, upgrade=True, editable=True)
         finally:
             if not has_setup:
                 os.remove(setup)


### PR DESCRIPTION
It's unclear to me at this point what the intention was of the code that hides `pyproject.toml` from pip during `poetry install`.  It has been there ever since https://github.com/python-poetry/poetry/commit/2ed53be4f7d9c86087e4a0b82984b9a718211a9b.

Anyway the practical effect is that of course `pip` can't see build requirements as defined in that file.  So simply removing that code fixes #6154 (and its duplicate #7909).