### PR TITLE
Fix install console script with extras

### DIFF
--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -158,8 +158,9 @@ class EditableBuilder(Builder):
 
         scripts = entry_points.get("console_scripts", [])
         for script in scripts:
-            name, script = script.split(" = ")
-            module, callable_ = script.split(":")
+            name, script_with_extras = script.split(" = ")
+            script_without_extras = script_with_extras.split("[")[0]
+            module, callable_ = script_without_extras.split(":")
             callable_holder = callable_.split(".", 1)[0]
 
             script_file = scripts_path.joinpath(name)


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8899

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

_Credit to @snorfalorpagus for finding the fix_

In the [documented example](https://python-poetry.org/docs/pyproject/#scripts), `poetry install` should generate a python file named `devtest` to run `test.run_tests()` NOT `test.run_tests[test]()