### PR TITLE
fix #8614 source constriants failed with extras

### DIFF
--- a/src/poetry/poetry.py
+++ b/src/poetry/poetry.py
@@ -41,7 +41,18 @@ class Poetry(BasePoetry):
 
         self._locker = locker
         self._config = config
-        self._pool = RepositoryPool(config=config)
+
+        local_config = local_config or {}
+        dependency_source_cache = {}
+
+        for group in [*local_config.get("group", {}).values(), local_config]:
+            for name, dependency in group.get("dependencies", {}).items():
+                if isinstance(dependency, dict) and "source" in dependency:
+                    dependency_source_cache[name] = dependency["source"]
+
+        self._pool = RepositoryPool(
+            config=config, dependency_source_mapping=dependency_source_cache
+        )
         self._plugin_manager: PluginManager | None = None
         self._disable_cache = disable_cache
 

--- a/tests/repositories/test_repository_pool.py
+++ b/tests/repositories/test_repository_pool.py
@@ -333,6 +333,23 @@ def test_pool_find_packages_in_specified_repository() -> None:
     assert returned_packages_unavailable == []
 
 
+def test_pool_find_packages_with_dependency_source_mapping() -> None:
+    package_foo1 = get_package("foo1", "1.1.1")
+    package_foo2 = get_package("foo2", "1.1.1")
+
+    bar = Repository("bar", [package_foo1, package_foo2])
+    pool = RepositoryPool(dependency_source_mapping={"foo1": "bar"})
+    pool.add_repository(bar, priority=Priority.EXPLICIT)
+
+    available_dependency = get_dependency("foo1", "^1.0.0")
+    returned_packages_available = pool.find_packages(available_dependency)
+    unavailable_dependency = get_dependency("foo2", "^1.0.0")
+    returned_unavailable_dependency = pool.find_packages(unavailable_dependency)
+
+    assert returned_packages_available == [package_foo1]
+    assert returned_unavailable_dependency == []
+
+
 def test_search_no_legacy_repositories() -> None:
     package_foo1 = get_package("foo", "1.0.0")
     package_foo2 = get_package("foo", "2.0.0")


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8614 
- try to solve the #8614
- Introduce a `dependency_source_mapping` parameter for the `RepositoryPool` class, which is derived directly from the `pyproject.toml` file.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
