### PR TITLE
Fix encoding warnings with PEP 597 enabled

### DIFF
--- a/.github/workflows/.tests-matrix.yaml
+++ b/.github/workflows/.tests-matrix.yaml
@@ -22,6 +22,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  PYTHONWARNDEFAULTENCODING: 'true'
+
 jobs:
   mypy:
     name: mypy

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  PYTHONWARNDEFAULTENCODING: 'true'
+
 jobs:
   changes:
     name: Detect changed files

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,9 +13,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  PYTHONWARNDEFAULTENCODING: 'true'
-
 jobs:
   changes:
     name: Detect changed files

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import csv
 import hashlib
 import json
-import locale
 import os
 
 from base64 import urlsafe_b64encode
@@ -16,6 +15,7 @@ from poetry.core.masonry.utils.package_include import PackageInclude
 
 from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import decode
+from poetry.utils._compat import getencoding
 from poetry.utils.env import build_environment
 from poetry.utils.helpers import is_dir_writable
 from poetry.utils.pip import pip_install
@@ -125,7 +125,7 @@ class EditableBuilder(Builder):
 
         try:
             pth_file = self._env.site_packages.write_text(
-                pth_file, content, encoding=locale.getpreferredencoding()
+                pth_file, content, encoding=getencoding()
             )
             self._debug(
                 f"  - Adding <c2>{pth_file.name}</c2> to <b>{pth_file.parent}</b> for"
@@ -252,7 +252,8 @@ class EditableBuilder(Builder):
                     "dir_info": {"editable": True},
                     "url": self._poetry.file.path.parent.absolute().as_uri(),
                 }
-            )
+            ),
+            encoding="utf-8",
         )
         added_files.append(direct_url_json)
 

--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -13,6 +13,7 @@ from poetry.core.packages.utils.utils import url_to_path
 from poetry.core.utils.helpers import module_name
 
 from poetry.repositories.repository import Repository
+from poetry.utils._compat import getencoding
 from poetry.utils._compat import metadata
 
 
@@ -58,7 +59,7 @@ class InstalledRepository(Repository):
             if not pth_file.exists():
                 continue
 
-            with pth_file.open() as f:
+            with pth_file.open(encoding=getencoding()) as f:
                 for line in f:
                     line = line.strip()
                     if line and not line.startswith(("#", "import ", "import\t")):

--- a/src/poetry/utils/_compat.py
+++ b/src/poetry/utils/_compat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import locale
 import sys
 
 from contextlib import suppress
@@ -52,6 +53,13 @@ def encode(string: str, encodings: list[str] | None = None) -> bytes:
     return string.encode(encodings[0], errors="ignore")
 
 
+def getencoding() -> str:
+    if sys.version_info < (3, 11):
+        return locale.getpreferredencoding()
+    else:
+        return locale.getencoding()
+
+
 def is_relative_to(this: Path, other: Path) -> bool:
     """
     Return whether `this` path is relative to the `other` path. This is compatibility wrapper around
@@ -72,6 +80,7 @@ __all__ = [
     "WINDOWS",
     "decode",
     "encode",
+    "getencoding",
     "is_relative_to",
     "metadata",
     "tomllib",

--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -330,8 +330,9 @@ class Env:
                 subprocess.check_call(cmd, stderr=stderr, env=env, **kwargs)
                 output = ""
             else:
+                encoding = "locale" if sys.version_info >= (3, 10) else None
                 output = subprocess.check_output(
-                    cmd, stderr=stderr, env=env, text=True, **kwargs
+                    cmd, stderr=stderr, env=env, text=True, encoding=encoding, **kwargs
                 )
         except CalledProcessError as e:
             raise EnvCommandError(e)

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -105,8 +105,11 @@ class EnvManager:
             return None
 
         try:
+            encoding = "locale" if sys.version_info >= (3, 10) else None
             executable = subprocess.check_output(
-                [path_python, "-c", "import sys; print(sys.executable)"], text=True
+                [path_python, "-c", "import sys; print(sys.executable)"],
+                text=True,
+                encoding=encoding,
             ).strip()
             return Path(executable)
 
@@ -147,8 +150,11 @@ class EnvManager:
             executable = EnvManager._detect_active_python(io)
 
             if executable:
+                encoding = "locale" if sys.version_info >= (3, 10) else None
                 python_patch = subprocess.check_output(
-                    [executable, "-c", GET_PYTHON_VERSION_ONELINER], text=True
+                    [executable, "-c", GET_PYTHON_VERSION_ONELINER],
+                    text=True,
+                    encoding=encoding,
                 ).strip()
 
                 version = ".".join(str(v) for v in python_patch.split(".")[:precision])
@@ -188,8 +194,11 @@ class EnvManager:
             raise PythonVersionNotFound(python)
 
         try:
+            encoding = "locale" if sys.version_info >= (3, 10) else None
             python_version_string = subprocess.check_output(
-                [python_path, "-c", GET_PYTHON_VERSION_ONELINER], text=True
+                [python_path, "-c", GET_PYTHON_VERSION_ONELINER],
+                text=True,
+                encoding=encoding,
             )
         except CalledProcessError as e:
             raise EnvCommandError(e)
@@ -354,8 +363,9 @@ class EnvManager:
         if python_path.is_file():
             # Validate env name if provided env is a full path to python
             try:
+                encoding = "locale" if sys.version_info >= (3, 10) else None
                 env_dir = subprocess.check_output(
-                    [python, "-c", GET_ENV_PATH_ONELINER], text=True
+                    [python, "-c", GET_ENV_PATH_ONELINER], text=True, encoding=encoding
                 ).strip("\n")
                 env_name = Path(env_dir).name
                 if not self.check_env_is_for_current_project(
@@ -398,8 +408,11 @@ class EnvManager:
             pass
 
         try:
+            encoding = "locale" if sys.version_info >= (3, 10) else None
             python_version_string = subprocess.check_output(
-                [python, "-c", GET_PYTHON_VERSION_ONELINER], text=True
+                [python, "-c", GET_PYTHON_VERSION_ONELINER],
+                text=True,
+                encoding=encoding,
             )
         except CalledProcessError as e:
             raise EnvCommandError(e)
@@ -481,8 +494,11 @@ class EnvManager:
         python_patch = ".".join([str(v) for v in sys.version_info[:3]])
         python_minor = ".".join([str(v) for v in sys.version_info[:2]])
         if executable:
+            encoding = "locale" if sys.version_info >= (3, 10) else None
             python_patch = subprocess.check_output(
-                [executable, "-c", GET_PYTHON_VERSION_ONELINER], text=True
+                [executable, "-c", GET_PYTHON_VERSION_ONELINER],
+                text=True,
+                encoding=encoding,
             ).strip()
             python_minor = ".".join(python_patch.split(".")[:2])
 
@@ -527,10 +543,12 @@ class EnvManager:
                     continue
 
                 try:
+                    encoding = "locale" if sys.version_info >= (3, 10) else None
                     python_patch = subprocess.check_output(
                         [python, "-c", GET_PYTHON_VERSION_ONELINER],
                         stderr=subprocess.STDOUT,
                         text=True,
+                        encoding=encoding,
                     ).strip()
                 except CalledProcessError:
                     continue

--- a/src/poetry/utils/env/virtual_env.py
+++ b/src/poetry/utils/env/virtual_env.py
@@ -136,7 +136,7 @@ class VirtualEnv(Env):
         return pyvenv_cfg.exists() and (
             re.search(
                 r"^\s*include-system-site-packages\s*=\s*true\s*$",
-                pyvenv_cfg.read_text(),
+                pyvenv_cfg.read_text(encoding="utf-8"),
                 re.IGNORECASE | re.MULTILINE,
             )
             is not None

--- a/src/poetry/vcs/git/system.py
+++ b/src/poetry/vcs/git/system.py
@@ -40,12 +40,13 @@ class SystemGit:
         git_command = find_git_command()
         env = os.environ.copy()
         env["GIT_TERMINAL_PROMPT"] = "0"
-        subprocess.check_call(
+        subprocess.check_call(  # type: ignore[call-arg]
             git_command + list(args),
             stderr=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             env=env,
             text=True,
+            encoding="utf-8",
         )
 
     @staticmethod

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -76,13 +76,18 @@ def test_remove_all(
     if envs_file == "empty":
         envs_file_path.touch()
     elif envs_file == "self":
-        envs_file_path.write_text(f'[{venv_name}]\nminor = "3.9"\npatch = "3.9.1"\n')
+        envs_file_path.write_text(
+            f'[{venv_name}]\nminor = "3.9"\npatch = "3.9.1"\n', encoding="utf-8"
+        )
     elif envs_file == "other":
-        envs_file_path.write_text('[other-abcdefgh]\nminor = "3.9"\npatch = "3.9.1"\n')
+        envs_file_path.write_text(
+            '[other-abcdefgh]\nminor = "3.9"\npatch = "3.9.1"\n', encoding="utf-8"
+        )
     elif envs_file == "self_and_other":
         envs_file_path.write_text(
             f'[{venv_name}]\nminor = "3.9"\npatch = "3.9.1"\n'
-            '[other-abcdefgh]\nminor = "3.9"\npatch = "3.9.1"\n'
+            '[other-abcdefgh]\nminor = "3.9"\npatch = "3.9.1"\n',
+            encoding="utf-8",
         )
     else:
         # no envs file -> nothing to prepare
@@ -97,7 +102,7 @@ def test_remove_all(
 
     if envs_file is not None:
         assert envs_file_path.exists()
-        envs_file_content = envs_file_path.read_text()
+        envs_file_content = envs_file_path.read_text(encoding="utf-8")
         assert venv_name not in envs_file_content
         if "other" in envs_file:
             assert "other-abcdefgh" in envs_file_content

--- a/tests/console/commands/self/test_install.py
+++ b/tests/console/commands/self/test_install.py
@@ -45,7 +45,7 @@ def test_self_install(
     assert isinstance(command, SelfInstallCommand)
     pyproject_path = command.system_pyproject
     if pyproject_content:
-        pyproject_path.write_text(pyproject_content)
+        pyproject_path.write_text(pyproject_content, encoding="utf-8")
     else:
         assert not pyproject_path.exists()
 

--- a/tests/console/commands/self/test_self_command.py
+++ b/tests/console/commands/self/test_self_command.py
@@ -29,9 +29,11 @@ def test_generate_system_pyproject_trailing_newline(
     example_system_pyproject: str,
 ) -> None:
     cmd = SelfCommand()
-    cmd.system_pyproject.write_text(example_system_pyproject + "\n" * existing_newlines)
+    cmd.system_pyproject.write_text(
+        example_system_pyproject + "\n" * existing_newlines, encoding="utf-8"
+    )
     cmd.generate_system_pyproject()
-    generated = cmd.system_pyproject.read_text()
+    generated = cmd.system_pyproject.read_text(encoding="utf-8")
 
     assert len(generated) - len(generated.rstrip("\n")) == existing_newlines
 
@@ -40,10 +42,12 @@ def test_generate_system_pyproject_carriage_returns(
     example_system_pyproject: str,
 ) -> None:
     cmd = SelfCommand()
-    cmd.system_pyproject.write_text(example_system_pyproject + "\n")
+    cmd.system_pyproject.write_text(example_system_pyproject + "\n", encoding="utf-8")
     cmd.generate_system_pyproject()
 
-    with open(cmd.system_pyproject, newline="") as f:  # do not translate newlines
+    with open(
+        cmd.system_pyproject, newline="", encoding="utf-8"
+    ) as f:  # do not translate newlines
         generated = f.read()
 
     assert "\r\r" not in generated

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -91,7 +91,7 @@ def test_noninteractive(
     assert tester.io.fetch_output() == expected
     assert tester.io.fetch_error() == ""
 
-    toml_content = (tmp_path / "pyproject.toml").read_text()
+    toml_content = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
     assert 'name = "my-package"' in toml_content
     assert 'pytest = "^3.6.0"' in toml_content
 
@@ -853,9 +853,11 @@ def test_init_existing_pyproject_simple(
 [tool.black]
 line-length = 88
 """
-    pyproject_file.write_text(existing_section)
+    pyproject_file.write_text(existing_section, encoding="utf-8")
     tester.execute(inputs=init_basic_inputs)
-    assert f"{existing_section}\n{init_basic_toml}" in pyproject_file.read_text()
+    assert f"{existing_section}\n{init_basic_toml}" in pyproject_file.read_text(
+        encoding="utf-8"
+    )
 
 
 @pytest.mark.parametrize("linesep", ["\n", "\r\n"])
@@ -871,10 +873,10 @@ def test_init_existing_pyproject_consistent_linesep(
 [tool.black]
 line-length = 88
 """.replace("\n", linesep)
-    with open(pyproject_file, "w", newline="") as f:
+    with open(pyproject_file, "w", newline="", encoding="utf-8") as f:
         f.write(existing_section)
     tester.execute(inputs=init_basic_inputs)
-    with open(pyproject_file, newline="") as f:
+    with open(pyproject_file, newline="", encoding="utf-8") as f:
         content = f.read()
     init_basic_toml = init_basic_toml.replace("\n", linesep)
     assert f"{existing_section}{linesep}{init_basic_toml}" in content
@@ -891,7 +893,7 @@ def test_init_non_interactive_existing_pyproject_add_dependency(
 [tool.black]
 line-length = 88
 """
-    pyproject_file.write_text(existing_section)
+    pyproject_file.write_text(existing_section, encoding="utf-8")
 
     repo.add_package(get_package("foo", "1.19.2"))
 
@@ -915,7 +917,9 @@ readme = "README.md"
 python = "^3.6"
 foo = "^1.19.2"
 """
-    assert f"{existing_section}\n{expected}" in pyproject_file.read_text()
+    assert f"{existing_section}\n{expected}" in pyproject_file.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_init_existing_pyproject_with_build_system_fails(
@@ -927,13 +931,13 @@ def test_init_existing_pyproject_with_build_system_fails(
 requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
 """
-    pyproject_file.write_text(existing_section)
+    pyproject_file.write_text(existing_section, encoding="utf-8")
     tester.execute(inputs=init_basic_inputs)
     assert (
         tester.io.fetch_error().strip()
         == "A pyproject.toml file with a defined build-system already exists."
     )
-    assert existing_section in pyproject_file.read_text()
+    assert existing_section in pyproject_file.read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize(
@@ -1069,7 +1073,7 @@ def test_respect_prefer_active_on_init(
 python = ">={python}"
 """
 
-    assert expected in pyproject_file.read_text()
+    assert expected in pyproject_file.read_text(encoding="utf-8")
 
 
 def test_get_pool(mocker: MockerFixture, source_dir: Path) -> None:

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -228,7 +228,7 @@ def test_respect_prefer_active_on_new(
 python = ">={python}"
 """
 
-    assert expected in pyproject_file.read_text()
+    assert expected in pyproject_file.read_text(encoding="utf-8")
 
 
 def test_basic_interactive_new(

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 
 from typing import TYPE_CHECKING
 
@@ -116,7 +117,8 @@ def test_run_console_scripts_of_editable_dependencies_on_windows(
 
     cmd_script_file = tmp_venv._bin_dir / "quix.cmd"
     # `/b` ensures we only exit the script instead of any cmd.exe proc that called it
-    cmd_script_file.write_text("exit /b 123")
+    encoding = "locale" if sys.version_info >= (3, 10) else None
+    cmd_script_file.write_text("exit /b 123", encoding=encoding)
     # We prove that the CMD script executed successfully by verifying the exit code
     # matches what we wrote in the script
     assert tester.execute("quix") == 123

--- a/tests/console/commands/test_version.py
+++ b/tests/console/commands/test_version.py
@@ -126,9 +126,9 @@ def test_phase_version_update(tester: CommandTester) -> None:
 
 def test_dry_run(tester: CommandTester) -> None:
     assert isinstance(tester.command, VersionCommand)
-    old_pyproject = tester.command.poetry.file.path.read_text()
+    old_pyproject = tester.command.poetry.file.path.read_text(encoding="utf-8")
     tester.execute("--dry-run major")
 
-    new_pyproject = tester.command.poetry.file.path.read_text()
+    new_pyproject = tester.command.poetry.file.path.read_text(encoding="utf-8")
     assert tester.io.fetch_output() == "Bumping version from 1.2.3 to 2.0.0\n"
     assert old_pyproject == new_pyproject

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -60,7 +60,8 @@ def demo_setup(source_dir: Path) -> Path:
         "from setuptools import setup; "
         'setup(name="demo", '
         'version="0.1.0", '
-        'install_requires=["package"])'
+        'install_requires=["package"])',
+        encoding="utf-8",
     )
     return source_dir
 
@@ -77,7 +78,8 @@ def demo_setup_cfg(source_dir: Path) -> Path:
                 "[options]",
                 "install_requires = package",
             ]
-        )
+        ),
+        encoding="utf-8",
     )
     return source_dir
 
@@ -89,7 +91,8 @@ def demo_setup_complex(source_dir: Path) -> Path:
         "from setuptools import setup; "
         'setup(name="demo", '
         'version="0.1.0", '
-        'install_requires=[i for i in ["package"]])'
+        'install_requires=[i for i in ["package"]])',
+        encoding="utf-8",
     )
     return source_dir
 
@@ -97,7 +100,9 @@ def demo_setup_complex(source_dir: Path) -> Path:
 @pytest.fixture
 def demo_setup_complex_pep517_legacy(demo_setup_complex: Path) -> Path:
     pyproject_toml = demo_setup_complex / "pyproject.toml"
-    pyproject_toml.write_text('[build-system]\nrequires = ["setuptools", "wheel"]')
+    pyproject_toml.write_text(
+        '[build-system]\nrequires = ["setuptools", "wheel"]', encoding="utf-8"
+    )
     return demo_setup_complex
 
 
@@ -115,7 +120,8 @@ def demo_setup_complex_calls_script(
     [build-system]
     requires = ["setuptools", "scripts @ {scripts_dir.as_uri()}"]
     build-backend = "setuptools.build_meta:__legacy__"
-"""
+""",
+        encoding="utf-8",
     )
 
     setup_py = source_dir / "setup.py"
@@ -126,7 +132,8 @@ from setuptools import setup
 if subprocess.call(["exit-code"]) != 42:
     raise RuntimeError("Wrong exit code.")
 setup(name="demo", version="0.1.0", install_requires=[i for i in ["package"]])
-"""
+""",
+        encoding="utf-8",
     )
 
     return source_dir
@@ -359,7 +366,7 @@ def test_info_setup_missing_mandatory_should_trigger_pep517(
     setup += ")"
 
     setup_py = source_dir / "setup.py"
-    setup_py.write_text(setup)
+    setup_py.write_text(setup, encoding="utf-8")
 
     spy = mocker.spy(ProjectBuilder, "from_isolated_env")
     _ = PackageInfo.from_directory(source_dir)

--- a/tests/installation/test_wheel_installer.py
+++ b/tests/installation/test_wheel_installer.py
@@ -54,7 +54,7 @@ def test_default_installation_dist_info_dir_content(default_installation: Path) 
 
 def test_installer_file_contains_valid_version(default_installation: Path) -> None:
     installer_file = default_installation / "demo-0.1.0.dist-info" / "INSTALLER"
-    with open(installer_file) as f:
+    with open(installer_file, encoding="utf-8") as f:
         installer_content = f.read()
     match = re.match(r"Poetry (?P<version>.*)", installer_content)
     assert match

--- a/tests/pyproject/conftest.py
+++ b/tests/pyproject/conftest.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 @pytest.fixture
 def pyproject_toml(tmp_path: Path) -> Path:
     path = tmp_path / "pyproject.toml"
-    with path.open(mode="w"):
+    with path.open(mode="w", encoding="utf-8"):
         pass
     return path
 
@@ -24,7 +24,7 @@ def build_system_section(pyproject_toml: Path) -> str:
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 """
-    with pyproject_toml.open(mode="a") as f:
+    with pyproject_toml.open(mode="a", encoding="utf-8") as f:
         f.write(content)
     return content
 
@@ -38,6 +38,6 @@ name = "poetry"
 [tool.poetry.dependencies]
 python = "^3.5"
 """
-    with pyproject_toml.open(mode="a") as f:
+    with pyproject_toml.open(mode="a", encoding="utf-8") as f:
         f.write(content)
     return content

--- a/tests/pyproject/test_pyproject_toml_file.py
+++ b/tests/pyproject/test_pyproject_toml_file.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def test_pyproject_toml_file_invalid(pyproject_toml: Path) -> None:
-    with pyproject_toml.open(mode="a") as f:
+    with pyproject_toml.open(mode="a", encoding="utf-8") as f:
         f.write("<<<<<<<<<<<")
 
     with pytest.raises(PoetryCoreException) as excval:

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -12,6 +12,7 @@ from typing import NamedTuple
 import pytest
 
 from poetry.repositories.installed_repository import InstalledRepository
+from poetry.utils._compat import getencoding
 from poetry.utils._compat import metadata
 from poetry.utils.env import EnvManager
 from poetry.utils.env import MockEnv
@@ -168,7 +169,7 @@ def fix_editable_path_for_windows(
     # to give inconsistent results at different phases of the test suite execution; additionally
     # this represents a more realistic scenario
     editable_pth_file = site_purelib / "editable.pth"
-    editable_pth_file.write_text(editable_source_directory_path)
+    editable_pth_file.write_text(editable_source_directory_path, encoding=getencoding())
 
 
 def test_load_successful(

--- a/tests/utils/env/test_env.py
+++ b/tests/utils/env/test_env.py
@@ -186,7 +186,8 @@ def test_call_does_not_block_on_full_pipe(
 import sys
 for i in range(10000):
     print('just print a lot of text to fill the buffer', file={out})
-"""
+""",
+        encoding="utf-8",
     )
 
     def target(result: list[int]) -> None:
@@ -276,7 +277,7 @@ def test_env_system_packages(
 
     assert (
         f"include-system-site-packages = {str(with_system_site_packages).lower()}"
-        in pyvenv_cfg.read_text()
+        in pyvenv_cfg.read_text(encoding="utf-8")
     )
     assert env.includes_system_site_packages is with_system_site_packages
 

--- a/tests/utils/env/test_env.py
+++ b/tests/utils/env/test_env.py
@@ -527,7 +527,8 @@ def test_detect_active_python_with_bat(poetry: Poetry, tmp_path: Path) -> None:
     """On Windows pyenv uses batch files for python management."""
     python_wrapper = tmp_path / "python.bat"
     wrapped_python = Path(r"C:\SpecialPython\python.exe")
-    with python_wrapper.open("w") as f:
+    encoding = "locale" if sys.version_info >= (3, 10) else None
+    with python_wrapper.open("w", encoding=encoding) as f:
         f.write(f"@echo {wrapped_python}")
     os.environ["PATH"] = str(python_wrapper.parent) + os.pathsep + os.environ["PATH"]
 

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -924,17 +924,13 @@ def test_create_venv_finds_no_python_executable(
     manager: EnvManager,
     poetry: Poetry,
     config: Config,
-    mocker: MockerFixture,
     config_virtualenvs_path: Path,
     venv_name: str,
 ) -> None:
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
-    poetry.package.python_versions = "^3.6"
-
-    mocker.patch("sys.version_info", (3, 4, 5))
-    mocker.patch("shutil.which", return_value=None)
+    poetry.package.python_versions = "^999"
 
     with pytest.raises(NoCompatiblePythonVersionFound) as e:
         manager.create_venv()

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -167,9 +167,12 @@ def test_detect_corrupted_cache_key_file(
 
     # original content: 9999999999"value"
 
-    write_modes = {str: "w", bytes: "wb"}
-    with open(key1_path, write_modes[type(corrupt_payload)]) as f:
-        f.write(corrupt_payload)  # write corrupt data
+    if isinstance(corrupt_payload, str):
+        with open(key1_path, "w", encoding="utf-8") as f:
+            f.write(corrupt_payload)  # write corrupt data
+    else:
+        with open(key1_path, "wb") as f:
+            f.write(corrupt_payload)  # write corrupt data
 
     assert poetry_file_cache.get("key1") is None
 
@@ -333,7 +336,7 @@ def test_get_cached_archive_for_link_no_race_condition(
     def replace_file(_: str, dest: Path) -> None:
         dest.unlink(missing_ok=True)
         # write some data (so it takes a while) to provoke possible race conditions
-        dest.write_text("a" * 2**20)
+        dest.write_text("a" * 2**20, encoding="utf-8")
 
     download_mock = mocker.Mock(side_effect=replace_file)
 

--- a/tests/vcs/git/test_system.py
+++ b/tests/vcs/git/test_system.py
@@ -23,6 +23,7 @@ def get_head_sha(cwd: Path) -> str:
         ["git", "rev-parse", "HEAD"],
         cwd=cwd,
         text=True,
+        encoding="utf-8",
     ).strip()
 
 
@@ -39,7 +40,7 @@ def temp_repo(tmp_path: Path) -> TempRepoFixture:
     repo = dulwich.repo.Repo.init(str(tmp_path))
 
     # init commit
-    (tmp_path / "foo").write_text("foo")
+    (tmp_path / "foo").write_text("foo", encoding="utf-8")
     repo.stage(["foo"])
 
     init_commit = repo.do_commit(
@@ -50,7 +51,7 @@ def temp_repo(tmp_path: Path) -> TempRepoFixture:
     )
 
     # extra commit
-    (tmp_path / "foo").write_text("bar")
+    (tmp_path / "foo").write_text("bar", encoding="utf-8")
     repo.stage(["foo"])
 
     head_commit = repo.do_commit(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8892 

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

This PR fixes Encoding Warnings with PEP 597 warnings enabled and enables the warnings in CI. There are also a few warnings with poetry-core and cleo, and I can submit PRs for those repos as well.