### PR TITLE
Trust the setup reader when it finds no requirements

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -369,16 +369,9 @@ class PackageInfo:
             name=result.get("name"),
             version=result.get("version"),
             summary=result.get("description", ""),
-            requires_dist=requirements or None,
+            requires_dist=requirements,
             requires_python=python_requires,
         )
-
-        if not (info.name and info.version) and not info.requires_dist:
-            # there is nothing useful here
-            raise PackageInfoError(
-                path,
-                "No core metadata (name, version, requires-dist) could be retrieved.",
-            )
 
         return info
 
@@ -582,7 +575,7 @@ def get_pep517_metadata(path: Path) -> PackageInfo:
 
     with contextlib.suppress(PackageInfoError):
         info = PackageInfo.from_setup_files(path)
-        if all([info.version, info.name, info.requires_dist]):
+        if all(x is not None for x in (info.version, info.name, info.requires_dist)):
             return info
 
     with ephemeral_environment(

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -318,7 +318,7 @@ def test_info_setup_complex_calls_script(demo_setup_complex_calls_script: Path) 
 
 
 @pytest.mark.network
-@pytest.mark.parametrize("missing", ["version", "name", "install_requires"])
+@pytest.mark.parametrize("missing", ["version", "name"])
 def test_info_setup_missing_mandatory_should_trigger_pep517(
     mocker: MockerFixture, source_dir: Path, missing: str
 ) -> None:
@@ -326,7 +326,7 @@ def test_info_setup_missing_mandatory_should_trigger_pep517(
     setup += "setup("
     setup += 'name="demo", ' if missing != "name" else ""
     setup += 'version="0.1.0", ' if missing != "version" else ""
-    setup += 'install_requires=["package"]' if missing != "install_requires" else ""
+    setup += 'install_requires=["package"]'
     setup += ")"
 
     setup_py = source_dir / "setup.py"
@@ -335,6 +335,24 @@ def test_info_setup_missing_mandatory_should_trigger_pep517(
     spy = mocker.spy(VirtualEnv, "run")
     _ = PackageInfo.from_directory(source_dir)
     assert spy.call_count == 1
+
+
+@pytest.mark.network
+def test_info_setup_missing_install_requires_is_fine(
+    mocker: MockerFixture, source_dir: Path
+) -> None:
+    setup = "from setuptools import setup; "
+    setup += "setup("
+    setup += 'name="demo", '
+    setup += 'version="0.1.0", '
+    setup += ")"
+
+    setup_py = source_dir / "setup.py"
+    setup_py.write_text(setup)
+
+    spy = mocker.spy(VirtualEnv, "run")
+    _ = PackageInfo.from_directory(source_dir)
+    assert spy.call_count == 0
 
 
 def test_info_prefer_poetry_config_over_egg_info(fixture_dir: FixtureDirGetter) -> None:


### PR DESCRIPTION
follow up to #9000 

the setup reader should now be failing if it is not confident about the answers that it is giving: so when it says that a package has no requirements we can believe it rather than assuming that we need to build that package to make sure.

gives a nice speed-up in the cases where it happens eg `petname` is a package out in the wild that has the necessary properties if you want to try it: on my computer `poetry add --lock --no-cache petname` goes from about 8 seconds to about 1 second