### PR TITLE
doc: add pytorch example for explicit source

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -320,6 +320,14 @@ poetry will choose a suitable one based on the available package versions.
 poetry add requests pendulum
 ```
 
+{{% note %}}
+A package is looked up, by default, only from the [Default Package Source]({{< relref "repositories/#default-package-source" >}}).
+You can modify the default source (PyPI); or add and use [Supplemental Package Sources]({{< relref "repositories/#supplemental-package-sources" >}})
+or [Explicit Package Sources]({{< relref "repositories/#explicit-package-sources" >}}).
+
+For more information, refer to the [Package Sources]({{< relref "repositories/#package-sources" >}}) documentation.
+{{% /note %}}
+
 You can also specify a constraint when adding a package:
 
 ```bash

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -275,6 +275,15 @@ poetry source add --priority=explicit foo https://foo.bar/simple/
 
 There can be more than one explicit package source.
 
+{{% note %}}
+A real-world example where an explicit package source is useful, is for PyTorch GPU packages.
+
+```bash
+poetry source add --priority=explicit pytorch-gpu-src https://download.pytorch.org/whl/cu118
+poetry add --source pytorch-gpu-src torch torchvision torchaudio
+```
+{{% /note %}}
+
 #### Package Source Constraint
 
 All package sources (including secondary and possibly supplemental sources) will be searched during the package lookup


### PR DESCRIPTION
Closes: #8246

This is a rework of #8246. 