### PR TITLE
remove fancy bullets, just use hyphens

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -298,5 +298,5 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
             " be skipped:\n"
         )
         for name in existing_packages:
-            self.line(f"  • <c1>{name}</c1>")
+            self.line(f"  - <c1>{name}</c1>")
         self.line(self._hint_update_packages)

--- a/src/poetry/console/commands/self/show/plugins.py
+++ b/src/poetry/console/commands/self/show/plugins.py
@@ -88,7 +88,7 @@ commands respectively.
             package = info.package
             description = " " + package.description if package.description else ""
             self.line("")
-            self.line(f"  • <c1>{name}</c1> (<c2>{package.version}</c2>){description}")
+            self.line(f"  - <c1>{name}</c1> (<c2>{package.version}</c2>){description}")
             provide_line = "     "
 
             if info.plugins:

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -248,18 +248,18 @@ class Executor:
                     with self._lock:
                         self._sections[id(operation)] = self._io.section()
                         self._sections[id(operation)].write_line(
-                            f"  <fg=blue;options=bold>•</> {op_message}:"
+                            f"  <fg=blue;options=bold>-</> {op_message}:"
                             " <fg=blue>Pending...</>"
                         )
             else:
                 if self._should_write_operation(operation):
                     if not operation.skipped:
                         self._io.write_line(
-                            f"  <fg=blue;options=bold>•</> {op_message}"
+                            f"  <fg=blue;options=bold>-</> {op_message}"
                         )
                     else:
                         self._io.write_line(
-                            f"  <fg=default;options=bold,dark>•</> {op_message}: "
+                            f"  <fg=default;options=bold,dark>-</> {op_message}: "
                             "<fg=default;options=bold,dark>Skipped</> "
                             "<fg=default;options=dark>for the following reason:</> "
                             f"<fg=default;options=bold,dark>{operation.skip_reason}</>"
@@ -287,7 +287,7 @@ class Executor:
                     io = self._io
                 else:
                     message = (
-                        "  <error>•</error>"
+                        "  <error>-</error>"
                         f" {self.get_operation_message(operation, error=True)}:"
                         " <error>Failed</error>"
                     )
@@ -343,7 +343,7 @@ class Executor:
         except KeyboardInterrupt:
             try:
                 message = (
-                    "  <warning>•</warning>"
+                    "  <warning>-</warning>"
                     f" {self.get_operation_message(operation, warning=True)}:"
                     " <warning>Cancelled</warning>"
                 )
@@ -363,7 +363,7 @@ class Executor:
             if self.supports_fancy_output():
                 self._write(
                     operation,
-                    f"  <fg=default;options=bold,dark>•</> {operation_message}: "
+                    f"  <fg=default;options=bold,dark>-</> {operation_message}: "
                     "<fg=default;options=bold,dark>Skipped</> "
                     "<fg=default;options=dark>for the following reason:</> "
                     f"<fg=default;options=bold,dark>{operation.skip_reason}</>",
@@ -382,7 +382,7 @@ class Executor:
             return result
 
         operation_message = self.get_operation_message(operation, done=True)
-        message = f"  <fg=green;options=bold>•</> {operation_message}"
+        message = f"  <fg=green;options=bold>-</> {operation_message}"
         self._write(operation, message)
 
         self._increment_operations_count(operation, True)
@@ -516,7 +516,7 @@ class Executor:
 
     def _execute_uninstall(self, operation: Uninstall) -> int:
         op_msg = self.get_operation_message(operation)
-        message = f"  <fg=blue;options=bold>•</> {op_msg}: <info>Removing...</info>"
+        message = f"  <fg=blue;options=bold>-</> {op_msg}: <info>Removing...</info>"
         self._write(operation, message)
 
         return self._remove(operation.package)
@@ -543,7 +543,7 @@ class Executor:
 
         operation_message = self.get_operation_message(operation)
         message = (
-            f"  <fg=blue;options=bold>•</> {operation_message}:"
+            f"  <fg=blue;options=bold>-</> {operation_message}:"
             " <info>Installing...</info>"
         )
         self._write(operation, message)
@@ -591,7 +591,7 @@ class Executor:
         operation_message = self.get_operation_message(operation)
 
         message = (
-            f"  <fg=blue;options=bold>•</> {operation_message}:"
+            f"  <fg=blue;options=bold>-</> {operation_message}:"
             " <info>Preparing...</info>"
         )
         self._write(operation, message)
@@ -630,7 +630,7 @@ class Executor:
         operation_message = self.get_operation_message(operation)
 
         message = (
-            f"  <fg=blue;options=bold>•</> {operation_message}: <info>Cloning...</info>"
+            f"  <fg=blue;options=bold>-</> {operation_message}: <info>Cloning...</info>"
         )
         self._write(operation, message)
 
@@ -673,7 +673,7 @@ class Executor:
         operation_message = self.get_operation_message(operation)
 
         message = (
-            f"  <fg=blue;options=bold>•</> {operation_message}:"
+            f"  <fg=blue;options=bold>-</> {operation_message}:"
             " <info>Building...</info>"
         )
         self._write(operation, message)
@@ -773,7 +773,7 @@ class Executor:
 
         if archive.suffix != ".whl":
             message = (
-                f"  <fg=blue;options=bold>•</> {self.get_operation_message(operation)}:"
+                f"  <fg=blue;options=bold>-</> {self.get_operation_message(operation)}:"
                 " <info>Preparing...</info>"
             )
             self._write(operation, message)
@@ -814,7 +814,7 @@ class Executor:
 
         operation_message = self.get_operation_message(operation)
         message = (
-            f"  <fg=blue;options=bold>•</> {operation_message}: <info>Downloading...</>"
+            f"  <fg=blue;options=bold>-</> {operation_message}: <info>Downloading...</>"
         )
         progress = None
         if self.supports_fancy_output():

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -580,18 +580,18 @@ class Provider:
         # the requirements will be merged.
         #
         # For instance:
-        #   • enum34; python_version=="2.7"
-        #   • enum34; python_version=="3.3"
+        #   - enum34; python_version=="2.7"
+        #   - enum34; python_version=="3.3"
         #
         # will become:
-        #   • enum34; python_version=="2.7" or python_version=="3.3"
+        #   - enum34; python_version=="2.7" or python_version=="3.3"
         #
         # If the duplicate dependencies have different constraints
         # we have to split the dependency graph.
         #
         # An example of this is:
-        #   • pypiwin32 (220); sys_platform == "win32" and python_version >= "3.6"
-        #   • pypiwin32 (219); sys_platform == "win32" and python_version < "3.6"
+        #   - pypiwin32 (220); sys_platform == "win32" and python_version >= "3.6"
+        #   - pypiwin32 (219); sys_platform == "win32" and python_version < "3.6"
         duplicates: dict[str, list[Dependency]] = defaultdict(list)
         for dep in dependencies:
             duplicates[dep.complete_name].append(dep)
@@ -617,13 +617,13 @@ class Provider:
             # tell the solver to make new resolutions with specific overrides.
             #
             # For instance, if the foo (1.2.3) package has the following dependencies:
-            #   • bar (>=2.0) ; python_version >= "3.6"
-            #   • bar (<2.0) ; python_version < "3.6"
+            #   - bar (>=2.0) ; python_version >= "3.6"
+            #   - bar (<2.0) ; python_version < "3.6"
             #
             # then the solver will need to make two new resolutions
             # with the following overrides:
-            #   • {<Package foo (1.2.3): {"bar": <Dependency bar (>=2.0)>}
-            #   • {<Package foo (1.2.3): {"bar": <Dependency bar (<2.0)>}
+            #   - {<Package foo (1.2.3): {"bar": <Dependency bar (>=2.0)>}
+            #   - {<Package foo (1.2.3): {"bar": <Dependency bar (<2.0)>}
 
             def fmt_warning(d: Dependency) -> str:
                 dependency_marker = d.marker if not d.marker.is_any() else "*"
@@ -915,10 +915,10 @@ class Provider:
                 # This is an edge case where the dependency is not required
                 # for the resulting marker. However, we have to consider it anyway
                 #  in order to not miss other dependencies later, for instance:
-                #   • foo (1.0) ; python == 3.7
-                #   • foo (2.0) ; python == 3.8
-                #   • bar (2.0) ; python == 3.8
-                #   • bar (3.0) ; python == 3.9
+                #   - foo (1.0) ; python == 3.7
+                #   - foo (2.0) ; python == 3.8
+                #   - bar (2.0) ; python == 3.8
+                #   - bar (3.0) ; python == 3.9
                 # the last dependency would be missed without this,
                 # because the intersection with both foo dependencies is empty.
 

--- a/tests/console/commands/self/test_add_plugins.py
+++ b/tests/console/commands/self/test_add_plugins.py
@@ -57,7 +57,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing poetry-plugin (0.1.0)
+  - Installing poetry-plugin (0.1.0)
 
 Writing lock file
 """
@@ -79,7 +79,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing poetry-plugin (0.2.0)
+  - Installing poetry-plugin (0.2.0)
 
 Writing lock file
 """
@@ -101,8 +101,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (2.0.5)
-  • Installing poetry-plugin (0.1.2 9cf87a2)
+  - Installing pendulum (2.0.5)
+  - Installing poetry-plugin (0.1.2 9cf87a2)
 
 Writing lock file
 """
@@ -127,9 +127,9 @@ Resolving dependencies...
 
 Package operations: 3 installs, 0 updates, 0 removals
 
-  • Installing pendulum (2.0.5)
-  • Installing tomlkit (0.7.0)
-  • Installing poetry-plugin (0.1.2 9cf87a2)
+  - Installing pendulum (2.0.5)
+  - Installing tomlkit (0.7.0)
+  - Installing poetry-plugin (0.1.2 9cf87a2)
 
 Writing lock file
 """
@@ -167,8 +167,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (2.0.5)
-  • Installing poetry-plugin (0.1.2 9cf87a2)
+  - Installing pendulum (2.0.5)
+  - Installing poetry-plugin (0.1.2 9cf87a2)
 
 Writing lock file
 """
@@ -220,7 +220,7 @@ poetry-plugin = "^1.2.3"
 The following packages are already present in the pyproject.toml and will be\
  skipped:
 
-  • poetry-plugin
+  - poetry-plugin
 {tester.command._hint_update_packages}
 Nothing to add.
 """
@@ -264,7 +264,7 @@ Resolving dependencies...
 
 Package operations: 0 installs, 1 update, 0 removals
 
-  • Updating poetry-plugin (1.2.3 -> 2.3.4)
+  - Updating poetry-plugin (1.2.3 -> 2.3.4)
 
 Writing lock file
 """
@@ -300,8 +300,8 @@ Resolving dependencies...
 
 Package operations: 1 install, 1 update, 0 removals
 
-  • Updating tomlkit (0.7.1 -> 0.7.2)
-  • Installing poetry-plugin (1.2.3)
+  - Updating tomlkit (0.7.1 -> 0.7.2)
+  - Installing poetry-plugin (1.2.3)
 
 Writing lock file
 """

--- a/tests/console/commands/self/test_remove_plugins.py
+++ b/tests/console/commands/self/test_remove_plugins.py
@@ -74,7 +74,7 @@ Resolving dependencies...
 
 Package operations: 0 installs, 0 updates, 1 removal
 
-  • Removing poetry-plugin (1.2.3)
+  - Removing poetry-plugin (1.2.3)
 
 Writing lock file
 """
@@ -95,8 +95,8 @@ Resolving dependencies...
 
 Package operations: 0 installs, 0 updates, 1 removal, 1 skipped
 
-  • Removing poetry-plugin (1.2.3)
-  • Installing poetry ({__version__}): Skipped for the following reason: Already \
+  - Removing poetry-plugin (1.2.3)
+  - Installing poetry ({__version__}): Skipped for the following reason: Already \
 installed
 """
 

--- a/tests/console/commands/self/test_show_plugins.py
+++ b/tests/console/commands/self/test_show_plugins.py
@@ -163,7 +163,7 @@ def test_show_displays_installed_plugins(
     tester.execute("")
 
     expected = """
-  • poetry-plugin (1.2.3)
+  - poetry-plugin (1.2.3)
       1 plugin and 1 application plugin
 """
 
@@ -189,7 +189,7 @@ def test_show_displays_installed_plugins_with_multiple_plugins(
     tester.execute("")
 
     expected = """
-  • poetry-plugin (1.2.3)
+  - poetry-plugin (1.2.3)
       2 plugins and 2 application plugins
 """
 
@@ -215,7 +215,7 @@ def test_show_displays_installed_plugins_with_dependencies(
     tester.execute("")
 
     expected = """
-  • poetry-plugin (1.2.3)
+  - poetry-plugin (1.2.3)
       1 plugin and 1 application plugin
 
       Dependencies

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -71,8 +71,8 @@ Resolving dependencies...
 
 Package operations: 0 installs, 2 updates, 0 removals
 
-  • Updating cleo (0.8.2 -> 1.0.0)
-  • Updating poetry ({__version__} -> {new_version})
+  - Updating cleo (0.8.2 -> 1.0.0)
+  - Updating poetry ({__version__} -> {new_version})
 
 Writing lock file
 """

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -85,7 +85,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -117,7 +117,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -138,7 +138,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.1.0)
+  - Installing cachy (0.1.0)
 
 Writing lock file
 """
@@ -189,7 +189,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.1.0)
+  - Installing cachy (0.1.0)
 
 Writing lock file
 """
@@ -212,7 +212,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -246,8 +246,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing msgpack-python (0.5.3)
-  • Installing cachy (0.1.0)
+  - Installing msgpack-python (0.5.3)
+  - Installing cachy (0.1.0)
 
 Writing lock file
 """
@@ -277,8 +277,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing msgpack-python (0.5.3)
-  • Installing cachy (0.2.0)
+  - Installing msgpack-python (0.5.3)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -309,8 +309,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (1.4.4)
-  • Installing demo (0.1.2 9cf87a2)
+  - Installing pendulum (1.4.4)
+  - Installing demo (0.1.2 9cf87a2)
 
 Writing lock file
 """
@@ -346,8 +346,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (1.4.4)
-  • Installing demo (0.1.2 9cf87a2)
+  - Installing pendulum (1.4.4)
+  - Installing demo (0.1.2 9cf87a2)
 
 Writing lock file
 """
@@ -380,10 +380,10 @@ Resolving dependencies...
 
 Package operations: 4 installs, 0 updates, 0 removals
 
-  • Installing cleo (0.6.5)
-  • Installing pendulum (1.4.4)
-  • Installing tomlkit (0.5.5)
-  • Installing demo (0.1.2 9cf87a2)
+  - Installing cleo (0.6.5)
+  - Installing pendulum (1.4.4)
+  - Installing tomlkit (0.5.5)
+  - Installing demo (0.1.2 9cf87a2)
 
 Writing lock file
 """
@@ -425,7 +425,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing two (2.0.0 9cf87a2)
+  - Installing two (2.0.0 9cf87a2)
 
 Writing lock file
 """
@@ -472,8 +472,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (1.4.4)
-  • Installing demo (0.1.2 9cf87a2)
+  - Installing pendulum (1.4.4)
+  - Installing demo (0.1.2 9cf87a2)
 
 Writing lock file
 """
@@ -521,8 +521,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (1.4.4)
-  • Installing demo (0.1.2 {demo_path})
+  - Installing pendulum (1.4.4)
+  - Installing demo (0.1.2 {demo_path})
 
 Writing lock file
 """
@@ -565,8 +565,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (1.4.4)
-  • Installing demo (0.1.2 {demo_path})
+  - Installing pendulum (1.4.4)
+  - Installing demo (0.1.2 {demo_path})
 
 Writing lock file
 """
@@ -598,8 +598,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (1.4.4)
-  • Installing demo (0.1.0 {demo_path})
+  - Installing pendulum (1.4.4)
+  - Installing demo (0.1.0 {demo_path})
 
 Writing lock file
 """
@@ -637,8 +637,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (1.4.4)
-  • Installing demo (0.1.0 {demo_path})
+  - Installing pendulum (1.4.4)
+  - Installing demo (0.1.0 {demo_path})
 
 Writing lock file
 """
@@ -679,8 +679,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing msgpack-python (0.5.3)
-  • Installing cachy (0.2.0)
+  - Installing msgpack-python (0.5.3)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -721,8 +721,8 @@ Resolving dependencies...
 
 Package operations: 2 installs, 0 updates, 0 removals
 
-  • Installing pendulum (1.4.4)
-  • Installing demo\
+  - Installing pendulum (1.4.4)
+  - Installing demo\
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 
 Writing lock file
@@ -764,10 +764,10 @@ Resolving dependencies...
 
 Package operations: 4 installs, 0 updates, 0 removals
 
-  • Installing cleo (0.6.5)
-  • Installing pendulum (1.4.4)
-  • Installing tomlkit (0.5.5)
-  • Installing demo\
+  - Installing cleo (0.6.5)
+  - Installing pendulum (1.4.4)
+  - Installing tomlkit (0.5.5)
+  - Installing demo\
  (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 
 Writing lock file
@@ -837,7 +837,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -876,7 +876,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -924,7 +924,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -985,7 +985,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -1034,7 +1034,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -1067,7 +1067,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing pyyaml (3.13)
+  - Installing pyyaml (3.13)
 
 Writing lock file
 """
@@ -1097,7 +1097,7 @@ def test_add_should_skip_when_adding_existing_package_with_no_constraint(
     expected = """\
 The following packages are already present in the pyproject.toml and will be skipped:
 
-  • foo
+  - foo
 
 If you want to update it to the latest compatible version,\
  you can use `poetry update package`.
@@ -1122,7 +1122,7 @@ def test_add_should_skip_when_adding_canonicalized_existing_package_with_no_cons
     expected = """\
 The following packages are already present in the pyproject.toml and will be skipped:
 
-  • Foo_Bar
+  - Foo_Bar
 
 If you want to update it to the latest compatible version,\
  you can use `poetry update package`.
@@ -1203,7 +1203,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing foo (1.1.2)
+  - Installing foo (1.1.2)
 
 Writing lock file
 """
@@ -1233,7 +1233,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing foo (1.2.3b1)
+  - Installing foo (1.2.3b1)
 
 Writing lock file
 """
@@ -1256,7 +1256,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing foo (1.2.3)
+  - Installing foo (1.2.3)
 
 Writing lock file
 """
@@ -1303,7 +1303,7 @@ Resolving dependencies...
 
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cachy (0.2.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """
@@ -1462,9 +1462,9 @@ Resolving dependencies...
 
 Package operations: 3 installs, 0 updates, 0 removals
 
-  • Installing msgpack-python (0.5.1)
-  • Installing redis (3.4.0)
-  • Installing cachy (0.2.0)
+  - Installing msgpack-python (0.5.1)
+  - Installing redis (3.4.0)
+  - Installing cachy (0.2.0)
 
 Writing lock file
 """

--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -327,7 +327,7 @@ Resolving dependencies...
 
 Package operations: 0 installs, 0 updates, 1 removal
 
-  • Removing docker (4.3.1)
+  - Removing docker (4.3.1)
 
 Writing lock file
 """

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -256,13 +256,13 @@ def test_execute_executes_a_batch_of_operations(
     expected = f"""
 Package operations: 4 installs, 2 updates, 1 removal
 
-  • Installing pytest (3.5.1)
-  • Removing attrs (17.4.0)
-  • Updating requests (2.18.3 -> 2.18.4)
-  • Downgrading pytest (3.5.1 -> 3.5.0)
-  • Installing demo (0.1.0 {file_package.source_url})
-  • Installing simple-project (1.2.3 {directory_package.source_url})
-  • Installing demo (0.1.0 master)
+  - Installing pytest (3.5.1)
+  - Removing attrs (17.4.0)
+  - Updating requests (2.18.3 -> 2.18.4)
+  - Downgrading pytest (3.5.1 -> 3.5.0)
+  - Installing demo (0.1.0 {file_package.source_url})
+  - Installing simple-project (1.2.3 {directory_package.source_url})
+  - Installing demo (0.1.0 master)
 """
 
     expected_lines = set(expected.splitlines())
@@ -419,7 +419,7 @@ def test_execute_shows_skipped_operations_if_verbose(
     expected = """
 Package operations: 0 installs, 0 updates, 0 removals, 1 skipped
 
-  • Removing clikit (0.2.3): Skipped for the following reason: Not currently installed
+  - Removing clikit (0.2.3): Skipped for the following reason: Not currently installed
 """
     assert io.fetch_output() == expected
     assert len(env.executed) == 0
@@ -442,7 +442,7 @@ def test_execute_should_show_errors(
     expected = """
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing clikit (0.2.3)
+  - Installing clikit (0.2.3)
 
   Exception
 
@@ -473,10 +473,10 @@ def test_execute_works_with_ansi_output(
     # fmt: off
     expected = [
         "\x1b[39;1mPackage operations\x1b[39;22m: \x1b[34m1\x1b[39m install, \x1b[34m0\x1b[39m updates, \x1b[34m0\x1b[39m removals",
-        "\x1b[34;1m•\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mPending...\x1b[39m",
-        "\x1b[34;1m•\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mDownloading...\x1b[39m",
-        "\x1b[34;1m•\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mInstalling...\x1b[39m",
-        "\x1b[32;1m•\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[32m1.0.0a5\x1b[39m\x1b[39m)\x1b[39m",  # finished
+        "\x1b[34;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mPending...\x1b[39m",
+        "\x1b[34;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mDownloading...\x1b[39m",
+        "\x1b[34;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mInstalling...\x1b[39m",
+        "\x1b[32;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[32m1.0.0a5\x1b[39m\x1b[39m)\x1b[39m",  # finished
     ]
     # fmt: on
 
@@ -510,7 +510,7 @@ def test_execute_works_with_no_ansi_output(
     expected = """
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing cleo (1.0.0a5)
+  - Installing cleo (1.0.0a5)
 """
     expected_lines = set(expected.splitlines())
     output_lines = set(io_not_decorated.fetch_output().splitlines())
@@ -536,8 +536,8 @@ def test_execute_should_show_operation_as_cancelled_on_subprocess_keyboard_inter
     expected = """
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing clikit (0.2.3)
-  • Installing clikit (0.2.3): Cancelled
+  - Installing clikit (0.2.3)
+  - Installing clikit (0.2.3): Cancelled
 """
 
     assert io.fetch_output() == expected
@@ -557,6 +557,7 @@ def test_execute_should_gracefully_handle_io_error(
 
     def write_line(string: str, **kwargs: Any) -> None:
         # Simulate UnicodeEncodeError
+        string = string.replace("-", "•")
         string.encode("ascii")
         original_write_line(string, **kwargs)
 
@@ -1228,7 +1229,7 @@ def test_executor_fallback_on_poetry_create_error_without_wheel_installer(
     expected = f"""
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing simple-project (1.2.3 {directory_package.source_url})
+  - Installing simple-project (1.2.3 {directory_package.source_url})
 """
 
     expected_lines = set(expected.splitlines())
@@ -1290,7 +1291,7 @@ def test_build_backend_errors_are_reported_correctly_if_caused_by_subprocess(
     expected_start = f"""
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing {package_name} ({package_version} {package_url})
+  - Installing {package_name} ({package_version} {package_url})
 
   ChefBuildError
 
@@ -1392,7 +1393,7 @@ def test_build_system_requires_not_available(
     expected_start = f"""\
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing {package_name} ({package_version} {package_url})
+  - Installing {package_name} ({package_version} {package_url})
 
   SolveFailure
 
@@ -1439,7 +1440,7 @@ def test_build_system_requires_install_failure(
     expected_start = f"""\
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing {package_name} ({package_version} {package_url})
+  - Installing {package_name} ({package_version} {package_url})
 
   ChefInstallError
 
@@ -1491,7 +1492,7 @@ def test_other_error(
     expected_start = f"""\
 Package operations: 1 install, 0 updates, 0 removals
 
-  • Installing {package_name} ({package_version} {package_url})
+  - Installing {package_name} ({package_version} {package_url})
 
   FileNotFoundError
 """


### PR DESCRIPTION
the fancy utf-8 bullets are unnecessary trouble: #8603, #3672, #3078, #1427, probably others.  Regular hyphens are just fine.

I said in #8603 I wasn't going to do this myself, but
```
sed -i 's/\xe2\x80\xa2/-/g' **/*.py
```
(and then deliberately inserting a fancy bullet in the testcase `test_execute_should_gracefully_handle_io_error`)

is all there is to it