### PR TITLE
lazy-wheel: handle internal server error and others

### DIFF
--- a/tests/inspection/test_lazy_wheel.py
+++ b/tests/inspection/test_lazy_wheel.py
@@ -156,9 +156,11 @@ def handle_request_factory(fixture_dir: FixtureDirGetter) -> RequestCallbackFact
     "negative_offset_error",
     [
         None,
+        (codes.not_found, b"Not found"),  # Nexus
         (codes.method_not_allowed, b"Method not allowed"),
         (codes.requested_range_not_satisfiable, b"Requested range not satisfiable"),
-        (codes.not_implemented, b"Unsupported client range"),
+        (codes.internal_server_error, b"Internal server error"),  # GAR
+        (codes.not_implemented, b"Unsupported client range"),  # PyPI
         (NEGATIVE_OFFSET_AS_POSITIVE, b"handle negative offset as positive"),
     ],
 )


### PR DESCRIPTION
if the server returns an internal server error (500), it probably does not support negative offsets

# Pull Request Check List

Resolves: #9026 #9030

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
