### PR TITLE
use ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,18 +20,13 @@ repos:
       - id: debug-statements
       - id: check-docstring-first
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.2.0
-    hooks:
-      - id: black
-        exclude: tests/([^/]*/)*fixtures/
-
   - repo: https://github.com/pre-commit/pre-commit
     rev: v3.6.2
     hooks:
       - id: validate_manifest
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.3.0
     hooks:
-    -   id: ruff
+      - id: ruff
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,11 +139,6 @@ required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 "src/poetry/console/*" = ["RUF012"]  # Can't annotate properly until new version of Cleo
 
-[tool.black]
-target-version = ['py38']
-preview = true
-extend-exclude = "tests/([^/]*/)*fixtures/"
-
 [tool.mypy]
 files = "src, tests"
 mypy_path = "src"

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -144,9 +144,9 @@ class Layout:
 
         if self._dev_dependencies:
             for dep_name, dep_constraint in self._dev_dependencies.items():
-                poetry_content["group"]["dev"]["dependencies"][
-                    dep_name
-                ] = dep_constraint
+                poetry_content["group"]["dev"]["dependencies"][dep_name] = (
+                    dep_constraint
+                )
         else:
             del poetry_content["group"]
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -903,9 +903,7 @@ def test_init_existing_pyproject_consistent_linesep(
     existing_section = """
 [tool.black]
 line-length = 88
-""".replace(
-        "\n", linesep
-    )
+""".replace("\n", linesep)
     with open(pyproject_file, "w", newline="") as f:
         f.write(existing_section)
     tester.execute(inputs=init_basic_inputs)

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -1127,9 +1127,7 @@ def test_lock_file_resolves_file_url_symlinks(root: ProjectPackage) -> None:
             dir=d1
         ) as d4, tempfile.TemporaryDirectory(dir=d2) as d3, tempfile.NamedTemporaryFile(
             dir=d4
-        ) as source_file, tempfile.NamedTemporaryFile(
-            dir=d3
-        ) as lock_file:
+        ) as source_file, tempfile.NamedTemporaryFile(dir=d3) as lock_file:
             lock_file.close()
             try:
                 os.symlink(Path(d3), symlink_path)

--- a/tests/utils/env/conftest.py
+++ b/tests/utils/env/conftest.py
@@ -8,7 +8,6 @@ from poetry.utils.env import EnvManager
 
 
 if TYPE_CHECKING:
-
     from poetry.poetry import Poetry
     from tests.types import FixtureDirGetter
     from tests.types import ProjectFactory

--- a/tests/utils/env/test_env.py
+++ b/tests/utils/env/test_env.py
@@ -27,7 +27,6 @@ from poetry.utils.env import build_environment
 
 
 if TYPE_CHECKING:
-
     from pytest_mock import MockerFixture
 
     from poetry.poetry import Poetry


### PR DESCRIPTION
differences between ruff format and black are pretty much negligible.

Since pre-commit is already installing ruff and the ruff formatter is faster... might as well switch