### PR TITLE
run python scripts as "python -c text"

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -586,11 +586,7 @@ def get_pep517_metadata(path: Path) -> PackageInfo:
                 "--no-input",
                 *PEP517_META_BUILD_DEPS,
             )
-            venv.run(
-                "python",
-                "-",
-                input_=pep517_meta_build_script,
-            )
+            venv.run_python_script(pep517_meta_build_script)
             info = PackageInfo.from_metadata(dest_dir)
         except EnvCommandError as e:
             # something went wrong while attempting pep517 metadata build

--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -327,8 +327,8 @@ class Env:
             "-I",
             "-W",
             "ignore",
-            "-",
-            input_=content,
+            "-c",
+            content,
             stderr=subprocess.PIPE,
             **kwargs,
         )
@@ -338,23 +338,11 @@ class Env:
         Run a command inside the Python environment.
         """
         call = kwargs.pop("call", False)
-        input_ = kwargs.pop("input_", None)
         env = kwargs.pop("env", dict(os.environ))
         stderr = kwargs.pop("stderr", subprocess.STDOUT)
 
         try:
-            if input_:
-                output: str = subprocess.run(
-                    cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=stderr,
-                    input=input_,
-                    check=True,
-                    env=env,
-                    text=True,
-                    **kwargs,
-                ).stdout
-            elif call:
+            if call:
                 assert stderr != subprocess.PIPE
                 subprocess.check_call(cmd, stderr=stderr, env=env, **kwargs)
                 output = ""
@@ -363,7 +351,7 @@ class Env:
                     cmd, stderr=stderr, env=env, text=True, **kwargs
                 )
         except CalledProcessError as e:
-            raise EnvCommandError(e, input=input_)
+            raise EnvCommandError(e)
 
         return output
 

--- a/src/poetry/utils/env/exceptions.py
+++ b/src/poetry/utils/env/exceptions.py
@@ -20,7 +20,7 @@ class IncorrectEnvError(EnvError):
 
 
 class EnvCommandError(EnvError):
-    def __init__(self, e: CalledProcessError, input: str | None = None) -> None:
+    def __init__(self, e: CalledProcessError) -> None:
         self.e = e
 
         message_parts = [
@@ -30,8 +30,6 @@ class EnvCommandError(EnvError):
             message_parts.append(f"Output:\n{decode(e.output)}")
         if e.stderr:
             message_parts.append(f"Error output:\n{decode(e.stderr)}")
-        if input:
-            message_parts.append(f"Input:\n{input}")
         super().__init__("\n\n".join(message_parts))
 
 

--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -24,17 +24,28 @@ def check_output_wrapper(
 ) -> Callable[[list[str], Any, Any], str]:
     def check_output(cmd: list[str], *args: Any, **kwargs: Any) -> str:
         # cmd is a list, like ["python", "-c", "do stuff"]
-        python_cmd = cmd[2]
+        python_cmd = cmd[-1]
+        if "print(json.dumps(env))" in python_cmd:
+            return (
+                f'{{"version_info": [{version.major}, {version.minor},'
+                f" {version.patch}]}}"
+            )
+
         if "sys.version_info[:3]" in python_cmd:
             return version.text
-        elif "sys.version_info[:2]" in python_cmd:
+
+        if "sys.version_info[:2]" in python_cmd:
             return f"{version.major}.{version.minor}"
-        elif "import sys; print(sys.executable)" in python_cmd:
+
+        if "import sys; print(sys.executable)" in python_cmd:
             executable = cmd[0]
             basename = os.path.basename(executable)
             return f"/usr/bin/{basename}"
-        else:
-            assert "import sys; print(sys.prefix)" in python_cmd
-            return "/prefix"
+
+        if "print(sys.base_prefix)" in python_cmd:
+            return "/usr"
+
+        assert "import sys; print(sys.prefix)" in python_cmd
+        return "/prefix"
 
     return check_output


### PR DESCRIPTION
and not as "python -", and then passing the script as input

this sidesteps encoding issues, fixes #8550

comments:
- this has knock-on effects in the unit tests: scripts that were previously executed via `subprocess.run()` are now executed via `subprocess.check_output()`
- since `run_python_script` was the only caller making use of `input_` in this code, I've removed the `subprocess.run()` branch altogether
- we're not close to worrying about too-long arguments
  - `len(GET_ENVIRONMENT_INFO)` is 1717, the Windows limit should be 8191, it's much larger elsewhere
  - (if we were I suppose we could write the script to a temporary directory and run it from there)
- this is the pattern already followed throughout `env_manager.py`