### PR TITLE
docs: Use `reference` instead of deprecated `callable` in scripts example

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -351,7 +351,7 @@ To specify a script that [depends on an extra](#extras), you may provide an entr
 
 ```toml
 [tool.poetry.scripts]
-devtest = { callable = "mypackage:test.run_tests", extras = ["test"] }
+devtest = { reference = "mypackage:test.run_tests", extras = ["test"], type = "console" }
 ```
 
 {{% note %}}


### PR DESCRIPTION
This has been deprecated since poetry-core [`1.1.0a5`](https://github.com/python-poetry/poetry-core/releases/tag/1.1.0a5) (https://github.com/python-poetry/poetry-core/pull/40).

# Pull Request Check List

Resolves: NA

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
