### PR TITLE
[1.8] Improve error message when installing non-package in package-mode

### DIFF
--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -191,8 +191,8 @@ you can set the "package-mode" to false in your pyproject.toml file.
                 "If you do not want to install the current project"
                 " use <c1>--no-root</c1>.\n"
                 "If you want to use Poetry only for dependency management"
-                " but not for packaging, you can set the operating mode to "
-                '"non-package" in your pyproject.toml file.\n'
+                " but not for packaging, you can disable package mode by setting"
+                " <c1>package-mode = false</> in your pyproject.toml file.\n"
                 "In a future version of Poetry this warning will become an error!",
                 style="warning",
             )


### PR DESCRIPTION
Backport of 026615676f835ff635e9027579dc64f9194cdc37 from #9073.

Looks like our bot is off at the weekend.