### PR TITLE
Trigger pre-commit hooks for pyproject.toml in subfolder

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,6 +12,7 @@
   entry: poetry lock
   language: python
   pass_filenames: false
+  files: ^(.*/)?(poetry.lock|pyproject.toml)$
 
 - id: poetry-export
   name: poetry-export
@@ -19,5 +20,5 @@
   entry: poetry export
   language: python
   pass_filenames: false
-  files: ^poetry.lock$
+  files: ^(.*/)?poetry.lock$
   args: ["-f", "requirements.txt", "-o", "requirements.txt"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: poetry check
   language: python
   pass_filenames: false
-  files: ^(.*/)?pyproject.toml$
+  files: ^(.*/)?pyproject\.toml$
 
 - id: poetry-lock
   name: poetry-lock
@@ -12,7 +12,7 @@
   entry: poetry lock
   language: python
   pass_filenames: false
-  files: ^(.*/)?(poetry.lock|pyproject.toml)$
+  files: ^(.*/)?(poetry\.lock|pyproject\.toml)$
 
 - id: poetry-export
   name: poetry-export
@@ -20,5 +20,5 @@
   entry: poetry export
   language: python
   pass_filenames: false
-  files: ^(.*/)?poetry.lock$
+  files: ^(.*/)?poetry\.lock$
   args: ["-f", "requirements.txt", "-o", "requirements.txt"]

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -24,6 +24,10 @@ the defaults are overwritten. You must fully specify all arguments for
 your hook if you make use of `args:`.
 {{% /note %}}
 
+{{% note %}}
+If the `pyproject.toml` file is not in the root directory, you can specify `args: ["-C", "./subdirectory"]`.
+{{% /note %}}
+
 ## poetry-check
 
 The `poetry-check` hook calls the `poetry check` command
@@ -34,10 +38,6 @@ to make sure the poetry configuration does not get committed in a broken state.
 The hook takes the same arguments as the poetry command.
 For more information see the [check command]({{< relref "cli#check" >}}).
 
-{{% note %}}
-If the `pyproject.toml` file is not in the root directory, you can specify `args: ["-C", "./subdirectory"]`.
-{{% /note %}}
-
 ## poetry-lock
 
 The `poetry-lock` hook calls the `poetry lock` command
@@ -47,7 +47,6 @@ to make sure the lock file is up-to-date when committing changes.
 
 The hook takes the same arguments as the poetry command.
 For more information see the [lock command]({{< relref "cli#lock" >}}).
-
 
 ## poetry-export
 
@@ -64,7 +63,7 @@ The hook takes the same arguments as the poetry command.
 For more information see the [export command]({{< relref "cli#export" >}}).
 
 The default arguments are `args: ["-f", "requirements.txt", "-o", "requirements.txt"]`,
-which will create/update the requirements.txt file in the current working directory.
+which will create/update the `requirements.txt` file in the current working directory.
 
 You may add `verbose: true` in your `.pre-commit-config.yaml` in order to output to the
 console:
@@ -84,12 +83,11 @@ hooks:
     args: ["--dev", "-f", "requirements.txt", "-o", "requirements.txt"]
 ```
 
-
 ## Usage
 
 For more information on how to use pre-commit please see the [official documentation](https://pre-commit.com/).
 
-A full `.pre-commit-config.yaml` example:
+A minimalistic `.pre-commit-config.yaml` example:
 
 ```yaml
 repos:
@@ -99,7 +97,21 @@ repos:
     -   id: poetry-check
     -   id: poetry-lock
     -   id: poetry-export
-        args: ["-f", "requirements.txt", "-o", "requirements.txt"]
+```
+
+A `.pre-commit-config.yaml` example for a monorepo setup or if the `pyproject.toml` file is not in the root directory:
+
+```yaml
+repos:
+-   repo: https://github.com/python-poetry/poetry
+    rev: ''  # add version here
+    hooks:
+    -   id: poetry-check
+        args: ["-C", "./subdirectory"]
+    -   id: poetry-lock
+        args: ["-C", "./subdirectory"]
+    -   id: poetry-export
+        args: ["-C", "./subdirectory", "-f", "requirements.txt", "-o", "./subdirectory/requirements.txt"]
 ```
 
 ## FAQ


### PR DESCRIPTION
This PR extends #7242 and #7295.

- Add docs for monorepo setup or if `pyproject.toml` / `poetry.lock` files are in sub directories
- Add `files` to `poetry-lock` pre-commit hook to only trigger hook if either `poetry.lock` or `pyproject.toml` files in root or any sub directory have changed --> Was triggered on all changes before
- Update `files` for `poetry-export` pre-commit hook to allow `poetry.lock` files in sub directories --> Threw an error when no `poetry.lock` in root
- Gracefully skip the hooks if neither `pyproject.toml` nor `poetry.lock` file exist

The `files` pattern `^(.*/)?poetry.lock$` chosen in this PR works for `poetry.lock` files in root and sub folders. It avoids the issue mentioned [here](https://github.com/python-poetry/poetry/pull/2511#issuecomment-996846667) which lead to #4907:

``` diff
-  files: '^.*/poetry\.lock$'  # This doesn't detect `poetry.lock` in root folder, because of the leading `/`, but works in sub folders
+  files: ^poetry.lock$  # This only detects `poetry.lock` in root folder
```

---

# Pull Request Check List

Resolves #8162, Resolves #6944
Closes #7295
Related to: #7239 #7247 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] ~Added **tests** for changed code.~ --> Does not apply for pre-commit hooks
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
