### PR TITLE
docs: add env configuration for modern installation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,6 +202,8 @@ This configuration is ignored when `installer.parallel` is set to `false`.
 
 **Default**: `true`
 
+**Environment Variable**: `POETRY_INSTALLER_MODERN_INSTALLATION`
+
 *Introduced in 1.4.0*
 
 Use a more modern and faster method for package installation.


### PR DESCRIPTION
Env variables in documentation where added a couple PRs ago, I guess this is just a leftover