### PR TITLE
avoid unwanted work during install

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -855,17 +855,18 @@ class Executor:
         package = operation.package
 
         if not package.source_url or package.source_type == "legacy":
-            # Since we are installing from our own distribution cache
-            # pip will write a `direct_url.json` file pointing to the cache
-            # distribution.
-            # That's not what we want, so we remove the direct_url.json file,
-            # if it exists.
-            for (
-                direct_url_json
-            ) in self._env.site_packages.find_distribution_direct_url_json_files(
-                distribution_name=package.name, writable_only=True
-            ):
-                direct_url_json.unlink(missing_ok=True)
+            if not self._use_modern_installation:
+                # Since we are installing from our own distribution cache pip will write
+                # a `direct_url.json` file pointing to the cache distribution.
+                #
+                # That's not what we want, so we remove the direct_url.json file, if it
+                # exists.
+                for (
+                    direct_url_json
+                ) in self._env.site_packages.find_distribution_direct_url_json_files(
+                    distribution_name=package.name, writable_only=True
+                ):
+                    direct_url_json.unlink(missing_ok=True)
             return
 
         url_reference: dict[str, Any] | None = None


### PR DESCRIPTION
#8984 got me wondering what the mis-typed code was even for.

It turns out that it is to remove `direct_url.json` files that pip includes because we install from the poetry cache.  But this is irrelevant with modern installation.

Saves about half a second - 10% or so - on my computer when installing poetry itself.  Presumably the savings are roughly proportional to the size of the packages being installed.