### PR TITLE
cli/new: support interactive config

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,11 +102,17 @@ my-package
 
 ### Options
 
+* `--interactive (-i)`: Allow interactive specification of project configuration.
 * `--name`: Set the resulting package name.
 * `--src`: Use the src layout for the project.
 * `--readme`: Specify the readme file extension. Default is `md`. If you intend to publish to PyPI
   keep the [recommendations for a PyPI-friendly README](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/)
   in mind.
+* `--description`: Description of the package.
+* `--author`: Author of the package.
+* `--python` Compatible Python versions.
+* `--dependency`: Package to require with a version constraint. Should be in format `foo:1.0.0`.
+* `--dev-dependency`: Development requirements, see `--dependency`.
 
 
 ## init

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -71,13 +72,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
     def handle(self) -> int:
         from pathlib import Path
 
-        from poetry.core.vcs.git import GitConfig
-
-        from poetry.config.config import Config
-        from poetry.layouts import layout
-        from poetry.pyproject.toml import PyProjectTOML
-        from poetry.utils.env import EnvManager
-
         project_path = Path.cwd()
 
         if self.io.input.option("directory"):
@@ -87,6 +81,24 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     "<error>The --directory path is not a directory.</error>"
                 )
                 return 1
+
+        return self._init_pyproject(project_path=project_path)
+
+    def _init_pyproject(
+        self,
+        project_path: Path,
+        allow_interactive: bool = True,
+        layout_name: str = "standard",
+        readme_format: str = "md",
+    ) -> int:
+        from poetry.core.vcs.git import GitConfig
+
+        from poetry.config.config import Config
+        from poetry.layouts import layout
+        from poetry.pyproject.toml import PyProjectTOML
+        from poetry.utils.env import EnvManager
+
+        is_interactive = self.io.is_interactive() and allow_interactive
 
         pyproject = PyProjectTOML(project_path / "pyproject.toml")
 
@@ -107,7 +119,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         vcs_config = GitConfig()
 
-        if self.io.is_interactive():
+        if is_interactive:
             self.line("")
             self.line(
                 "This command will guide you through creating your"
@@ -117,21 +129,24 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         name = self.option("name")
         if not name:
-            name = Path.cwd().name.lower()
+            name = project_path.name.lower()
 
-            question = self.create_question(
-                f"Package name [<comment>{name}</comment>]: ", default=name
-            )
-            name = self.ask(question)
+            if is_interactive:
+                question = self.create_question(
+                    f"Package name [<comment>{name}</comment>]: ", default=name
+                )
+                name = self.ask(question)
 
         version = "0.1.0"
-        question = self.create_question(
-            f"Version [<comment>{version}</comment>]: ", default=version
-        )
-        version = self.ask(question)
 
-        description = self.option("description")
-        if not description:
+        if is_interactive:
+            question = self.create_question(
+                f"Version [<comment>{version}</comment>]: ", default=version
+            )
+            version = self.ask(question)
+
+        description = self.option("description") or ""
+        if not description and is_interactive:
             description = self.ask(self.create_question("Description []: ", default=""))
 
         author = self.option("author")
@@ -141,22 +156,23 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             if author_email:
                 author += f" <{author_email}>"
 
-        question = self.create_question(
-            f"Author [<comment>{author}</comment>, n to skip]: ", default=author
-        )
-        question.set_validator(lambda v: self._validate_author(v, author))
-        author = self.ask(question)
+        if is_interactive:
+            question = self.create_question(
+                f"Author [<comment>{author}</comment>, n to skip]: ", default=author
+            )
+            question.set_validator(lambda v: self._validate_author(v, author))
+            author = self.ask(question)
 
         authors = [author] if author else []
 
-        license = self.option("license")
-        if not license:
-            license = self.ask(self.create_question("License []: ", default=""))
+        license_name = self.option("license")
+        if not license_name and is_interactive:
+            license_name = self.ask(self.create_question("License []: ", default=""))
 
         python = self.option("python")
         if not python:
             config = Config.create()
-            default_python = (
+            python = (
                 "^"
                 + EnvManager.get_python_version(
                     precision=2,
@@ -165,13 +181,14 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 ).to_string()
             )
 
-            question = self.create_question(
-                f"Compatible Python versions [<comment>{default_python}</comment>]: ",
-                default=default_python,
-            )
-            python = self.ask(question)
+            if is_interactive:
+                question = self.create_question(
+                    f"Compatible Python versions [<comment>{python}</comment>]: ",
+                    default=python,
+                )
+                python = self.ask(question)
 
-        if self.io.is_interactive():
+        if is_interactive:
             self.line("")
 
         requirements: Requirements = {}
@@ -182,27 +199,25 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         question_text = "Would you like to define your main dependencies interactively?"
         help_message = """\
-You can specify a package in the following forms:
-  - A single name (<b>requests</b>): this will search for matches on PyPI
-  - A name and a constraint (<b>requests@^2.23.0</b>)
-  - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)
-  - A git url with a revision\
- (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
-  - A file path (<b>../my-package/my-package.whl</b>)
-  - A directory (<b>../my-package/</b>)
-  - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)
-"""
+        You can specify a package in the following forms:
+          - A single name (<b>requests</b>): this will search for matches on PyPI
+          - A name and a constraint (<b>requests@^2.23.0</b>)
+          - A git url (<b>git+https://github.com/python-poetry/poetry.git</b>)
+          - A git url with a revision\
+         (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
+          - A file path (<b>../my-package/my-package.whl</b>)
+          - A directory (<b>../my-package/</b>)
+          - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)
+        """
 
         help_displayed = False
-        if self.confirm(question_text, True):
-            if self.io.is_interactive():
-                self.line(help_message)
-                help_displayed = True
+        if is_interactive and self.confirm(question_text, True):
+            self.line(help_message)
+            help_displayed = True
             requirements.update(
                 self._format_requirements(self._determine_requirements([]))
             )
-            if self.io.is_interactive():
-                self.line("")
+            self.line("")
 
         dev_requirements: Requirements = {}
         if self.option("dev-dependency"):
@@ -213,43 +228,60 @@ You can specify a package in the following forms:
         question_text = (
             "Would you like to define your development dependencies interactively?"
         )
-        if self.confirm(question_text, True):
-            if self.io.is_interactive() and not help_displayed:
+        if is_interactive and self.confirm(question_text, True):
+            if not help_displayed:
                 self.line(help_message)
 
             dev_requirements.update(
                 self._format_requirements(self._determine_requirements([]))
             )
-            if self.io.is_interactive():
-                self.line("")
 
-        layout_ = layout("standard")(
+            self.line("")
+
+        layout_ = layout(layout_name)(
             name,
             version,
             description=description,
             author=authors[0] if authors else None,
-            license=license,
+            readme_format=readme_format,
+            license=license_name,
             python=python,
             dependencies=requirements,
             dev_dependencies=dev_requirements,
         )
 
+        create_layout = not project_path.exists()
+
+        if create_layout:
+            layout_.create(project_path, with_pyproject=False)
+
         content = layout_.generate_poetry_content()
         for section, item in content.items():
             pyproject.data.append(section, item)
 
-        if self.io.is_interactive():
+        if is_interactive:
             self.line("<info>Generated file</info>")
             self.line("")
             self.line(pyproject.data.as_string().replace("\r\n", "\n"))
             self.line("")
 
-        if not self.confirm("Do you confirm generation?", True):
+        if is_interactive and not self.confirm("Do you confirm generation?", True):
             self.line_error("<error>Command aborted</error>")
 
             return 1
 
         pyproject.save()
+
+        if create_layout:
+            path = project_path.resolve()
+
+            with suppress(ValueError):
+                path = path.relative_to(Path.cwd())
+
+            self.line(
+                f"Created package <info>{layout_._package_name}</> in"
+                f" <fg=blue>{path.as_posix()}</>"
+            )
 
         return 0
 
@@ -278,7 +310,11 @@ You can specify a package in the following forms:
         requires: list[str],
         allow_prereleases: bool = False,
         source: str | None = None,
+        is_interactive: bool | None = None,
     ) -> list[dict[str, Any]]:
+        if is_interactive is None:
+            is_interactive = self.io.is_interactive()
+
         if not requires:
             result = []
 
@@ -368,7 +404,7 @@ You can specify a package in the following forms:
                 if package:
                     result.append(constraint)
 
-                if self.io.is_interactive():
+                if is_interactive:
                     package = self.ask(follow_up_question)
 
             return result

--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from contextlib import suppress
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
 from cleo.helpers import argument
 from cleo.helpers import option
 
-from poetry.console.commands.command import Command
+from poetry.console.commands.init import InitCommand
 
 
 if TYPE_CHECKING:
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
     from cleo.io.inputs.option import Option
 
 
-class NewCommand(Command):
+class NewCommand(InitCommand):
     name = "new"
     description = "Creates a new Python project at <path>."
 
@@ -23,6 +22,12 @@ class NewCommand(Command):
         argument("path", "The path to create the project at.")
     ]
     options: ClassVar[list[Option]] = [
+        option(
+            "interactive",
+            "i",
+            "Allow interactive specification of project configuration.",
+            flag=True,
+        ),
         option("name", None, "Set the resulting package name.", flag=False),
         option("src", None, "Use the src layout for the project."),
         option(
@@ -31,16 +36,23 @@ class NewCommand(Command):
             "Specify the readme file format. One of md (default) or rst",
             flag=False,
         ),
+        *[
+            o
+            for o in InitCommand.options
+            if o.name
+            in {
+                "description",
+                "author",
+                "python",
+                "dependency",
+                "dev-dependency",
+                "license",
+            }
+        ],
     ]
 
     def handle(self) -> int:
         from pathlib import Path
-
-        from poetry.core.vcs.git import GitConfig
-
-        from poetry.config.config import Config
-        from poetry.layouts import layout
-        from poetry.utils.env import EnvManager
 
         if self.io.input.option("directory"):
             self.line_error(
@@ -48,17 +60,11 @@ class NewCommand(Command):
                 " be ignored. You should consider the option --path instead.</warning>"
             )
 
-        layout_cls = layout("src") if self.option("src") else layout("standard")
-
         path = Path(self.argument("path"))
         if not path.is_absolute():
             # we do not use resolve here due to compatibility issues
             # for path.resolve(strict=False)
             path = Path.cwd().joinpath(path)
-
-        name = self.option("name")
-        if not name:
-            name = path.name
 
         if path.exists() and list(path.glob("*")):
             # Directory is not empty. Aborting.
@@ -66,45 +72,9 @@ class NewCommand(Command):
                 f"Destination <fg=yellow>{path}</> exists and is not empty"
             )
 
-        readme_format = self.option("readme") or "md"
-
-        config = GitConfig()
-        author = None
-        if config.get("user.name"):
-            author = config["user.name"]
-            author_email = config.get("user.email")
-            if author_email:
-                author += f" <{author_email}>"
-
-        poetry_config = Config.create()
-        default_python = (
-            "^"
-            + EnvManager.get_python_version(
-                precision=2,
-                prefer_active_python=poetry_config.get(
-                    "virtualenvs.prefer-active-python"
-                ),
-                io=self.io,
-            ).to_string()
+        return self._init_pyproject(
+            project_path=path,
+            allow_interactive=self.option("interactive"),
+            layout_name="src" if self.option("src") else "standard",
+            readme_format=self.option("readme") or "md",
         )
-
-        layout_ = layout_cls(
-            name,
-            "0.1.0",
-            author=author,
-            readme_format=readme_format,
-            python=default_python,
-        )
-        layout_.create(path)
-
-        path = path.resolve()
-
-        with suppress(ValueError):
-            path = path.relative_to(Path.cwd())
-
-        self.line(
-            f"Created package <info>{layout_._package_name}</> in"
-            f" <fg=blue>{path.as_posix()}</>"
-        )
-
-        return 0

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -103,7 +103,9 @@ class Layout:
 
         return package
 
-    def create(self, path: Path, with_tests: bool = True) -> None:
+    def create(
+        self, path: Path, with_tests: bool = True, with_pyproject: bool = True
+    ) -> None:
         path.mkdir(parents=True, exist_ok=True)
 
         self._create_default(path)
@@ -112,7 +114,8 @@ class Layout:
         if with_tests:
             self._create_tests(path)
 
-        self._write_poetry(path)
+        if with_pyproject:
+            self._write_poetry(path)
 
     def generate_poetry_content(self) -> TOMLDocument:
         template = POETRY_DEFAULT

--- a/tests/console/commands/conftest.py
+++ b/tests/console/commands/conftest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def init_basic_inputs() -> str:
+    return "\n".join(
+        [
+            "my-package",  # Package name
+            "1.2.3",  # Version
+            "This is a description",  # Description
+            "n",  # Author
+            "MIT",  # License
+            "~2.7 || ^3.6",  # Python
+            "n",  # Interactive packages
+            "n",  # Interactive dev packages
+            "\n",  # Generate
+        ]
+    )
+
+
+@pytest.fixture()
+def init_basic_toml() -> str:
+    return """\
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.6"
+"""

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -60,39 +60,6 @@ def tester(patches: None) -> CommandTester:
     return CommandTester(app.find("init"))
 
 
-@pytest.fixture
-def init_basic_inputs() -> str:
-    return "\n".join(
-        [
-            "my-package",  # Package name
-            "1.2.3",  # Version
-            "This is a description",  # Description
-            "n",  # Author
-            "MIT",  # License
-            "~2.7 || ^3.6",  # Python
-            "n",  # Interactive packages
-            "n",  # Interactive dev packages
-            "\n",  # Generate
-        ]
-    )
-
-
-@pytest.fixture()
-def init_basic_toml() -> str:
-    return """\
-[tool.poetry]
-name = "my-package"
-version = "1.2.3"
-description = "This is a description"
-authors = ["Your Name <you@example.com>"]
-license = "MIT"
-readme = "README.md"
-
-[tool.poetry.dependencies]
-python = "~2.7 || ^3.6"
-"""
-
-
 def test_basic_interactive(
     tester: CommandTester, init_basic_inputs: str, init_basic_toml: str
 ) -> None:

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -229,3 +229,12 @@ python = "^{python}"
 """
 
     assert expected in pyproject_file.read_text()
+
+
+def test_basic_interactive_new(
+    tester: CommandTester, tmp_path: Path, init_basic_inputs: str, init_basic_toml: str
+) -> None:
+    path = tmp_path / "somepackage"
+    tester.execute(f"--interactive {path.as_posix()}", inputs=init_basic_inputs)
+    verify_project_directory(path, "my-package", "my_package", None)
+    assert init_basic_toml in tester.io.fetch_output()


### PR DESCRIPTION
This change allows new command to be used interactively similar to the init command. Additionally, this also allows for configuration of description, author, python and dependencies via command line options.

Closes: #8943 #1854 #5710