### PR TITLE
installer: report more details on build failures

### DIFF
--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 
 from pathlib import Path
@@ -13,12 +14,19 @@ from poetry.core.packages.utils.link import Link
 
 from poetry.factory import Factory
 from poetry.installation.chef import Chef
+from poetry.installation.chef import ChefInstallError
+from poetry.installation.chef import IsolatedEnv
+from poetry.puzzle.exceptions import SolverProblemError
+from poetry.puzzle.provider import IncompatibleConstraintsError
 from poetry.repositories import RepositoryPool
 from poetry.utils.env import EnvManager
+from poetry.utils.env import ephemeral_environment
 from tests.repositories.test_pypi_repository import MockRepository
 
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from pytest_mock import MockerFixture
 
     from poetry.utils.cache import ArtifactCache
@@ -38,6 +46,41 @@ def pool() -> RepositoryPool:
 @pytest.fixture(autouse=True)
 def setup(mocker: MockerFixture, pool: RepositoryPool) -> None:
     mocker.patch.object(Factory, "create_pool", return_value=pool)
+
+
+def test_isolated_env_install_success(pool: RepositoryPool) -> None:
+    with ephemeral_environment(Path(sys.executable)) as venv:
+        env = IsolatedEnv(venv, pool)
+        assert "poetry-core" not in venv.run("pip", "freeze")
+        env.install({"poetry-core"})
+        assert "poetry-core" in venv.run("pip", "freeze")
+
+
+@pytest.mark.parametrize(
+    ("requirements", "exception"),
+    [
+        ({"poetry-core==1.5.0", "poetry-core==1.6.0"}, IncompatibleConstraintsError),
+        ({"black==19.10b0", "attrs==17.4.0"}, SolverProblemError),
+    ],
+)
+def test_isolated_env_install_error(
+    requirements: Collection[str], exception: type[Exception], pool: RepositoryPool
+) -> None:
+    with ephemeral_environment(Path(sys.executable)) as venv:
+        env = IsolatedEnv(venv, pool)
+        with pytest.raises(exception):
+            env.install(requirements)
+
+
+def test_isolated_env_install_failure(
+    pool: RepositoryPool, mocker: MockerFixture
+) -> None:
+    mocker.patch("poetry.installation.installer.Installer.run", return_value=1)
+    with ephemeral_environment(Path(sys.executable)) as venv:
+        env = IsolatedEnv(venv, pool)
+        with pytest.raises(ChefInstallError) as e:
+            env.install({"a", "b>1"})
+        assert e.value.requirements == {"a", "b>1"}
 
 
 def test_prepare_sdist(


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Yesterday, I was able to reproduce errors similar to #7611 in python-poetry/poetry-plugin-export#235 for a short time. (After a few runs it suddenly stopped to reproduce.)

Nevertheless, I think I gained a few new insights: The build backend is not available in the isolated venv because the installation of the build system requirements failed! Up to now, we did not check the result of the installation. (I do not know yet why the installation fails because the issue stopped to reproduce after I added additional output.)

In order to provide better error messages and facilitate future investigations, this PR checks the return code of the installation of build system requirements and prints additional information in case of failure.
