### PR TITLE
Access keyring only when needed.

### DIFF
--- a/src/poetry/utils/constants.py
+++ b/src/poetry/utils/constants.py
@@ -10,3 +10,6 @@ RETRY_AFTER_HEADER = "retry-after"
 
 # Server response codes to retry requests on.
 STATUS_FORCELIST = [429, 500, 501, 502, 503, 504]
+
+# Server response code to try to retrieve authentication on.
+STATUS_AUTHLIST = [401, 403, 404]

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -26,6 +26,10 @@ class HTTPAuthCredential:
     username: str | None = dataclasses.field(default=None)
     password: str | None = dataclasses.field(default=None)
 
+    @property
+    def empty(self) -> bool:
+        return self.username is None and self.password is None
+
 
 class PoetryKeyring:
     def __init__(self, namespace: str) -> None:
@@ -192,13 +196,15 @@ class PasswordManager:
 
         self.keyring.delete_password(name, "__token__")
 
-    def get_http_auth(self, name: str) -> dict[str, str | None] | None:
+    def get_http_auth(
+        self, name: str, keyring: bool = True
+    ) -> dict[str, str | None] | None:
         username = self._config.get(f"http-basic.{name}.username")
         password = self._config.get(f"http-basic.{name}.password")
         if not username and not password:
             return None
 
-        if not password:
+        if not password and keyring:
             password = self.keyring.get_password(name, username)
 
         return {


### PR DESCRIPTION
# Pull Request Check List

Resolves: #1917

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

***

Requesting a network page is first tried without retrieving authentication from the keyring. Credentials provided by other means are used already. If no authentication was found and the server answers with 401 or 403 the keyring is queried for credentials. This fixes #1917.

* src/poetry/utils/constants.py (STATUS_AUTHLIST): A list of HTTP errors requesting authentication. Currently 401 and 403.

* src/poetry/utils/authenticator.py (Authenticator.request): Retrieve credentials with disabled keyring first. On auth error try again with enabled keyring.

* src/poetry/utils/authenticator.py (Authenticator.get_credentials_for_url): Add `keyring` option.
* src/poetry/utils/authenticator.py (Authenticator._get_credentials_for_url: ^^^ same as above
* src/poetry/utils/authenticator.py (Authenticator._get_credentials_for_repository): ^^^
* src/poetry/utils/authenticator.py (AuthenticatorRepositoryConfig.get_http_credentials): ^^^
* src/poetry/utils/password_manager.py (PasswordManager.get_http_auth): ^^^


