### PR TITLE
Add --sync CLI option to update subcommand

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -303,6 +303,7 @@ You can do this using the `add` command.
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
 * `--no-dev` : Do not update the development dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--lock` : Do not perform install (only update the lockfile).
+* `--sync`: Synchronize the environment with the locked packages and the specified groups.
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.

--- a/src/poetry/console/commands/update.py
+++ b/src/poetry/console/commands/update.py
@@ -24,6 +24,12 @@ class UpdateCommand(InstallerCommand):
             " (<warning>Deprecated</warning>)",
         ),
         option(
+            "sync",
+            None,
+            "Synchronize the environment with the locked packages and the specified"
+            " groups.",
+        ),
+        option(
             "dry-run",
             None,
             "Output the operations but do not execute anything "
@@ -41,6 +47,7 @@ class UpdateCommand(InstallerCommand):
 
         self.installer.only_groups(self.activated_groups)
         self.installer.dry_run(self.option("dry-run"))
+        self.installer.requires_synchronization(self.option("sync"))
         self.installer.execute_operations(not self.option("lock"))
 
         # Force update

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -4,13 +4,14 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from tests.helpers import get_package
 from poetry.console.commands.update import UpdateCommand
+from tests.helpers import get_package
 
 
 if TYPE_CHECKING:
-    from poetry.poetry import Poetry
     from pytest_mock import MockerFixture
+
+    from poetry.poetry import Poetry
     from tests.helpers import TestRepository
     from tests.types import CommandTesterFactory
     from tests.types import FixtureDirGetter

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -84,6 +84,7 @@ def test_update_prints_operations(
 
 @pytest.fixture()
 def test_update_sync_option_is_passed_to_the_installer(
+    command_tester_factory: CommandTesterFactory,
     mocker: MockerFixture
 ) -> None:
     """

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -9,6 +9,7 @@ from tests.helpers import get_package
 
 if TYPE_CHECKING:
     from poetry.poetry import Poetry
+    from pytest_mock import MockerFixture
     from tests.helpers import TestRepository
     from tests.types import CommandTesterFactory
     from tests.types import FixtureDirGetter
@@ -80,3 +81,17 @@ def test_update_prints_operations(
 
     assert ("Package operations:" in output) is expected
     assert ("Installing docker (4.3.1)" in output) is expected
+
+@pytest.fixture()
+def test_update_sync_option_is_passed_to_the_installer(
+    mocker: MockerFixture
+) -> None:
+    """
+    The --sync option is passed properly to the installer from update.
+    """
+    tester = command_tester_factory("update", poetry=poetry_with_outdated_lockfile)
+    mocker.patch.object(tester.command.installer, "run", return_value=1)
+
+    tester.execute("--sync")
+
+    assert tester.command.installer._requires_synchronization

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from tests.helpers import get_package
+from poetry.console.commands.update import UpdateCommand
 
 
 if TYPE_CHECKING:
@@ -92,6 +93,7 @@ def test_update_sync_option_is_passed_to_the_installer(
     The --sync option is passed properly to the installer from update.
     """
     tester = command_tester_factory("update", poetry=poetry_with_outdated_lockfile)
+    assert isinstance(tester.command, UpdateCommand)
     mocker.patch.object(tester.command.installer, "run", return_value=1)
 
     tester.execute("--sync")

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -83,9 +83,10 @@ def test_update_prints_operations(
     assert ("Installing docker (4.3.1)" in output) is expected
 
 
-@pytest.fixture()
 def test_update_sync_option_is_passed_to_the_installer(
-    command_tester_factory: CommandTesterFactory, mocker: MockerFixture
+    poetry_with_outdated_lockfile: Poetry,
+    command_tester_factory: CommandTesterFactory,
+    mocker: MockerFixture,
 ) -> None:
     """
     The --sync option is passed properly to the installer from update.

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -82,10 +82,10 @@ def test_update_prints_operations(
     assert ("Package operations:" in output) is expected
     assert ("Installing docker (4.3.1)" in output) is expected
 
+
 @pytest.fixture()
 def test_update_sync_option_is_passed_to_the_installer(
-    command_tester_factory: CommandTesterFactory,
-    mocker: MockerFixture
+    command_tester_factory: CommandTesterFactory, mocker: MockerFixture
 ) -> None:
     """
     The --sync option is passed properly to the installer from update.


### PR DESCRIPTION
Adds `--sync` to the `update` subcommand to match `install`.