### PR TITLE
installer: add config installer.only-binary

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -268,8 +268,7 @@ across all your projects if incorrectly set.
 
 *Introduced in 1.9.0*
 
-When set this configuration allows users to configure package distribution format policy for all or
-specific packages. Specifically, to enforce the use of binary distribution format for all, none or
+When set, this configuration allows users to enforce the use of binary distribution format for all, none or
 specific packages.
 
 {{% note %}}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,6 +222,7 @@ you encounter on the [issue tracker](https://github.com/python-poetry/poetry/iss
 *Introduced in 1.2.0*
 
 When set this configuration allows users to configure package distribution format policy for all or
+specific packages. Specifically, to disallow the use of binary distribution format for all, none or
 specific packages.
 
 | Configuration          | Description                                                |
@@ -258,6 +259,25 @@ export POETRY_INSTALLER_NO_BINARY=:all:
 Unless this is required system-wide, if configured globally, you could encounter slower install times
 across all your projects if incorrectly set.
 {{% /warning %}}
+
+### `installer.only-binary`
+
+**Type**: `string | boolean`
+
+**Default**: `false`
+
+**Environment Variable**: `POETRY_INSTALLER_ONLY_BINARY`
+
+*Introduced in 1.9.0*
+
+When set this configuration allows users to configure package distribution format policy for all or
+specific packages. Specifically, to enforce the use of binary distribution format for all, none or
+specific packages.
+
+{{% note %}}
+Please refer to [`installer.no-binary`]({{< relref "configuration#installerno-binary" >}}) for information on allowed
+values, usage instructions and warnings.
+{{% /note %}}
 
 ### `installer.parallel`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,9 +221,7 @@ you encounter on the [issue tracker](https://github.com/python-poetry/poetry/iss
 
 *Introduced in 1.2.0*
 
-When set this configuration allows users to configure package distribution format policy for all or
-specific packages. Specifically, to disallow the use of binary distribution format for all, none or
-specific packages.
+When set, this configuration allows users to disallow the use of binary distribution format for all, none or specific packages.
 
 | Configuration          | Description                                                |
 |------------------------|------------------------------------------------------------|

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -132,6 +132,7 @@ class Config:
             "parallel": True,
             "max-workers": None,
             "no-binary": None,
+            "only-binary": None,
         },
         "solver": {
             "lazy-wheel": True,
@@ -323,7 +324,7 @@ class Config:
         if name == "installer.max-workers":
             return int_normalizer
 
-        if name == "installer.no-binary":
+        if name in ["installer.no-binary", "installer.only-binary"]:
             return PackageFilterPolicy.normalize
 
         return lambda val: val

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -81,6 +81,10 @@ To remove a repository (repo is a short alias for repositories):
                 PackageFilterPolicy.validator,
                 PackageFilterPolicy.normalize,
             ),
+            "installer.only-binary": (
+                PackageFilterPolicy.validator,
+                PackageFilterPolicy.normalize,
+            ),
             "solver.lazy-wheel": (boolean_validator, boolean_normalizer),
             "warnings.export": (boolean_validator, boolean_normalizer),
             "keyring.enabled": (boolean_validator, boolean_normalizer),

--- a/src/poetry/installation/chooser.py
+++ b/src/poetry/installation/chooser.py
@@ -39,6 +39,9 @@ class Chooser:
         self._no_binary_policy: PackageFilterPolicy = PackageFilterPolicy(
             self._config.get("installer.no-binary", [])
         )
+        self._only_binary_policy: PackageFilterPolicy = PackageFilterPolicy(
+            self._config.get("installer.only-binary", [])
+        )
 
     def choose_for(self, package: Package) -> Link:
         """
@@ -66,6 +69,15 @@ class Chooser:
 
             if link.ext in {".egg", ".exe", ".msi", ".rpm", ".srpm"}:
                 logger.debug("Skipping unsupported distribution %s", link.filename)
+                continue
+
+            if link.is_sdist and not self._only_binary_policy.allows(package.name):
+                logger.debug(
+                    "Skipping source distribution for %s as requested in only binary policy for"
+                    " package (%s)",
+                    link.filename,
+                    package.name,
+                )
                 continue
 
             links.append(link)

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -58,6 +58,7 @@ experimental.system-git-client = false
 installer.max-workers = null
 installer.modern-installation = true
 installer.no-binary = null
+installer.only-binary = null
 installer.parallel = true
 keyring.enabled = true
 solver.lazy-wheel = true
@@ -90,6 +91,7 @@ experimental.system-git-client = false
 installer.max-workers = null
 installer.modern-installation = true
 installer.no-binary = null
+installer.only-binary = null
 installer.parallel = true
 keyring.enabled = true
 solver.lazy-wheel = true
@@ -143,6 +145,7 @@ experimental.system-git-client = false
 installer.max-workers = null
 installer.modern-installation = true
 installer.no-binary = null
+installer.only-binary = null
 installer.parallel = true
 keyring.enabled = true
 solver.lazy-wheel = true
@@ -174,6 +177,7 @@ experimental.system-git-client = false
 installer.max-workers = null
 installer.modern-installation = true
 installer.no-binary = null
+installer.only-binary = null
 installer.parallel = true
 keyring.enabled = true
 solver.lazy-wheel = true
@@ -303,6 +307,7 @@ experimental.system-git-client = false
 installer.max-workers = null
 installer.modern-installation = true
 installer.no-binary = null
+installer.only-binary = null
 installer.parallel = true
 keyring.enabled = true
 solver.lazy-wheel = true
@@ -342,6 +347,7 @@ experimental.system-git-client = false
 installer.max-workers = null
 installer.modern-installation = true
 installer.no-binary = null
+installer.only-binary = null
 installer.parallel = true
 keyring.enabled = true
 repositories.foo.url = "https://foo.bar/simple/"
@@ -516,6 +522,13 @@ def test_config_installer_parallel(
 
 
 @pytest.mark.parametrize(
+    ("setting",),
+    [
+        ("installer.no-binary",),
+        ("installer.only-binary",),
+    ],
+)
+@pytest.mark.parametrize(
     ("value", "expected"),
     [
         ("true", [":all:"]),
@@ -528,11 +541,9 @@ def test_config_installer_parallel(
         ("", []),
     ],
 )
-def test_config_installer_no_binary(
-    tester: CommandTester, value: str, expected: list[str]
+def test_config_installer_binary_filter_config(
+    tester: CommandTester, setting: str, value: str, expected: list[str]
 ) -> None:
-    setting = "installer.no-binary"
-
     tester.execute(setting)
     assert tester.io.fetch_output().strip() == "null"
 


### PR DESCRIPTION
This configuration allows users to enforce the use of binary distribution formats for all, none or specific packages within their working environment.

Closes https://github.com/python-poetry/poetry/issues/6798