### PR TITLE
Fix dependency cache inconsistency with prerelease versions

### DIFF
--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -56,12 +56,21 @@ class DependencyCache:
         )
 
         packages = self.cache.get(key)
-        if packages is None:
-            packages = self.provider.search_for(dependency)
-        else:
+
+        if packages:
             packages = [
                 p for p in packages if dependency.constraint.allows(p.package.version)
             ]
+
+        # provider.search_for() normally does not include pre-release packages
+        # (unless requested), but will include them if there are no other
+        # eligible package versions for a version constraint.
+        #
+        # Therefore, if the eligible versions have been filtered down to
+        # nothing, we need to call provider.search_for() again as it may return
+        # additional results this time.
+        if not packages:
+            packages = self.provider.search_for(dependency)
 
         self.cache[key] = packages
 


### PR DESCRIPTION
This PR fixes an inconsistency identified in https://github.com/python-poetry/poetry/pull/7950#issuecomment-1555344115 where in some situations Poetry will not select a prerelease package version even though it satisfies all constraints.

Poetry is supposed to consider prerelease package versions if no other package versions satisfy the constraints. I believe this works if the constrained dependency is at the top level, but not necessarily if the constraint is introduced at a later level. Currently, whether it works or not depends on some arbitrary factors like the order dependencies are evaluated in and if the solver recently backtracked.


### Regression test

I introduced a regression test which fails on `master`:

```
____ test_solver_with_dependency_and_prerelease_sub_dependencies_increasing_constraints _____
Traceback (most recent call last):
  File "/home/ckuehl/proj/poetry/src/poetry/puzzle/solver.py", line 155, in _solve
    result = resolve_version(self._package, self._provider)
  File "/home/ckuehl/proj/poetry/src/poetry/mixology/__init__.py", line 18, in resolve_version
    return solver.solve()
  File "/home/ckuehl/proj/poetry/src/poetry/mixology/version_solver.py", line 111, in solve
    self._propagate(next)
  File "/home/ckuehl/proj/poetry/src/poetry/mixology/version_solver.py", line 150, in _propagate
    root_cause = self._resolve_conflict(incompatibility)
  File "/home/ckuehl/proj/poetry/src/poetry/mixology/version_solver.py", line 351, in _resolve_conflict
    raise SolveFailure(incompatibility)
poetry.mixology.failure.SolveFailure: Because no versions of a match !=1.0
 and a (1.0) depends on B (>0.9.0), every version of a requires B (>0.9.0).
So, because no versions of b match >0.9.0
 and root depends on A (*), version solving failed.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ckuehl/proj/poetry/tests/puzzle/test_solver.py", line 1222, in test_solver_with_dependency_and_prerelease_sub_dependencies_increasing_constraints
    transaction = solver.solve()
  File "/home/ckuehl/proj/poetry/src/poetry/puzzle/solver.py", line 72, in solve
    packages, depths = self._solve()
  File "/home/ckuehl/proj/poetry/src/poetry/puzzle/solver.py", line 161, in _solve
    raise SolverProblemError(e)
poetry.puzzle.exceptions.SolverProblemError: Because no versions of a match !=1.0
 and a (1.0) depends on B (>0.9.0), every version of a requires B (>0.9.0).
So, because no versions of b match >0.9.0
 and root depends on A (*), version solving failed.
```

The test passes if I disable the `DependencyCache` (replace the contents of `DependencyCache._search_for()` with `return self.provider.search_for(dependency)`, and also passes with the patch provided in this PR.

Additionally, the reproduction using `black<22` from https://github.com/python-poetry/poetry/pull/7950#issuecomment-1555344115 also succeeds for me now.