### PR TITLE
test: enforce tmp working directory

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -338,3 +338,32 @@ def http_setup_redirect(
             status=status_code,
             body=redirect_request_callback,
         )
+
+
+@contextlib.contextmanager
+def switch_working_directory(path: Path, remove: bool = False) -> Iterator[Path]:
+    original_cwd = Path.cwd()
+    os.chdir(path)
+
+    with contextlib.suppress(Exception) as exception:
+        yield path
+
+    os.chdir(original_cwd)
+
+    if remove:
+        shutil.rmtree(path, ignore_errors=True)
+
+    if exception is not None:
+        raise exception
+
+
+@contextlib.contextmanager
+def with_working_directory(source: Path, target: Path | None = None) -> Iterator[Path]:
+    use_copy = target is not None
+
+    if use_copy:
+        assert target is not None
+        shutil.copytree(source, target)
+
+    with switch_working_directory(target or source, remove=use_copy) as path:
+        yield path

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -5,6 +5,7 @@ import zipfile
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Iterator
 from typing import NamedTuple
 
 import pytest
@@ -12,8 +13,9 @@ import pytest
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.utils._compat import metadata
 from poetry.utils.env import EnvManager
-from poetry.utils.env import MockEnv as BaseMockEnv
+from poetry.utils.env import MockEnv
 from poetry.utils.env import VirtualEnv
+from tests.helpers import with_working_directory
 
 
 if TYPE_CHECKING:
@@ -25,57 +27,84 @@ if TYPE_CHECKING:
     from tests.types import FixtureDirGetter
     from tests.types import ProjectFactory
 
-FIXTURES_DIR = Path(__file__).parent / "fixtures"
-ENV_DIR = (FIXTURES_DIR / "installed").resolve()
-SITE_PURELIB = ENV_DIR / "lib" / "python3.7" / "site-packages"
-SITE_PLATLIB = ENV_DIR / "lib64" / "python3.7" / "site-packages"
-SRC = ENV_DIR / "src"
-INSTALLED_RESULTS = [
-    metadata.PathDistribution(SITE_PURELIB / "cleo-0.7.6.dist-info"),
-    metadata.PathDistribution(SRC / "pendulum" / "pendulum.egg-info"),
-    metadata.PathDistribution(
-        zipfile.Path(  # type: ignore[arg-type]
-            str(SITE_PURELIB / "foo-0.1.0-py3.8.egg"),
-            "EGG-INFO",
-        )
-    ),
-    metadata.PathDistribution(SITE_PURELIB / "standard-1.2.3.dist-info"),
-    metadata.PathDistribution(SITE_PURELIB / "editable-2.3.4.dist-info"),
-    metadata.PathDistribution(SITE_PURELIB / "editable-with-import-2.3.4.dist-info"),
-    metadata.PathDistribution(SITE_PLATLIB / "lib64-2.3.4.dist-info"),
-    metadata.PathDistribution(SITE_PLATLIB / "bender-2.0.5.dist-info"),
-    metadata.PathDistribution(SITE_PURELIB / "git_pep_610-1.2.3.dist-info"),
-    metadata.PathDistribution(
-        SITE_PURELIB / "git_pep_610_no_requested_version-1.2.3.dist-info"
-    ),
-    metadata.PathDistribution(
-        SITE_PURELIB / "git_pep_610_subdirectory-1.2.3.dist-info"
-    ),
-    metadata.PathDistribution(SITE_PURELIB / "url_pep_610-1.2.3.dist-info"),
-    metadata.PathDistribution(SITE_PURELIB / "file_pep_610-1.2.3.dist-info"),
-    metadata.PathDistribution(SITE_PURELIB / "directory_pep_610-1.2.3.dist-info"),
-    metadata.PathDistribution(
-        SITE_PURELIB / "editable_directory_pep_610-1.2.3.dist-info"
-    ),
-]
+
+@pytest.fixture(scope="session")
+def env_dir(tmp_session_working_directory: Path) -> Iterator[Path]:
+    source = Path(__file__).parent / "fixtures" / "installed"
+    target = tmp_session_working_directory / source.name
+
+    with with_working_directory(source=source, target=target) as path:
+        yield path
 
 
-class MockEnv(BaseMockEnv):
-    @property
-    def paths(self) -> dict[str, str]:
-        return {
-            "purelib": SITE_PURELIB.as_posix(),
-            "platlib": SITE_PLATLIB.as_posix(),
-        }
+@pytest.fixture(scope="session")
+def site_purelib(env_dir: Path) -> Path:
+    return env_dir / "lib" / "python3.7" / "site-packages"
 
-    @property
-    def sys_path(self) -> list[str]:
-        return [str(path) for path in [ENV_DIR, SITE_PLATLIB, SITE_PURELIB]]
+
+@pytest.fixture(scope="session")
+def site_platlib(env_dir: Path) -> Path:
+    return env_dir / "lib64" / "python3.7" / "site-packages"
+
+
+@pytest.fixture(scope="session")
+def src_dir(env_dir: Path) -> Path:
+    return env_dir / "src"
+
+
+@pytest.fixture(scope="session")
+def installed_results(
+    site_purelib: Path, site_platlib: Path, src_dir: Path
+) -> list[metadata.PathDistribution]:
+    return [
+        metadata.PathDistribution(site_purelib / "cleo-0.7.6.dist-info"),
+        metadata.PathDistribution(src_dir / "pendulum" / "pendulum.egg-info"),
+        metadata.PathDistribution(
+            zipfile.Path(  # type: ignore[arg-type]
+                str(site_purelib / "foo-0.1.0-py3.8.egg"),
+                "EGG-INFO",
+            )
+        ),
+        metadata.PathDistribution(site_purelib / "standard-1.2.3.dist-info"),
+        metadata.PathDistribution(site_purelib / "editable-2.3.4.dist-info"),
+        metadata.PathDistribution(
+            site_purelib / "editable-with-import-2.3.4.dist-info"
+        ),
+        metadata.PathDistribution(site_platlib / "lib64-2.3.4.dist-info"),
+        metadata.PathDistribution(site_platlib / "bender-2.0.5.dist-info"),
+        metadata.PathDistribution(site_purelib / "git_pep_610-1.2.3.dist-info"),
+        metadata.PathDistribution(
+            site_purelib / "git_pep_610_no_requested_version-1.2.3.dist-info"
+        ),
+        metadata.PathDistribution(
+            site_purelib / "git_pep_610_subdirectory-1.2.3.dist-info"
+        ),
+        metadata.PathDistribution(site_purelib / "url_pep_610-1.2.3.dist-info"),
+        metadata.PathDistribution(site_purelib / "file_pep_610-1.2.3.dist-info"),
+        metadata.PathDistribution(site_purelib / "directory_pep_610-1.2.3.dist-info"),
+        metadata.PathDistribution(
+            site_purelib / "editable_directory_pep_610-1.2.3.dist-info"
+        ),
+    ]
 
 
 @pytest.fixture
-def env() -> MockEnv:
-    return MockEnv(path=ENV_DIR)
+def env(
+    env_dir: Path, site_purelib: Path, site_platlib: Path, src_dir: Path
+) -> MockEnv:
+    class _MockEnv(MockEnv):
+        @property
+        def paths(self) -> dict[str, str]:
+            return {
+                "purelib": site_purelib.as_posix(),
+                "platlib": site_platlib.as_posix(),
+            }
+
+        @property
+        def sys_path(self) -> list[str]:
+            return [str(path) for path in [env_dir, site_platlib, site_purelib]]
+
+    return _MockEnv(path=env_dir)
 
 
 @pytest.fixture(autouse=True)
@@ -94,10 +123,14 @@ def mock_git_info(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
-def repository(mocker: MockerFixture, env: MockEnv) -> InstalledRepository:
+def repository(
+    mocker: MockerFixture,
+    env: MockEnv,
+    installed_results: list[metadata.PathDistribution],
+) -> InstalledRepository:
     mocker.patch(
         "poetry.utils._compat.metadata.Distribution.discover",
-        return_value=INSTALLED_RESULTS,
+        return_value=installed_results,
     )
     return InstalledRepository.load(env)
 
@@ -112,26 +145,36 @@ def get_package_from_repository(
 
 
 @pytest.fixture
-def poetry(project_factory: ProjectFactory, fixture_dir: FixtureDirGetter) -> Poetry:
+def poetry(
+    project_factory: ProjectFactory,
+    fixture_dir: FixtureDirGetter,
+    installed_results: list[metadata.PathDistribution],
+) -> Poetry:
     return project_factory("simple", source=fixture_dir("simple_project"))
 
 
-def test_load_successful(repository: InstalledRepository) -> None:
-    assert len(repository.packages) == len(INSTALLED_RESULTS)
+def test_load_successful(
+    repository: InstalledRepository, installed_results: list[metadata.PathDistribution]
+) -> None:
+    assert len(repository.packages) == len(installed_results)
 
 
 def test_load_successful_with_invalid_distribution(
-    caplog: LogCaptureFixture, mocker: MockerFixture, env: MockEnv, tmp_path: Path
+    caplog: LogCaptureFixture,
+    mocker: MockerFixture,
+    env: MockEnv,
+    tmp_path: Path,
+    installed_results: list[metadata.PathDistribution],
 ) -> None:
     invalid_dist_info = tmp_path / "site-packages" / "invalid-0.1.0.dist-info"
     invalid_dist_info.mkdir(parents=True)
     mocker.patch(
         "poetry.utils._compat.metadata.Distribution.discover",
-        return_value=[*INSTALLED_RESULTS, metadata.PathDistribution(invalid_dist_info)],
+        return_value=[*installed_results, metadata.PathDistribution(invalid_dist_info)],
     )
     repository_with_invalid_distribution = InstalledRepository.load(env)
 
-    assert len(repository_with_invalid_distribution.packages) == len(INSTALLED_RESULTS)
+    assert len(repository_with_invalid_distribution.packages) == len(installed_results)
     assert len(caplog.messages) == 1
 
     message = caplog.messages[0]
@@ -316,7 +359,7 @@ def test_load_pep_610_compliant_editable_directory_packages(
 
 
 def test_system_site_packages_source_type(
-    tmp_path: Path, mocker: MockerFixture, poetry: Poetry
+    tmp_path: Path, mocker: MockerFixture, poetry: Poetry, site_purelib: Path
 ) -> None:
     """
     The source type of system site packages
@@ -325,7 +368,7 @@ def test_system_site_packages_source_type(
     venv_path = tmp_path / "venv"
     site_path = tmp_path / "site"
     for dist_info in {"cleo-0.7.6.dist-info", "directory_pep_610-1.2.3.dist-info"}:
-        shutil.copytree(SITE_PURELIB / dist_info, site_path / dist_info)
+        shutil.copytree(site_purelib / dist_info, site_path / dist_info)
     mocker.patch("poetry.utils.env.virtual_env.VirtualEnv.sys_path", [str(site_path)])
     mocker.patch("site.getsitepackages", return_value=[str(site_path)])
 

--- a/tests/types.py
+++ b/tests/types.py
@@ -8,6 +8,7 @@ from typing import Protocol
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+    from typing import ContextManager
     from typing import Dict
     from typing import Tuple
 
@@ -79,3 +80,9 @@ class HTMLPageGetter(Protocol):
 
 class RequestsSessionGet(Protocol):
     def __call__(self, url: str, **__: Any) -> requests.Response: ...
+
+
+class SetProjectContext(Protocol):
+    def __call__(
+        self, project: str | Path, in_place: bool = False
+    ) -> ContextManager[Path]: ...


### PR DESCRIPTION
This change ensures that working director when executing a test is set to `tmp_path` fixture value.

Additionally, we introduce the `set_project_context` fixture that allows for test cases to switch cwd to the required fixture project (copied to `tmp_path` by default) to ensure correct source files are used. Previously, some tests accidentally picked up incorrect pyproject.toml files as a result.
