### PR TITLE
Add a dir generated by `pytest` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST.in
 /docs/site/*
 /tests/fixtures/simple_project/setup.py
 /tests/fixtures/project_with_extras/setup.py
+/tests/fixtures/project_with_setup_calls_script/project_with_setup_calls_script.egg-info/
 .mypy_cache
 
 .venv


### PR DESCRIPTION
I'm guessing we don't want it in the repo, though adding
it would be an alternative.