### PR TITLE
Remove package pyproject line if package is module to resolve #7609

### DIFF
--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -96,7 +96,7 @@ class Layout:
         if self.basedir != Path():
             package.append("from", self.basedir.as_posix())
         else:
-            if include == self._project:
+            if module_name(self._project) == include:
                 # package include and package name are the same,
                 # packages table is redundant here.
                 return None

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -86,7 +86,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -169,7 +168,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -218,7 +216,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -249,7 +246,6 @@ version = "1.2.3"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{{include = "my_package"}}]
 
 [tool.poetry.dependencies]
 python = "^{python}"
@@ -290,7 +286,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -383,7 +378,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -429,7 +423,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -481,7 +474,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -532,7 +524,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -584,7 +575,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -629,7 +619,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
@@ -664,7 +653,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -697,7 +685,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -739,7 +726,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -775,7 +761,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -819,7 +804,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -868,7 +852,6 @@ description = "This is a description"
 authors = ["Foo Bar <foo@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
@@ -963,7 +946,6 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "^3.6"
@@ -1047,7 +1029,17 @@ def test_package_include(
         ),
     )
 
-    packages = "" if include is None else f'packages = [{{include = "{include}"}}]\n'
+    def module_name(name: str) -> str:
+        return name.replace("_", "-")
+
+    if (
+        include is None
+        or package_name == include
+        or package_name == module_name(include)
+    ):
+        packages = ""
+    else:
+        packages = f'packages = [{{include = "{include}"}}]\n'
 
     expected = (
         f"[tool.poetry]\n"

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -13,6 +13,7 @@ import pytest
 
 from cleo.testers.command_tester import CommandTester
 from packaging.utils import canonicalize_name
+from poetry.core.utils.helpers import module_name
 
 from poetry.console.application import Application
 from poetry.console.commands.init import InitCommand
@@ -1025,16 +1026,8 @@ def test_package_include(
         ),
     )
 
-    def module_name(name: str) -> str:
-        return name.replace("_", "-")
-
-    if (
-        include is None
-        or package_name == include
-        or package_name == module_name(include)
-    ):
-        packages = ""
-    else:
+    packages = ""
+    if include and module_name(package_name) != include:
         packages = f'packages = [{{include = "{include}"}}]\n'
 
     expected = (

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -57,9 +57,7 @@ def verify_project_directory(
 
     packages = poetry.local_config.get("packages")
 
-    if not packages:
-        assert poetry.local_config.get("name") == package_include.get("include")
-    else:
+    if packages:
         assert len(packages) == 1
         assert packages[0] == package_include
 

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -57,11 +57,11 @@ def verify_project_directory(
     else:
         package_include = {"include": package_path.parts[0]}
 
-    name = poetry.local_config.get("name")
+    name = poetry.local_config.get("name", "")
     packages = poetry.local_config.get("packages")
 
     if not packages:
-        assert module_name(name) == package_include.get("include") if name else ""
+        assert module_name(name) == package_include.get("include")
     else:
         assert len(packages) == 1
         assert packages[0] == package_include

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import pytest
 
+from poetry.core.utils.helpers import module_name
+
 from poetry.factory import Factory
 
 
@@ -55,9 +57,12 @@ def verify_project_directory(
     else:
         package_include = {"include": package_path.parts[0]}
 
+    name = poetry.local_config.get("name")
     packages = poetry.local_config.get("packages")
 
-    if packages:
+    if not packages:
+        assert module_name(name) == package_include.get("include") if name else ""
+    else:
         assert len(packages) == 1
         assert packages[0] == package_include
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7609

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

While it does resolve the issue, I'm a little worried it completely removed the package pyproject line in `poetry init`. I'm not familiar with how this line is meant to be used on `init`, so please provide feedback or make edits. 

Tests were modified to support this change, which removes the package line from pyproject on init.
I don't think a documentation change should be made - but I do think the error message should be clarified for the user, since I believe it still occurs if a package can't be found. This is more involved though as the `raise` is coming from poetry-core.