### PR TITLE
Correct command for listing installed plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -214,7 +214,7 @@ poetry self remove poetry-plugin
 You can also list all currently installed plugins by running:
 
 ```shell
-poetry self show
+poetry self show plugins
 ```
 
 ### With `pipx inject`


### PR DESCRIPTION
It seems like the documentation on listing installed plugins uses the wrong command.