### PR TITLE
Fix documentation command for adding a supplemental source 

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -247,7 +247,7 @@ You can configure a package source as a supplemental source with `priority = "su
 source configuration.
 
 ```bash
-poetry source add --priority=supplemental https://foo.bar/simple/
+poetry source add --priority=supplemental foo https://foo.bar/simple/
 ```
 
 There can be more than one supplemental package source.

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -226,7 +226,7 @@ You can configure a package source as a secondary source with `priority = "secon
 source configuration.
 
 ```bash
-poetry source add --priority=secondary https://foo.bar/simple/
+poetry source add --priority=secondary foo https://foo.bar/simple/
 ```
 
 There can be more than one secondary package source.


### PR DESCRIPTION
The command requires both a name and an URL
