### PR TITLE
deprecate "installer.modern-installation false"

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -70,7 +70,7 @@ class Executor:
         )
         if not self._use_modern_installation:
             self._io.write_line(
-                "<warning>Setting `installer.modern-installation` to `false` "
+                "<warning>Warning: Setting `installer.modern-installation` to `false` "
                 "is deprecated.</>"
             )
             self._io.write_line(

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -68,6 +68,17 @@ class Executor:
         self._use_modern_installation = config.get(
             "installer.modern-installation", True
         )
+        if not self._use_modern_installation:
+            self._io.write_line(
+                "<warning>Setting `installer.modern-installation` to `false` "
+                "is deprecated.</>"
+            )
+            self._io.write_line(
+                "<warning>The pip-based installer will be removed in a future release.</>"
+            )
+            self._io.write_line(
+                "<warning>See https://github.com/python-poetry/poetry/issues/8987.</>"
+            )
 
         if parallel is None:
             parallel = config.get("installer.parallel", True)

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1169,6 +1169,12 @@ def test_executor_fallback_on_poetry_create_error_without_wheel_installer(
     })
 
     executor = Executor(env, pool, config, io)
+    warning_lines = io.fetch_output().splitlines()
+    assert warning_lines == [
+        "Setting `installer.modern-installation` to `false` is deprecated.",
+        "The pip-based installer will be removed in a future release.",
+        "See https://github.com/python-poetry/poetry/issues/8987.",
+    ]
 
     directory_package = Package(
         "simple-project",

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1171,7 +1171,7 @@ def test_executor_fallback_on_poetry_create_error_without_wheel_installer(
     executor = Executor(env, pool, config, io)
     warning_lines = io.fetch_output().splitlines()
     assert warning_lines == [
-        "Setting `installer.modern-installation` to `false` is deprecated.",
+        "Warning: Setting `installer.modern-installation` to `false` is deprecated.",
         "The pip-based installer will be removed in a future release.",
         "See https://github.com/python-poetry/poetry/issues/8987.",
     ]


### PR DESCRIPTION
As proposed at #8987

I started with `warnings.warn` but something about all the cleo io cleverness results in those messages disappearing.  Anyway this deprecation is more user-facing than developer-facing, so regular warning output is probably fine.

I'd be happy to see this deprecation in the upcoming release, might as well get it out there and see who squeals.  But no big deal if it misses the cut.