### PR TITLE
sources: change future warning that PyPI will only be disabled automatically if there are no primary sources

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -164,7 +164,7 @@ poetry source add --priority=default foo https://foo.bar/simple/
 {{% warning %}}
 
 In a future version of Poetry, PyPI will be disabled automatically
-if there is at least one custom source configured with another priority than `explicit`.
+if at least one custom primary source is configured.
 If you are using custom sources in addition to PyPI, you should configure PyPI explicitly
 with a certain priority, e.g.
 

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -181,12 +181,12 @@ class Factory(BaseFactory):
             else:
                 from poetry.repositories.pypi_repository import PyPiRepository
 
-                if pool.repositories:
+                if pool.has_primary_repositories():
                     io.write_error_line(
                         "<warning>"
                         "Warning: In a future version of Poetry, PyPI will be disabled"
-                        " automatically if at least one custom source is configured"
-                        " with another priority than 'explicit'. In order to avoid"
+                        " automatically if at least one custom primary source is"
+                        " configured. In order to avoid"
                         " a breaking change and make your pyproject.toml forward"
                         " compatible, add PyPI explicitly via 'poetry source add pypi'."
                         " By the way, this has the advantage that you can set the"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -420,7 +420,8 @@ def test_poetry_with_no_default_source(fixture_dir: FixtureDirGetter) -> None:
 def test_poetry_with_supplemental_source(
     fixture_dir: FixtureDirGetter, with_simple_keyring: None
 ) -> None:
-    poetry = Factory().create_poetry(fixture_dir("with_supplemental_source"))
+    io = BufferedIO()
+    poetry = Factory().create_poetry(fixture_dir("with_supplemental_source"), io=io)
 
     assert poetry.pool.has_repository("PyPI")
     assert poetry.pool.get_priority("PyPI") is Priority.DEFAULT
@@ -429,12 +430,14 @@ def test_poetry_with_supplemental_source(
     assert poetry.pool.get_priority("supplemental") is Priority.SUPPLEMENTAL
     assert isinstance(poetry.pool.repository("supplemental"), LegacyRepository)
     assert {repo.name for repo in poetry.pool.repositories} == {"PyPI", "supplemental"}
+    assert io.fetch_error() == ""
 
 
 def test_poetry_with_explicit_source(
     fixture_dir: FixtureDirGetter, with_simple_keyring: None
 ) -> None:
-    poetry = Factory().create_poetry(fixture_dir("with_explicit_source"))
+    io = BufferedIO()
+    poetry = Factory().create_poetry(fixture_dir("with_explicit_source"), io=io)
 
     assert len(poetry.pool.repositories) == 1
     assert len(poetry.pool.all_repositories) == 2
@@ -444,6 +447,7 @@ def test_poetry_with_explicit_source(
     assert poetry.pool.has_repository("explicit")
     assert isinstance(poetry.pool.repository("explicit"), LegacyRepository)
     assert {repo.name for repo in poetry.pool.repositories} == {"PyPI"}
+    assert io.fetch_error() == ""
 
 
 def test_poetry_with_explicit_pypi_and_other(


### PR DESCRIPTION
As per https://github.com/python-poetry/poetry/issues/6713#issuecomment-1574388095:

> I don't really understand why this exception is only relevant to the explicit priority, but not to the supplemental one. If I add some source as a supplemental, it means I expect something different to be the primary one, which is also stated in docs quite clearly:
>
> > Package sources configured as supplemental are only searched if no other (higher-priority) source yields a compatible package distribution.
>
> If I don't specify any primary source directly, imho it's quite obvious to assume it should be still PyPI.

and https://github.com/python-poetry/poetry/issues/6713#issuecomment-1574779218:

> > I don't really understand why this exception is only relevant to the `explicit` priority, but not to the `supplemental` one.
> 
> It has a technical background. We need at least one non-explicit source. Otherwise, we'll get a "no versions for package xyz found" error which would be quite obscure.
> 
> > If I don't specify any `primary` source directly, imho it's quite obvious to assume it should be still PyPI.
> 
> Your reasoning makes sense. We probably should change it.

IMO, we should keep the warning for at least one more minor version (maybe two). Thus, let's change it.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
