### PR TITLE
Update description of --why flag for poetry show

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -503,7 +503,7 @@ required by
 ### Options
 
 * `--without`: The dependency groups to ignore.
-* `--why`: When showing the full list, or a `--tree` for a single package, display why a package is included.
+* `--why`: When showing the full list, or a `--tree` for a single package, display whether they are direct dependency or required by other packages.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
 * `--no-dev`: Do not list the dev dependencies. (**Deprecated**, use `--without dev` or `--only main` instead)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -503,7 +503,7 @@ required by
 ### Options
 
 * `--without`: The dependency groups to ignore.
-* `--why`: When showing the full list, or a `--tree` for a single package, display whether they are direct dependency or required by other packages.
+* `--why`: When showing the full list, or a `--tree` for a single package, display whether they are a direct dependency or required by other packages.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
 * `--no-dev`: Do not list the dev dependencies. (**Deprecated**, use `--without dev` or `--only main` instead)

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -49,7 +49,8 @@ class ShowCommand(GroupCommand, EnvCommand):
             "why",
             None,
             "When showing the full list, or a <info>--tree</info> for a single package,"
-            " display whether they are a direct dependency or required by other packages",
+            " display whether they are a direct dependency or required by other"
+            " packages",
         ),
         option("latest", "l", "Show the latest version."),
         option(

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -48,8 +48,8 @@ class ShowCommand(GroupCommand, EnvCommand):
         option(
             "why",
             None,
-            "When showing the full list, or a <info>--tree</info> for a single"
-            " package, display whether they are direct dependency or required by other packages",
+            "When showing the full list, or a <info>--tree</info> for a single package,"
+            " display whether they are direct dependency or required by other packages",
         ),
         option("latest", "l", "Show the latest version."),
         option(

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -49,7 +49,7 @@ class ShowCommand(GroupCommand, EnvCommand):
             "why",
             None,
             "When showing the full list, or a <info>--tree</info> for a single"
-            " package, also display why it's included.",
+            " package, display whether they are direct dependency or required by other packages",
         ),
         option("latest", "l", "Show the latest version."),
         option(

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -49,7 +49,7 @@ class ShowCommand(GroupCommand, EnvCommand):
             "why",
             None,
             "When showing the full list, or a <info>--tree</info> for a single package,"
-            " display whether they are direct dependency or required by other packages",
+            " display whether they are a direct dependency or required by other packages",
         ),
         option("latest", "l", "Show the latest version."),
         option(


### PR DESCRIPTION
Resolves: #8816 

Changes:
- Update description in `docs/cli.md`
- Kept the description in the `docs` in sync with the `cli` by updating `src/poetry/console/commands/show.py`

Motivation:

The current description was unclear. "display why a package is included" could suggest that users could get back a motivation or rationale behind why the package is added. But that's not the case.

`--why` returns whether a package is a direct dependency or whether it is itself a dependency of another package in the project.
