### PR TITLE
Replace cachecontrol with a fork

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -42,23 +42,23 @@ typing = ["importlib-metadata (>=5.1)", "mypy (==0.991)", "tomli", "typing-exten
 virtualenv = ["virtualenv (>=20.0.35)"]
 
 [[package]]
-name = "cachecontrol"
-version = "0.12.11"
+name = "cacheyou"
+version = "23.2"
 description = "httplib2 caching for requests"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "CacheControl-0.12.11-py2.py3-none-any.whl", hash = "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b"},
-    {file = "CacheControl-0.12.11.tar.gz", hash = "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"},
+    {file = "cacheyou-23.2-py3-none-any.whl", hash = "sha256:c0d7ac6742b1a56d9767bf694e2774e70da7979254e4f947360a72d25a3ed1b6"},
+    {file = "cacheyou-23.2.tar.gz", hash = "sha256:e64cd34f65e3e121df1ad6e2a70f87b42970b7cbba233a1c38b34d1a3fbb8131"},
 ]
 
 [package.dependencies]
-lockfile = {version = ">=0.9", optional = true, markers = "extra == \"filecache\""}
+filelock = {version = ">=3.8.0", optional = true, markers = "extra == \"filecache\""}
 msgpack = ">=0.5.2"
 requests = "*"
 
 [package.extras]
-filecache = ["lockfile (>=0.9)"]
+filecache = ["filelock (>=3.8.0)"]
 redis = ["redis (>=2.10.5)"]
 
 [[package]]
@@ -704,17 +704,6 @@ SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 completion = ["shtab"]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
 testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
-
-[[package]]
-name = "lockfile"
-version = "0.12.2"
-description = "Platform-independent file locking module"
-optional = false
-python-versions = "*"
-files = [
-    {file = "lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa"},
-    {file = "lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"},
-]
 
 [[package]]
 name = "more-itertools"
@@ -1672,4 +1661,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "fab5b1b0800c476f29b2f064c2c664cde4bcf7b8fbe98c58feb529d0935f98fb"
+content-hash = "92b0e928a46397c58c764c1c6ce4e10538447e52d8145c88dbd0b0e813b2d400"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,16 +35,15 @@ python = "^3.8"
 poetry-core = "1.6.0"
 poetry-plugin-export = "^1.3.1"
 build = "^0.10.0"
-cachecontrol = { version = "^0.12.9", extras = ["filecache"] }
+# cacheyou uses calver, so version is unclamped
+cacheyou = { version = ">=23.2", extras = ["filecache"] }
 cleo = "^2.0.0"
 crashtest = "^0.4.1"
 dulwich = "^0.21.2"
-filelock = "^3.8.0"
 importlib-metadata = { version = ">=4.4", python = "<3.10" }
 installer = "^0.7.0"
 jsonschema = "^4.10.0"
 keyring = "^23.9.0"
-lockfile = "^0.12.2"
 # packaging uses calver, so version is unclamped
 packaging = ">=20.4"
 pexpect = "^4.7.0"
@@ -181,17 +180,14 @@ warn_unused_ignores = false
 
 [[tool.mypy.overrides]]
 module = [
-    'cachecontrol.*',
     'deepdiff.*',
     'httpretty.*',
     'keyring.*',
-    'lockfile.*',
     'pexpect.*',
     'requests_toolbelt.*',
     'shellingham.*',
     'virtualenv.*',
     'xattr.*',
-    'zipp.*',
 ]
 ignore_missing_imports = true
 

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import requests
 
-from cachecontrol.controller import logger as cache_control_logger
+from cacheyou.controller import logger as cache_control_logger
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.version.exceptions import InvalidVersion

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -12,14 +12,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 
-import lockfile
 import requests
 import requests.auth
 import requests.exceptions
 
-from cachecontrol import CacheControlAdapter
-from cachecontrol.caches import FileCache
-from filelock import FileLock
+from cacheyou import CacheControlAdapter
+from cacheyou.caches import FileCache
 
 from poetry.config.config import Config
 from poetry.exceptions import PoetryException
@@ -35,26 +33,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-class FileLockLockFile(lockfile.LockBase):  # type: ignore[misc]
-    # The default LockFile from the lockfile package as used by cachecontrol can remain
-    # locked if a process exits ungracefully.  See eg
-    # <https://github.com/python-poetry/poetry/issues/6030#issuecomment-1189383875>.
-    #
-    # FileLock from the filelock package does not have this problem, so we use that to
-    # construct something compatible with cachecontrol.
-    def __init__(
-        self, path: str, threaded: bool = True, timeout: float | None = None
-    ) -> None:
-        super().__init__(path, threaded, timeout)
-        self.file_lock = FileLock(self.lock_file)
-
-    def acquire(self, timeout: float | None = None) -> None:
-        self.file_lock.acquire(timeout=timeout)
-
-    def release(self) -> None:
-        self.file_lock.release()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -148,7 +126,6 @@ class Authenticator:
                     / (cache_id or "_default_cache")
                     / "_http"
                 ),
-                lock_class=FileLockLockFile,
             )
             if not disable_cache
             else None

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -319,7 +319,7 @@ def test_invalid_versions_ignored() -> None:
 def test_get_should_invalid_cache_on_too_many_redirects_error(
     mocker: MockerFixture,
 ) -> None:
-    delete_cache = mocker.patch("cachecontrol.caches.file_cache.FileCache.delete")
+    delete_cache = mocker.patch("cacheyou.caches.file_cache.FileCache.delete")
 
     response = Response()
     response.status_code = 200


### PR DESCRIPTION
CacheControl package was largely unmaintained and made us haul around a deprecated dependency, `lockfile`. Due to recent changes connected to `urllib3` 2.0 release, a fork was made and is now maintained by @frostming. This fork merges some long-waiting PRs of cachecontrol, one of them being typing support, so we no longer need to ignore typing errors from that library.
