### PR TITLE
Consider system packages as installed if the venv includes them

### DIFF
--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -18,6 +18,7 @@ from poetry.factory import Factory
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.toml.file import TOMLFile
 from poetry.utils._compat import WINDOWS
+from poetry.utils._compat import metadata
 from poetry.utils.env import GET_BASE_PREFIX
 from poetry.utils.env import GET_PYTHON_VERSION_ONELINER
 from poetry.utils.env import EnvCommandError
@@ -1462,8 +1463,20 @@ def test_env_system_packages(tmp_path: Path, poetry: Poetry) -> None:
     pyvenv_cfg = venv_path / "pyvenv.cfg"
 
     EnvManager(poetry).build_venv(path=venv_path, flags={"system-site-packages": True})
+    env = VirtualEnv(venv_path)
 
     assert "include-system-site-packages = true" in pyvenv_cfg.read_text()
+    assert env.includes_system_site_packages()
+
+
+def test_env_system_packages_are_relative_to_lib(
+    tmp_path: Path, poetry: Poetry
+) -> None:
+    venv_path = tmp_path / "venv"
+    EnvManager(poetry).build_venv(path=venv_path, flags={"system-site-packages": True})
+    env = VirtualEnv(venv_path)
+    pytest_dist = metadata.distribution("pytest")
+    assert env.is_path_relative_to_lib(pytest_dist._path)  # type: ignore[attr-defined]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This changesets adds a getter to `env.virtual_env.VirtualEnv` to check whether it has access to system packages, and overrides the `is_path_relative_to_lib` method to take it into account.

This will prevent Poetry from reinstalling system packages in the venv when they are already installed with a compatible version.

Resolves: #6035

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (N/A)