### PR TITLE
FIPS compliance during publish

### DIFF
--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -114,8 +114,12 @@ class Uploader:
         file_type = self._get_type(file)
 
         blake2_256_hash = hashlib.blake2b(digest_size=256 // 8)
+        # Enable FIPS support if Python version is greater or equal to 3.9
+        if sys.version_info >= (3, 9):
+            md5_hash = hashlib.md5(usedforsecurity=False)
+        else:
+            md5_hash = hashlib.md5()
 
-        md5_hash = hashlib.md5()
         sha256_hash = hashlib.sha256()
         with file.open("rb") as fp:
             for content in iter(lambda: fp.read(io.DEFAULT_BUFFER_SIZE), b""):


### PR DESCRIPTION
As md5 is only used to get additional hash alongside with sha256, a passing of usedforsecurity=False is required. This option was introduced in Python 3.9 so we need to make sure we check whether that version is present

# Pull Request Check List

Resolves: #8310 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
