### PR TITLE
Use package.pretty_name in poetry version

### DIFF
--- a/src/poetry/console/commands/version.py
+++ b/src/poetry/console/commands/version.py
@@ -86,7 +86,7 @@ patch, minor, major, prepatch, preminor, premajor, prerelease.
                 self.line(self.poetry.package.pretty_version)
             else:
                 self.line(
-                    f"<comment>{self.poetry.package.name}</>"
+                    f"<comment>{self.poetry.package.pretty_name}</>"
                     f" <info>{self.poetry.package.pretty_version}</>"
                 )
 


### PR DESCRIPTION
# Pull Request Check List

This PR changes the `poetry version` command to output the `pretty_name` instead of the normalized `name`. This makes it easier to retrieve the package name, e.g. in CI tooling.

Related, but not entirely matching issue: #8848

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
