### PR TITLE
build: make build formats dict available, handle deprecation of `poetry.core.masonry.builder`

### DIFF
--- a/src/poetry/masonry/builders/__init__.py
+++ b/src/poetry/masonry/builders/__init__.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
+from poetry.core.masonry.builders.sdist import SdistBuilder
+from poetry.core.masonry.builders.wheel import WheelBuilder
+
 from poetry.masonry.builders.editable import EditableBuilder
 
 
-__all__ = ["EditableBuilder"]
+__all__ = ["BUILD_FORMATS", "EditableBuilder"]
+
+
+# might be extended by plugins
+BUILD_FORMATS = {
+    "sdist": SdistBuilder,
+    "wheel": WheelBuilder,
+}


### PR DESCRIPTION
Companion of python-poetry/poetry-core#682 and alternative to python-poetry/poetry-core#679

- Move code deprecated in python-poetry/poetry-core#682 into the `build` command.
- Move relevant tests from poetry-core to poetry.
  (One of the three tests could not be moved because #8828 is required first. The concerning test will be added in #8828.)
- Move build formats dict into `poetry.masonry.builders`.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
