### PR TITLE
[Docs] removed quotes on plugin name.

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -452,7 +452,7 @@ The syntax for registering a plugin is:
 [tool.poetry.plugins] # Optional super table
 
 [tool.poetry.plugins."A"]
-"B" = "C:D"
+B = "C:D"
 ```
 Which are:
 


### PR DESCRIPTION
The quotes were confusing since the name of the plugin does need to wrapped in quote, even according the example bellow it.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

~~- [ ] Added **tests** for changed code.~~ 
~~- [ ] Updated **documentation** for changed code.~~

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
