### PR TITLE
Docs, FAQ: Replace deprecated `--no-dev` with `--without dev`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -206,7 +206,7 @@ For example, you might have a Dockerfile that looks something like this:
 FROM python
 COPY pyproject.toml poetry.lock .
 COPY src/ ./src
-RUN pip install poetry && poetry install --no-dev
+RUN pip install poetry && poetry install --without dev
 ```
 
 As soon as *any* source file changes, the cache for the `RUN` layer will be invalidated, which forces all 3rd party dependencies (likely the slowest step out of these) to be installed again if you changed any files in `src/`.
@@ -223,7 +223,7 @@ FROM python
 COPY pyproject.toml poetry.lock .
 RUN pip install poetry && poetry install --no-root --no-directory
 COPY src/ ./src
-RUN poetry install --no-dev
+RUN poetry install --without dev
 ```
 
 The two key options we are using here are `--no-root` (skips installing the project source) and `--no-directory` (skips installing any local directory path dependencies, you can omit this if you don't have any).


### PR DESCRIPTION
Resolves: Could not find an issue, but `--no-dev` is deprecated according to the docs and [source](https://github.com/python-poetry/poetry/blob/b25ebfd1ec7cc116bf87cf796002f07a4f3e6e1c/src/poetry/console/commands/install.py#L18).

- [ ] ~Added **tests** for changed code.~ PR only affects markdown docs.
- [x] Updated **documentation** for changed code. No code change.