### PR TITLE
Add example for dependency with multiple extras

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -423,7 +423,8 @@ Note that `install --extras` and the variations mentioned above (`--all-extras`,
 ```toml
 [tool.poetry.dependencies]
 pandas = {version="^2.2.1", extras=["computation", "performance"]}
-
+```
+```toml
 [tool.poetry.group.dev.dependencies]
 fastapi = {version="^0.92.0", extras=["all"]}
 ```

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -423,6 +423,7 @@ Note that `install --extras` and the variations mentioned above (`--all-extras`,
 ```toml
 [tool.poetry.dependencies]
 pandas = {version="^2.2.1", extras=["computation", "performance"]}
+
 [tool.poetry.group.dev.dependencies]
 fastapi = {version="^0.92.0", extras=["all"]}
 ```

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -421,6 +421,8 @@ poetry install --all-extras
 {{% note %}}
 Note that `install --extras` and the variations mentioned above (`--all-extras`, `--extras foo`, etc.) only work on dependencies defined in the current project. If you want to install extras defined by dependencies, you'll have to express that in the dependency itself:
 ```toml
+[tool.poetry.dependencies]
+pandas = {version="^2.2.1", extras=["computation", "performance"]}
 [tool.poetry.group.dev.dependencies]
 fastapi = {version="^0.92.0", extras=["all"]}
 ```


### PR DESCRIPTION
The currently existing example on how to install dependency extras only shows a single dependency:
`fastapi = {version="^0.92.0", extras=["all"]}`

Since right before this example it is shown how to install multiple extras using the command line interface, this can be confusing and lead to hard to understand missing dependencies:
`poetry install --extras "mysql pgsql"`

Note that the CLI has quotes around both extras and no commas, while in pyproject.toml each extra *must* be quoted and comma-separated, which is currently not documented.

Thus the change adds an example with more than one extra, based on pandas.

# Pull Request Check List

Resolves: -



- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Not applicable, pure documentation change.