### PR TITLE
tweak messaging re incompatible python versions

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -163,7 +163,7 @@ In this case, you can disable this feature by setting the `virtualenvs.create` s
 poetry config virtualenvs.create false
 ```
 
-### Why is Poetry telling me that the current project's Python requirement is not compatible with one or more packages' Python requirements?
+### Why is Poetry telling me that the current project's supported Python range is not compatible with one or more packages' Python requirements?
 
 Unlike `pip`, Poetry doesn't resolve for just the Python in the current environment. Instead it makes sure that a dependency
 is resolvable within the given Python version range in `pyproject.toml`.
@@ -179,18 +179,18 @@ This means your project aims to be compatible with any Python version >=3.7,<4.0
 whose Python requirement doesn't match the whole range Poetry will tell you this, e.g.:
 
 ```
-The current project's Python requirement (>=3.7.0,<4.0.0) is not compatible with some of the required packages Python requirement:
+The current project's supported Python range (>=3.7.0,<4.0.0) is not compatible with some of the required packages Python requirement:
     - scipy requires Python >=3.7,<3.11, so it will not be satisfied for Python >=3.11,<4.0.0
 ```
 
-Usually you will want to match the Python requirement of your project with the upper bound of the failing dependency.
-Alternative you can tell Poetry to install this dependency [only for a specific range of Python versions]({{< relref "dependency-specification#multiple-constraints-dependencies" >}}),
+Usually you will want to match the supported Python range of your project with the upper bound of the failing dependency.
+Alternatively you can tell Poetry to install this dependency [only for a specific range of Python versions]({{< relref "dependency-specification#multiple-constraints-dependencies" >}}),
 if you know that it's not needed in all versions.
 
 
 ### Why does Poetry enforce PEP 440 versions?
 
-This is done so to be compliant with the broader Python ecosystem.
+This is done to be compliant with the broader Python ecosystem.
 
 For example, if Poetry builds a distribution for a project that uses a version that is not valid according to
 [PEP 440](https://peps.python.org/pep-0440), third party tools will be unable to parse the version correctly.

--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -22,7 +22,7 @@ By default, Poetry will try to use the Python version used during Poetry's insta
 to create the virtual environment for the current project.
 
 However, for various reasons, this Python version might not be compatible
-with the `python` requirement of the project. In this case, Poetry will try
+with the `python` range supported by the project. In this case, Poetry will try
 to find one that is and use it. If it's unable to do so then you will be prompted
 to activate one explicitly, see [Switching environments](#switching-between-environments).
 

--- a/src/poetry/mixology/failure.py
+++ b/src/poetry/mixology/failure.py
@@ -41,7 +41,7 @@ class _Writer:
             if isinstance(incompatibility.cause, PythonCause):
                 if not required_python_version_notification:
                     buffer.append(
-                        "The current project's Python requirement"
+                        "The current project's supported Python range"
                         f" ({incompatibility.cause.root_python_version}) is not"
                         " compatible with some of the required packages Python"
                         " requirement:"

--- a/src/poetry/mixology/solutions/providers/python_requirement_solution_provider.py
+++ b/src/poetry/mixology/solutions/providers/python_requirement_solution_provider.py
@@ -19,7 +19,7 @@ class PythonRequirementSolutionProvider(HasSolutionsForException):
             return False
 
         m = re.match(
-            "^The current project's Python requirement (.+) is not compatible "
+            "^The current project's supported Python range (.+) is not compatible "
             "with some of the required packages Python requirement",
             str(exception),
         )

--- a/tests/mixology/version_solver/test_python_constraint.py
+++ b/tests/mixology/version_solver/test_python_constraint.py
@@ -23,8 +23,8 @@ def test_dependency_does_not_match_root_python_constraint(
     add_to_repo(repo, "foo", "1.0.0", python="<3.5")
 
     error = """\
-The current project's Python requirement (>=3.6,<4.0) is not compatible with some of\
- the required packages Python requirement:
+The current project's supported Python range (>=3.6,<4.0) is not compatible with some\
+ of the required packages Python requirement:
   - foo requires Python <3.5, so it will not be satisfied for Python >=3.6,<4.0
 
 Because no versions of foo match !=1.0.0


### PR DESCRIPTION
A probably futile attempt to slow the steady drip of people reporting that they don't understand what poetry is telling them about python versions.

switching from "the current project's Python requirement" to "the current project's supported Python range" is intended:
- to encourage readers to realise that poetry has to think not only about the current environment but about the whole range for which their project declares support
- to de-emphasise "requirement", I can see why people read that and think "but my environment _does_ satisfy that requirement"