### PR TITLE
WIP: Fix pyenv local venv

### DIFF
--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -237,6 +237,12 @@ class EnvManager:
         prefer_active_python = self._poetry.config.get(
             "virtualenvs.prefer-active-python"
         )
+        if prefer_active_python:
+            executable = self._detect_active_python()
+            bin_dir = executable.parent
+            path = bin_dir.parent
+            return VirtualEnv(path, Path(executable.name))
+
         python_minor = self.get_python_version(
             precision=2, prefer_active_python=prefer_active_python, io=self._io
         ).to_string()


### PR DESCRIPTION
The `virtualenvs.prefer-active-python` flag (originally added in https://github.com/python-poetry/poetry/pull/4852) is currently not working for me; instead of selecting the local env, I get the poetry venv.

This change resolves the problem for me.

FIXES: https://github.com/python-poetry/poetry/issues/8119

# Pull Request Check List

Resolves: #8119

TODO:

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

