### PR TITLE
fix: error when lockfile without metadata entry is encountered

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -323,8 +323,9 @@ class Locker:
             except tomllib.TOMLDecodeError as e:
                 raise RuntimeError(f"Unable to read the lock file ({e}).")
 
-        # if the lockfile doesn't contain a metadata section at all, it probably needs to be rebuilt completely
-        if not "metadata" in lock_data:
+        # if the lockfile doesn't contain a metadata section at all,
+        # it probably needs to be rebuilt completely
+        if "metadata" not in lock_data:
             raise RuntimeError(
                 "The lock file does not have a metadata entry.\n"
                 "Regenerate the lock file with the `poetry lock` command."

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -323,6 +323,13 @@ class Locker:
             except tomllib.TOMLDecodeError as e:
                 raise RuntimeError(f"Unable to read the lock file ({e}).")
 
+        # if the lockfile doesn't contain a metadata section at all, it probably needs to be rebuilt completely
+        if not "metadata" in lock_data:
+            raise RuntimeError(
+                "The lock file does not have a metadata entry.\n"
+                "Regenerate the lock file with the `poetry lock` command."
+            )
+
         metadata = lock_data["metadata"]
         lock_version = Version.parse(metadata.get("lock-version", "1.0"))
         current_version = Version.parse(self._VERSION)

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -647,11 +647,11 @@ reference = "legacy"
     with pytest.raises(RuntimeError) as e:
         _ = locker.lock_data
 
-        assert (
-            "The lock file does not have a metadata entry.\nRegenerate the lock file with"
-            " the `poetry lock` command."
-            in str(e.value)
-        )
+    assert (
+        "The lock file does not have a metadata entry.\nRegenerate the lock file with"
+        " the `poetry lock` command."
+        in str(e.value)
+    )
 
 
 def test_locking_legacy_repository_package_should_include_source_section(

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -647,11 +647,11 @@ reference = "legacy"
     with pytest.raises(RuntimeError) as e:
         _ = locker.lock_data
 
-    assert (
-        "The lock file does not have a metadata entry.\nRegenerate the lock file with"
-        " the `poetry lock` command."
-        in str(e.value)
-    )
+        assert (
+            "The lock file does not have a metadata entry.\nRegenerate the lock file with"
+            " the `poetry lock` command."
+            in str(e.value)
+        )
 
 
 def test_locking_legacy_repository_package_should_include_source_section(

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -621,6 +621,7 @@ content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8
 
     assert "Unable to read the lock file" in str(e.value)
 
+
 def test_reading_lock_file_should_raise_an_error_on_missing_metadata(
     locker: Locker,
 ) -> None:
@@ -646,7 +647,11 @@ reference = "legacy"
     with pytest.raises(RuntimeError) as e:
         _ = locker.lock_data
 
-    assert 'The lock file does not have a metadata entry.\nRegenerate the lock file with the `poetry lock` command.' in str(e.value)
+    assert (
+        "The lock file does not have a metadata entry.\nRegenerate the lock file with"
+        " the `poetry lock` command."
+        in str(e.value)
+    )
 
 
 def test_locking_legacy_repository_package_should_include_source_section(

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -621,6 +621,33 @@ content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8
 
     assert "Unable to read the lock file" in str(e.value)
 
+def test_reading_lock_file_should_raise_an_error_on_missing_metadata(
+    locker: Locker,
+) -> None:
+    content = f"""\
+# {GENERATED_COMMENT}
+
+[[package]]
+name = "A"
+version = "1.0.0"
+description = ""
+optional = false
+python-versions = "*"
+files = []
+
+[package.source]
+type = "legacy"
+url = "https://foo.bar"
+reference = "legacy"
+"""
+    with locker.lock.open("w", encoding="utf-8") as f:
+        f.write(content)
+
+    with pytest.raises(RuntimeError) as e:
+        _ = locker.lock_data
+
+    assert 'The lock file does not have a metadata entry.\nRegenerate the lock file with the `poetry lock` command.' in str(e.value)
+
 
 def test_locking_legacy_repository_package_should_include_source_section(
     root: ProjectPackage, locker: Locker


### PR DESCRIPTION
Without this, you'll get a cryptic 'metadata' in red when running `poetry install`. This can occur if a poetry.lock file is empty

Not sure of the best way to write a test for this, point me in the right direction and I'll write a test.

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
