### PR TITLE
docs: add git subdirectory example to `poetry add`

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -79,6 +79,8 @@ You can specify a package in the following forms:
   - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)
   - A git url with a revision\
  (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
+  - A subdirectory of a git repository\
+ (<b>git+https://github.com/python-poetry/poetry.git#subdirectory=tests/fixtures/sample_project</b>)
   - A git SSH url (<b>git+ssh://github.com/python-poetry/poetry.git</b>)
   - A git SSH url with a revision\
  (<b>git+ssh://github.com/python-poetry/poetry.git#develop</b>)


### PR DESCRIPTION
I managed to find the correct incantation by trial and error, but thought it'd be nice to have an example in the help message. I noticed afterwards that it is already described in the actual documentation (https://python-poetry.org/docs/dependency-specification/#git-dependencies).