### PR TITLE
trust empty requires dist with modern metadata

### DIFF
--- a/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps_dynamic/PKG-INFO
+++ b/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps_dynamic/PKG-INFO
@@ -1,0 +1,11 @@
+Metadata-Version: 2.2
+Name: demo
+Version: 0.1.0
+Summary: Demo project.
+Home-page: https://github.com/demo/demo
+Author: Sébastien Eustace
+Author-email: sebastien@eustace.io
+License: MIT
+Description: UNKNOWN
+Platform: UNKNOWN
+Dynamic: Requires-Dist

--- a/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps_dynamic/pyproject.toml
+++ b/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps_dynamic/pyproject.toml
@@ -1,0 +1,19 @@
+# this was copied over and modified from orjson project's pyproject.toml
+# https://github.com/ijl/orjson/blob/master/pyproject.toml
+[project]
+name = "demo"
+repository = "https://github.com/demo/demo"
+
+[build-system]
+build-backend = "maturin"
+requires = ["maturin>=0.8.1,<0.9"]
+
+[tool.maturin]
+manylinux = "off"
+sdist-include = ["Cargo.lock", "json/**/*"]
+strip = "on"
+
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'

--- a/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps_for_sure/PKG-INFO
+++ b/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps_for_sure/PKG-INFO
@@ -1,0 +1,10 @@
+Metadata-Version: 2.3
+Name: demo
+Version: 0.1.0
+Summary: Demo project.
+Home-page: https://github.com/demo/demo
+Author: Sébastien Eustace
+Author-email: sebastien@eustace.io
+License: MIT
+Description: UNKNOWN
+Platform: UNKNOWN

--- a/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps_for_sure/pyproject.toml
+++ b/tests/fixtures/inspection/demo_no_setup_pkg_info_no_deps_for_sure/pyproject.toml
@@ -1,0 +1,19 @@
+# this was copied over and modified from orjson project's pyproject.toml
+# https://github.com/ijl/orjson/blob/master/pyproject.toml
+[project]
+name = "demo"
+repository = "https://github.com/demo/demo"
+
+[build-system]
+build-backend = "maturin"
+requires = ["maturin>=0.8.1,<0.9"]
+
+[tool.maturin]
+manylinux = "off"
+sdist-include = ["Cargo.lock", "json/**/*"]
+strip = "on"
+
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -272,10 +272,30 @@ def test_info_from_setup_cfg(demo_setup_cfg: Path) -> None:
 
 
 def test_info_no_setup_pkg_info_no_deps(fixture_dir: FixtureDirGetter) -> None:
-    info = PackageInfo.from_directory(
-        fixture_dir("inspection") / "demo_no_setup_pkg_info_no_deps",
-        disable_build=True,
+    info = PackageInfo.from_metadata_directory(
+        fixture_dir("inspection") / "demo_no_setup_pkg_info_no_deps"
     )
+    assert info is not None
+    assert info.name == "demo"
+    assert info.version == "0.1.0"
+    assert info.requires_dist is None
+
+
+def test_info_no_setup_pkg_info_no_deps_for_sure(fixture_dir: FixtureDirGetter) -> None:
+    info = PackageInfo.from_metadata_directory(
+        fixture_dir("inspection") / "demo_no_setup_pkg_info_no_deps_for_sure",
+    )
+    assert info is not None
+    assert info.name == "demo"
+    assert info.version == "0.1.0"
+    assert info.requires_dist == []
+
+
+def test_info_no_setup_pkg_info_no_deps_dynamic(fixture_dir: FixtureDirGetter) -> None:
+    info = PackageInfo.from_metadata_directory(
+        fixture_dir("inspection") / "demo_no_setup_pkg_info_no_deps_dynamic",
+    )
+    assert info is not None
     assert info.name == "demo"
     assert info.version == "0.1.0"
     assert info.requires_dist is None


### PR DESCRIPTION
when modern metadata says that it has no requires-dist, we can trust it

I bet it doesn't often matter:
- https://github.com/pypi/warehouse/pull/13606 was only just released
- as of today presumably more or less no-one (poetry included) is yet publishing metadata versioned at 2.2 or higher
- and probably nearly all newly published packages also publish wheels anyway.

still, when it happens it happens, and avoiding unnecessary builds is a good win