### PR TITLE
Fix documentation for default `format` option for `include` and `exclude`

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -279,7 +279,9 @@ include = [
 ]
 ```
 
-If no format is specified, it will default to include both `sdist` and `wheel`.
+If no format is specified, `include` defaults to only `sdist`.
+
+In constrast, `exclude` defaults to both `sdist` and `wheel`.
 
 ```toml
 exclude = ["my_package/excluded.py"]

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -281,7 +281,7 @@ include = [
 
 If no format is specified, `include` defaults to only `sdist`.
 
-In constrast, `exclude` defaults to both `sdist` and `wheel`.
+In contrast, `exclude` defaults to both `sdist` and `wheel`.
 
 ```toml
 exclude = ["my_package/excluded.py"]


### PR DESCRIPTION
The existing documentation is incorrect, which confused me when attempting to `include` a directory.

I verified this behavior by building a package with `include` and `exclude` and inspecting the tarballs created.

I'd appreciate if someone pointed me to the code for this — I tried to find it but could not :)

# Pull Request Check List

Closes https://github.com/python-poetry/poetry/issues/8698

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
