### PR TITLE
transitive-python-versions is not used

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -682,7 +682,6 @@ class Provider:
                 if python_constraint_intersection.is_empty():
                     # This dependency is not needed under current python constraint.
                     continue
-                dep.transitive_python_versions = str(python_constraint_intersection)
 
             clean_dependencies.append(dep)
 


### PR DESCRIPTION
`transitive_python_versions` is unused (and confusing), let's put it on the path to removal