### PR TITLE
Add a warning about config in the docs for possible faliure point

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -580,6 +580,8 @@ poetry config [options] [setting-key] [setting-value1] ... [setting-valueN]
 `setting-key` is a configuration option name and `setting-value1` is a configuration value.
 See [Configuration]({{< relref "configuration" >}}) for all available settings.
 
+{{% warning %}} Use `--` to terminate option parsing in the traditional Unix tradition else, commands like `poetry config http-basic.custom-repo gitlab-ci-token ${GITLAB_JOB_TOKEN}` will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphen (`-`). {{% /note %}}
+
 ### Options
 
 * `--unset`: Remove the configuration element named by `setting-key`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -582,7 +582,7 @@ See [Configuration]({{< relref "configuration" >}}) for all available settings.
 
 {{% warning %}}
 Use `--` to terminate option parsing, otherwise commands like
-`poetry config http-basic.custom-repo gitlab-ci-token ${GITLAB_JOB_TOKEN}`
+`poetry config http-basic.custom-repo gitlab-ci-token -- ${GITLAB_JOB_TOKEN}`
 will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphen (`-`).
 {{% /warning%}}
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -581,9 +581,11 @@ poetry config [options] [setting-key] [setting-value1] ... [setting-valueN]
 See [Configuration]({{< relref "configuration" >}}) for all available settings.
 
 {{% warning %}}
-Use `--` to terminate option parsing, otherwise commands like
-`poetry config http-basic.custom-repo gitlab-ci-token -- ${GITLAB_JOB_TOKEN}`
-will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphen (`-`).
+Use `--` to terminate option parsing if your values may start with a hyphen (`-`), e.g.
+```bash
+poetry config http-basic.custom-repo gitlab-ci-token -- ${GITLAB_JOB_TOKEN}
+```
+Without `--` this command will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphen.
 {{% /warning%}}
 
 ### Options

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -580,7 +580,11 @@ poetry config [options] [setting-key] [setting-value1] ... [setting-valueN]
 `setting-key` is a configuration option name and `setting-value1` is a configuration value.
 See [Configuration]({{< relref "configuration" >}}) for all available settings.
 
-{{% warning %}} Use `--` to terminate option parsing in the traditional Unix tradition else, commands like `poetry config http-basic.custom-repo gitlab-ci-token ${GITLAB_JOB_TOKEN}` will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphen (`-`). {{% /note %}}
+{{% warning %}}
+Use `--` to terminate option parsing, otherwise commands like
+`poetry config http-basic.custom-repo gitlab-ci-token ${GITLAB_JOB_TOKEN}`
+will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphen (`-`).
+{{% /warning%}}
 
 ### Options
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4699

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

There was a mention in #4699 where in a command:

```shell
poetry config http-basic.custom-repo gitlab-ci-token ${GITLAB_JOB_TOKEN}
``` 

if `${GITLAB_JOB_TOKEN}` starts with a hyphen (`-`) the command fails as the parser interprets it as an option being passed. 

The work-around is to use:
```shell
poetry config http-basic.custom-repo -- gitlab-ci-token ${GITLAB_JOB_TOKEN}
``` 


Where the double hyphen (`--`) terminates the options and removes the error.

This can be extremely confusing and a warning for the same must be mentioned in the docs. 
That is what I've done in the PR by changing the docs to include this warning.


