### PR TITLE
have subprocess deal with text

### DIFF
--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -14,8 +14,6 @@ from typing import Any
 
 from virtualenv.seed.wheels.embed import get_embed_wheel
 
-from poetry.utils._compat import decode
-from poetry.utils._compat import encode
 from poetry.utils.env.exceptions import EnvCommandError
 from poetry.utils.env.site_packages import SitePackages
 from poetry.utils.helpers import get_real_windows_path
@@ -343,13 +341,14 @@ class Env:
 
         try:
             if input_:
-                output = subprocess.run(
+                output: str = subprocess.run(
                     cmd,
                     stdout=subprocess.PIPE,
                     stderr=stderr,
-                    input=encode(input_),
+                    input=input_,
                     check=True,
                     env=env,
+                    text=True,
                     **kwargs,
                 ).stdout
             elif call:
@@ -357,11 +356,13 @@ class Env:
                 subprocess.check_call(cmd, stderr=stderr, env=env, **kwargs)
                 output = ""
             else:
-                output = subprocess.check_output(cmd, stderr=stderr, env=env, **kwargs)
+                output = subprocess.check_output(
+                    cmd, stderr=stderr, env=env, text=True, **kwargs
+                )
         except CalledProcessError as e:
             raise EnvCommandError(e, input=input_)
 
-        return decode(output)
+        return output
 
     def execute(self, bin: str, *args: str, **kwargs: Any) -> int:
         command = self.get_command_from_bin(bin) + list(args)

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -23,7 +23,6 @@ from poetry.core.constraints.version import parse_constraint
 
 from poetry.toml.file import TOMLFile
 from poetry.utils._compat import WINDOWS
-from poetry.utils._compat import decode
 from poetry.utils._compat import encode
 from poetry.utils.env.exceptions import EnvCommandError
 from poetry.utils.env.exceptions import IncorrectEnvError
@@ -67,11 +66,9 @@ class EnvManager:
             return None
 
         try:
-            executable = decode(
-                subprocess.check_output(
-                    [path_python, "-c", "import sys; print(sys.executable)"],
-                ).strip()
-            )
+            executable = subprocess.check_output(
+                [path_python, "-c", "import sys; print(sys.executable)"], text=True
+            ).strip()
             return Path(executable)
 
         except CalledProcessError:
@@ -115,11 +112,9 @@ class EnvManager:
             executable = EnvManager._detect_active_python(io)
 
             if executable:
-                python_patch = decode(
-                    subprocess.check_output(
-                        [executable, "-c", GET_PYTHON_VERSION_ONELINER],
-                    ).strip()
-                )
+                python_patch = subprocess.check_output(
+                    [executable, "-c", GET_PYTHON_VERSION_ONELINER], text=True
+                ).strip()
 
                 version = ".".join(str(v) for v in python_patch.split(".")[:precision])
 
@@ -150,10 +145,8 @@ class EnvManager:
             raise PythonVersionNotFound(python)
 
         try:
-            python_version_string = decode(
-                subprocess.check_output(
-                    [python_path, "-c", GET_PYTHON_VERSION_ONELINER],
-                )
+            python_version_string = subprocess.check_output(
+                [python_path, "-c", GET_PYTHON_VERSION_ONELINER], text=True
             )
         except CalledProcessError as e:
             raise EnvCommandError(e)
@@ -334,10 +327,8 @@ class EnvManager:
         if python_path.is_file():
             # Validate env name if provided env is a full path to python
             try:
-                env_dir = decode(
-                    subprocess.check_output(
-                        [python, "-c", GET_ENV_PATH_ONELINER],
-                    )
+                env_dir = subprocess.check_output(
+                    [python, "-c", GET_ENV_PATH_ONELINER], text=True
                 ).strip("\n")
                 env_name = Path(env_dir).name
                 if not self.check_env_is_for_current_project(env_name, base_env_name):
@@ -393,10 +384,8 @@ class EnvManager:
             pass
 
         try:
-            python_version_string = decode(
-                subprocess.check_output(
-                    [python, "-c", GET_PYTHON_VERSION_ONELINER],
-                )
+            python_version_string = subprocess.check_output(
+                [python, "-c", GET_PYTHON_VERSION_ONELINER], text=True
             )
         except CalledProcessError as e:
             raise EnvCommandError(e)
@@ -485,11 +474,9 @@ class EnvManager:
         python_patch = ".".join([str(v) for v in sys.version_info[:3]])
         python_minor = ".".join([str(v) for v in sys.version_info[:2]])
         if executable:
-            python_patch = decode(
-                subprocess.check_output(
-                    [executable, "-c", GET_PYTHON_VERSION_ONELINER],
-                ).strip()
-            )
+            python_patch = subprocess.check_output(
+                [executable, "-c", GET_PYTHON_VERSION_ONELINER], text=True
+            ).strip()
             python_minor = ".".join(python_patch.split(".")[:2])
 
         supported_python = self._poetry.package.python_constraint
@@ -533,12 +520,11 @@ class EnvManager:
                     continue
 
                 try:
-                    python_patch = decode(
-                        subprocess.check_output(
-                            [python, "-c", GET_PYTHON_VERSION_ONELINER],
-                            stderr=subprocess.STDOUT,
-                        ).strip()
-                    )
+                    python_patch = subprocess.check_output(
+                        [python, "-c", GET_PYTHON_VERSION_ONELINER],
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                    ).strip()
                 except CalledProcessError:
                     continue
 

--- a/src/poetry/vcs/git/system.py
+++ b/src/poetry/vcs/git/system.py
@@ -53,15 +53,12 @@ class SystemGit:
         git_command = find_git_command()
         env = os.environ.copy()
         env["GIT_TERMINAL_PROMPT"] = "0"
-        return (
-            subprocess.check_output(
-                git_command + list(args),
-                stderr=subprocess.STDOUT,
-                env=env,
-            )
-            .decode()
-            .strip()
-        )
+        return subprocess.check_output(
+            git_command + list(args),
+            stderr=subprocess.STDOUT,
+            env=env,
+            text=True,
+        ).strip()
 
     @staticmethod
     def _check_parameter(parameter: str) -> None:

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -968,7 +968,7 @@ def test_env_has_symlinks_on_nix(tmp_path: Path, tmp_venv: VirtualEnv) -> None:
 def test_run_with_input(tmp_path: Path, tmp_venv: VirtualEnv) -> None:
     result = tmp_venv.run("python", "-", input_=MINIMAL_SCRIPT)
 
-    assert result == "Minimal Output" + os.linesep
+    assert result == "Minimal Output\n"
 
 
 def test_run_with_input_non_zero_return(tmp_path: Path, tmp_venv: VirtualEnv) -> None:


### PR DESCRIPTION
might or might not fix #7313, #7643

poetry has its own `encode()` and `decode()` for switching between strings and bytes, and does all subprocess work in bytes.

but subprocess already knows how to work in text and do that encoding / decoding automatically; and also poetry doesn't always remember to do it.

eg see those two issues in which something is going wrong when paths have accented or cyrillic characters: #7313 reports that `text=True` resolves this (though apparently they didn't find it worthwhile to make a merge request)

Unclear how to add tests for this, I expect it would be awkward enough that I can't be bothered...