### PR TITLE
installer: remove unrequested extras if `requires_synchronization` is set

### DIFF
--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -993,73 +993,20 @@ def test_run_with_dependencies_nested_extras(
     assert locker.written_data == expected
 
 
-def test_run_does_not_install_extras_if_not_requested(
-    installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
-) -> None:
-    package.extras[canonicalize_name("foo")] = [get_dependency("D")]
-    package_a = get_package("A", "1.0")
-    package_b = get_package("B", "1.0")
-    package_c = get_package("C", "1.0")
-    package_d = get_package("D", "1.1")
-
-    repo.add_package(package_a)
-    repo.add_package(package_b)
-    repo.add_package(package_c)
-    repo.add_package(package_d)
-
-    package.add_dependency(Factory.create_dependency("A", "^1.0"))
-    package.add_dependency(Factory.create_dependency("B", "^1.0"))
-    package.add_dependency(Factory.create_dependency("C", "^1.0"))
-    package.add_dependency(
-        Factory.create_dependency("D", {"version": "^1.0", "optional": True})
-    )
-
-    result = installer.run()
-    assert result == 0
-
-    expected = fixture("extras")
-    # Extras are pinned in lock
-    assert locker.written_data == expected
-
-    # But should not be installed
-    assert installer.executor.installations_count == 3  # A, B, C
-
-
-def test_run_installs_extras_if_requested(
-    installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
-) -> None:
-    package.extras[canonicalize_name("foo")] = [get_dependency("D")]
-    package_a = get_package("A", "1.0")
-    package_b = get_package("B", "1.0")
-    package_c = get_package("C", "1.0")
-    package_d = get_package("D", "1.1")
-
-    repo.add_package(package_a)
-    repo.add_package(package_b)
-    repo.add_package(package_c)
-    repo.add_package(package_d)
-
-    package.add_dependency(Factory.create_dependency("A", "^1.0"))
-    package.add_dependency(Factory.create_dependency("B", "^1.0"))
-    package.add_dependency(Factory.create_dependency("C", "^1.0"))
-    package.add_dependency(
-        Factory.create_dependency("D", {"version": "^1.0", "optional": True})
-    )
-
-    installer.extras(["foo"])
-    result = installer.run()
-    assert result == 0
-
-    # Extras are pinned in lock
-    expected = fixture("extras")
-    assert locker.written_data == expected
-
-    # But should not be installed
-    assert installer.executor.installations_count == 4  # A, B, C, D
-
-
+@pytest.mark.parametrize("is_locked", [False, True])
+@pytest.mark.parametrize("is_installed", [False, True])
+@pytest.mark.parametrize("with_extras", [False, True])
+@pytest.mark.parametrize("do_sync", [False, True])
 def test_run_installs_extras_with_deps_if_requested(
-    installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
+    installer: Installer,
+    locker: Locker,
+    repo: Repository,
+    installed: CustomInstalledRepository,
+    package: ProjectPackage,
+    is_locked: bool,
+    is_installed: bool,
+    with_extras: bool,
+    do_sync: bool,
 ) -> None:
     package.extras[canonicalize_name("foo")] = [get_dependency("C")]
     package_a = get_package("A", "1.0")
@@ -1080,48 +1027,38 @@ def test_run_installs_extras_with_deps_if_requested(
 
     package_c.add_dependency(Factory.create_dependency("D", "^1.0"))
 
-    installer.extras(["foo"])
+    if is_locked:
+        locker.locked(True)
+        locker.mock_lock_data(fixture("extras-with-dependencies"))
+
+    if is_installed:
+        installed.add_package(package_a)
+        installed.add_package(package_b)
+        installed.add_package(package_c)
+        installed.add_package(package_d)
+
+    if with_extras:
+        installer.extras(["foo"])
+    installer.requires_synchronization(do_sync)
     result = installer.run()
     assert result == 0
 
-    expected = fixture("extras-with-dependencies")
+    if not is_locked:
+        assert locker.written_data == fixture("extras-with-dependencies")
 
-    # Extras are pinned in lock
-    assert locker.written_data == expected
+    if with_extras:
+        # A, B, C, D
+        expected_installations_count = 0 if is_installed else 4
+        expected_removals_count = 0
+    else:
+        # A, B
+        expected_installations_count = 0 if is_installed else 2
+        # We only want to uninstall extras if we do a "poetry install" without extras,
+        # not if we do a "poetry update" or "poetry add".
+        expected_removals_count = 2 if is_installed and is_locked else 0
 
-    # But should not be installed
-    assert installer.executor.installations_count == 4  # A, B, C, D
-
-
-def test_run_installs_extras_with_deps_if_requested_locked(
-    installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
-) -> None:
-    locker.locked(True)
-    locker.mock_lock_data(fixture("extras-with-dependencies"))
-    package.extras[canonicalize_name("foo")] = [get_dependency("C")]
-    package_a = get_package("A", "1.0")
-    package_b = get_package("B", "1.0")
-    package_c = get_package("C", "1.0")
-    package_d = get_package("D", "1.1")
-
-    repo.add_package(package_a)
-    repo.add_package(package_b)
-    repo.add_package(package_c)
-    repo.add_package(package_d)
-
-    package.add_dependency(Factory.create_dependency("A", "^1.0"))
-    package.add_dependency(Factory.create_dependency("B", "^1.0"))
-    package.add_dependency(
-        Factory.create_dependency("C", {"version": "^1.0", "optional": True})
-    )
-
-    package_c.add_dependency(Factory.create_dependency("D", "^1.0"))
-
-    installer.extras(["foo"])
-    result = installer.run()
-    assert result == 0
-
-    assert installer.executor.installations_count == 4  # A, B, C, D
+    assert installer.executor.installations_count == expected_installations_count
+    assert installer.executor.removals_count == expected_removals_count
 
 
 @pytest.mark.network


### PR DESCRIPTION
**tl;dr**

- fix an issue where `poetry install --sync` does not remove unrequested `extras` (funny enough `poetry install` without `--sync` does remove them)
- increase test coverage of the `installer` regarding `extras`

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

**Long story**

Originally, I was just poking around with https://github.com/python-poetry/poetry-core/pull/613#issuecomment-1694697769. However, I noticed that all `installer` tests still passed if one of the following lines were removed:

- https://github.com/python-poetry/poetry/blob/f5b022843660988daaf4153cf3058a33b389b4f6/src/poetry/installation/installer.py#L386-L388
- https://github.com/python-poetry/poetry/blob/f5b022843660988daaf4153cf3058a33b389b4f6/src/poetry/installation/installer.py#L394-L395

Thus, I decided to improve the test coverage before trying to fix bugs. I merged some quite similar tests and used `pytest.mark.parametrize` to cover the missing cases. However, https://github.com/python-poetry/poetry/blob/f5b022843660988daaf4153cf3058a33b389b4f6/src/poetry/installation/installer.py#L386-L388 was still irrelevant.

After some code spelunking, I suppose that these lines became irrelevant with [ea8fb8c](https://github.com/python-poetry/poetry/commit/ea8fb8c6679f1b9afee4ef141467acc615eca71f#diff-95c2e34175a95676a55830f8442a68da156ae6a31dfec68317a2fd746be2243f). However, that introduced the mentioned bug. After adding `@pytest.mark.parametrize("do_sync", [False, True])` to the test and fixing the bug, the mentioned lines of code are relevant again.