### PR TITLE
Change docs to use `--only main` syntax, and add missing argument to Dockerfile example

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,7 +153,7 @@ poetry install --without test,docs
 ```
 
 {{% note %}}
-The `--no-dev` option is now deprecated. You should use the `--without dev` notation instead.
+The `--no-dev` option is now deprecated. You should use the `--without dev` or `--only main` notation instead.
 {{% /note %}}
 
 You can also select optional dependency groups with the `--with` option.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,7 +153,7 @@ poetry install --without test,docs
 ```
 
 {{% note %}}
-The `--no-dev` option is now deprecated. You should use the `--without dev` or `--only main` notation instead.
+The `--no-dev` option is now deprecated. You should use the `--only main` or `--without dev` notation instead.
 {{% /note %}}
 
 You can also select optional dependency groups with the `--with` option.
@@ -262,7 +262,7 @@ is set to `false` because the old installer always compiles source files to byte
 * `--extras (-E)`: Features to install (multiple values allowed).
 * `--all-extras`: Install all extra features (conflicts with --extras).
 * `--compile`: Compile Python source files to bytecode.
-* `--no-dev`: Do not install dev dependencies. (**Deprecated**, use `--without dev` or `--only main` instead)
+* `--no-dev`: Do not install dev dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--remove-untracked`: Remove dependencies not presented in the lock file. (**Deprecated**, use `--sync` instead)
 
 {{% note %}}
@@ -301,7 +301,7 @@ You can do this using the `add` command.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
-* `--no-dev` : Do not update the development dependencies. (**Deprecated**, use `--without dev` or `--only main` instead)
+* `--no-dev` : Do not update the development dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--lock` : Do not perform install (only update the lockfile).
 
 {{% note %}}
@@ -509,7 +509,7 @@ required by
 * `--why`: When showing the full list, or a `--tree` for a single package, display whether they are a direct dependency or required by other packages.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
-* `--no-dev`: Do not list the dev dependencies. (**Deprecated**, use `--without dev` or `--only main` instead)
+* `--no-dev`: Do not list the dev dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -214,7 +214,7 @@ For example, you might have a Dockerfile that looks something like this:
 FROM python
 COPY pyproject.toml poetry.lock .
 COPY src/ ./src
-RUN pip install poetry && poetry install --without dev
+RUN pip install poetry && poetry install --only main
 ```
 
 As soon as *any* source file changes, the cache for the `RUN` layer will be invalidated, which forces all 3rd party dependencies (likely the slowest step out of these) to be installed again if you changed any files in `src/`.
@@ -229,9 +229,9 @@ This might look something like this:
 ```text
 FROM python
 COPY pyproject.toml poetry.lock .
-RUN pip install poetry && poetry install --no-root --no-directory
+RUN pip install poetry && poetry install --only main --no-root --no-directory
 COPY src/ ./src
-RUN poetry install --without dev
+RUN poetry install --only main
 ```
 
 The two key options we are using here are `--no-root` (skips installing the project source) and `--no-directory` (skips installing any local directory path dependencies, you can omit this if you don't have any).


### PR DESCRIPTION
This PR describes a suggestion which I believe improves upon two small issues I have with the docs regarding the `--without dev`/`--only main` option for the `poetry install` command.

1) The Commands page disagrees with the deprecation warning when using the deprecated `--no-dev` option: the Commands page suggests using `--without dev` instead, but the deprecation warning suggests using `--only main` here: https://github.com/python-poetry/poetry/blob/ed1dcddebb6337997829df5b6c73b020cdcdee99/src/poetry/console/commands/group_command.py#L86

    To resolve this, I updated the Commands page to suggest both options. Personally, I think `--only main` is preferrable overall because it works even if the dev dependency group doesn't exist, but it might be helpful for readers to know that both options are viable.

2) The FAQ entry about avoiding Docker cache busting doesn't apply either of the `--without dev` or `--only main` options to the first install statement, but rather only the second install statement. Based on my testing, this causes dev dependencies to get installed, which I think is not intended.

    To resolve this I added `--only main` to the first install statement, and also changed the second install statement to use the `--only main` syntax rather than the `--without dev` syntax for the reasons described above.