### PR TITLE
provider: consider explicit source when searching for a locked package with a source reference in the repository pool

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -487,7 +487,9 @@ class Provider:
                         package.pretty_name,
                         package.version,
                         extras=list(dependency.extras),
-                        repository_name=dependency.source_name,
+                        repository_name=(
+                            dependency.source_name or package.source_reference
+                        ),
                     ),
                 )
             except PackageNotFound as e:

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -3417,6 +3417,104 @@ def test_direct_dependency_with_extras_from_explicit_and_transitive_dependency2(
     )
 
 
+@pytest.mark.parametrize("locked", [False, True])
+def test_multiple_constraints_explicit_source_transitive_locked_use_latest(
+    package: ProjectPackage,
+    repo: Repository,
+    pool: RepositoryPool,
+    io: NullIO,
+    locked: bool,
+) -> None:
+    """
+    The root package depends on
+     * lib[extra] == 1.0; sys_platform != "linux" with source=explicit1
+     * lib[extra] == 2.0; sys_platform == "linux" with source=explicit2
+     * other >= 1.0
+    "other" depends on "lib" (without an extra and of course without an explicit source
+    because explicit sources can only be defined in the root package).
+
+    If only "other" is in use_latest (equivalent to "poetry update other"),
+    the transitive dependency of "other" on "lib" is resolved before
+    the direct dependency on "lib[extra]" (if packages have been locked before).
+    We still have to make sure that the locked package is looked up in the explicit
+    source although the DependencyCache is not used for locked packages,
+    so we can't rely on it to propagate the correct source.
+    """
+    package.add_dependency(
+        Factory.create_dependency(
+            "lib",
+            {
+                "version": "1.0",
+                "extras": ["extra"],
+                "source": "explicit1",
+                "markers": "sys_platform != 'linux'",
+            },
+        )
+    )
+    package.add_dependency(
+        Factory.create_dependency(
+            "lib",
+            {
+                "version": "2.0",
+                "extras": ["extra"],
+                "source": "explicit2",
+                "markers": "sys_platform == 'linux'",
+            },
+        )
+    )
+    package.add_dependency(Factory.create_dependency("other", {"version": ">=1.0"}))
+
+    explicit_repo1 = Repository("explicit1")
+    pool.add_repository(explicit_repo1, priority=Priority.EXPLICIT)
+    explicit_repo2 = Repository("explicit2")
+    pool.add_repository(explicit_repo2, priority=Priority.EXPLICIT)
+
+    dep_extra = get_dependency("extra", ">=1.0")
+    dep_extra_opt = Factory.create_dependency(
+        "extra", {"version": ">=1.0", "optional": True}
+    )
+    package_lib1 = Package(
+        "lib", "1.0", source_type="legacy", source_reference="explicit1"
+    )
+    package_lib1.extras = {canonicalize_name("extra"): [dep_extra]}
+    package_lib1.add_dependency(dep_extra_opt)
+    explicit_repo1.add_package(package_lib1)
+    package_lib2 = Package(
+        "lib", "2.0", source_type="legacy", source_reference="explicit2"
+    )
+    package_lib2.extras = {canonicalize_name("extra"): [dep_extra]}
+    package_lib2.add_dependency(dep_extra_opt)
+    explicit_repo2.add_package(package_lib2)
+
+    package_extra = Package("extra", "1.0")
+    repo.add_package(package_extra)
+    package_other = Package("other", "1.5")
+    package_other.add_dependency(Factory.create_dependency("lib", ">=1.0"))
+    repo.add_package(package_other)
+
+    if locked:
+        locked_packages = [package_extra, package_lib1, package_lib2, package_other]
+        use_latest = [canonicalize_name("other")]
+    else:
+        locked_packages = []
+        use_latest = None
+    solver = Solver(package, pool, [], locked_packages, io)
+
+    transaction = solver.solve(use_latest=use_latest)
+
+    ops = check_solver_result(
+        transaction,
+        [
+            {"job": "install", "package": package_extra},
+            {"job": "install", "package": package_lib1},
+            {"job": "install", "package": package_lib2},
+            {"job": "install", "package": package_other},
+        ],
+    )
+    assert ops[1].package.source_reference == "explicit1"
+    assert ops[2].package.source_reference == "explicit2"
+
+
 def test_solver_discards_packages_with_empty_markers(
     package: ProjectPackage,
     repo: Repository,

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -3826,7 +3826,7 @@ def test_solver_should_not_update_same_version_packages_if_installed_has_no_sour
         "1.0.0",
         source_type="legacy",
         source_url="https://foo.bar",
-        source_reference="custom",
+        source_reference="repo",
     )
     repo.add_package(foo)
 

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -3826,7 +3826,7 @@ def test_solver_should_not_update_same_version_packages_if_installed_has_no_sour
         "1.0.0",
         source_type="legacy",
         source_url="https://foo.bar",
-        source_reference="repo",
+        source_reference="custom",
     )
     repo.add_package(foo)
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8928

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

1st commit: naive approach

- fixes first test added in `test_provider`
- breaks second and third test added in `test_provider` (which both succed without the change)

2nd commit: more sophisticated, robust approach