### PR TITLE
chore: use `exclude_also` in coverage settings

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1600,4 +1600,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "76abb6495cbcef7b89640281ed30ed217b4a160bd72851ee5c5a3b0fec99bf4e"
+content-hash = "d283a1e7872f7f0f9de312844af38c73a763deafc0a839e398207f55ad3a5bed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ xattr = { version = "^0.10.0", markers = "sys_platform == 'darwin'" }
 pre-commit = ">=2.10"
 
 [tool.poetry.group.test.dependencies]
+coverage = ">=7.2.0"
 deepdiff = "^6.3"
 httpretty = "^1.1"
 pytest = "^7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ markers = [
 
 
 [tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
+exclude_also = [
     "if TYPE_CHECKING:"
 ]


### PR DESCRIPTION
According to https://coverage.readthedocs.io/en/7.3.2/excluding.html#advanced-exclusion, `exclude_also` is a newer option that does not overwrite the lines excluded from coverage checks by default. Using it removes an extra setting and allows future default exclusions ([see the current defaults](https://github.com/nedbat/coveragepy/blob/7.3.2/coverage/config.py#L152-L154)) to apply.
