### PR TITLE
fix: cache corruption due to broken connections, where of the wheel is only partially downloaded

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -870,6 +870,15 @@ class Executor:
             with self._lock:
                 progress.finish()
 
+        # Validate expected byte size based on http headers
+        if wheel_size is not None and done != int(wheel_size):
+            raise RuntimeError(
+                "Downloaded wheel does not match expected size, "
+                f" was {done} expected {wheel_size}. "
+                "This means probably connection was interrupted "
+                "and might corrupt the cache."
+            )
+
         return archive
 
     def _should_write_operation(self, operation: Operation) -> bool:


### PR DESCRIPTION
This issue occurs mostly when having unstable connections and package is only half downloaded and it causes cache corruption. Raising a runtime error will fix the issue as it does not cause hash issues while retrying the install

# Pull Request Check List

Resolves: #7881
