### PR TITLE
Fix debug logging for `build` with a build script

### DIFF
--- a/src/poetry/console/logging/io_formatter.py
+++ b/src/poetry/console/logging/io_formatter.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
 import textwrap
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from poetry.console.logging.filters import POETRY_FILTER
@@ -47,23 +47,25 @@ class IOFormatter(logging.Formatter):
 
 
 def _log_prefix(record: LogRecord) -> str:
-    prefix = _path_to_package(record.pathname) or record.module
+    prefix = _path_to_package(Path(record.pathname)) or record.module
     if record.name != "root":
         prefix = ":".join([prefix, record.name])
     return prefix
 
 
-def _path_to_package(pathname: str) -> str | None:
+def _path_to_package(path: Path) -> str | None:
     """Return main package name from the LogRecord.pathname."""
-    # strip any file extension
-    module = os.path.splitext(pathname)[0]
-    # strip first matching python path from the pathname
+    prefix: Path | None = None
+    # Find the most specific prefix in sys.path.
+    # We have to search the entire sys.path because a subsequent path might be
+    # a sub path of the first match and thereby a better match.
     for syspath in sys.path:
-        if pathname.startswith(syspath):
-            module = module[len(syspath) :].lstrip(os.sep)
-            break
-    else:
+        if (
+            prefix and prefix in (p := Path(syspath)).parents and p in path.parents
+        ) or (not prefix and (p := Path(syspath)) in path.parents):
+            prefix = p
+    if not prefix:
         # this is unexpected, but let's play it safe
         return None
-    module = module.partition(os.sep)[0]  # main package name
-    return module
+    path = path.relative_to(prefix)
+    return path.parts[0]  # main package name

--- a/src/poetry/console/logging/io_formatter.py
+++ b/src/poetry/console/logging/io_formatter.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-import sys
 import os
+import sys
 import textwrap
 
 from typing import TYPE_CHECKING
@@ -39,30 +39,31 @@ class IOFormatter(logging.Formatter):
 
         if not POETRY_FILTER.filter(record):
             # prefix all lines from third-party packages for easier debugging
-            formatted = textwrap.indent(formatted, f"[{_log_prefix(record)}] ", lambda line: True)
+            formatted = textwrap.indent(
+                formatted, f"[{_log_prefix(record)}] ", lambda line: True
+            )
 
         return formatted
 
 
 def _log_prefix(record: LogRecord) -> str:
     prefix = _path_to_package(record.pathname) or record.module
-    if record.name != 'root':
+    if record.name != "root":
         prefix = ":".join([prefix, record.name])
     return prefix
 
 
 def _path_to_package(pathname: str) -> str | None:
-    """Return main package name of the LogRecord.pathname."""
+    """Return main package name from the LogRecord.pathname."""
     # strip any file extension
     module = os.path.splitext(pathname)[0]
     # strip first matching python path from the pathname
     for syspath in sys.path:
         if pathname.startswith(syspath):
-            module = module[len(syspath):].lstrip(os.sep)
+            module = module[len(syspath) :].lstrip(os.sep)
             break
     else:
         # this is unexpected, but let's play it safe
         return None
-    # module = module.replace(os.sep, '.')  # full relative module path (quite verbose)
-    module = module.partition(os.sep)[0]  # main package name (just about right)
+    module = module.partition(os.sep)[0]  # main package name
     return module

--- a/src/poetry/console/logging/io_formatter.py
+++ b/src/poetry/console/logging/io_formatter.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import logging
+import sys
+import os
+import textwrap
 
 from typing import TYPE_CHECKING
 
@@ -32,8 +35,34 @@ class IOFormatter(logging.Formatter):
 
             record.msg = msg
 
-        if not POETRY_FILTER.filter(record):
-            # prefix third-party packages with name for easier debugging
-            record.msg = f"[{record.name}] {record.msg}"
+        formatted = super().format(record)
 
-        return super().format(record)
+        if not POETRY_FILTER.filter(record):
+            # prefix all lines from third-party packages for easier debugging
+            formatted = textwrap.indent(formatted, f"[{_log_prefix(record)}] ", lambda line: True)
+
+        return formatted
+
+
+def _log_prefix(record: LogRecord) -> str:
+    prefix = _path_to_package(record.pathname) or record.module
+    if record.name != 'root':
+        prefix = ":".join([prefix, record.name])
+    return prefix
+
+
+def _path_to_package(pathname: str) -> str | None:
+    """Return main package name of the LogRecord.pathname."""
+    # strip any file extension
+    module = os.path.splitext(pathname)[0]
+    # strip first matching python path from the pathname
+    for syspath in sys.path:
+        if pathname.startswith(syspath):
+            module = module[len(syspath):].lstrip(os.sep)
+            break
+    else:
+        # this is unexpected, but let's play it safe
+        return None
+    # module = module.replace(os.sep, '.')  # full relative module path (quite verbose)
+    module = module.partition(os.sep)[0]  # main package name (just about right)
+    return module

--- a/src/poetry/utils/env/__init__.py
+++ b/src/poetry/utils/env/__init__.py
@@ -67,22 +67,15 @@ def build_environment(
     """
     if not env or poetry.package.build_script:
         with ephemeral_environment(executable=env.python if env else None) as venv:
-            overwrite = (
-                io is not None and io.output.is_decorated() and not io.is_debug()
-            )
-
             if io:
-                if not overwrite:
-                    io.write_error_line("")
-
                 requires = [
                     f"<c1>{requirement}</c1>"
                     for requirement in poetry.pyproject.build_system.requires
                 ]
 
-                io.overwrite_error(
+                io.write_error_line(
                     "<b>Preparing</b> build environment with build-system requirements"
-                    f" {', '.join(requires)}\n"
+                    f" {', '.join(requires)}"
                 )
 
             output = venv.run_pip(
@@ -95,10 +88,6 @@ def build_environment(
 
             if io and io.is_debug() and output:
                 io.write_error(output)
-
-            if not overwrite:
-                assert io is not None
-                io.write_error_line("")
 
             yield venv
     else:

--- a/src/poetry/utils/env/__init__.py
+++ b/src/poetry/utils/env/__init__.py
@@ -82,10 +82,10 @@ def build_environment(
 
                 io.overwrite_error(
                     "<b>Preparing</b> build environment with build-system requirements"
-                    f" {', '.join(requires)}"
+                    f" {', '.join(requires)}\n"
                 )
 
-            venv.run_pip(
+            output = venv.run_pip(
                 "install",
                 "--disable-pip-version-check",
                 "--ignore-installed",
@@ -93,7 +93,10 @@ def build_environment(
                 *poetry.pyproject.build_system.requires,
             )
 
-            if overwrite:
+            if io and io.is_debug() and output:
+                io.write_error(output)
+
+            if not overwrite:
                 assert io is not None
                 io.write_error_line("")
 

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -675,7 +675,7 @@ class EnvManager:
 
         args.append(str(path))
 
-        cli_result = virtualenv.cli_run(args)
+        cli_result = virtualenv.cli_run(args, setup_logging=False)
 
         # Exclude the venv folder from from macOS Time Machine backups
         # TODO: Add backup-ignore markers for other platforms too

--- a/tests/console/logging/test_io_formatter.py
+++ b/tests/console/logging/test_io_formatter.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from logging import LogRecord
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from poetry.console.logging.io_formatter import IOFormatter
+from poetry.console.logging.io_formatter import _log_prefix
+from poetry.console.logging.io_formatter import _path_to_package
+
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.mark.parametrize(
+    ("record_name", "record_pathname", "record_msg", "expected"),
+    [
+        ("poetry", "foo/bar.py", "msg", "msg"),
+        ("poetry.core", "foo/bar.py", "msg", "msg"),
+        ("baz", "syspath/foo/bar.py", "msg", "[foo:baz] msg"),
+        ("root", "syspath/foo/bar.py", "1\n\n2", "[foo] 1\n[foo] \n[foo] 2"),
+    ],
+)
+def test_format(
+    mocker: MockerFixture,
+    record_name: str,
+    record_pathname: str,
+    record_msg: str,
+    expected: str,
+) -> None:
+    mocker.patch("sys.path", [str(Path("syspath"))])
+    record = LogRecord(record_name, 0, record_pathname, 0, record_msg, (), None)
+    formatter = IOFormatter()
+    assert formatter.format(record) == expected
+
+
+@pytest.mark.parametrize(
+    ("record_name", "record_pathname", "expected"),
+    [
+        ("root", "syspath/foo/bar.py", "foo"),
+        ("baz", "syspath/foo/bar.py", "foo:baz"),
+        ("baz", "unexpected/foo/bar.py", "bar:baz"),
+    ],
+)
+def test_log_prefix(
+    mocker: MockerFixture,
+    record_name: str,
+    record_pathname: str,
+    expected: str,
+) -> None:
+    mocker.patch("sys.path", [str(Path("syspath"))])
+    record = LogRecord(record_name, 0, record_pathname, 0, "msg", (), None)
+    assert _log_prefix(record) == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("python-l/lib/python3.9/site-packages/foo/bar/baz.py", "foo"),  # Linux
+        ("python-w/lib/site-packages/foo/bar/baz.py", "foo"),  # Windows
+        ("unexpected/foo/bar/baz.py", None),  # unexpected
+    ],
+)
+def test_path_to_package(
+    mocker: MockerFixture, path: str, expected: str | None
+) -> None:
+    mocker.patch(
+        "sys.path",
+        # We just put the Linux and the Windows variants in the path,
+        # so we do not have to create different mocks based on the subtest.
+        [
+            # On Linux, only the site-packages directory is in the path.
+            str(Path("python-l/lib/python3.9/site-packages")),
+            # On Windows, both the base directory and the site-packages directory
+            # are in the path.
+            str(Path("python-w")),
+            str(Path("python-w/other")),  # this one is just to test for robustness
+            str(Path("python-w/lib/site-packages")),
+            str(Path("python-w/lib")),  # this one is just to test for robustness
+        ],
+    )
+    assert _path_to_package(Path(path)) == expected

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 
@@ -1229,6 +1230,16 @@ def test_create_venv_accepts_fallback_version_w_nonzero_patchlevel(
         },
         prompt="simple-project-py3.5",
     )
+
+
+def test_build_venv_does_not_change_loglevel(
+    tmp_path: Path, manager: EnvManager
+) -> None:
+    # see https://github.com/python-poetry/poetry/pull/8760
+    venv_path = tmp_path / "venv"
+    logging.root.level = logging.DEBUG
+    manager.build_venv(venv_path)
+    assert logging.root.level == logging.DEBUG
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="requires darwin")

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterator
 
+    from _pytest.logging import LogCaptureFixture
     from pytest_mock import MockerFixture
 
     from poetry.poetry import Poetry
@@ -1233,11 +1234,11 @@ def test_create_venv_accepts_fallback_version_w_nonzero_patchlevel(
 
 
 def test_build_venv_does_not_change_loglevel(
-    tmp_path: Path, manager: EnvManager
+    tmp_path: Path, manager: EnvManager, caplog: LogCaptureFixture
 ) -> None:
     # see https://github.com/python-poetry/poetry/pull/8760
     venv_path = tmp_path / "venv"
-    logging.root.level = logging.DEBUG
+    caplog.set_level(logging.DEBUG)
     manager.build_venv(venv_path)
     assert logging.root.level == logging.DEBUG
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8756 

- [ ] Added **tests** for changed code.
  Haven't seen any existing tests for log output :thinking: should I hack it nevertheless?
- [x] Updated **documentation** for changed code.
  This shouldn't need any change.

This change aims to fix the muted debug level logs for builds with a custom build script.

Trying to understand in depth what the optional build script can do, I ran into a very scarce output despite using `-vvv`. Roaming the building/packaging code, I found out there's definitely some debug logging that might come in handy but is not getting out.

First I found a [piece of logging](https://github.com/python-poetry/poetry/blob/6f9de73b7525504f21a6eaf46e66bbd49708bd7b/src/poetry/utils/env/__init__.py#L69-L98) (https://github.com/python-poetry/poetry/commit/a7a42905 by @abn) that lacked a newline. I tried to fix that in line with what I understood the original code tries to do (I still have a feeling I didn't hit the exact spot, but it sure works better now). It also seemed like a lost opportunity not to log the pip call there, so I added it for debug. It looks quite good as is, but we it might want to prefix those lines with something to make it clear it's a 3rd party log. Either way, this doesn't really tackle the original problem...

I found that despite the `poetry-core` builders' loggers [have their log level set properly](https://github.com/python-poetry/poetry/blob/6f9de73b7525504f21a6eaf46e66bbd49708bd7b/src/poetry/console/application.py#L267-L279), they have no handlers of their own, so rely on the parent's (root logger's) custom handler [set a couple lines above](https://github.com/python-poetry/poetry/blob/master/src/poetry/console/application.py#L261). This works nice, until something touches the root logger, which is exactly what happens by default in the [`virtualenv.cli_run` call](https://github.com/python-poetry/poetry/blob/6f9de73b7525504f21a6eaf46e66bbd49708bd7b/src/poetry/utils/env/env_manager.py#L671). With the default `setup_logging=True` it pretty much resets the root logger level to `WARNING` (or to its desired verbosity in `args`, but that's not being used). I'm setting the `setup_logging=False`, which then adopts the root logger as is. That fixes the original problem, now every Poetry's `info` and `debug` logs pass through again, but also all `info` and `debug` logs from `virtualenv` hitch a ride, which is not the prettiest thing under the sun. But it's the debug logs we're after, right, so this might be a good thing!

Either way, this surely requires at least your aesthetic opinion, as I'm not aware of any logging guideline you stand by. Thank you for helping me out.

PS: I think there's a way how to avoid the `virutalenv`'s verbose logs.
- One way is by setting the custom handler on the particular named log handlers and setting back `setup_logging=True` for `virtualenv`. But that tramples the root logger, which definitely sucks and seems hardly as a conceptual thing to do.
- ~~Another way might be to monkey-patch the `virtualenv.report.LOGGER` (root logger) to some logger we control.~~ Won't work, they directly use `logging.info` etc. for logging :disappointed: that always goes back to the root logger.