### PR TITLE
print a future warning that poetry-plugin-export will not be installed by default anymore

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -720,9 +720,17 @@ This command exports the lock file to other formats.
 poetry export -f requirements.txt --output requirements.txt
 ```
 
+{{% warning %}}
+This command is provided by the [Export Poetry Plugin](https://github.com/python-poetry/poetry-plugin-export).
+In a future version of Poetry this plugin will not be installed by default anymore.
+In order to avoid a breaking change and make your automation forward-compatible,
+please install poetry-plugin-export explicitly.
+See [Using plugins]({{< relref "plugins#using-plugins" >}}) for details on how to install a plugin.
+{{% /warning %}}
+
 {{% note %}}
-This command is provided by the [Export Poetry Plugin](https://github.com/python-poetry/poetry-plugin-export)
-and is also available as a pre-commit hook. See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-export" >}}) for more information.
+This command is also available as a pre-commit hook.
+See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-export" >}}) for more information.
 {{% /note %}}
 
 {{% note %}}

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -53,6 +53,10 @@ For more information see the [lock command]({{< relref "cli#lock" >}}).
 The `poetry-export` hook calls the `poetry export` command
 to sync your `requirements.txt` file with your current dependencies.
 
+{{% warning %}}
+This hook is provided by the [Export Poetry Plugin](https://github.com/python-poetry/poetry-plugin-export).
+{{% /warning %}}
+
 {{% note %}}
 It is recommended to run the [`poetry-lock`](#poetry-lock) hook prior to this one.
 {{% /note %}}

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -133,6 +133,9 @@ class Config:
             "max-workers": None,
             "no-binary": None,
         },
+        "warnings": {
+            "export": True,
+        },
     }
 
     def __init__(
@@ -279,6 +282,7 @@ class Config:
             "experimental.system-git-client",
             "installer.modern-installation",
             "installer.parallel",
+            "warnings.export",
         }:
             return boolean_normalizer
 

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -354,6 +354,12 @@ class Application(BaseApplication):
             manager.load_plugins()
             manager.activate(self)
 
+            # We have to override the command from poetry-plugin-export
+            # with the wrapper.
+            if self.command_loader.has("export"):
+                del self.command_loader._factories["export"]
+            self.command_loader._factories["export"] = load_command("export")
+
         self._plugins_loaded = True
 
     @property

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -77,6 +77,7 @@ To remove a repository (repo is a short alias for repositories):
                 PackageFilterPolicy.validator,
                 PackageFilterPolicy.normalize,
             ),
+            "warnings.export": (boolean_validator, boolean_normalizer),
         }
 
         return unique_config_values

--- a/src/poetry/console/commands/export.py
+++ b/src/poetry/console/commands/export.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from poetry_plugin_export.command import (  # type: ignore[import-untyped]
+    ExportCommand as BaseExportCommand,
+)
+
+
+class ExportCommand(BaseExportCommand):  # type: ignore[misc]
+    def handle(self) -> int:
+        if self.poetry.config.get("warnings.export"):
+            self.line_error(
+                "Warning: poetry-plugin-export will not be installed by default in a"
+                " future version of Poetry.\n"
+                "In order to avoid a breaking change and make your automation"
+                " forward-compatible, please install poetry-plugin-export explicitly."
+                " See https://python-poetry.org/docs/plugins/#using-plugins for details"
+                " on how to install a plugin.\n"
+                "To disable this warning run 'poetry config warnings.export false'.",
+                style="warning",
+            )
+        return super().handle()  # type: ignore[no-any-return]

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -67,6 +67,7 @@ virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
 virtualenvs.prefer-active-python = false
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+warnings.export = true
 """
 
     assert tester.io.fetch_output() == expected
@@ -96,6 +97,7 @@ virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
 virtualenvs.prefer-active-python = false
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+warnings.export = true
 """
 
     assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
@@ -146,6 +148,7 @@ virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
 virtualenvs.prefer-active-python = false
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+warnings.export = true
 """
     assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
     assert tester.io.fetch_output() == expected
@@ -174,6 +177,7 @@ virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
 virtualenvs.prefer-active-python = false
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+warnings.export = true
 """
     assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
     assert tester.io.fetch_output() == expected
@@ -301,6 +305,7 @@ virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
 virtualenvs.prefer-active-python = false
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+warnings.export = true
 """
 
     assert config.set_config_source.call_count == 1  # type: ignore[attr-defined]
@@ -338,6 +343,7 @@ virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
 virtualenvs.prefer-active-python = false
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+warnings.export = true
 """
 
     assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_export.py
+++ b/tests/console/commands/test_export.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from tests.conftest import Config
+    from tests.types import CommandTesterFactory
+
+
+@pytest.fixture
+def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
+    return command_tester_factory("export")
+
+
+def test_export_prints_warning(tester: CommandTester) -> None:
+    tester.execute("")
+    assert (
+        "Warning: poetry-plugin-export will not be installed by default"
+        in tester.io.fetch_error()
+    )
+
+
+def test_disable_export_warning(tester: CommandTester, config: Config) -> None:
+    config.config["warnings"]["export"] = False
+    tester.execute("")
+    assert "poetry-plugin-export" not in tester.io.fetch_error()


### PR DESCRIPTION
# Pull Request Check List

Related-to: #5980, #6441, python-poetry/poetry-plugin-export#240

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Since I don't see a more elegant solution to proceed with #5980 in the near future, maybe just do it the simple way:
Print a warning for, let's say, 3 minor versions and then just remove the dependency.

With this PR the following deprecation warning will be printed as soon as `poetry export` is run:

```
Warning: poetry-plugin-export will not be installed by default in the future.
In order to avoid a breaking change and make your automation forward-compatible, please install poetry-plugin-export explicitly. See https://python-poetry.org/docs/plugins/#using-plugins for details on how to install a plugin.
To disable this warning run 'poetry config warnings.export false'.
```