### PR TITLE
lazy-wheel: allow redirects for HEAD request

### DIFF
--- a/src/poetry/inspection/lazy_wheel.py
+++ b/src/poetry/inspection/lazy_wheel.py
@@ -410,7 +410,9 @@ class LazyFileOverHTTP(ReadOnlyIOWrapper):
         :raises HTTPRangeRequestUnsupported: if the response fails to indicate support
                                              for "bytes" ranges."""
         self._request_count += 1
-        head = self._session.head(self._url, headers=self._uncached_headers())
+        head = self._session.head(
+            self._url, headers=self._uncached_headers(), allow_redirects=True
+        )
         head.raise_for_status()
         assert head.status_code == codes.ok
         accepted_range = head.headers.get("Accept-Ranges", None)

--- a/tests/inspection/test_lazy_wheel.py
+++ b/tests/inspection/test_lazy_wheel.py
@@ -317,6 +317,16 @@ def test_metadata_from_wheel_url_with_redirect(
     )
 
 
+def test_metadata_from_wheel_url_with_redirect_after_500(
+    assert_metadata_from_wheel_url: AssertMetadataFromWheelUrl,
+) -> None:
+    assert_metadata_from_wheel_url(
+        negative_offset_error=(codes.internal_server_error, b"Internal server error"),
+        expected_requests=10,
+        redirect=True,
+    )
+
+
 @pytest.mark.parametrize(
     ("negative_offset_failure", "expected_requests"),
     [


### PR DESCRIPTION
Resolves: #9039
Closes: #9040

Rework for #9040 as we prepare for 1.8.2. Reduces scope to actual issue in #9039, fixes pre-commit issues and adds test coverage.