### PR TITLE
gh: tweak issue templates for wrapping issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---bug-report.yml
@@ -8,8 +8,7 @@ body:
       value: |
         Thank you for taking the time to file a complete bug report.
 
-        Before submitting your issue, please review the [Before submitting a bug report](https://python-poetry.org/docs/contributing/#before-submitting-a-bug-report)
-        section of our documentation.
+        Before submitting your issue, please review the [Before submitting a bug report](https://python-poetry.org/docs/contributing/#before-submitting-a-bug-report) section of our documentation.
 
   - type: textarea
     attributes:
@@ -17,8 +16,7 @@ body:
       description: |
         Please describe what happened, with as much pertinent information as you can. Feel free to use markdown syntax.
 
-        Also, ensure that the issue is not already fixed in the [latest](https://github.com/python-poetry/poetry/releases/latest)
-        Poetry release.
+        Also, ensure that the issue is not already fixed in the [latest](https://github.com/python-poetry/poetry/releases/latest) Poetry release.
       render: "Markdown"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/---documentation.yml
+++ b/.github/ISSUE_TEMPLATE/---documentation.yml
@@ -8,11 +8,11 @@ body:
       value: |
         Thank you for taking the time to file a complete bug report.
 
-        Before submitting your issue, please review the [Suggesting enhancements](https://python-poetry.org/docs/contributing/#suggesting-enhancements)
-        section of our documentation.
+        Before submitting your issue, please review the [Suggesting enhancements](https://python-poetry.org/docs/contributing/#suggesting-enhancements) section of our documentation.
 
-        - [ ] I have searched the [issues](https://github.com/python-poetry/poetry/issues) of this repo and believe that this is not a duplicate.
-        - [ ] I have searched the [FAQ](https://python-poetry.org/docs/faq/) and general [documentation](https://python-poetry.org/docs/) and believe that my question is not already covered.
+        Please also confirm the following:
+        - I have searched the [issues](https://github.com/python-poetry/poetry/issues) of this repo and believe that this is not a duplicate.
+        - I have searched the [FAQ](https://python-poetry.org/docs/faq/) and general [documentation](https://python-poetry.org/docs/) and believe that my question is not already covered.
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/---documentation.yml
+++ b/.github/ISSUE_TEMPLATE/---documentation.yml
@@ -11,8 +11,8 @@ body:
         Before submitting your issue, please review the [Suggesting enhancements](https://python-poetry.org/docs/contributing/#suggesting-enhancements) section of our documentation.
 
         Please also confirm the following:
-        - I have searched the [issues](https://github.com/python-poetry/poetry/issues) of this repo and believe that this is not a duplicate.
-        - I have searched the [FAQ](https://python-poetry.org/docs/faq/) and general [documentation](https://python-poetry.org/docs/) and believe that my question is not already covered.
+        - You have searched the [issues](https://github.com/python-poetry/poetry/issues) of this repository and believe that this is not a duplicate.
+        - You have searched the [FAQ](https://python-poetry.org/docs/faq/) and general [documentation](https://python-poetry.org/docs/) and believe that your question is not already covered.
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/---feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/---feature-request.yml
@@ -8,8 +8,7 @@ body:
       value: |
         Thank you for taking the time to file a complete bug report.
 
-        Before submitting your issue, please search [issues](https://github.com/python-poetry/poetry/issues) to ensure
-        this is not a duplicate.
+        Before submitting your issue, please search [issues](https://github.com/python-poetry/poetry/issues) to ensure this is not a duplicate.
 
         If the issue is trivial, why not submit a pull request instead?
 
@@ -40,8 +39,7 @@ body:
     attributes:
       label: Impact
       description: |
-        Please describe the motivation for this issue. Describe, as best you can, how this improves or impacts the users
-        of Poetry and why this is important.
+        Please describe the motivation for this issue. Describe, as best you can, how this improves or impacts the users of Poetry and why this is important.
       render: "Markdown"
     validations:
       required: true


### PR DESCRIPTION
Follow-up to https://github.com/python-poetry/poetry/pull/9027, tweak the wrapping of the new issue forms since modified Markdown rules appear to apply. Also remove check-boxes that cannot actually be checked by the user.