### PR TITLE
installer: respect source if the same version of a package has been locked from different sources

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -211,8 +211,7 @@ lists all packages available."""
         from poetry.utils.helpers import get_package_version_display_string
 
         locked_packages = locked_repository.packages
-        pool = RepositoryPool(ignore_repository_names=True, config=self.poetry.config)
-        pool.add_repository(locked_repository)
+        pool = RepositoryPool.from_packages(locked_packages, self.poetry.config)
         solver = Solver(
             root,
             pool=pool,

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -286,19 +286,8 @@ class Installer:
             )
 
         # We resolve again by only using the lock file
-        pool = RepositoryPool(config=self._config)
-
-        # Make a new collection of repositories containing the packages newly resolved
-        # and the ones from the current lock file.
-        for package in lockfile_repo.packages + locked_repository.packages:
-            if not package.is_direct_origin():
-                repo_name = package.source_reference or "PyPI"
-                try:
-                    repo = pool.repository(repo_name)
-                except IndexError:
-                    repo = Repository(repo_name)
-                    pool.add_repository(repo)
-                repo.add_package(package)
+        packages = lockfile_repo.packages + locked_repository.packages
+        pool = RepositoryPool.from_packages(packages, self._config)
 
         solver = Solver(
             root,

--- a/src/poetry/repositories/repository_pool.py
+++ b/src/poetry/repositories/repository_pool.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from poetry.config.config import Config
 from poetry.repositories.abstract_repository import AbstractRepository
 from poetry.repositories.exceptions import PackageNotFound
+from poetry.repositories.repository import Repository
 from poetry.utils.cache import ArtifactCache
 
 
@@ -18,8 +19,6 @@ if TYPE_CHECKING:
     from poetry.core.constraints.version import Version
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
-
-    from poetry.repositories.repository import Repository
 
 
 class Priority(IntEnum):
@@ -42,13 +41,11 @@ class RepositoryPool(AbstractRepository):
     def __init__(
         self,
         repositories: list[Repository] | None = None,
-        ignore_repository_names: bool = False,
         *,
         config: Config | None = None,
     ) -> None:
         super().__init__("poetry-repository-pool")
         self._repositories: OrderedDict[str, PrioritizedRepository] = OrderedDict()
-        self._ignore_repository_names = ignore_repository_names
 
         if repositories is None:
             repositories = []
@@ -58,6 +55,25 @@ class RepositoryPool(AbstractRepository):
         self._artifact_cache = ArtifactCache(
             cache_dir=(config or Config.create()).artifacts_cache_directory
         )
+
+    @staticmethod
+    def from_packages(packages: list[Package], config: Config | None) -> RepositoryPool:
+        pool = RepositoryPool(config=config)
+        for package in packages:
+            if package.is_direct_origin():
+                continue
+
+            repo_name = package.source_reference or "PyPI"
+            try:
+                repo = pool.repository(repo_name)
+            except IndexError:
+                repo = Repository(repo_name)
+                pool.add_repository(repo)
+
+            if not repo.has_package(package):
+                repo.add_package(package)
+
+        return pool
 
     @property
     def repositories(self) -> list[Repository]:
@@ -166,7 +182,7 @@ class RepositoryPool(AbstractRepository):
         extras: list[str] | None = None,
         repository_name: str | None = None,
     ) -> Package:
-        if repository_name and not self._ignore_repository_names:
+        if repository_name:
             return self.repository(repository_name).package(
                 name, version, extras=extras
             )
@@ -180,7 +196,7 @@ class RepositoryPool(AbstractRepository):
 
     def find_packages(self, dependency: Dependency) -> list[Package]:
         repository_name = dependency.source_name
-        if repository_name and not self._ignore_repository_names:
+        if repository_name:
             return self.repository(repository_name).find_packages(dependency)
 
         packages: list[Package] = []

--- a/src/poetry/repositories/repository_pool.py
+++ b/src/poetry/repositories/repository_pool.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
 
+_SENTINEL = object()
+
 
 class Priority(IntEnum):
     # The order of the members below dictates the actual priority. The first member has
@@ -41,6 +43,7 @@ class RepositoryPool(AbstractRepository):
     def __init__(
         self,
         repositories: list[Repository] | None = None,
+        ignore_repository_names: object = _SENTINEL,
         *,
         config: Config | None = None,
     ) -> None:
@@ -55,6 +58,15 @@ class RepositoryPool(AbstractRepository):
         self._artifact_cache = ArtifactCache(
             cache_dir=(config or Config.create()).artifacts_cache_directory
         )
+
+        if ignore_repository_names is not _SENTINEL:
+            warnings.warn(
+                "The 'ignore_repository_names' argument to 'RepositoryPool.__init__' is"
+                " deprecated. It has no effect anymore and will be removed in a future"
+                " version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     @staticmethod
     def from_packages(packages: list[Package], config: Config | None) -> RepositoryPool:

--- a/src/poetry/utils/env/mock_env.py
+++ b/src/poetry/utils/env/mock_env.py
@@ -16,8 +16,10 @@ class MockEnv(NullEnv):
     def __init__(
         self,
         version_info: tuple[int, int, int] = (3, 7, 0),
+        *,
         python_implementation: str = "CPython",
         platform: str = "darwin",
+        platform_machine: str = "amd64",
         os_name: str = "posix",
         is_venv: bool = False,
         pip_version: str = "19.1",
@@ -31,6 +33,7 @@ class MockEnv(NullEnv):
         self._version_info = version_info
         self._python_implementation = python_implementation
         self._platform = platform
+        self._platform_machine = platform_machine
         self._os_name = os_name
         self._is_venv = is_venv
         self._pip_version: Version = Version.parse(pip_version)
@@ -41,6 +44,10 @@ class MockEnv(NullEnv):
     @property
     def platform(self) -> str:
         return self._platform
+
+    @property
+    def platform_machine(self) -> str:
+        return self._platform_machine
 
     @property
     def os(self) -> str:
@@ -67,6 +74,7 @@ class MockEnv(NullEnv):
         marker_env["python_version"] = ".".join(str(v) for v in self._version_info[:2])
         marker_env["python_full_version"] = ".".join(str(v) for v in self._version_info)
         marker_env["sys_platform"] = self._platform
+        marker_env["platform_machine"] = self._platform_machine
         marker_env["interpreter_name"] = self._python_implementation.lower()
         marker_env["interpreter_version"] = "cp" + "".join(
             str(v) for v in self._version_info[:2]

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -902,21 +902,16 @@ def test_add_constraint_with_source(
     mocker: MockerFixture,
 ) -> None:
     repo = LegacyRepository(name="my-index", url="https://my-index.fake")
-    repo.add_package(get_package("cachy", "0.2.0"))
-    mocker.patch.object(
-        repo,
-        "_find_packages",
-        wraps=lambda _, name: [
-            Package(
-                "cachy",
-                Version.parse("0.2.0"),
-                source_type="legacy",
-                source_reference=repo.name,
-                source_url=repo._url,
-                yanked=False,
-            )
-        ],
+    package = Package(
+        "cachy",
+        Version.parse("0.2.0"),
+        source_type="legacy",
+        source_reference=repo.name,
+        source_url=repo._url,
+        yanked=False,
     )
+    mocker.patch.object(repo, "package", return_value=package)
+    mocker.patch.object(repo, "_find_packages", wraps=lambda _, name: [package])
 
     poetry.pool.add_repository(repo)
 

--- a/tests/repositories/test_repository_pool.py
+++ b/tests/repositories/test_repository_pool.py
@@ -38,6 +38,17 @@ def test_repository_no_repository() -> None:
         pool.repository("foo")
 
 
+def test_repository_deprecated_ignore_repository_names() -> None:
+    with pytest.warns(DeprecationWarning):
+        RepositoryPool(ignore_repository_names=True)
+    with pytest.warns(DeprecationWarning):
+        RepositoryPool(ignore_repository_names=False)
+    with pytest.warns(DeprecationWarning):
+        RepositoryPool(None, True)
+    with pytest.warns(DeprecationWarning):
+        RepositoryPool(None, False)
+
+
 def test_adding_repositories_with_same_name_twice_raises_value_error() -> None:
     repo1 = Repository("repo")
     repo2 = Repository("repo")


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8303

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

fix from https://github.com/python-poetry/poetry/issues/8303#issuecomment-1676175485 enriched with a testcase (`test_installer_distinguishes_locked_packages_with_same_version_by_source` in `test_installer.py`).

### Notable changes other testcases

I changed `test_explicit_source_dependency_with_direct_origin_dependency` from unlocked to locked because our test setup in this module does not handle locking good enough anymore: `repo` is just a `Repository` but had to be a `LegacyRepository`. However, that would require more effort to change. Since the test has been added in #7973 and locking is already tested in the other test case (in `test_solver.py`) added in the same PR, it does not give any additional value to keep an unlocked version of the test.
