### PR TITLE
chore: use freebsd-13-2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-13-1
+  image_family: freebsd-13-2
   cpu: 2
   memory: 4G
 


### PR DESCRIPTION
As it seems `freebsd-13-1` is not available anymore, see e.g. https://github.com/python-poetry/poetry/pull/8898/checks?check_run_id=20752096072