### PR TITLE
Optionally only install the group holding the incoming dependencies

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -68,7 +68,7 @@ class AddCommand(InstallerCommand, InitCommand):
             " --verbose).",
         ),
         option("lock", None, "Do not perform operations (only update the lockfile)."),
-        option("only" None, "Do not install additional packages from the toml."),
+        option("only", None, "Do not install additional packages from the toml."),
     ]
     examples = """\
 If you do not specify a version constraint, poetry will choose a suitable one based on\

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -68,6 +68,7 @@ class AddCommand(InstallerCommand, InitCommand):
             " --verbose).",
         ),
         option("lock", None, "Do not perform operations (only update the lockfile)."),
+        option("only" None, "Do not install additional packages from the toml."),
     ]
     examples = """\
 If you do not specify a version constraint, poetry will choose a suitable one based on\
@@ -261,6 +262,8 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
         self.installer.verbose(self.io.is_verbose())
         self.installer.update(True)
         self.installer.execute_operations(not self.option("lock"))
+        if self.option("only"):
+            self.installer.only_groups(group)
 
         self.installer.whitelist([r["name"] for r in requirements])
 


### PR DESCRIPTION
This pull request adds the `--only` flag to `poetry add`. The rationale is to counteract the following situation:

```
poetry install --without=somegroup
poetry add new-dependency
# Poetry now installs new-dependency as well as dependencies in somegroup
```

By invoking `--only` the group of the incoming dependencies is passed to the install command via `self.installer.only_groups(group)`.

This is the best solution/simplicity ratio I have found to mimic the current workaround
```
poetry add new-dependency --lock
poetry install --without=somegroup
```

Tests incoming.
Doc updates incoming. 

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
