### PR TITLE
report more details on build backend exception

### DIFF
--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -137,14 +137,12 @@ class Chef:
                     )
             except BuildBackendException as e:
                 message_parts = [str(e)]
-                if isinstance(e.exception, CalledProcessError) and (
-                    e.exception.stdout is not None or e.exception.stderr is not None
-                ):
-                    message_parts.append(
-                        decode(e.exception.stderr)
-                        if e.exception.stderr is not None
-                        else decode(e.exception.stdout)
-                    )
+                if isinstance(e.exception, CalledProcessError):
+                    text = e.exception.stderr or e.exception.stdout
+                    if text is not None:
+                        message_parts.append(decode(text))
+                else:
+                    message_parts.append(str(e.exception))
 
                 error = ChefBuildError("\n\n".join(message_parts))
 


### PR DESCRIPTION
show the inner error associated with a `BuildBackendException`

eg for https://github.com/python-poetry/poetry/issues/8137#issuecomment-1732389285 this gives the extra output:
```
  Traceback (most recent call last):
    File "/home/dch/.virtualenvs/poetry/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 77, in _build_backend
      obj = import_module(mod_path)
            ^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "<frozen importlib._bootstrap>", line 1381, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1354, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1304, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
    File "<frozen importlib._bootstrap>", line 1381, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1354, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1325, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 929, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 994, in exec_module
    File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
    File "/tmp/tmp6wqbgy0u/.venv/lib/python3.12/site-packages/setuptools/__init__.py", line 10, in <module>
      import distutils.core
  ModuleNotFoundError: No module named 'distutils'
```
which makes it considerably more obvious what the problem is (`distutils` doesn't exist in python 3.12).  

Maybe it'll show something helpful in #7611 too.