### PR TITLE
fix: remove exception when keyring is locked

### DIFF
--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -48,7 +48,11 @@ class PoetryKeyring:
         import keyring
 
         for name in names:
-            credential = keyring.get_credential(name, username)
+            try:
+                credential = keyring.get_credential(name, username)
+            except keyring.errors.KeyringLocked:
+                logger.debug("Keyring %s is locked", name)
+                credential = None
             if credential:
                 return HTTPAuthCredential(
                     username=credential.username, password=credential.password

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -47,12 +47,18 @@ class PoetryKeyring:
 
         import keyring
 
+        from keyring.errors import KeyringError
+        from keyring.errors import KeyringLocked
+
         for name in names:
+            credential = None
             try:
                 credential = keyring.get_credential(name, username)
-            except keyring.errors.KeyringLocked:
+            except KeyringLocked:
                 logger.debug("Keyring %s is locked", name)
-                credential = None
+            except (KeyringError, RuntimeError):
+                logger.debug("Accessing keyring %s failed", name, exc_info=True)
+
             if credential:
                 return HTTPAuthCredential(
                     username=credential.username, password=credential.password

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,11 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 import httpretty
+import keyring
 import pytest
 
 from keyring.backend import KeyringBackend
+from keyring.errors import KeyringLocked
 
 from poetry.config.config import Config as BaseConfig
 from poetry.config.dict_config_source import DictConfigSource
@@ -113,6 +115,24 @@ class DummyBackend(KeyringBackend):
             del self._passwords[service][username]
 
 
+class LockedBackend(KeyringBackend):
+    @classmethod
+    def priority(cls) -> int:
+        return 42
+
+    def set_password(self, service: str, username: str | None, password: Any) -> None:
+        raise KeyringLocked()
+
+    def get_password(self, service: str, username: str | None) -> Any:
+        raise KeyringLocked()
+
+    def get_credential(self, service: str, username: str | None) -> Any:
+        raise KeyringLocked()
+
+    def delete_password(self, service: str, username: str | None) -> None:
+        raise KeyringLocked()
+
+
 @pytest.fixture()
 def dummy_keyring() -> DummyBackend:
     return DummyBackend()
@@ -120,24 +140,23 @@ def dummy_keyring() -> DummyBackend:
 
 @pytest.fixture()
 def with_simple_keyring(dummy_keyring: DummyBackend) -> None:
-    import keyring
-
     keyring.set_keyring(dummy_keyring)
 
 
 @pytest.fixture()
 def with_fail_keyring() -> None:
-    import keyring
-
     from keyring.backends.fail import Keyring
 
     keyring.set_keyring(Keyring())  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture()
-def with_null_keyring() -> None:
-    import keyring
+def with_locked_keyring() -> None:
+    keyring.set_keyring(LockedBackend())  # type: ignore[no-untyped-call]
 
+
+@pytest.fixture()
+def with_null_keyring() -> None:
     from keyring.backends.null import Keyring
 
     keyring.set_keyring(Keyring())  # type: ignore[no-untyped-call]
@@ -151,8 +170,6 @@ def with_chained_fail_keyring(mocker: MockerFixture) -> None:
         "keyring.backend.get_all_keyring",
         lambda: [Keyring()],  # type: ignore[no-untyped-call]
     )
-    import keyring
-
     from keyring.backends.chainer import ChainerBackend
 
     keyring.set_keyring(ChainerBackend())  # type: ignore[no-untyped-call]
@@ -166,8 +183,6 @@ def with_chained_null_keyring(mocker: MockerFixture) -> None:
         "keyring.backend.get_all_keyring",
         lambda: [Keyring()],  # type: ignore[no-untyped-call]
     )
-    import keyring
-
     from keyring.backends.chainer import ChainerBackend
 
     keyring.set_keyring(ChainerBackend())  # type: ignore[no-untyped-call]
@@ -206,8 +221,6 @@ def config(
     auth_config_source: DictConfigSource,
     mocker: MockerFixture,
 ) -> Config:
-    import keyring
-
     from keyring.backends.fail import Keyring
 
     keyring.set_keyring(Keyring())  # type: ignore[no-untyped-call]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,19 @@ class LockedBackend(KeyringBackend):
         raise KeyringLocked()
 
 
+from keyring import backends
+from keyring.errors import KeyringError
+
+
+class ErroneousBackend(backends.fail.Keyring):
+    @classmethod
+    def priority(cls) -> int:
+        return 42
+
+    def get_credential(self, service: str, username: str | None) -> Any:
+        raise KeyringError()
+
+
 @pytest.fixture()
 def dummy_keyring() -> DummyBackend:
     return DummyBackend()
@@ -153,6 +166,11 @@ def with_fail_keyring() -> None:
 @pytest.fixture()
 def with_locked_keyring() -> None:
     keyring.set_keyring(LockedBackend())  # type: ignore[no-untyped-call]
+
+
+@pytest.fixture()
+def with_erroneous_keyring() -> None:
+    keyring.set_keyring(ErroneousBackend())  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,9 @@ import httpretty
 import keyring
 import pytest
 
+from keyring import backends
 from keyring.backend import KeyringBackend
+from keyring.errors import KeyringError
 from keyring.errors import KeyringLocked
 
 from poetry.config.config import Config as BaseConfig
@@ -131,10 +133,6 @@ class LockedBackend(KeyringBackend):
 
     def delete_password(self, service: str, username: str | None) -> None:
         raise KeyringLocked()
-
-
-from keyring import backends
-from keyring.errors import KeyringError
 
 
 class ErroneousBackend(backends.fail.Keyring):

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -94,6 +94,19 @@ def test_authenticator_uses_username_only_credentials(
     assert request.headers["Authorization"] == "Basic Zm9vMDAxOg=="
 
 
+def test_authenticator_ignores_locked_keyring(
+    mock_config: Config,
+    mock_remote: None,
+    http: type[httpretty.httpretty],
+    with_locked_keyring: None,
+) -> None:
+    authenticator = Authenticator(mock_config, NullIO())
+    authenticator.request("get", "https://foo001@foo.bar/files/foo-0.1.0.tar.gz")
+    request = http.last_request()
+
+    assert request.headers["Authorization"] == "Basic Zm9vMDAxOg=="
+
+
 def test_authenticator_uses_password_only_credentials(
     mock_config: Config, mock_remote: None, http: type[httpretty.httpretty]
 ) -> None:

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import logging
 import re
 import uuid
 
@@ -20,6 +21,7 @@ from poetry.utils.authenticator import RepositoryCertificateConfig
 
 
 if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
     from _pytest.monkeypatch import MonkeyPatch
     from pytest_mock import MockerFixture
 
@@ -65,8 +67,8 @@ def test_authenticator_uses_url_provided_credentials(
     authenticator.request("get", "https://foo001:bar002@foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-
-    assert request.headers["Authorization"] == "Basic Zm9vMDAxOmJhcjAwMg=="
+    basic_auth = base64.b64encode(b"foo001:bar002").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_authenticator_uses_credentials_from_config_if_not_provided(
@@ -76,8 +78,8 @@ def test_authenticator_uses_credentials_from_config_if_not_provided(
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-
-    assert request.headers["Authorization"] == "Basic YmFyOmJheg=="
+    basic_auth = base64.b64encode(b"bar:baz").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_authenticator_uses_username_only_credentials(
@@ -90,34 +92,38 @@ def test_authenticator_uses_username_only_credentials(
     authenticator.request("get", "https://foo001@foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-
-    assert request.headers["Authorization"] == "Basic Zm9vMDAxOg=="
+    basic_auth = base64.b64encode(b"foo001:").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_authenticator_ignores_locked_keyring(
-    mock_config: Config,
     mock_remote: None,
     http: type[httpretty.httpretty],
     with_locked_keyring: None,
+    caplog: LogCaptureFixture,
 ) -> None:
-    authenticator = Authenticator(mock_config, NullIO())
-    authenticator.request("get", "https://foo001@foo.bar/files/foo-0.1.0.tar.gz")
-    request = http.last_request()
+    caplog.set_level(logging.DEBUG, logger="poetry.utils.password_manager")
+    authenticator = Authenticator()
+    authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
-    assert request.headers["Authorization"] == "Basic Zm9vMDAxOg=="
+    request = http.last_request()
+    assert request.headers["Authorization"] is None
+    assert "Keyring foo.bar is locked" in caplog.messages
 
 
 def test_authenticator_ignores_failing_keyring(
-    mock_config: Config,
     mock_remote: None,
     http: type[httpretty.httpretty],
     with_erroneous_keyring: None,
+    caplog: LogCaptureFixture,
 ) -> None:
-    authenticator = Authenticator(mock_config, NullIO())
-    authenticator.request("get", "https://foo001@foo.bar/files/foo-0.1.0.tar.gz")
-    request = http.last_request()
+    caplog.set_level(logging.DEBUG, logger="poetry.utils.password_manager")
+    authenticator = Authenticator()
+    authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
-    assert request.headers["Authorization"] == "Basic Zm9vMDAxOg=="
+    request = http.last_request()
+    assert request.headers["Authorization"] is None
+    assert "Accessing keyring foo.bar failed" in caplog.messages
 
 
 def test_authenticator_uses_password_only_credentials(
@@ -127,8 +133,8 @@ def test_authenticator_uses_password_only_credentials(
     authenticator.request("get", "https://:bar002@foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-
-    assert request.headers["Authorization"] == "Basic OmJhcjAwMg=="
+    basic_auth = base64.b64encode(b":bar002").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_authenticator_uses_empty_strings_as_default_password(
@@ -149,8 +155,8 @@ def test_authenticator_uses_empty_strings_as_default_password(
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-
-    assert request.headers["Authorization"] == "Basic YmFyOg=="
+    basic_auth = base64.b64encode(b"bar:").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_authenticator_uses_empty_strings_as_default_username(
@@ -170,8 +176,8 @@ def test_authenticator_uses_empty_strings_as_default_username(
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-
-    assert request.headers["Authorization"] == "Basic OmJhcg=="
+    basic_auth = base64.b64encode(b":bar").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_authenticator_falls_back_to_keyring_url(
@@ -196,8 +202,8 @@ def test_authenticator_falls_back_to_keyring_url(
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-
-    assert request.headers["Authorization"] == "Basic Zm9vOmJhcg=="
+    basic_auth = base64.b64encode(b"foo:bar").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_authenticator_falls_back_to_keyring_netloc(
@@ -220,8 +226,8 @@ def test_authenticator_falls_back_to_keyring_netloc(
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-
-    assert request.headers["Authorization"] == "Basic Zm9vOmJhcg=="
+    basic_auth = base64.b64encode(b"foo:bar").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
@@ -356,7 +362,8 @@ def test_authenticator_uses_env_provided_credentials(
 
     request = http.last_request()
 
-    assert request.headers["Authorization"] == "Basic YmFyOmJheg=="
+    basic_auth = base64.b64encode(b"bar:baz").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -107,6 +107,19 @@ def test_authenticator_ignores_locked_keyring(
     assert request.headers["Authorization"] == "Basic Zm9vMDAxOg=="
 
 
+def test_authenticator_ignores_failing_keyring(
+    mock_config: Config,
+    mock_remote: None,
+    http: type[httpretty.httpretty],
+    with_erroneous_keyring: None,
+) -> None:
+    authenticator = Authenticator(mock_config, NullIO())
+    authenticator.request("get", "https://foo001@foo.bar/files/foo-0.1.0.tar.gz")
+    request = http.last_request()
+
+    assert request.headers["Authorization"] == "Basic Zm9vMDAxOg=="
+
+
 def test_authenticator_uses_password_only_credentials(
     mock_config: Config, mock_remote: None, http: type[httpretty.httpretty]
 ) -> None:

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -235,6 +235,12 @@ def test_locked_keyring_should_be_available(with_locked_keyring: None) -> None:
     assert key_ring.is_available()
 
 
+def test_erroneous_keyring_should_be_available(with_erroneous_keyring: None) -> None:
+    key_ring = PoetryKeyring("poetry")
+
+    assert key_ring.is_available()
+
+
 def test_get_http_auth_from_environment_variables(
     environ: None, config: Config
 ) -> None:

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -190,6 +190,13 @@ def test_keyring_raises_errors_on_keyring_errors(
         key_ring.delete_password("foo", "bar")
 
 
+def test_keyring_returns_none_on_locked_keyring(with_locked_keyring: None) -> None:
+    key_ring = PoetryKeyring("poetry")
+
+    cred = key_ring.get_credential("any password", "any name")
+    assert cred.password is None
+
+
 def test_keyring_with_chainer_backend_and_fail_keyring_should_be_unavailable(
     with_chained_fail_keyring: None,
 ) -> None:
@@ -220,6 +227,12 @@ def test_fail_keyring_should_be_unavailable(
     key_ring = PoetryKeyring("poetry")
 
     assert not key_ring.is_available()
+
+
+def test_locked_keyring_should_be_available(with_locked_keyring: None) -> None:
+    key_ring = PoetryKeyring("poetry")
+
+    assert key_ring.is_available()
 
 
 def test_get_http_auth_from_environment_variables(


### PR DESCRIPTION
Resolves: https://github.com/python-poetry/poetry/issues/1917
This inherits and therefore closes #6612.

* src/poetry/utils/password_manager.py (PoetryKeyring.get_credential): Catch `KeyringError` and `RuntimeError` when accessing keyring.