### PR TITLE
Add warning about pip ignoring lock files

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -234,6 +234,10 @@ Even if you develop alone, in six months when reinstalling the project you can f
 the dependencies installed are still working even if your dependencies released many new versions since then.
 (See note below about using the update command.)
 
+{{% warning %}} If you have added the recommended [`[build-system]`]({{< relref "pyproject#poetry-and-pep-517" >}}) section to your project's pyproject.toml then you _can_ successfully install your project and its dependencies into a virtual environment using a command like `pip install -e .`. However, pip will not use the lock file to determine dependency versions as the poetry-core build system is intended for library developers (see next section).
+{{% /warning %}}
+
+
 #### As a library developer
 
 Library developers have more to consider. Your users are application developers, and your library will run in a Python environment you don't control.


### PR DESCRIPTION
Add a warning about `pip install` ignoring the poetry.lock so that application developers know to always use `poetry install`.

Background:

I have a project with a simple flask web service which is bundled into a container image. I was using `pip install` to install my project and its dependencies in the Dockerfile so that I wouldn't need an additional image layer to install poetry. I had incorrectly assumed that the poetry-core build backend would respect the poetry lock file and so I was unexpectedly getting the latest versions of my dependencies in my docker image.

This PR is my attempt at helping other developers enjoy poetry without repeating this same mistake. Please feel free to modify or adjust this change however you see fit as this is really just my suggested wording and placement from a quick scan through the poetry online docs.