### PR TITLE
config: fix handling of venv opts env vars

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -299,6 +299,8 @@ class Config:
             "virtualenvs.create",
             "virtualenvs.in-project",
             "virtualenvs.options.always-copy",
+            "virtualenvs.options.no-pip",
+            "virtualenvs.options.no-setuptools",
             "virtualenvs.options.system-site-packages",
             "virtualenvs.options.prefer-active-python",
             "experimental.system-git-client",

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -275,6 +275,11 @@ class Config:
 
             value = value[key]
 
+        if self._use_environment and isinstance(value, dict):
+            # this is a configuration table, it is likely that we missed env vars
+            # in order to capture them recurse, eg: virtualenvs.options
+            return {k: self.get(f"{setting_name}.{k}") for k in value}
+
         return self.process(value)
 
     def process(self, value: Any) -> Any:

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -75,6 +75,23 @@ def test_config_get_from_environment_variable(
     assert config.get(name) is value
 
 
+def test_config_get_from_environment_variable_nested(
+    config: Config,
+    environ: Iterator[None],
+) -> None:
+    options = config.default_config["virtualenvs"]["options"]
+    expected = {}
+
+    for k, v in options.items():
+        if isinstance(v, bool):
+            expected[k] = not v
+            os.environ[f"POETRY_VIRTUALENVS_OPTIONS_{k.upper().replace('-', '_')}"] = (
+                "true" if expected[k] else "false"
+            )
+
+    assert config.get("virtualenvs.options") == expected
+
+
 @pytest.mark.parametrize(
     ("path_config", "expected"),
     [("~/.venvs", Path.home() / ".venvs"), ("venv", Path("venv"))],


### PR DESCRIPTION
This change correctly handles virtual environment creation options provided via environment variables. For example, previously when `POETRY_VIRTUALENVS_OPTIONS_SYSTEM_SITE_PACKAGES` was specified via an environment variable, this was incorrectly ignored when a virtual environment was created.

### Reproduction Instruction
```sh
podman run --rm -i --entrypoint bash docker.io/python:3.12 <<EOF
set -xe
python -m pip install --disable-pip-version-check -q git+https://github.com/python-poetry/poetry.git
export POETRY_VIRTUALENVS_OPTIONS_SYSTEM_SITE_PACKAGES=true
export POETRY_VIRTUALENVS_IN_PROJECT=true
poetry new demo
pushd demo
poetry install
cat .venv/pyvenv.cfg
EOF
```

### Current Behaviour
The key `include-system-site-packages`  is set to `false`.

```ini
home = /usr/local/bin
implementation = CPython
version_info = 3.12.2.final.0
virtualenv = 20.25.1
include-system-site-packages = false
base-prefix = /usr/local
base-exec-prefix = /usr/local
base-executable = /usr/local/bin/python3.12
prompt = demo-py3.12
```

### After Fix Behaviour
```sh
podman run --rm -i --entrypoint bash docker.io/python:3.12 <<EOF
set -xe
python -m pip install --disable-pip-version-check -q git+https://github.com/python-poetry/poetry.git@refs/pull/9015/head
export POETRY_VIRTUALENVS_OPTIONS_SYSTEM_SITE_PACKAGES=true
export POETRY_VIRTUALENVS_IN_PROJECT=true
poetry new demo
pushd demo
poetry install
cat .venv/pyvenv.cfg
EOF
```

The key `include-system-site-packages`  is correctly set to `true`.

```ini
home = /usr/local/bin
implementation = CPython
version_info = 3.12.2.final.0
virtualenv = 20.25.1
include-system-site-packages = true
base-prefix = /usr/local
base-exec-prefix = /usr/local
base-executable = /usr/local/bin/python3.12
prompt = demo-py3.12
```