### PR TITLE
Add Dev Container configuration 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+
+ARG IMAGE="python:3.11"
+FROM --platform=amd64 mcr.microsoft.com/vscode/devcontainers/${IMAGE}
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends build-essential libssl-dev gdb cmake
+
+ENV POETRY_HOME="/opt/poetry"
+ENV PATH="$POETRY_HOME/bin:$PATH"
+RUN curl -sSL https://install.python-poetry.org | python3 -

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,3 @@
-
 ARG IMAGE="python:3.11"
 FROM --platform=amd64 mcr.microsoft.com/vscode/devcontainers/${IMAGE}
 RUN apt-get update \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,30 +1,32 @@
 {
-	"name": "Poetry",
-	"build": {
-        "dockerfile": "Dockerfile",
-        "context": "..",
-        "args": {
-            "IMAGE": "python:3.11"
-        }
-    },
-	"postCreateCommand": "bash .devcontainer/setup.sh",
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"python.formatting.blackPath": "black",
-				"python.formatting.provider": "black",
-				"python.testing.pytestEnabled": true,
-				"python.testing.pytestPath": "pytest",
-				"python.editor.codeActionsOnSave": {"source.fixAll": true},
-				"python.testing.pytestArgs": [
-					"tests"
-				]
-			},
-			"extensions": [
-				"ms-python.python",
-				"ms-python.black-formatter",
-                "charliermarsh.ruff"
-			]
-		}
-	}
+  "name": "Poetry",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      "IMAGE": "python:3.11"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.formatting.blackPath": "black",
+        "python.formatting.provider": "black",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestPath": "pytest",
+        "python.editor.codeActionsOnSave": {
+          "source.fixAll": true
+        },
+        "python.testing.pytestArgs": [
+          "tests"
+        ]
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.black-formatter",
+        "charliermarsh.ruff"
+      ]
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+	"name": "Poetry",
+	"build": {
+        "dockerfile": "Dockerfile",
+        "context": "..",
+        "args": {
+            "IMAGE": "python:3.11"
+        }
+    },
+	"postCreateCommand": "bash .devcontainer/setup.sh",
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.formatting.blackPath": "black",
+				"python.formatting.provider": "black",
+				"python.testing.pytestEnabled": true,
+				"python.testing.pytestPath": "pytest",
+				"python.editor.codeActionsOnSave": {"source.fixAll": true},
+				"python.testing.pytestArgs": [
+					"tests"
+				]
+			},
+			"extensions": [
+				"ms-python.python",
+				"ms-python.black-formatter",
+                "charliermarsh.ruff"
+			]
+		}
+	}
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,4 @@
+poetry install
+poetry run pytest
+poetry run mypy
+poetry run pre-commit install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
         exclude: tests/fixtures/invalid_lock/poetry\.lock
       - id: check-yaml
       - id: pretty-format-json
-        exclude: .devcontainer/devcontainer.json
         args: [--autofix, --no-ensure-ascii, --no-sort-keys]
       - id: check-ast
       - id: debug-statements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
         exclude: tests/fixtures/invalid_lock/poetry\.lock
       - id: check-yaml
       - id: pretty-format-json
+        exclude: .devcontainer/devcontainer.json
         args: [--autofix, --no-ensure-ascii, --no-sort-keys]
       - id: check-ast
       - id: debug-statements


### PR DESCRIPTION
This PR adds a [Dev Container](https://containers.dev/) configuration to Poetry. By adding this to the repo, contributors will be able to open the Poetry codebase in a Dev Container (via Visual Studio Code or Codespaces, for example) and have the local development environment setup for them per https://python-poetry.org/docs/contributing/.

I haven't updated the documentation in this PR but can if maintainers would like me to. No tests applicable here.