### PR TITLE
Add shadowing warning to supplemental source docs

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -232,6 +232,14 @@ poetry source add --priority=supplemental https://foo.bar/simple/
 
 There can be more than one supplemental package source.
 
+{{% warning %}}
+
+Take into account that someone could publish a new package to a primary source
+which matches a package in your supplemental source. They could coincidentally
+or intentionally replace your dependency with something you did not expect.
+
+{{% /warning %}}
+
 
 #### Explicit Package Sources
 


### PR DESCRIPTION
We may want people to consider what happens if someone publishes a new package to PyPI which matches one in their supplemental source. There were a few dependency confusion vulnerabilities a while back that were caused by something similar. I presume lock files help to some extent though.

# Pull Request Check List

Resolves: None

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
