### PR TITLE
Make warning about disabling PyPI become true and deprecate default source

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -126,9 +126,9 @@ priority = "primary"
 If `priority` is undefined, the source is considered a primary source that takes precedence over PyPI, secondary, supplemental and explicit sources.
 
 Package sources are considered in the following order:
-1. [default source](#default-package-source),
+1. [default source](#default-package-source-deprecated) (DEPRECATED),
 2. [primary sources](#primary-package-sources),
-3. implicit PyPI (unless disabled by another [primary source](#primary-package-sources), [default source](#default-package-source) or configured explicitly),
+3. implicit PyPI (unless disabled by another [primary source](#primary-package-sources), [default source](#default-package-source-deprecated) or configured explicitly),
 4. [secondary sources](#secondary-package-sources-deprecated) (DEPRECATED),
 5. [supplemental sources](#supplemental-package-sources).
 
@@ -145,20 +145,29 @@ poetry source add --priority=primary PyPI
 ```
 
 If you prefer to disable PyPI completely,
-you may choose to set one of your package sources to be the [default](#default-package-source),
 just add a [primary source](#primary-package-sources)
 or configure PyPI as [explicit source](#explicit-package-sources).
 
 {{% /note %}}
 
 
-#### Default Package Source
+#### Default Package Source (DEPRECATED)
+
+*Deprecated in 1.8.0*
+
+{{% warning %}}
+
+Configuring a default package source is deprecated because it is the same
+as the topmost [primary source](#primary-package-sources).
+Just configure a primary package source and put it first in the list of package sources.
+
+{{% /warning %}}
 
 By default, if you have not configured any primary source,
 Poetry will configure [PyPI](https://pypi.org) as the package source for your project.
 You can alter this behaviour and exclusively look up packages only from the configured
-package sources by adding at least one primary source
-or a **single** source with `priority = "default"`.
+package sources by adding at least one primary source (recommended)
+or a **single** source with `priority = "default"` (deprecated).
 
 ```bash
 poetry source add --priority=default foo https://foo.bar/simple/

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -127,9 +127,9 @@ If `priority` is undefined, the source is considered a primary source that takes
 
 Package sources are considered in the following order:
 1. [default source](#default-package-source),
-2. primary sources,
-3. implicit PyPI (unless disabled by another [default source](#default-package-source) or configured explicitly),
-4. [secondary sources](#secondary-package-sources) (DEPRECATED),
+2. [primary sources](#primary-package-sources),
+3. implicit PyPI (unless disabled by another [primary source](#primary-package-sources), [default source](#default-package-source) or configured explicitly),
+4. [secondary sources](#secondary-package-sources-deprecated) (DEPRECATED),
 5. [supplemental sources](#supplemental-package-sources).
 
 [Explicit sources](#explicit-package-sources) are considered only for packages that explicitly [indicate their source](#package-source-constraint).
@@ -145,7 +145,8 @@ poetry source add --priority=primary PyPI
 ```
 
 If you prefer to disable PyPI completely,
-you may choose to set one of your package sources to be the [default](#default-package-source)
+you may choose to set one of your package sources to be the [default](#default-package-source),
+just add a [primary source](#primary-package-sources)
 or configure PyPI as [explicit source](#explicit-package-sources).
 
 {{% /note %}}
@@ -153,19 +154,36 @@ or configure PyPI as [explicit source](#explicit-package-sources).
 
 #### Default Package Source
 
-By default, Poetry configures [PyPI](https://pypi.org) as the default package source for your
-project. You can alter this behaviour and exclusively look up packages only from the configured
-package sources by adding a **single** source with `priority = "default"`.
+By default, if you have not configured any primary source,
+Poetry will configure [PyPI](https://pypi.org) as the package source for your project.
+You can alter this behaviour and exclusively look up packages only from the configured
+package sources by adding at least one primary source
+or a **single** source with `priority = "default"`.
 
 ```bash
 poetry source add --priority=default foo https://foo.bar/simple/
 ```
 
+
+#### Primary Package Sources
+
+All primary package sources are searched for each dependency without a [source constraint](#package-source-constraint).
+If you configure at least one primary source, the implicit PyPI source is disabled.
+
+```bash
+poetry source add --priority=primary foo https://foo.bar/simple/
+```
+
+Sources without a priority are considered primary sources, too.
+
+```bash
+poetry source add foo https://foo.bar/simple/
+```
+
 {{% warning %}}
 
-In a future version of Poetry, PyPI will be disabled automatically
-if at least one custom primary source is configured.
-If you are using custom sources in addition to PyPI, you should configure PyPI explicitly
+The implicit PyPI source is disabled automatically if at least one primary source is configured.
+If you want to use PyPI in addition to a primary source, configure it explicitly
 with a certain priority, e.g.
 
 ```bash
@@ -185,13 +203,6 @@ priority = "primary"
 **Omit the `url` when specifying PyPI explicitly.** Because PyPI is internally configured
 with Poetry, the PyPI repository cannot be configured with a given URL. Remember, you can always use
 `poetry check` to ensure the validity of the `pyproject.toml` file.
-
-{{% /warning %}}
-
-{{% warning %}}
-
-Configuring a custom package source as default, will effectively disable [PyPI](https://pypi.org)
-as a package source for your project.
 
 {{% /warning %}}
 

--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -107,11 +107,19 @@ class SourceAddCommand(Command):
             priority = Priority[priority_str.upper()]
 
         if priority is Priority.SECONDARY:
-            allowed_prios = (p for p in Priority if p is not Priority.SECONDARY)
+            allowed_prios = (
+                p for p in Priority if p not in {Priority.DEFAULT, Priority.SECONDARY}
+            )
             self.line_error(
                 "<warning>Warning: Priority 'secondary' is deprecated. Consider"
                 " changing the priority to one of the non-deprecated values:"
                 f" {', '.join(repr(p.name.lower()) for p in allowed_prios)}.</warning>"
+            )
+        if priority is Priority.DEFAULT:
+            self.line_error(
+                "<warning>Warning: Priority 'default' is deprecated. You can achieve"
+                " the same effect by changing the priority to 'primary' and putting"
+                " the source first.</warning>"
             )
 
         sources = AoT([])

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -159,6 +159,14 @@ class Factory(BaseFactory):
                     f" {', '.join(repr(p.name.lower()) for p in allowed_prios)}."
                 )
                 io.write_error_line(f"<warning>Warning: {warning}</warning>")
+            elif priority is Priority.DEFAULT:
+                warning = (
+                    "Found deprecated priority 'default' for source"
+                    f" '{source.get('name')}' in pyproject.toml. You can achieve"
+                    " the same effect by changing the priority to 'primary' and putting"
+                    " the source first."
+                )
+                io.write_error_line(f"<warning>Warning: {warning}</warning>")
 
             if io.is_debug():
                 message = f"Adding repository {repository.name} ({repository.url})"

--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -175,32 +175,15 @@ class Factory(BaseFactory):
 
         # Only add PyPI if no default repository is configured
         if not explicit_pypi:
-            if pool.has_default():
+            if pool.has_default() or pool.has_primary_repositories():
                 if io.is_debug():
                     io.write_line("Deactivating the PyPI repository")
             else:
                 from poetry.repositories.pypi_repository import PyPiRepository
 
-                if pool.has_primary_repositories():
-                    io.write_error_line(
-                        "<warning>"
-                        "Warning: In a future version of Poetry, PyPI will be disabled"
-                        " automatically if at least one custom primary source is"
-                        " configured. In order to avoid"
-                        " a breaking change and make your pyproject.toml forward"
-                        " compatible, add PyPI explicitly via 'poetry source add pypi'."
-                        " By the way, this has the advantage that you can set the"
-                        " priority of PyPI as with any other source."
-                        "</warning>"
-                    )
-
-                if pool.has_primary_repositories():
-                    pypi_priority = Priority.SECONDARY
-                else:
-                    pypi_priority = Priority.DEFAULT
-
                 pool.add_repository(
-                    PyPiRepository(disable_cache=disable_cache), priority=pypi_priority
+                    PyPiRepository(disable_cache=disable_cache),
+                    priority=Priority.PRIMARY,
                 )
 
         if not pool.repositories:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -241,7 +241,12 @@ def test_poetry_with_default_source(
     poetry = Factory().create_poetry(fixture_dir("with_default_source"), io=io)
 
     assert len(poetry.pool.repositories) == 1
-    assert io.fetch_error() == ""
+    assert (
+        io.fetch_error().strip()
+        == "<warning>Warning: Found deprecated priority 'default' for source 'foo' in"
+        " pyproject.toml. You can achieve the same effect by changing the priority"
+        " to 'primary' and putting the source first."
+    )
 
 
 def test_poetry_with_default_source_and_pypi(

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -280,15 +280,11 @@ def test_poetry_with_non_default_source(
     poetry = Factory().create_poetry(fixture_dir(project), io=io)
 
     assert not poetry.pool.has_default()
-    assert poetry.pool.has_repository("PyPI")
-    assert poetry.pool.get_priority("PyPI") is Priority.SECONDARY
-    assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
+    assert not poetry.pool.has_repository("PyPI")
     assert poetry.pool.has_repository("foo")
     assert poetry.pool.get_priority("foo") is Priority.PRIMARY
     assert isinstance(poetry.pool.repository("foo"), LegacyRepository)
-    assert {repo.name for repo in poetry.pool.repositories} == {"PyPI", "foo"}
-    error = io.fetch_error()
-    assert "Warning: In a future version of Poetry, PyPI will be disabled" in error
+    assert {repo.name for repo in poetry.pool.repositories} == {"foo"}
 
 
 def test_poetry_with_non_default_secondary_source_legacy(
@@ -300,7 +296,7 @@ def test_poetry_with_non_default_secondary_source_legacy(
 
     assert poetry.pool.has_repository("PyPI")
     assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
-    assert poetry.pool.get_priority("PyPI") is Priority.DEFAULT
+    assert poetry.pool.get_priority("PyPI") is Priority.PRIMARY
     assert poetry.pool.has_repository("foo")
     assert isinstance(poetry.pool.repository("foo"), LegacyRepository)
     assert {repo.name for repo in poetry.pool.repositories} == {"PyPI", "foo"}
@@ -313,7 +309,7 @@ def test_poetry_with_non_default_secondary_source(
 
     assert poetry.pool.has_repository("PyPI")
     assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
-    assert poetry.pool.get_priority("PyPI") is Priority.DEFAULT
+    assert poetry.pool.get_priority("PyPI") is Priority.PRIMARY
     assert poetry.pool.has_repository("foo")
     assert isinstance(poetry.pool.repository("foo"), LegacyRepository)
     assert {repo.name for repo in poetry.pool.repositories} == {"PyPI", "foo"}
@@ -329,7 +325,7 @@ def test_poetry_with_non_default_multiple_secondary_sources_legacy(
 
     assert poetry.pool.has_repository("PyPI")
     assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
-    assert poetry.pool.get_priority("PyPI") is Priority.DEFAULT
+    assert poetry.pool.get_priority("PyPI") is Priority.PRIMARY
     assert poetry.pool.has_repository("foo")
     assert isinstance(poetry.pool.repository("foo"), LegacyRepository)
     assert poetry.pool.has_repository("bar")
@@ -346,7 +342,7 @@ def test_poetry_with_non_default_multiple_secondary_sources(
 
     assert poetry.pool.has_repository("PyPI")
     assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
-    assert poetry.pool.get_priority("PyPI") is Priority.DEFAULT
+    assert poetry.pool.get_priority("PyPI") is Priority.PRIMARY
     assert poetry.pool.has_repository("foo")
     assert isinstance(poetry.pool.repository("foo"), LegacyRepository)
     assert poetry.pool.has_repository("bar")
@@ -364,12 +360,10 @@ def test_poetry_with_non_default_multiple_sources_legacy(
     assert not poetry.pool.has_default()
     assert poetry.pool.has_repository("bar")
     assert isinstance(poetry.pool.repository("bar"), LegacyRepository)
-    assert poetry.pool.has_repository("PyPI")
-    assert poetry.pool.get_priority("PyPI") is Priority.SECONDARY
-    assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
+    assert not poetry.pool.has_repository("PyPI")
     assert poetry.pool.has_repository("foo")
     assert isinstance(poetry.pool.repository("foo"), LegacyRepository)
-    assert {repo.name for repo in poetry.pool.repositories} == {"bar", "PyPI", "foo"}
+    assert {repo.name for repo in poetry.pool.repositories} == {"bar", "foo"}
 
 
 def test_poetry_with_non_default_multiple_sources(
@@ -378,14 +372,12 @@ def test_poetry_with_non_default_multiple_sources(
     poetry = Factory().create_poetry(fixture_dir("with_non_default_multiple_sources"))
 
     assert not poetry.pool.has_default()
-    assert poetry.pool.has_repository("PyPI")
-    assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
-    assert poetry.pool.get_priority("PyPI") is Priority.SECONDARY
+    assert not poetry.pool.has_repository("PyPI")
     assert poetry.pool.has_repository("bar")
     assert isinstance(poetry.pool.repository("bar"), LegacyRepository)
     assert poetry.pool.has_repository("foo")
     assert isinstance(poetry.pool.repository("foo"), LegacyRepository)
-    assert {repo.name for repo in poetry.pool.repositories} == {"PyPI", "bar", "foo"}
+    assert {repo.name for repo in poetry.pool.repositories} == {"bar", "foo"}
 
 
 def test_poetry_with_non_default_multiple_sources_pypi(
@@ -417,7 +409,7 @@ def test_poetry_with_no_default_source(fixture_dir: FixtureDirGetter) -> None:
     poetry = Factory().create_poetry(fixture_dir("sample_project"))
 
     assert poetry.pool.has_repository("PyPI")
-    assert poetry.pool.get_priority("PyPI") is Priority.DEFAULT
+    assert poetry.pool.get_priority("PyPI") is Priority.PRIMARY
     assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
     assert {repo.name for repo in poetry.pool.repositories} == {"PyPI"}
 
@@ -429,7 +421,7 @@ def test_poetry_with_supplemental_source(
     poetry = Factory().create_poetry(fixture_dir("with_supplemental_source"), io=io)
 
     assert poetry.pool.has_repository("PyPI")
-    assert poetry.pool.get_priority("PyPI") is Priority.DEFAULT
+    assert poetry.pool.get_priority("PyPI") is Priority.PRIMARY
     assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
     assert poetry.pool.has_repository("supplemental")
     assert poetry.pool.get_priority("supplemental") is Priority.SUPPLEMENTAL
@@ -447,7 +439,7 @@ def test_poetry_with_explicit_source(
     assert len(poetry.pool.repositories) == 1
     assert len(poetry.pool.all_repositories) == 2
     assert poetry.pool.has_repository("PyPI")
-    assert poetry.pool.get_priority("PyPI") is Priority.DEFAULT
+    assert poetry.pool.get_priority("PyPI") is Priority.PRIMARY
     assert isinstance(poetry.pool.repository("PyPI"), PyPiRepository)
     assert poetry.pool.has_repository("explicit")
     assert isinstance(poetry.pool.repository("explicit"), LegacyRepository)


### PR DESCRIPTION
# Pull Request Check List

Continues #7801 (see target image in issue description)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

If there is a primary source, no default source and PyPI is not configured explicitly, we print the following warning since Poetry 1.5:
```
"Warning: In a future version of Poetry, PyPI will be disabled"
" automatically if at least one custom primary source is"
" configured. In order to avoid"
" a breaking change and make your pyproject.toml forward"
" compatible, add PyPI explicitly via 'poetry source add pypi'."
" By the way, this has the advantage that you can set the"
" priority of PyPI as with any other source."
```

Since we are printing it for three versions now, I suppose we can consider to make this warning become true. When we do that, the priority `default` is the same as the topmost primary source (if there is no default source). Thus, we can deprecate `default` to make source priorities simpler.