### PR TITLE
test: check that invalid package names are filtered out

### DIFF
--- a/tests/repositories/fixtures/legacy/pytest-with-extra-packages.html
+++ b/tests/repositories/fixtures/legacy/pytest-with-extra-packages.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Links for pytest</title>
+</head>
+
+<body>
+  <h1>Links for pytest</h1>
+  <a href="https://files.pythonhosted.org/packages/ed/96/271c93f75212c06e2a7ec3e2fa8a9c90acee0a4838dc05bf379ea09aae31/pytest-3.5.0-py2.py3-none-any.whl#sha256=6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c"
+    data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">pytest-3.5.0-py2.py3-none-any.whl</a><br />
+  <a href="https://files.pythonhosted.org/packages/2d/56/6019153cdd743300c5688ab3b07702355283e53c83fbf922242c053ffb7b/pytest-3.5.0.tar.gz#sha256=fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
+    data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">pytest-3.5.0.tar.gz</a><br />
+  <a href="https://files.pythonhosted.org/packages/2d/99/b2c4e9d5a30f6471e410a146232b4118e697fa3ffc06d6a65efde84debd0/futures-3.2.0-py2-none-any.whl#sha256=ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
+    data-requires-python="&gt;=2.6, &lt;3">futures-3.2.0-py2-none-any.whl</a><br />
+  <a href="https://files.pythonhosted.org/packages/2d/99/b2c4e9d5a30f6471e410a146232b4118e697fa3ffc06d6a65efde84debd0/futures-3.2.0-py2-none-any.whl#sha256=ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
+    data-requires-python="&gt;=2.6, &lt;3">pytest-3.10.0-py2.py3-none-any.whl</a><br />
+  <a href="https://files.pythonhosted.org/packages/2d/99/b2c4e9d5a30f6471e410a146232b4118e697fa3ffc06d6a65efde84debd0/futures-3.2.0-py2-none-any.whl#sha256=ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
+    data-requires-python="&gt;=2.6, &lt;3">pytest-3.5.0-py2.py3-none-any.whl</a><br />
+</body>
+
+</html>
+<!--SERIAL 7198641-->


### PR DESCRIPTION
# Pull Request Check List

Resolves: #2770 
Resolves: https://github.com/python-poetry/poetry/issues/1983

Added a test to verify that #2770 and https://github.com/python-poetry/poetry/issues/1983 are in fact now solved. The weird page returned by the repository contains a mixture of invalid combinations and they are all filtered out.

- [x] Added **tests** for changed code.
- ~[ ] Updated **documentation** for changed code.~
