### PR TITLE
fix: revert #7916

### DIFF
--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -76,15 +76,11 @@ class HTTPRepository(CachedRepository):
 
     @contextmanager
     def _cached_or_downloaded_file(self, link: Link) -> Iterator[Path]:
-        filepath = self._authenticator.get_cached_file_for_url(link.url)
-        if filepath:
+        self._log(f"Downloading: {link.url}", level="debug")
+        with temporary_directory() as temp_dir:
+            filepath = Path(temp_dir) / link.filename
+            self._download(link.url, filepath)
             yield filepath
-        else:
-            self._log(f"Downloading: {link.url}", level="debug")
-            with temporary_directory() as temp_dir:
-                filepath = Path(temp_dir) / link.filename
-                self._download(link.url, filepath)
-                yield filepath
 
     def _get_info_from_wheel(self, url: str) -> PackageInfo:
         from poetry.inspection.info import PackageInfo

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -19,7 +19,6 @@ import requests.exceptions
 
 from cachecontrol import CacheControlAdapter
 from cachecontrol.caches import FileCache
-from cachecontrol.caches.file_cache import url_to_file_path
 from filelock import FileLock
 
 from poetry.config.config import Config
@@ -463,13 +462,6 @@ class Authenticator:
         if selected:
             return selected.certs(config=self._config)
         return RepositoryCertificateConfig()
-
-    def get_cached_file_for_url(self, url: str) -> Path | None:
-        if self._cache_control is None:
-            return None
-
-        path = Path(url_to_file_path(url, self._cache_control))
-        return path if path.exists() else None
 
 
 _authenticator: Authenticator | None = None

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -627,22 +627,6 @@ def test_authenticator_git_repositories(
     assert not three.password
 
 
-def test_authenticator_get_cached_file_for_url__cache_miss(config: Config) -> None:
-    authenticator = Authenticator(config, NullIO())
-    assert (
-        authenticator.get_cached_file_for_url("https://foo.bar/cache/miss.whl") is None
-    )
-
-
-def test_authenticator_get_cached_file_for_url__cache_hit(config: Config) -> None:
-    authenticator = Authenticator(config, NullIO())
-    url = "https://foo.bar/files/foo-0.1.0.tar.gz"
-
-    authenticator._cache_control.set(url, b"hello")
-
-    assert authenticator.get_cached_file_for_url(url)
-
-
 @pytest.mark.parametrize(
     ("ca_cert", "client_cert", "result"),
     [


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7961 

Reverting #7916 (funny how it's the same issue numbers reverted) as the cached file from `cachecontrol` contains the entire HTTP response, not just its content. Terribly sorry for that, I don't know how this slipped when debugging.

There's still probably some optimizations we could do but we should prioritize making Poetry correct again. The PR reverts the old unwanted behaviours:
- An unwanted file copy operation
- An unwanted _slow_ file copy operation, as we perform it with a relative small chunk size
- An unwanted "Downloading <wheel>" log when in reality we are not

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
