### PR TITLE
env: rename "system" to "base" in output of `env info`

### DIFF
--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -88,13 +88,13 @@ poetry env info
 will output something similar to this:
 
 ```text
-Virtual environment
+Virtualenv
 Python:         3.7.1
 Implementation: CPython
 Path:           /path/to/poetry/cache/virtualenvs/test-O3eWbxRl-py3.7
 Valid:          True
 
-System
+Base
 Platform: darwin
 OS:       posix
 Python:   /path/to/main/python

--- a/src/poetry/console/commands/env/info.py
+++ b/src/poetry/console/commands/env/info.py
@@ -71,15 +71,15 @@ class EnvInfoCommand(Command):
 
         self.line("")
 
-        system_env = env.parent_env
-        python = ".".join(str(v) for v in system_env.version_info[:3])
-        self.line("<b>System</b>")
+        base_env = env.parent_env
+        python = ".".join(str(v) for v in base_env.version_info[:3])
+        self.line("<b>Base</b>")
         self.line(
             "\n".join([
                 f"<info>Platform</info>:   <comment>{env.platform}</>",
                 f"<info>OS</info>:         <comment>{env.os}</>",
                 f"<info>Python</info>:     <comment>{python}</>",
-                f"<info>Path</info>:       <comment>{system_env.path}</>",
-                f"<info>Executable</info>: <comment>{system_env.python}</>",
+                f"<info>Path</info>:       <comment>{base_env.path}</>",
+                f"<info>Executable</info>: <comment>{base_env.python}</>",
             ])
         )

--- a/tests/console/commands/env/test_info.py
+++ b/tests/console/commands/env/test_info.py
@@ -43,7 +43,7 @@ Path:           {Path('/prefix')}
 Executable:     {sys.executable}
 Valid:          True
 
-System
+Base
 Platform:   darwin
 OS:         posix
 Python:     {'.'.join(str(v) for v in sys.version_info[:3])}


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

When running `poetry env info`, information about the currently active virtualenv and it's base Python is printed. However, the base Python is called system, which might be confusing if the base Python is not the system Python. For example, consider the following sequence of commands:

```
$ poetry env use 3.9
Using virtualenv: /home/randy/.cache/pypoetry/virtualenvs/poetry-gXMMKm0L-py3.9

$ poetry env info

Virtualenv
Python:         3.9.16
Implementation: CPython
Path:           /home/randy/.cache/pypoetry/virtualenvs/poetry-gXMMKm0L-py3.9
Executable:     /home/randy/.cache/pypoetry/virtualenvs/poetry-gXMMKm0L-py3.9/bin/python
Valid:          True

System
Platform:   linux
OS:         posix
Python:     3.9.16
Path:       /usr
Executable: /usr/bin/python3.9

$ poetry env use system
Deactivating virtualenv: /home/randy/.cache/pypoetry/virtualenvs/poetry-gXMMKm0L-py3.9

$ poetry env info

Virtualenv
Python:         3.8.10
Implementation: CPython
Path:           /home/randy/.cache/pypoetry/virtualenvs/poetry-gXMMKm0L-py3.8
Executable:     /home/randy/.cache/pypoetry/virtualenvs/poetry-gXMMKm0L-py3.8/bin/python
Valid:          True

System
Platform:   linux
OS:         posix
Python:     3.8.10
Path:       /usr
Executable: /usr/bin/python3.8
```

Thus, it probably makes more sense to call it "base" instead of "system".