### PR TITLE
fix `poetry init`

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -481,6 +481,7 @@ You can specify a package in the following forms:
         return package
 
     def _get_pool(self) -> RepositoryPool:
+        from poetry.config.config import Config
         from poetry.repositories import RepositoryPool
         from poetry.repositories.pypi_repository import PyPiRepository
 
@@ -489,7 +490,7 @@ You can specify a package in the following forms:
 
         if self._pool is None:
             self._pool = RepositoryPool()
-            pool_size = self.poetry.config.installer_max_workers
+            pool_size = Config.create().installer_max_workers
             self._pool.add_repository(PyPiRepository(pool_size=pool_size))
 
         return self._pool

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1087,3 +1087,17 @@ python = "^{python}"
 """
 
     assert expected in pyproject_file.read_text()
+
+
+def test_get_pool(mocker: MockerFixture, source_dir: Path) -> None:
+    """
+    Since we are mocking _get_pool() in the other tests, we at least should make
+    sure it works in general. See https://github.com/python-poetry/poetry/issues/8634.
+    """
+    mocker.patch("pathlib.Path.cwd", return_value=source_dir)
+
+    app = Application()
+    command = app.find("init")
+    assert isinstance(command, InitCommand)
+    pool = command._get_pool()
+    assert pool.repositories


### PR DESCRIPTION
Resolves: #8634

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

https://github.com/python-poetry/poetry/issues/8634#issuecomment-1802393575:

> I think it's a regression from https://github.com/python-poetry/poetry/pull/8559, which now tries to get hold of the poetry configuration before the poetry object exists.
