### PR TITLE
install: add warning if current project cannot be installed

### DIFF
--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -162,10 +162,16 @@ dependencies and not including the current project, run the command with the
         # i.e. during EditableBuilder.build().
         try:
             builder = EditableBuilder(self.poetry, self.env, self.io)
-        except ModuleOrPackageNotFound:
+        except (ModuleOrPackageNotFound, FileNotFoundError) as e:
             # This is likely due to the fact that the project is an application
             # not following the structure expected by Poetry
             # If this is a true error it will be picked up later by build anyway.
+            self.line_error(
+                f"The current project could not be installed: <error>{e}</error>\n"
+                "If you do not want to install the current project"
+                " use <c1>--no-root</c1>",
+                style="warning",
+            )
             return 0
 
         log_install = (
@@ -185,10 +191,17 @@ dependencies and not including the current project, run the command with the
 
         try:
             builder.build()
-        except ModuleOrPackageNotFound:
+        except (ModuleOrPackageNotFound, FileNotFoundError) as e:
             # This is likely due to the fact that the project is an application
             # not following the structure expected by Poetry.
             # No need for an editable install in this case.
+            self.line("")
+            self.line_error(
+                f"The current project could not be installed: <error>{e}</error>\n"
+                "If you do not want to install the current project"
+                " use <c1>--no-root</c1>",
+                style="warning",
+            )
             return 0
 
         if overwrite:

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -155,25 +155,6 @@ dependencies and not including the current project, run the command with the
         if self.option("no-root"):
             return 0
 
-        # Prior to https://github.com/python-poetry/poetry-core/pull/629
-        # the existence of a module/package was checked when creating the
-        # EditableBuilder. Afterwards, the existence is checked after
-        # executing the build script (if there is one),
-        # i.e. during EditableBuilder.build().
-        try:
-            builder = EditableBuilder(self.poetry, self.env, self.io)
-        except (ModuleOrPackageNotFound, FileNotFoundError) as e:
-            # This is likely due to the fact that the project is an application
-            # not following the structure expected by Poetry
-            # If this is a true error it will be picked up later by build anyway.
-            self.line_error(
-                f"The current project could not be installed: <error>{e}</error>\n"
-                "If you do not want to install the current project"
-                " use <c1>--no-root</c1>",
-                style="warning",
-            )
-            return 0
-
         log_install = (
             "<b>Installing</> the current project:"
             f" <c1>{self.poetry.package.pretty_name}</c1>"
@@ -189,7 +170,13 @@ dependencies and not including the current project, run the command with the
             self.line("")
             return 0
 
+        # Prior to https://github.com/python-poetry/poetry-core/pull/629
+        # the existence of a module/package was checked when creating the
+        # EditableBuilder. Afterwards, the existence is checked after
+        # executing the build script (if there is one),
+        # i.e. during EditableBuilder.build().
         try:
+            builder = EditableBuilder(self.poetry, self.env, self.io)
             builder.build()
         except (ModuleOrPackageNotFound, FileNotFoundError) as e:
             # This is likely due to the fact that the project is an application

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -33,7 +33,6 @@ authors = [
     "Python Poetry <tests@python-poetry.org>"
 ]
 license = "MIT"
-readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.4"


### PR DESCRIPTION
Companion to python-poetry/poetry-core#629

- `ModuleOrPackageNotFound` is now raised in `EditableBuilder.build()` instead of `EditableBuilder.__init__()`
- The existence of a specified readme is now checked before the existence of the module. -> Just not declare a non-existing readme in the test.

**Update:** In the second commit, I changed the current behavior so that errors are no longer swallowed silently when the installation of the current project fails. I only added a warning and did not change the return code to avoid a breaking change. We can decide if we only want to go with the first commit or both commits.

Pro second commit: Currently, the user will not know if installing the current project succeeds or fails.

Contra second commit: Users who don't use `--no-root` and don't care about the current project being installed or not, might be annoyed by the warning.