### PR TITLE
Ensure UTF-8 encoding when communicating with a subprocess

### DIFF
--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -327,6 +327,8 @@ class Env:
             "-I",
             "-W",
             "ignore",
+            "-X",
+            "utf8",
             "-",
             input_=content,
             stderr=subprocess.PIPE,
@@ -352,6 +354,7 @@ class Env:
                     check=True,
                     env=env,
                     text=True,
+                    encoding="utf-8",
                     **kwargs,
                 ).stdout
             elif call:

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1124,6 +1124,16 @@ def test_run_python_script_only_stdout(tmp_path: Path, tmp_venv: VirtualEnv) -> 
     assert "some warning" not in output
 
 
+def test_run_python_script_non_ascii_input(
+    tmp_path: Path, tmp_venv: VirtualEnv
+) -> None:
+    output = tmp_venv.run_python_script(
+        "import sys; print('👎', file=sys.stderr); print('👍')"
+    )
+    assert "👍" in output
+    assert "👎" not in output
+
+
 def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_ones_first(  # noqa: E501
     manager: EnvManager,
     poetry: Poetry,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8550
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Manual tests

- I checked that the added test `test_run_python_script_non_ascii_input` failed on windows instances before fixing `base_env`: https://github.com/privet-kitty/poetry/actions/runs/6591942649
  - This is because the default encoding of `sys.stdin` is [not utf-8 but cp1252](https://github.com/privet-kitty/ci-encoding/actions/runs/6592097084/job/17912064455) on a Windows instance (when piped) . So I didn't need to prepare a special non-utf-8 environment for testing. If it is better to set up the test environment explicitly, the only way I know is invoking a PowerShell command `Set-WinSystemLocale <some locale>` before testing in workflows.
- Unfortunately I didn't come up with a good and simple test case that tests the reported error itself, which is about [GET_SYS_TAGS](https://github.com/python-poetry/poetry/blob/d826e8a0123ee10a6cbf2a53837eb519ce19c17e/src/poetry/utils/env/script_strings.py#L6). (I feel mocking this string is much the same as `test_run_python_script_non_ascii_input`.) As a one-time testing, I modified the master branch to use a [non-ascii working directory](https://github.com/privet-kitty/poetry/commit/da7937ebf3ad2b4e80b9c2696451445ee818f37a) in CI, saw [some test cases failed](https://github.com/privet-kitty/poetry/actions/runs/6595660977), and [it succeeded](https://github.com/privet-kitty/poetry/actions/runs/6595690924) after merging this change.