### PR TITLE
perf: remove unnecessary deepcopy

### DIFF
--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -115,6 +115,6 @@ class Repository(AbstractRepository):
         canonicalized_name = canonicalize_name(name)
         for package in self.packages:
             if canonicalized_name == package.name and package.version == version:
-                return package.clone()
+                return package
 
         raise PackageNotFound(f"Package {name} ({version}) not found.")


### PR DESCRIPTION
Related to: https://github.com/python-poetry/poetry/issues/7459

This removes an unnecessary `deepcopy` of a `Package` once returned by `Repository`. The object returned is in fact [used in a read-only way](https://github.com/python-poetry/poetry/blob/198d6ff8caf22215f85e055578fa4b6c4526d061/src/poetry/puzzle/provider.py#L461).
Here's the performance comparison by timing the [solver](https://github.com/python-poetry/poetry/blob/198d6ff8caf22215f85e055578fa4b6c4526d061/src/poetry/installation/installer.py#L312) on a `poetry install --dry-run`:
- A mildly complex project where the Solver still has to perform a good amount of calculations before installing dependencies: from `3.4s` to `2.4s`
- Poetry itself: from `0.1s` to `0.07s`

That's about a 30% performance boost.

Feedback welcome on how to possible test this 🤷 Although I think the long-run solution would be to refactor the `poetry-core` classes in a more read-only / frozen way
