### PR TITLE
tests: reduce internet access in tests

### DIFF
--- a/tests/installation/conftest.py
+++ b/tests/installation/conftest.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from urllib.parse import urlparse
+
+import pytest
+
+
+if TYPE_CHECKING:
+    from httpretty import httpretty
+    from httpretty.core import HTTPrettyRequest
+
+    from tests.types import FixtureDirGetter
+
+
+@pytest.fixture
+def mock_file_downloads(http: type[httpretty], fixture_dir: FixtureDirGetter) -> None:
+    def callback(
+        request: HTTPrettyRequest, uri: str, headers: dict[str, Any]
+    ) -> list[int | dict[str, Any] | bytes]:
+        name = Path(urlparse(uri).path).name
+
+        fixture = Path(__file__).parent.parent.joinpath(
+            "repositories/fixtures/pypi.org/dists/" + name
+        )
+
+        if not fixture.exists():
+            fixture = fixture_dir("distributions") / name
+
+            if not fixture.exists():
+                fixture = (
+                    fixture_dir("distributions") / "demo-0.1.0-py2.py3-none-any.whl"
+                )
+
+        return [200, headers, fixture.read_bytes()]
+
+    http.register_uri(
+        http.GET,
+        re.compile("^https://files.pythonhosted.org/.*$"),
+        body=callback,
+    )

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -50,7 +50,9 @@ def setup(mocker: MockerFixture, pool: RepositoryPool) -> None:
     mocker.patch.object(Factory, "create_pool", return_value=pool)
 
 
-def test_isolated_env_install_success(pool: RepositoryPool) -> None:
+def test_isolated_env_install_success(
+    pool: RepositoryPool, mock_file_downloads: None
+) -> None:
     with ephemeral_environment(Path(sys.executable)) as venv:
         env = IsolatedEnv(venv, pool)
         assert "poetry-core" not in venv.run("pip", "freeze")
@@ -85,12 +87,12 @@ def test_isolated_env_install_failure(
         assert e.value.requirements == {"a", "b>1"}
 
 
-@pytest.mark.network
 def test_prepare_sdist(
     config: Config,
     config_cache_dir: Path,
     artifact_cache: ArtifactCache,
     fixture_dir: FixtureDirGetter,
+    mock_file_downloads: None,
 ) -> None:
     chef = Chef(
         artifact_cache, EnvManager.get_system_env(), Factory.create_pool(config)
@@ -104,12 +106,12 @@ def test_prepare_sdist(
     assert wheel.name == "demo-0.1.0-py3-none-any.whl"
 
 
-@pytest.mark.network
 def test_prepare_directory(
     config: Config,
     config_cache_dir: Path,
     artifact_cache: ArtifactCache,
     fixture_dir: FixtureDirGetter,
+    mock_file_downloads: None,
 ) -> None:
     chef = Chef(
         artifact_cache, EnvManager.get_system_env(), Factory.create_pool(config)
@@ -145,12 +147,12 @@ def test_prepare_directory_with_extensions(
     os.unlink(wheel)
 
 
-@pytest.mark.network
 def test_prepare_directory_editable(
     config: Config,
     config_cache_dir: Path,
     artifact_cache: ArtifactCache,
     fixture_dir: FixtureDirGetter,
+    mock_file_downloads: None,
 ) -> None:
     chef = Chef(
         artifact_cache, EnvManager.get_system_env(), Factory.create_pool(config)


### PR DESCRIPTION
Closes: #8741

Use `mock_file_downloads` consequently for files we have in our repository anyway.
(Move `mock_file_downloads` from `test_executor.py` to `conftest.py`.)