### PR TITLE
poetry shell: fix nushell

### DIFF
--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -114,10 +114,9 @@ class Shell:
             c.sendline(f"emulate bash -c '. {shlex.quote(str(activate_path))}'")
         elif self._name == "xonsh":
             c.sendline(f"vox activate {shlex.quote(str(env.path))}")
-
-        # if this is nu, we don't want to send the activation command to the
-        # command line since we already ran it via the shell's invocation
         elif self._name == "nu":
+            # If this is nu, we don't want to send the activation command to the
+            # command line since we already ran it via the shell's invocation.
             pass
         else:
             if self._name in ["fish"]:


### PR DESCRIPTION
Presently, there are two bugs with `poetry shell` on nushell:

1. The `overlay use` command that poetry sends to the subshell does not get run, but merely appears on the command line as if the user had typed it themselves. Hitting the enter key is still necessary to activate the virtualenv.
2. In the subshell, whenever the user uses a tool that requires interactive keyboard input, the input is not echoed on the screen. This is because the current code specifically and explicitly turns off the terminal echo mode. It is unclear why.

This change fixes both of these problems by changing the invocation of `nu` to run the `overlay use` command with the `-e` flag, which runs the given command and then starts an interactive shell.

Disabling echo mode is also removed.