### PR TITLE
Add documentation of auto-included files in wheels and sdist

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -60,7 +60,7 @@ a `wheel`, the following files are included in the `.dist-info` directory:
 - `COPYING.*`
 - `LICENSES/**`
 
-When building a sdist, the following files will be included in the root folder:
+When building an `sdist`, the following files will be included in the root folder:
   - `LICENSE*`
 
 Once building is done you are ready to publish your library.

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -53,7 +53,7 @@ This command will package your library in two different formats: `sdist` which i
 the source format, and `wheel` which is a `compiled` package.
 
 Poetry will automatically include some metadata files when building a package. When building
-a wheel, the following files are included in the `.dist-info` directory:
+a `wheel`, the following files are included in the `.dist-info` directory:
 - `LICENSE`
 - `LICENSE.*`
 - `COPYING`

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -52,7 +52,17 @@ poetry build
 This command will package your library in two different formats: `sdist` which is
 the source format, and `wheel` which is a `compiled` package.
 
-Once that's done you are ready to publish your library
+If present in the project root directory, Poetry will automatically include the following files:
+- in the `.dist-info` directory of a `wheel`:
+  - `LICENSE`
+  - `LICENSE.*`
+  - `COPYING`
+  - `COPYING.*`
+  - `LICENSES/**`
+- in the root of a `sdist`:
+  - `LICENSE*`
+
+Once this is done you are ready to publish your library.
 
 ## Publishing to PyPI
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -52,17 +52,18 @@ poetry build
 This command will package your library in two different formats: `sdist` which is
 the source format, and `wheel` which is a `compiled` package.
 
-If present in the project root directory, Poetry will automatically include the following files:
-- in the `.dist-info` directory of a `wheel`:
-  - `LICENSE`
-  - `LICENSE.*`
-  - `COPYING`
-  - `COPYING.*`
-  - `LICENSES/**`
-- in the root of a `sdist`:
+Poetry will automatically include some metadata files when building a package. When building
+a wheel, the following files are included in the `.dist-info` directory:
+- `LICENSE`
+- `LICENSE.*`
+- `COPYING`
+- `COPYING.*`
+- `LICENSES/**`
+
+When building a sdist, the following files will be included in the root folder:
   - `LICENSE*`
 
-Once this is done you are ready to publish your library.
+Once building is done you are ready to publish your library.
 
 ## Publishing to PyPI
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8553

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
`poetry build` includes some files automatically in the wheel's `.dist-info` and the root of the `sdist`, and this is not documented anywhere. This PR adds this to the `Libraries/Packaging` section.