### PR TITLE
faster PEP517 builds

### DIFF
--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -127,7 +127,10 @@ class Chef:
     ) -> Path:
         from subprocess import CalledProcessError
 
-        with ephemeral_environment(self._env.python) as venv:
+        with ephemeral_environment(
+            self._env.python,
+            flags={"no-pip": True, "no-setuptools": True, "no-wheel": True},
+        ) as venv:
             env = IsolatedEnv(venv, self._pool)
             builder = ProjectBuilder.from_isolated_env(
                 env, directory, runner=quiet_subprocess_runner


### PR DESCRIPTION
minor simplifications and tweaks to pep517 builds

- update version of `build` used during metadata extraction
- if pep517 metadata extraction fails, don't try fallback to `setup.py egg_info`
  - eggs are long deprecated
  - using setup.py directly from the command line is deprecated
  - if pep517 builds fail then poetry will later refuse to install the package in any case
- no need to install setuptools or wheel in the build environments, if they are needed as build requirements then they will be installed as build requirements
- need pip in the build environment for metadata extraction because we run `venv.run_pip()`, but don't need it in the build environment during final build