### PR TITLE
Improve venv shell activation in fish shell

### DIFF
--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -106,7 +106,12 @@ class Shell:
         cmd = f"{self._get_source_command()} {shlex.quote(str(activate_path))}"
 
         with env.temp_environ():
-            args = ["-e", cmd] if self._name == "nu" else ["-i"]
+            if self._name == "nu":
+                args = ["-e", cmd]
+            elif self._name == "fish":
+                args = ["-i", "--init-command", cmd]
+            else:
+                args = ["-i"]
 
             c = pexpect.spawn(
                 self._path, args, dimensions=(terminal.lines, terminal.columns)
@@ -120,14 +125,11 @@ class Shell:
             c.sendline(f"emulate bash -c '. {shlex.quote(str(activate_path))}'")
         elif self._name == "xonsh":
             c.sendline(f"vox activate {shlex.quote(str(env.path))}")
-        elif self._name == "nu":
-            # If this is nu, we don't want to send the activation command to the
+        elif self._name in ["nu", "fish"]:
+            # If this is nu or fish, we don't want to send the activation command to the
             # command line since we already ran it via the shell's invocation.
             pass
         else:
-            if self._name in ["fish"]:
-                # Under fish, "\r" should be sent explicitly
-                cmd += "\r"
             c.sendline(cmd)
 
         def resize(sig: Any, data: Any) -> None:


### PR DESCRIPTION
Instead of mimicking a user typing the command we use fish's builtin `--init-command` option. This is similar to how `poetry` already does it in `nushell`. This makes the experience a bit nicer because instead of it looking something like this:

```
poetry on  master is 📦 v1.8.0.dev0 via 🐍 v3.12.0 
❯ poetry shell
Spawning shell within ~/virtualenvs/poetry-4gAzItFB-py3.11
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish

poetry on  master is 📦 v1.8.0.dev0 via 🐍 v3.12.0 
❯ source ~/.cache/pypoetry/virtualenvs/poetry-4gAzItFB-py3.11/bin/activate.fish

poetry on  master is 📦 v1.8.0.dev0 via 🐍 v3.12.0 (poetry-py3.11) 
❯  _
```

it now looks like this (notice the missing `source` invokation)

```
❯ poetry shell
Spawning shell within ~/virtualenvs/poetry-4gAzItFB-py3.11
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish

poetry on  master is 📦 v1.8.0.dev0 via 🐍 v3.12.0 (poetry-py3.11) 
❯  _
```

The `--init-command` option has been released with `fish` version `2.7b1` in 2017 [according to their changelog](https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#fish-27b1-released-october-31-2017) so in my opinion should not cause compatibility issues.

_I didn't find any tests for the nu behavior but would add tests for this if wanted and with some small pointers about how you would like this to be tested._

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

