### PR TITLE
refactor(env_manager): split out python detection

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -16,6 +16,7 @@ from tomlkit import inline_table
 from poetry.console.commands.command import Command
 from poetry.console.commands.env_command import EnvCommand
 from poetry.utils.dependency_specification import RequirementsParser
+from poetry.utils.env.python_manager import Python
 
 
 if TYPE_CHECKING:
@@ -96,7 +97,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         from poetry.config.config import Config
         from poetry.layouts import layout
         from poetry.pyproject.toml import PyProjectTOML
-        from poetry.utils.env import EnvManager
 
         is_interactive = self.io.is_interactive() and allow_interactive
 
@@ -174,11 +174,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             config = Config.create()
             python = (
                 ">="
-                + EnvManager.get_python_version(
-                    precision=2,
-                    prefer_active_python=config.get("virtualenvs.prefer-active-python"),
-                    io=self.io,
-                ).to_string()
+                + Python.get_preferred_python(config, self.io).minor_version.to_string()
             )
 
             if is_interactive:

--- a/src/poetry/utils/env/python_manager.py
+++ b/src/poetry/utils/env/python_manager.py
@@ -102,6 +102,14 @@ class Python:
         return cls(executable=sys.executable)
 
     @classmethod
+    def get_by_name(cls, python_name: str) -> Python | None:
+        executable = cls._full_python_path(python_name)
+        if not executable:
+            return None
+
+        return cls(executable=executable)
+
+    @classmethod
     def get_preferred_python(cls, config: Config, io: IO | None = None) -> Python:
         io = io or NullIO()
 

--- a/src/poetry/utils/env/python_manager.py
+++ b/src/poetry/utils/env/python_manager.py
@@ -46,3 +46,7 @@ class Python:
     @cached_property
     def minor_version(self) -> Version:
         return Version.from_parts(major=self.version.major, minor=self.version.minor)
+
+    @classmethod
+    def get_system_python(cls) -> Python:
+        return cls(executable=sys.executable)

--- a/src/poetry/utils/env/python_manager.py
+++ b/src/poetry/utils/env/python_manager.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from functools import cached_property
+from pathlib import Path
+
+from poetry.core.constraints.version import Version
+
+from poetry.utils._compat import decode
+from poetry.utils.env.script_strings import GET_PYTHON_VERSION_ONELINER
+
+
+class Python:
+    def __init__(self, executable: str | Path, version: Version | None = None) -> None:
+        self.executable = Path(executable)
+        self._version = version
+
+    @property
+    def version(self) -> Version:
+        if not self._version:
+            if self.executable == Path(sys.executable):
+                python_version = ".".join(str(v) for v in sys.version_info[:3])
+            else:
+                encoding = "locale" if sys.version_info >= (3, 10) else None
+                python_version = decode(
+                    subprocess.check_output(
+                        [str(self.executable), "-c", GET_PYTHON_VERSION_ONELINER],
+                        text=True,
+                        encoding=encoding,
+                    ).strip()
+                )
+            self._version = Version.parse(python_version)
+
+        return self._version
+
+    @cached_property
+    def patch_version(self) -> Version:
+        return Version.from_parts(
+            major=self.version.major,
+            minor=self.version.minor,
+            patch=self.version.patch,
+        )
+
+    @cached_property
+    def minor_version(self) -> Version:
+        return Version.from_parts(major=self.version.major, minor=self.version.minor)

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1113,7 +1113,10 @@ def test_respect_prefer_active_on_init(
         return result
 
     mocker.patch("subprocess.check_output", side_effect=mock_check_output)
-
+    mocker.patch(
+        "poetry.utils.env.python_manager.Python._full_python_path",
+        return_value=Path(f"/usr/bin/python{python}"),
+    )
     config.config["virtualenvs"]["prefer-active-python"] = prefer_active
     pyproject_file = source_dir / "pyproject.toml"
 

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -215,6 +215,10 @@ def test_respect_prefer_active_on_new(
         return output
 
     mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+    mocker.patch(
+        "poetry.utils.env.python_manager.Python._full_python_path",
+        return_value=Path(f"/usr/bin/python{python}"),
+    )
 
     config.config["virtualenvs"]["prefer-active-python"] = prefer_active
 

--- a/tests/utils/env/test_env.py
+++ b/tests/utils/env/test_env.py
@@ -492,35 +492,6 @@ def test_build_environment_not_called_without_build_script_specified(
         assert not env.executed  # type: ignore[attr-defined]
 
 
-def test_fallback_on_detect_active_python(
-    poetry: Poetry, mocker: MockerFixture
-) -> None:
-    m = mocker.patch(
-        "subprocess.check_output",
-        side_effect=subprocess.CalledProcessError(1, "some command"),
-    )
-    env_manager = EnvManager(poetry)
-    active_python = env_manager._detect_active_python()
-
-    assert active_python is None
-    assert m.call_count == 1
-
-
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-def test_detect_active_python_with_bat(poetry: Poetry, tmp_path: Path) -> None:
-    """On Windows pyenv uses batch files for python management."""
-    python_wrapper = tmp_path / "python.bat"
-    wrapped_python = Path(r"C:\SpecialPython\python.exe")
-    encoding = "locale" if sys.version_info >= (3, 10) else None
-    with python_wrapper.open("w", encoding=encoding) as f:
-        f.write(f"@echo {wrapped_python}")
-    os.environ["PATH"] = str(python_wrapper.parent) + os.pathsep + os.environ["PATH"]
-
-    active_python = EnvManager(poetry)._detect_active_python()
-
-    assert active_python == wrapped_python
-
-
 def test_command_from_bin_preserves_relative_path(manager: EnvManager) -> None:
     # https://github.com/python-poetry/poetry/issues/7959
     env = manager.get()

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -1070,7 +1070,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
 
     m.assert_called_with(
         config_virtualenvs_path / f"{venv_name}-py{version.major}.{version.minor}",
-        executable=None,
+        executable=Path(sys.executable),
         flags=venv_flags_default,
         prompt=f"simple-project-py{version.major}.{version.minor}",
     )

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -992,7 +992,10 @@ def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
 
     poetry.package.python_versions = "^4.8"
 
-    mocker.patch("subprocess.check_output", side_effect=[sys.base_prefix])
+    mocker.patch(
+        "subprocess.check_output",
+        side_effect=[sys.base_prefix, "/usr/bin/python", "3.9.0"],
+    )
     m = mocker.patch(
         "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
     )

--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -22,3 +22,12 @@ def test_python_get_version_on_the_fly() -> None:
     assert python.minor_version == Version.parse(
         ".".join([str(s) for s in sys.version_info[:2]])
     )
+
+
+def test_python_get_system_python() -> None:
+    python = Python.get_system_python()
+
+    assert python.executable == Path(sys.executable)
+    assert python.version == Version.parse(
+        ".".join(str(v) for v in sys.version_info[:3])
+    )

--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import sys
+
+from pathlib import Path
+
+from poetry.core.constraints.version import Version
+
+from poetry.utils.env.python_manager import Python
+
+
+def test_python_get_version_on_the_fly() -> None:
+    python = Python(executable=sys.executable)
+
+    assert python.executable == Path(sys.executable)
+    assert python.version == Version.parse(
+        ".".join([str(s) for s in sys.version_info[:3]])
+    )
+    assert python.patch_version == Version.parse(
+        ".".join([str(s) for s in sys.version_info[:3]])
+    )
+    assert python.minor_version == Version.parse(
+        ".".join([str(s) for s in sys.version_info[:2]])
+    )

--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+import pytest
+
+from cleo.io.null_io import NullIO
 from poetry.core.constraints.version import Version
 
 from poetry.utils.env.python_manager import Python
+from tests.utils.env.test_env_manager import check_output_wrapper
+
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from poetry.config.config import Config
 
 
 def test_python_get_version_on_the_fly() -> None:
@@ -31,3 +44,64 @@ def test_python_get_system_python() -> None:
     assert python.version == Version.parse(
         ".".join(str(v) for v in sys.version_info[:3])
     )
+
+
+def test_python_get_preferred_default(config: Config) -> None:
+    python = Python.get_preferred_python(config)
+
+    assert python.executable == Path(sys.executable)
+    assert python.version == Version.parse(
+        ".".join(str(v) for v in sys.version_info[:3])
+    )
+
+
+def test_python_get_preferred_activated(config: Config, mocker: MockerFixture) -> None:
+    mocker.patch(
+        "subprocess.check_output",
+        side_effect=check_output_wrapper(Version.parse("3.7.1")),
+    )
+    config.config["virtualenvs"]["prefer-active-python"] = True
+    python = Python.get_preferred_python(config)
+
+    assert python.executable.as_posix().startswith("/usr/bin/python")
+    assert python.version == Version.parse("3.7.1")
+
+
+def test_python_get_preferred_activated_fallback(
+    config: Config, mocker: MockerFixture
+) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = True
+    with mocker.patch(
+        "subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "some command"),
+    ):
+        python = Python.get_preferred_python(config)
+
+    assert python.executable == Path(sys.executable)
+
+
+def test_fallback_on_detect_active_python(mocker: MockerFixture) -> None:
+    m = mocker.patch(
+        "subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "some command"),
+    )
+
+    active_python = Python._detect_active_python(NullIO())
+
+    assert active_python is None
+    assert m.call_count == 1
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+def test_detect_active_python_with_bat(tmp_path: Path) -> None:
+    """On Windows pyenv uses batch files for python management."""
+    python_wrapper = tmp_path / "python.bat"
+    wrapped_python = Path(r"C:\SpecialPython\python.exe")
+    encoding = "locale" if sys.version_info >= (3, 10) else None
+    with python_wrapper.open("w", encoding=encoding) as f:
+        f.write(f"@echo {wrapped_python}")
+    os.environ["PATH"] = str(python_wrapper.parent) + os.pathsep + os.environ["PATH"]
+
+    active_python = Python._detect_active_python(NullIO())
+
+    assert active_python == wrapped_python

--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from poetry.config.config import Config
+    from tests.types import ProjectFactory
 
 
 def test_python_get_version_on_the_fly() -> None:
@@ -105,3 +106,16 @@ def test_detect_active_python_with_bat(tmp_path: Path) -> None:
     active_python = Python._detect_active_python(NullIO())
 
     assert active_python == wrapped_python
+
+
+def test_python_find_compatible(project_factory: ProjectFactory) -> None:
+    # Note: This test may fail on Windows systems using Python from the Microsoft Store,
+    # as the executable is named `py.exe`, which is not currently recognized by
+    # Python.get_compatible_python. This issue will be resolved in #2117.
+    # However, this does not cause problems in our case because Poetry's own
+    # Python interpreter is used before attempting to find another compatible version.
+    fixture = Path(__file__).parent.parent / "fixtures" / "simple_project"
+    poetry = project_factory("simple-project", source=fixture)
+    python = Python.get_compatible_python(poetry)
+
+    assert Version.from_parts(3, 4) <= python.version <= Version.from_parts(4, 0)


### PR DESCRIPTION
At the moment the `env_manager` is more or less a big ball of mud, mainly due to violating the single responsible principle. Beside the original purpose - handling environments - it also includes lot of logic to find the desired python interpreter.

This PR refactor the env_manager by split out the logic for finding the path to the desired python interpreter.