### PR TITLE
Moving "poetry lock --check" to "poetry check --lock"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
           timeout 10s poetry run pip --version || rm -rf .venv
 
       - name: Check lock file
-        run: poetry lock --check
+        run: poetry check --lock
 
       - name: Install dependencies
         run: poetry install --with github-actions

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -636,6 +636,10 @@ This command is also available as a pre-commit hook. See [pre-commit hooks]({{< 
 poetry check
 ```
 
+### Options
+
+* `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml`.
+
 ## search
 
 This command searches for packages on a remote index.
@@ -659,7 +663,7 @@ poetry lock
 
 ### Options
 
-* `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml`
+* `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml`. (**Deprecated**) Use `poetry check --lock` instead.
 * `--no-update`: Do not update locked versions, only refresh lock file.
 
 ## version
@@ -944,7 +948,7 @@ poetry self lock
 
 #### Options
 
-* `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml`
+* `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml`. (**Deprecated**) Use `poetry check --lock` instead.
 * `--no-update`: Do not update locked versions, only refresh lock file.
 
 ### self show

--- a/src/poetry/console/commands/lock.py
+++ b/src/poetry/console/commands/lock.py
@@ -18,7 +18,8 @@ class LockCommand(InstallerCommand):
             None,
             (
                 "Check that the <comment>poetry.lock</> file corresponds to the current"
-                " version of <comment>pyproject.toml</>."
+                " version of <comment>pyproject.toml</>. (<warning>Deprecated</>) Use"
+                " <comment>poetry check --lock</> instead."
             ),
         ),
     ]
@@ -36,6 +37,10 @@ file.
 
     def handle(self) -> int:
         if self.option("check"):
+            self.line_error(
+                "<warning>poetry lock --check is deprecated, use `poetry"
+                " check --lock` instead.</warning>"
+            )
             if self.poetry.locker.is_locked() and self.poetry.locker.is_fresh():
                 self.line("poetry.lock is consistent with pyproject.toml.")
                 return 0

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -4,18 +4,54 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poetry.packages import Locker
+
 
 if TYPE_CHECKING:
+    import httpretty
+
     from cleo.testers.command_tester import CommandTester
     from pytest_mock import MockerFixture
 
+    from poetry.poetry import Poetry
     from tests.types import CommandTesterFactory
     from tests.types import FixtureDirGetter
+    from tests.types import ProjectFactory
 
 
 @pytest.fixture()
 def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
     return command_tester_factory("check")
+
+
+def _project_factory(
+    fixture_name: str,
+    project_factory: ProjectFactory,
+    fixture_dir: FixtureDirGetter,
+) -> Poetry:
+    source = fixture_dir(fixture_name)
+    pyproject_content = (source / "pyproject.toml").read_text(encoding="utf-8")
+    poetry_lock_content = (source / "poetry.lock").read_text(encoding="utf-8")
+    return project_factory(
+        name="foobar",
+        pyproject_content=pyproject_content,
+        poetry_lock_content=poetry_lock_content,
+        source=source,
+    )
+
+
+@pytest.fixture
+def poetry_with_outdated_lockfile(
+    project_factory: ProjectFactory, fixture_dir: FixtureDirGetter
+) -> Poetry:
+    return _project_factory("outdated_lock", project_factory, fixture_dir)
+
+
+@pytest.fixture
+def poetry_with_up_to_date_lockfile(
+    project_factory: ProjectFactory, fixture_dir: FixtureDirGetter
+) -> Poetry:
+    return _project_factory("up_to_date_lock", project_factory, fixture_dir)
 
 
 def test_check_valid(tester: CommandTester) -> None:
@@ -74,3 +110,51 @@ All set!
 """
 
     assert tester.io.fetch_output() == expected
+
+
+def test_lock_check_outdated(
+    command_tester_factory: CommandTesterFactory,
+    poetry_with_outdated_lockfile: Poetry,
+    http: type[httpretty.httpretty],
+) -> None:
+    http.disable()
+
+    locker = Locker(
+        lock=poetry_with_outdated_lockfile.pyproject.file.path.parent / "poetry.lock",
+        local_config=poetry_with_outdated_lockfile.locker._local_config,
+    )
+    poetry_with_outdated_lockfile.set_locker(locker)
+
+    tester = command_tester_factory("check", poetry=poetry_with_outdated_lockfile)
+    status_code = tester.execute("--lock")
+    expected = (
+        "Error: poetry.lock is not consistent with pyproject.toml. "
+        "Run `poetry lock [--no-update]` to fix it.\n"
+    )
+
+    assert tester.io.fetch_error() == expected
+
+    # exit with an error
+    assert status_code == 1
+
+
+def test_lock_check_up_to_date(
+    command_tester_factory: CommandTesterFactory,
+    poetry_with_up_to_date_lockfile: Poetry,
+    http: type[httpretty.httpretty],
+) -> None:
+    http.disable()
+
+    locker = Locker(
+        lock=poetry_with_up_to_date_lockfile.pyproject.file.path.parent / "poetry.lock",
+        local_config=poetry_with_up_to_date_lockfile.locker._local_config,
+    )
+    poetry_with_up_to_date_lockfile.set_locker(locker)
+
+    tester = command_tester_factory("check", poetry=poetry_with_up_to_date_lockfile)
+    status_code = tester.execute("--lock")
+    expected = "poetry.lock is consistent with pyproject.toml.\n"
+    assert tester.io.fetch_output() == expected
+
+    # exit with an error
+    assert status_code == 0

--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -89,7 +89,7 @@ def poetry_with_invalid_lockfile(
     return _project_factory("invalid_lock", project_factory, fixture_dir)
 
 
-def test_lock_check_outdated(
+def test_lock_check_outdated_legacy(
     command_tester_factory: CommandTesterFactory,
     poetry_with_outdated_lockfile: Poetry,
     http: type[httpretty.httpretty],
@@ -105,6 +105,7 @@ def test_lock_check_outdated(
     tester = command_tester_factory("lock", poetry=poetry_with_outdated_lockfile)
     status_code = tester.execute("--check")
     expected = (
+        "poetry lock --check is deprecated, use `poetry check --lock` instead.\n"
         "Error: poetry.lock is not consistent with pyproject.toml. "
         "Run `poetry lock [--no-update]` to fix it.\n"
     )
@@ -115,7 +116,7 @@ def test_lock_check_outdated(
     assert status_code == 1
 
 
-def test_lock_check_up_to_date(
+def test_lock_check_up_to_date_legacy(
     command_tester_factory: CommandTesterFactory,
     poetry_with_up_to_date_lockfile: Poetry,
     http: type[httpretty.httpretty],
@@ -132,6 +133,11 @@ def test_lock_check_up_to_date(
     status_code = tester.execute("--check")
     expected = "poetry.lock is consistent with pyproject.toml.\n"
     assert tester.io.fetch_output() == expected
+
+    expected_error = (
+        "poetry lock --check is deprecated, use `poetry check --lock` instead.\n"
+    )
+    assert tester.io.fetch_error() == expected_error
 
     # exit with an error
     assert status_code == 0


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6756

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This PR moves `poetry lock --check` to `poetry check --lock` while still retaining functionality on the old command. It also marks the old command as deprecated. I've also updated the docs and CI to use the moved command.

### Old Command Deprecation Notice

![out_old_1](https://github.com/python-poetry/poetry/assets/3933065/0dd68e40-2299-4f73-a93c-e34349b3ff9c)

![out_old_2](https://github.com/python-poetry/poetry/assets/3933065/c4ff4a0e-1809-424c-94f9-09f0ed8724d5)

### New Command

![out_new_1](https://github.com/python-poetry/poetry/assets/3933065/acb41493-1781-49ba-a49b-a28f301f7842)

![out_new_2](https://github.com/python-poetry/poetry/assets/3933065/cbb88d2e-48c9-4760-8595-5087ab7b05c7)

