### PR TITLE
Introduce non-package-mode

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -76,6 +76,29 @@ cd pre-existing-project
 poetry init
 ```
 
+### Operating modes
+
+Poetry can be operated in two different modes. The default mode is the **package mode**, which is the right mode
+if you want to package your project into an sdist or a wheel and perhaps publish it to a package index.
+In this mode, some metadata such as `name` and `version`, which are required for packaging, are mandatory.
+Further, the project itself will be installed in editable mode when running `poetry install`.
+
+If you want to use Poetry only for dependency management but not for packaging, you can use the **non-package mode**:
+
+```toml
+[tool.poetry]
+mode = "non-package"
+```
+
+In this mode, metadata such as `name` and `version` are optional.
+Therefore, it is not possible to build a distribution or publish the project to a package index.
+Further, when running `poetry install`, Poetry does not try to install the project itself,
+but only its dependencies (same as `poetry install --no-root`).
+
+{{% note %}}
+In the [pyproject section]({{< relref "pyproject" >}}) you can see which fields are required in package mode.
+{{% /note %}}
+
 ### Specifying dependencies
 
 If you want to add dependencies to your project, you can specify them in the `tool.poetry.dependencies` section.

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -87,7 +87,7 @@ If you want to use Poetry only for dependency management but not for packaging, 
 
 ```toml
 [tool.poetry]
-mode = "non-package"
+package-mode = false
 ```
 
 In this mode, metadata such as `name` and `version` are optional.

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -13,9 +13,19 @@ menu:
 
 The `tool.poetry` section of the `pyproject.toml` file is composed of multiple sections.
 
+## mode
+
+The mode of the project, either `"package"` (default) or `"non-package"`. **Optional**
+
+See [basic usage]({{< relref "basic-usage#operating-modes" >}}) for more information.
+
+```toml
+mode = "non-package"
+```
+
 ## name
 
-The name of the package. **Required**
+The name of the package. **Required in package mode**
 
 This should be a valid name as defined by [PEP 508](https://peps.python.org/pep-0508/#names).
 
@@ -26,7 +36,7 @@ name = "my-package"
 
 ## version
 
-The version of the package. **Required**
+The version of the package. **Required in package mode**
 
 This should be a valid [PEP 440](https://peps.python.org/pep-0440/) string.
 
@@ -43,7 +53,7 @@ If you would like to use semantic versioning for your project, please see
 
 ## description
 
-A short description of the package. **Required**
+A short description of the package. **Required in package mode**
 
 ```toml
 description = "A short description of the package."
@@ -81,7 +91,7 @@ If your project is proprietary and does not use a specific licence, you can set 
 
 ## authors
 
-The authors of the package. **Required**
+The authors of the package. **Required in package mode**
 
 This is a list of authors and should contain at least one author. Authors must be in the form `name <email>`.
 

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -13,14 +13,14 @@ menu:
 
 The `tool.poetry` section of the `pyproject.toml` file is composed of multiple sections.
 
-## mode
+## package-mode
 
-The mode of the project, either `"package"` (default) or `"non-package"`. **Optional**
+Whether Poetry operates in package mode (default) or not. **Optional**
 
 See [basic usage]({{< relref "basic-usage#operating-modes" >}}) for more information.
 
 ```toml
-mode = "non-package"
+package-mode = false
 ```
 
 ## name

--- a/src/poetry/console/commands/build.py
+++ b/src/poetry/console/commands/build.py
@@ -49,6 +49,10 @@ class BuildCommand(EnvCommand):
             builder(self.poetry, executable=executable).build(target_dir)
 
     def handle(self) -> int:
+        if not self.poetry.is_package_mode:
+            self.line_error("Building a package is not possible in non-package mode.")
+            return 1
+
         with build_environment(poetry=self.poetry, env=self.env, io=self.io) as env:
             fmt = self.option("format") or "all"
             dist_dir = Path(self.option("output"))

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -187,7 +187,7 @@ you can set the "package-mode" to false in your pyproject.toml file.
             # No need for an editable install in this case.
             self.line("")
             self.line_error(
-                f"The current project could not be installed: <error>{e}</error>\n"
+                f"Warning: The current project could not be installed: {e}\n"
                 "If you do not want to install the current project"
                 " use <c1>--no-root</c1>.\n"
                 "If you want to use Poetry only for dependency management"

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -79,7 +79,7 @@ dependencies and not including the current project, run the command with the
 <info> poetry install --no-root</info>
 
 If you want to use Poetry only for dependency management but not for packaging,
-you can set the operating mode to "non-package" in your pyproject.toml file.
+you can set the "package-mode" to false in your pyproject.toml file.
 """
 
     _loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -77,6 +77,9 @@ dependencies and not including the current project, run the command with the
 <info>--no-root</info> option like below:
 
 <info> poetry install --no-root</info>
+
+If you want to use Poetry only for dependency management but not for packaging,
+you can set the operating mode to "non-package" in your pyproject.toml file.
 """
 
     _loggers = ["poetry.repositories.pypi_repository", "poetry.inspection.info"]
@@ -152,7 +155,7 @@ dependencies and not including the current project, run the command with the
         if return_code != 0:
             return return_code
 
-        if self.option("no-root"):
+        if self.option("no-root") or not self.poetry.is_package_mode:
             return 0
 
         log_install = (
@@ -186,7 +189,11 @@ dependencies and not including the current project, run the command with the
             self.line_error(
                 f"The current project could not be installed: <error>{e}</error>\n"
                 "If you do not want to install the current project"
-                " use <c1>--no-root</c1>",
+                " use <c1>--no-root</c1>.\n"
+                "If you want to use Poetry only for dependency management"
+                " but not for packaging, you can set the operating mode to "
+                '"non-package" in your pyproject.toml file.\n'
+                "In a future version of Poetry this warning will become an error!",
                 style="warning",
             )
             return 0

--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -56,6 +56,10 @@ the config command.
     def handle(self) -> int:
         from poetry.publishing.publisher import Publisher
 
+        if not self.poetry.is_package_mode:
+            self.line_error("Publishing a package is not possible in non-package mode.")
+            return 1
+
         dist_dir = self.option("dist-dir")
 
         publisher = Publisher(self.poetry, self.io, Path(dist_dir))

--- a/tests/console/commands/test_build.py
+++ b/tests/console/commands/test_build.py
@@ -62,6 +62,22 @@ def test_build_creates_packages_in_dist_directory_if_no_output_is_specified(
     assert all(archive.exists() for archive in build_artifacts)
 
 
+def test_build_not_possible_in_non_package_mode(
+    fixture_dir: FixtureDirGetter,
+    command_tester_factory: CommandTesterFactory,
+) -> None:
+    source_dir = fixture_dir("non_package_mode")
+
+    poetry = Factory().create_poetry(source_dir)
+    tester = command_tester_factory("build", poetry)
+
+    assert tester.execute() == 1
+    assert (
+        tester.io.fetch_error()
+        == "Building a package is not possible in non-package mode.\n"
+    )
+
+
 def test_build_with_multiple_readme_files(
     fixture_dir: FixtureDirGetter,
     tmp_path: Path,

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -122,6 +122,24 @@ All set!
     assert tester.io.fetch_output() == expected
 
 
+def test_check_non_package_mode(
+    mocker: MockerFixture, tester: CommandTester, fixture_dir: FixtureDirGetter
+) -> None:
+    mocker.patch(
+        "poetry.poetry.Poetry.file",
+        return_value=TOMLFile(fixture_dir("non_package_mode") / "pyproject.toml"),
+        new_callable=mocker.PropertyMock,
+    )
+
+    tester.execute()
+
+    expected = """\
+All set!
+"""
+
+    assert tester.io.fetch_output() == expected
+
+
 @pytest.mark.parametrize(
     ("options", "expected", "expected_status"),
     [

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -506,3 +506,20 @@ def test_install_missing_directory_dependency_with_no_directory(
     else:
         with pytest.raises(ValueError, match="does not exist"):
             tester.execute(options)
+
+
+def test_non_package_mode_does_not_try_to_install_root(
+    command_tester_factory: CommandTesterFactory,
+    project_factory: ProjectFactory,
+) -> None:
+    content = """\
+[tool.poetry]
+mode = "non-package"
+"""
+    poetry = project_factory(name="non-package-mode", pyproject_content=content)
+
+    tester = command_tester_factory("install", poetry=poetry)
+    tester.execute()
+
+    assert tester.status_code == 0
+    assert tester.io.fetch_error() == ""

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -514,7 +514,7 @@ def test_non_package_mode_does_not_try_to_install_root(
 ) -> None:
     content = """\
 [tool.poetry]
-mode = "non-package"
+package-mode = false
 """
     poetry = project_factory(name="non-package-mode", pyproject_content=content)
 

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -25,6 +25,22 @@ if TYPE_CHECKING:
     from tests.types import FixtureDirGetter
 
 
+def test_publish_not_possible_in_non_package_mode(
+    fixture_dir: FixtureDirGetter,
+    command_tester_factory: CommandTesterFactory,
+) -> None:
+    source_dir = fixture_dir("non_package_mode")
+
+    poetry = Factory().create_poetry(source_dir)
+    tester = command_tester_factory("publish", poetry)
+
+    assert tester.execute() == 1
+    assert (
+        tester.io.fetch_error()
+        == "Publishing a package is not possible in non-package mode.\n"
+    )
+
+
 def test_publish_returns_non_zero_code_for_upload_errors(
     app: PoetryTestApplication,
     app_tester: ApplicationTester,

--- a/tests/fixtures/non_package_mode/pyproject.toml
+++ b/tests/fixtures/non_package_mode/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.poetry]
+mode = "non-package"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+cleo = "^0.6"
+pendulum = { git = "https://github.com/sdispater/pendulum.git", branch = "2.0" }

--- a/tests/fixtures/non_package_mode/pyproject.toml
+++ b/tests/fixtures/non_package_mode/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-mode = "non-package"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -224,6 +224,12 @@ def test_create_poetry_with_multi_constraints_dependency(
     assert len(package.requires) == 2
 
 
+def test_create_poetry_non_package_mode(fixture_dir: FixtureDirGetter) -> None:
+    poetry = Factory().create_poetry(fixture_dir("non_package_mode"))
+
+    assert not poetry.is_package_mode
+
+
 def test_poetry_with_default_source_legacy(
     fixture_dir: FixtureDirGetter, with_simple_keyring: None
 ) -> None:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #1132

Requires: python-poetry/poetry-core#661

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Introduce non-package mode

- add a new attribute ~`mode`~ `package-mode` in `tool.poetry`
- ~`mode` can be either `package` (default) or `non-package`~
- `package-mode` can be either `true` (default) or `false`
- in non-package mode:
  - metadata like `name` and `version` is not required
  - the root package is never installed (same as `--no-root`)
  - building and publishing is not possible

[Docs preview](https://website-jeevwq2md-python-poetry.vercel.app/docs/basic-usage/#operating-modes)

Example Config:

```
[tool.poetry]
package-mode = false

[tool.poetry.dependencies]
python = "^3.8"
cleo = ">=2.0.0"
```

You can install this branch with pipx as follows:
```
pipx install --suffix _npm git+https://github.com/radoering/poetry.git@non-package-mode
```

This will install poetry with the suffix "_npm" so that you have to call `poetry_npm` instead of `poetry`. (The suffix is arbitrary, I chose "npm" as an abbreviation for non-package-mode. 😉)