### PR TITLE
fix: Correct error message when pypi-token.pypi has incorrect number of arguments.

### DIFF
--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -122,6 +122,9 @@ To remove a repository (repo is a short alias for repositories):
 
         # show the value if no value is provided
         if not self.argument("value") and not self.option("unset"):
+            if setting_key.split(".")[0] in self.LIST_PROHIBITED_SETTINGS:
+                raise ValueError(f"Expected a value for {setting_key} setting.")
+
             m = re.match(r"^repos?(?:itories)?(?:\.(.+))?", self.argument("key"))
             value: str | dict[str, Any]
             if m:
@@ -138,8 +141,6 @@ To remove a repository (repo is a short alias for repositories):
 
                 self.line(str(value))
             else:
-                if setting_key.split(".")[0] in self.LIST_PROHIBITED_SETTINGS:
-                    raise ValueError(f"Expected a value for {setting_key} setting.")
                 if setting_key not in self.unique_config_values:
                     raise ValueError(f"There is no {setting_key} setting.")
 

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -138,6 +138,8 @@ To remove a repository (repo is a short alias for repositories):
 
                 self.line(str(value))
             else:
+                if setting_key.split(".")[0] in self.LIST_PROHIBITED_SETTINGS:
+                    raise ValueError(f"Expected a value for {setting_key} setting.")
                 if setting_key not in self.unique_config_values:
                     raise ValueError(f"There is no {setting_key} setting.")
 

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -405,7 +405,6 @@ def test_set_pypi_token_unsuccessful_multiple_values(
 def test_set_pypi_token_no_values(
     tester: CommandTester,
 ) -> None:
-    print("Running this test")
     with pytest.raises(ValueError) as e:
         tester.execute("pypi-token.pypi")
 

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -402,6 +402,16 @@ def test_set_pypi_token_unsuccessful_multiple_values(
     assert str(e.value) == "Expected only one argument (token), got 2"
 
 
+def test_set_pypi_token_no_values(
+    tester: CommandTester,
+) -> None:
+    print("Running this test")
+    with pytest.raises(ValueError) as e:
+        tester.execute("pypi-token.pypi")
+
+    assert str(e.value) == "Expected a value for pypi-token.pypi setting."
+
+
 def test_set_client_cert(
     tester: CommandTester,
     auth_config_source: DictConfigSource,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8503

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
