### PR TITLE
hooks: add poetry-update hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -31,4 +31,3 @@
   pass_filenames: false
   stages: [post-checkout, post-merge]
   always_run: true
-  args: ["--sync"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -25,7 +25,7 @@
 
 - id: poetry-install
   name: poetry-install
-  description: Synchronize the Poetry dependencies with the lock file if out of sync
+  description: run poetry install to install dependencies from the lock file
   entry: poetry install
   language: python
   pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -23,8 +23,8 @@
   files: ^(.*/)?poetry\.lock$
   args: ["-f", "requirements.txt", "-o", "requirements.txt"]
 
-- id: poetry-sync
-  name: poetry-sync
+- id: poetry-install
+  name: poetry-install
   description: Synchronize the Poetry dependencies with the lock file if out of sync
   entry: poetry install
   language: python

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -31,3 +31,4 @@
   pass_filenames: false
   stages: [post-checkout, post-merge]
   always_run: true
+  args: ["--sync"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,3 +22,12 @@
   pass_filenames: false
   files: ^(.*/)?poetry\.lock$
   args: ["-f", "requirements.txt", "-o", "requirements.txt"]
+
+- id: poetry-update
+  name: poetry-update
+  description: Update the Poetry dependencies if out of sync
+  entry: poetry install --sync
+  language: python
+  pass_filenames: false
+  stages: [post-checkout, post-merge]
+  always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -23,10 +23,10 @@
   files: ^(.*/)?poetry\.lock$
   args: ["-f", "requirements.txt", "-o", "requirements.txt"]
 
-- id: poetry-update
-  name: poetry-update
-  description: Update the Poetry dependencies if out of sync
-  entry: poetry install --sync
+- id: poetry-sync
+  name: poetry-sync
+  description: Synchronize the Poetry dependencies with the lock file if out of sync
+  entry: poetry install
   language: python
   pass_filenames: false
   stages: [post-checkout, post-merge]

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -83,9 +83,9 @@ hooks:
     args: ["--dev", "-f", "requirements.txt", "-o", "requirements.txt"]
 ```
 
-## poetry-sync
+## poetry-install
 
-The `poetry-sync` hook calls the `poetry install --sync` command
+The `poetry-install` hook calls the `poetry install --sync` command
 to make sure the installed dependencies match the packages defined in `poetry.lock`.
 In order to install this hook, you either need to specify `default_install_hook_types`, or you have
 to install it via `pre-commit install --install-hooks -t post-checkout -t post-merge`.
@@ -109,7 +109,7 @@ repos:
     -   id: poetry-check
     -   id: poetry-lock
     -   id: poetry-export
-    -   id: poetry-sync
+    -   id: poetry-install
 ```
 
 A `.pre-commit-config.yaml` example for a monorepo setup or if the `pyproject.toml` file is not in the root directory:
@@ -125,7 +125,7 @@ repos:
         args: ["-C", "./subdirectory"]
     -   id: poetry-export
         args: ["-C", "./subdirectory", "-f", "requirements.txt", "-o", "./subdirectory/requirements.txt"]
-    -   id: poetry-sync
+    -   id: poetry-install
         args: ["-C", "./subdirectory"]
 ```
 

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -85,8 +85,8 @@ hooks:
 
 ## poetry-install
 
-The `poetry-install` hook calls the `poetry install --sync` command
-to make sure the installed dependencies match the packages defined in `poetry.lock`.
+The `poetry-install` hook calls the `poetry install` command
+to make sure all locked packages are installed.
 In order to install this hook, you either need to specify `default_install_hook_types`, or you have
 to install it via `pre-commit install --install-hooks -t post-checkout -t post-merge`.
 

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -83,6 +83,18 @@ hooks:
     args: ["--dev", "-f", "requirements.txt", "-o", "requirements.txt"]
 ```
 
+## poetry-update
+
+The `poetry-update` hook calls the `poetry install --sync` command
+to make sure the installed dependencies match the packages defined in `poetry.lock`.
+In order to install this hook, you either need to specify `default_install_hook_types`, or you have
+to install it via `pre-commit install --install-hooks -t post-checkout -t post-merge`.
+
+### Arguments
+
+The hook takes the same arguments as the poetry command.
+For more information see the [install command]({{< relref "cli#install" >}}).
+
 ## Usage
 
 For more information on how to use pre-commit please see the [official documentation](https://pre-commit.com/).

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -83,9 +83,9 @@ hooks:
     args: ["--dev", "-f", "requirements.txt", "-o", "requirements.txt"]
 ```
 
-## poetry-update
+## poetry-sync
 
-The `poetry-update` hook calls the `poetry install --sync` command
+The `poetry-sync` hook calls the `poetry install --sync` command
 to make sure the installed dependencies match the packages defined in `poetry.lock`.
 In order to install this hook, you either need to specify `default_install_hook_types`, or you have
 to install it via `pre-commit install --install-hooks -t post-checkout -t post-merge`.
@@ -109,6 +109,7 @@ repos:
     -   id: poetry-check
     -   id: poetry-lock
     -   id: poetry-export
+    -   id: poetry-sync
 ```
 
 A `.pre-commit-config.yaml` example for a monorepo setup or if the `pyproject.toml` file is not in the root directory:
@@ -124,6 +125,8 @@ repos:
         args: ["-C", "./subdirectory"]
     -   id: poetry-export
         args: ["-C", "./subdirectory", "-f", "requirements.txt", "-o", "./subdirectory/requirements.txt"]
+    -   id: poetry-sync
+        args: ["-C", "./subdirectory"]
 ```
 
 ## FAQ

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -85,8 +85,7 @@ hooks:
 
 ## poetry-install
 
-The `poetry-install` hook calls the `poetry install` command
-to make sure all locked packages are installed.
+The `poetry-install` hook calls the `poetry install` command to make sure all locked packages are installed.
 In order to install this hook, you either need to specify `default_install_hook_types`, or you have
 to install it via `pre-commit install --install-hooks -t post-checkout -t post-merge`.
 


### PR DESCRIPTION
When switching branches keeping dependencies in sync with the lock file can become cumbersome, because it is easy to forget. Therefore poetry supplies a pre-commit hook, that can take care of it. After switching branches or checking out a file `poetry install --sync` is invoked and keeps everything nice and tidy.
To make use of that, you need to either supply `default_install_hook_types` inside of your `.pre-commit-config.yaml` or you need to manually install them with: `pre-commit install --install-hooks -t pre-commit -t post-checkout -t post-merge`.

# Pull Request Check List

Resolves: #2863 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
