### PR TITLE
non-package-mode: make tests forward compatible with poetry-core

### DIFF
--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -76,8 +76,8 @@ def test_check_invalid(
 
     tester.execute("--lock")
 
-    jsonschema_error = "'description' is a required property"
     fastjsonschema_error = "data must contain ['description'] properties"
+    custom_error = "The fields ['description'] are required in package mode."
     expected_template = """\
 Error: {schema_error}
 Error: Project name (invalid) is same as one of its dependencies
@@ -96,7 +96,7 @@ Warning: Deprecated classifier\
 """
     expected = {
         expected_template.format(schema_error=schema_error)
-        for schema_error in (jsonschema_error, fastjsonschema_error)
+        for schema_error in (fastjsonschema_error, custom_error)
     }
 
     assert tester.io.fetch_error() in expected

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -524,13 +524,20 @@ def test_create_poetry_fails_on_invalid_configuration(
     with pytest.raises(RuntimeError) as e:
         Factory().create_poetry(fixture_dir("invalid_pyproject") / "pyproject.toml")
 
-    expected = """\
+    fastjsonschema_error = "data must contain ['description'] properties"
+    custom_error = "The fields ['description'] are required in package mode."
+
+    expected_template = """\
 The Poetry configuration is invalid:
-  - data must contain ['description'] properties
+  - {schema_error}
   - Project name (invalid) is same as one of its dependencies
 """
+    expected = {
+        expected_template.format(schema_error=schema_error)
+        for schema_error in (fastjsonschema_error, custom_error)
+    }
 
-    assert str(e.value) == expected
+    assert str(e.value) in expected
 
 
 def test_create_poetry_fails_on_nameless_project(
@@ -539,12 +546,19 @@ def test_create_poetry_fails_on_nameless_project(
     with pytest.raises(RuntimeError) as e:
         Factory().create_poetry(fixture_dir("nameless_pyproject") / "pyproject.toml")
 
-    expected = """\
-The Poetry configuration is invalid:
-  - data must contain ['name'] properties
-"""
+    fastjsonschema_error = "data must contain ['name'] properties"
+    custom_error = "The fields ['name'] are required in package mode."
 
-    assert str(e.value) == expected
+    expected_template = """\
+The Poetry configuration is invalid:
+  - {schema_error}
+"""
+    expected = {
+        expected_template.format(schema_error=schema_error)
+        for schema_error in (fastjsonschema_error, custom_error)
+    }
+
+    assert str(e.value) in expected
 
 
 def test_create_poetry_with_local_config(fixture_dir: FixtureDirGetter) -> None:


### PR DESCRIPTION
Precondition for python-poetry/poetry-core#661 and thereby for #8650