### PR TITLE
Added 'dev' as a version bump rule to increment versions with .devM

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -675,7 +675,7 @@ bump rule is provided.
 
 The new version should be a valid [PEP 440](https://peps.python.org/pep-0440/)
 string or a valid bump rule: `patch`, `minor`, `major`, `prepatch`, `preminor`,
-`premajor`, `prerelease`.
+`premajor`, `prerelease`, `dev`.
 
 {{% note %}}
 
@@ -697,6 +697,9 @@ The table below illustrates the effect of these rules with concrete examples.
 | prerelease | 1.0.2   | 1.0.3a0 |
 | prerelease | 1.0.3a0 | 1.0.3a1 |
 | prerelease | 1.0.3b0 | 1.0.3b1 |
+| dev        | 1.0.2   | 1.0.2.dev0 |
+| dev        | 1.0.2.dev0 | 1.0.2.dev1 |
+| dev        | 1.0.2a0 | 1.0.2a0.dev0 |
 
 The option `--next-phase` allows the increment of prerelease phase versions.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -684,6 +684,10 @@ If you would like to use semantic versioning for your project, please see
 
 {{% /note %}}
 
+If you use the `dev` rule on a stable version, it will first be updated to a
+prerelease version to increment the version numbers before appending the
+`.dev0` suffix.
+
 The table below illustrates the effect of these rules with concrete examples.
 
 | rule       | before  | after   |
@@ -697,8 +701,8 @@ The table below illustrates the effect of these rules with concrete examples.
 | prerelease | 1.0.2   | 1.0.3a0 |
 | prerelease | 1.0.3a0 | 1.0.3a1 |
 | prerelease | 1.0.3b0 | 1.0.3b1 |
-| dev        | 1.0.2   | 1.0.2.dev0 |
-| dev        | 1.0.2.dev0 | 1.0.2.dev1 |
+| dev        | 1.0.2   | 1.0.3a0.dev0 |
+| dev        | 1.1.0a0 | 1.1.0a0.dev0 |
 | dev        | 1.0.2a0 | 1.0.2a0.dev0 |
 
 The option `--next-phase` allows the increment of prerelease phase versions.

--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
 class VersionCommand(Command):
     name = "version"
     description = (
-        "Shows the version of the project or bumps it when a valid "
-        "bump rule is provided."
+        "Shows the version of the project or bumps it when a valid bump rule is"
+        " provided."
     )
 
     arguments = [
@@ -45,7 +45,7 @@ the project and writes the new version back to <comment>pyproject.toml</> if a v
 bump rule is provided.
 
 The new version should ideally be a valid semver string or a valid bump rule:
-patch, minor, major, prepatch, preminor, premajor, prerelease.
+patch, minor, major, prepatch, preminor, premajor, prerelease, dev.
 """
 
     RESERVED = {
@@ -56,6 +56,7 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
         "preminor",
         "prepatch",
         "prerelease",
+        "dev",
     }
 
     def handle(self) -> int:
@@ -122,6 +123,11 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
                 new = Version(parsed.epoch, parsed.release, pre)
             else:
                 new = parsed.next_patch().first_prerelease()
+        elif rule == "dev":
+            if parsed.is_devrelease():
+                new = parsed.next_devrelease()
+            else:
+                new = parsed.first_devrelease()
         else:
             new = Version.parse(rule)
 

--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -124,7 +124,11 @@ patch, minor, major, prepatch, preminor, premajor, prerelease, dev.
             else:
                 new = parsed.next_patch().first_prerelease()
         elif rule == "dev":
-            if parsed.is_devrelease():
+            if parsed.is_stable():
+                new = self.increment_version(
+                    version, "prerelease", next_phase
+                ).first_devrelease()
+            elif parsed.is_devrelease():
                 new = parsed.next_devrelease()
             else:
                 new = parsed.first_devrelease()

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -46,9 +46,9 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
         ("1.2.3beta1", "prerelease", "1.2.3b2"),
         ("1.2.3b1", "prerelease", "1.2.3b2"),
         ("1.2.3", "prerelease", "1.2.4a0"),
-        ("1.2.3", "dev", "1.2.3.dev0"),
-        ("1.2.3.dev0", "dev", "1.2.3.dev1"),
+        ("1.2.3", "dev", "1.2.4a0.dev0"),
         ("1.2.3a0", "dev", "1.2.3a0.dev0"),
+        ("1.2.3a0.dev0", "dev", "1.2.3a0.dev1"),
         ("0.0.0", "1.2.3", "1.2.3"),
     ],
 )

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -46,6 +46,9 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
         ("1.2.3beta1", "prerelease", "1.2.3b2"),
         ("1.2.3b1", "prerelease", "1.2.3b2"),
         ("1.2.3", "prerelease", "1.2.4a0"),
+        ("1.2.3", "dev", "1.2.3.dev0"),
+        ("1.2.3.dev0", "dev", "1.2.3.dev1"),
+        ("1.2.3a0", "dev", "1.2.3a0.dev0"),
         ("0.0.0", "1.2.3", "1.2.3"),
     ],
 )


### PR DESCRIPTION
This adds `dev` as a version bump rule for [developmental releases](https://peps.python.org/pep-0440/#developmental-releases). This was already implemented in `poetry-core`, I've just added the option to the cli. 

This is my first contribution, I hope I followed the correct procedure!

# Pull Request Check List

Resolves: #8718 

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.



