### PR TITLE
Use requests^2.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ pexpect = "^4.7.0"
 pkginfo = "^1.9.4"
 platformdirs = "^3.0.0"
 pyproject-hooks = "^1.0.0"
-requests = "^2.18"
+requests = "^2.26"
 requests-toolbelt = ">=0.9.1,<2"
 shellingham = "^1.5"
 tomli = { version = "^2.0.1", python = "<3.11" }


### PR DESCRIPTION
[src/poetry/utils/helpers.py](https://github.com/python-poetry/poetry/blob/1.6.0/src/poetry/utils/helpers.py) imports `atomic_open` from `requests.utils` but the function exists only with requests 2.26.0 or newer.

:o: https://github.com/psf/requests/blob/v2.26.0/requests/utils.py 
:x: https://github.com/psf/requests/blob/v2.25.1/requests/utils.py

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
