### PR TITLE
Limit default max-workers to 8

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,7 @@ If you encounter any problems with it, set to `true` to use the system git backe
 
 **Type**: `int`
 
-**Default**: `number_of_cores + 4`
+**Default**: `min(number_of_cores + 4, 8)`
 
 **Environment Variable**: `POETRY_INSTALLER_MAX_WORKERS`
 

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -234,7 +234,7 @@ class Executor:
             default_max_workers = 5
 
         if desired_max_workers is None:
-            return default_max_workers
+            return min(default_max_workers, 8)
         return min(default_max_workers, desired_max_workers)
 
     def _write(self, operation: Operation, line: str) -> None:

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1151,6 +1151,8 @@ def test_executor_should_write_pep610_url_references_for_git_with_subdirectories
     ("max_workers", "cpu_count", "side_effect", "expected_workers"),
     [
         (None, 3, None, 7),
+        (None, 5, None, 8),
+        (9, 5, None, 9),
         (3, 4, None, 3),
         (8, 3, None, 7),
         (None, 8, NotImplementedError(), 5),


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3219

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

When `os.cpu_count()` reports a large number of cores, "Connection reset by peer" errors seem to be raised fairly often because of the resulting huge number of requests being made. It struck me as more intuitive for the end user to use a safer value as the default maximum, rather than letting it be unbound to whatever the executing machine reports.

With this change, a power user can still configure a larger number of max workers if it is desirable and choose the upper limit themselves.

I do not have any specific data on the number of workers to cause this error to start cropping up due to its non-deterministic nature, so 8 was chosen conservatively. 5 might be best to make the default behavior be only a single core.