### PR TITLE
Fix git clone test on non-English locale

### DIFF
--- a/src/poetry/vcs/git/system.py
+++ b/src/poetry/vcs/git/system.py
@@ -15,18 +15,18 @@ if TYPE_CHECKING:
 
 class SystemGit:
     @classmethod
-    def clone(cls, repository: str, dest: Path) -> str:
+    def clone(cls, repository: str, dest: Path) -> None:
         cls._check_parameter(repository)
 
-        return cls.run("clone", "--recurse-submodules", "--", repository, str(dest))
+        cls.run("clone", "--recurse-submodules", "--", repository, str(dest))
 
     @classmethod
-    def checkout(cls, rev: str, target: Path | None = None) -> str:
+    def checkout(cls, rev: str, target: Path | None = None) -> None:
         cls._check_parameter(rev)
-        return cls.run("checkout", rev, folder=target)
+        cls.run("checkout", rev, folder=target)
 
     @staticmethod
-    def run(*args: Any, **kwargs: Any) -> str:
+    def run(*args: Any, **kwargs: Any) -> None:
         folder = kwargs.pop("folder", None)
         if folder:
             args = (
@@ -40,12 +40,13 @@ class SystemGit:
         git_command = find_git_command()
         env = os.environ.copy()
         env["GIT_TERMINAL_PROMPT"] = "0"
-        return subprocess.check_output(
+        subprocess.check_call(
             git_command + list(args),
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
             env=env,
             text=True,
-        ).strip()
+        )
 
     @staticmethod
     def _check_parameter(parameter: str) -> None:

--- a/tests/vcs/git/test_system.py
+++ b/tests/vcs/git/test_system.py
@@ -72,8 +72,7 @@ def temp_repo(tmp_path: Path) -> TempRepoFixture:
 class TestSystemGit:
     def test_clone_success(self, tmp_path: Path, temp_repo: TempRepoFixture) -> None:
         target_dir = tmp_path / "test-repo"
-        stdout = SystemGit.clone(temp_repo.path.as_uri(), target_dir)
-        assert re.search(r"Cloning into '.+[\\/]test-repo'...", stdout)
+        SystemGit.clone(temp_repo.path.as_uri(), target_dir)
         assert (target_dir / ".git").is_dir()
 
     def test_clone_invalid_parameter(self, tmp_path: Path) -> None:


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

-----
When running tests using a non-English locale `vcs.git.test_system.TestSystemGit` test fails because git uses localized messages in its output.  

To reproduce run:

```sh
LANG=uk_UA.UTF-8 poetry run pytest
```

This PR fixes the issue by ignoring any output from git commands.


