### PR TITLE
Fix race condition in artifact cache

### DIFF
--- a/src/poetry/packages/direct_origin.py
+++ b/src/poetry/packages/direct_origin.py
@@ -76,14 +76,9 @@ class DirectOrigin:
 
     def get_package_from_url(self, url: str) -> Package:
         link = Link(url)
-        artifact = self._artifact_cache.get_cached_archive_for_link(link, strict=True)
-
-        if not artifact:
-            artifact = (
-                self._artifact_cache.get_cache_directory_for_link(link) / link.filename
-            )
-            artifact.parent.mkdir(parents=True, exist_ok=True)
-            download_file(url, artifact)
+        artifact = self._artifact_cache.get_cached_archive_for_link(
+            link, strict=True, download_func=download_file
+        )
 
         package = self.get_package_from_file(artifact)
         package.files = [

--- a/tests/packages/test_direct_origin.py
+++ b/tests/packages/test_direct_origin.py
@@ -43,7 +43,7 @@ def test_direct_origin_does_not_download_url_dependency_when_cached(
     )
     direct_origin = DirectOrigin(artifact_cache)
     url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
-    mocker.patch(
+    download_file = mocker.patch(
         "poetry.packages.direct_origin.download_file",
         side_effect=Exception("download_file should not be called"),
     )
@@ -52,5 +52,5 @@ def test_direct_origin_does_not_download_url_dependency_when_cached(
 
     assert package.name == "demo"
     artifact_cache.get_cached_archive_for_link.assert_called_once_with(
-        Link(url), strict=True
+        Link(url), strict=True, download_func=download_file
     )


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7611

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Fixes the race condition identified in https://github.com/python-poetry/poetry/issues/7611#issuecomment-1747836233

The first two commits are refactorings to reduce duplicated code and let the artifact cache handle downloads of archives that will be stored in the artifact cache. The third commit is the actual fix, which uses per-artifact locks.