### PR TITLE
use poetry to manage deps for isolated build envs

### DIFF
--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -1,105 +1,26 @@
 from __future__ import annotations
 
-import os
 import tempfile
 
-from contextlib import redirect_stdout
-from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from build import BuildBackendException
-from build import ProjectBuilder
-from build.env import IsolatedEnv as BaseIsolatedEnv
 from poetry.core.utils.helpers import temporary_directory
-from pyproject_hooks import quiet_subprocess_runner  # type: ignore[import-untyped]
 
 from poetry.utils._compat import decode
-from poetry.utils.env import ephemeral_environment
 from poetry.utils.helpers import extractall
+from poetry.utils.isolated_build import IsolatedBuildError
+from poetry.utils.isolated_build import isolated_builder
 
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
-
     from poetry.repositories import RepositoryPool
     from poetry.utils.cache import ArtifactCache
     from poetry.utils.env import Env
 
 
 class ChefError(Exception): ...
-
-
-class ChefBuildError(ChefError): ...
-
-
-class ChefInstallError(ChefError):
-    def __init__(self, requirements: Collection[str], output: str, error: str) -> None:
-        message = "\n\n".join(
-            (
-                f"Failed to install {', '.join(requirements)}.",
-                f"Output:\n{output}",
-                f"Error:\n{error}",
-            )
-        )
-        super().__init__(message)
-        self._requirements = requirements
-
-    @property
-    def requirements(self) -> Collection[str]:
-        return self._requirements
-
-
-class IsolatedEnv(BaseIsolatedEnv):
-    def __init__(self, env: Env, pool: RepositoryPool) -> None:
-        self._env = env
-        self._pool = pool
-
-    @property
-    def python_executable(self) -> str:
-        return str(self._env.python)
-
-    def make_extra_environ(self) -> dict[str, str]:
-        path = os.environ.get("PATH")
-        scripts_dir = str(self._env._bin_dir)
-        return {
-            "PATH": (
-                os.pathsep.join([scripts_dir, path])
-                if path is not None
-                else scripts_dir
-            )
-        }
-
-    def install(self, requirements: Collection[str]) -> None:
-        from cleo.io.buffered_io import BufferedIO
-        from poetry.core.packages.dependency import Dependency
-        from poetry.core.packages.project_package import ProjectPackage
-
-        from poetry.config.config import Config
-        from poetry.installation.installer import Installer
-        from poetry.packages.locker import Locker
-        from poetry.repositories.installed_repository import InstalledRepository
-
-        # We build Poetry dependencies from the requirements
-        package = ProjectPackage("__root__", "0.0.0")
-        package.python_versions = ".".join(str(v) for v in self._env.version_info[:3])
-        for requirement in requirements:
-            dependency = Dependency.create_from_pep_508(requirement)
-            package.add_dependency(dependency)
-
-        io = BufferedIO()
-        installer = Installer(
-            io,
-            self._env,
-            package,
-            Locker(self._env.path.joinpath("poetry.lock"), {}),
-            self._pool,
-            Config.create(),
-            InstalledRepository.load(self._env),
-        )
-        installer.update(True)
-        if installer.run() != 0:
-            raise ChefInstallError(requirements, io.fetch_output(), io.fetch_error())
 
 
 class Chef:
@@ -127,46 +48,36 @@ class Chef:
     ) -> Path:
         from subprocess import CalledProcessError
 
-        with ephemeral_environment(
-            self._env.python,
-            flags={"no-pip": True, "no-setuptools": True, "no-wheel": True},
-        ) as venv:
-            env = IsolatedEnv(venv, self._pool)
-            builder = ProjectBuilder.from_isolated_env(
-                env, directory, runner=quiet_subprocess_runner
-            )
-            env.install(builder.build_system_requires)
+        distribution = "wheel" if not editable else "editable"
+        error: Exception | None = None
 
-            stdout = StringIO()
-            error: Exception | None = None
-            try:
-                with redirect_stdout(stdout):
-                    dist_format = "wheel" if not editable else "editable"
-                    env.install(
-                        builder.build_system_requires
-                        | builder.get_requires_for_build(dist_format)
+        try:
+            with isolated_builder(
+                source=directory,
+                distribution=distribution,
+                python_executable=self._env.python,
+                pool=self._pool,
+            ) as builder:
+                return Path(
+                    builder.build(
+                        distribution,
+                        destination.as_posix(),
                     )
-                    path = Path(
-                        builder.build(
-                            dist_format,
-                            destination.as_posix(),
-                        )
-                    )
-            except BuildBackendException as e:
-                message_parts = [str(e)]
-                if isinstance(e.exception, CalledProcessError):
-                    text = e.exception.stderr or e.exception.stdout
-                    if text is not None:
-                        message_parts.append(decode(text))
-                else:
-                    message_parts.append(str(e.exception))
+                )
+        except BuildBackendException as e:
+            message_parts = [str(e)]
 
-                error = ChefBuildError("\n\n".join(message_parts))
+            if isinstance(e.exception, CalledProcessError):
+                text = e.exception.stderr or e.exception.stdout
+                if text is not None:
+                    message_parts.append(decode(text))
+            else:
+                message_parts.append(str(e.exception))
 
-            if error is not None:
-                raise error from None
+            error = IsolatedBuildError("\n\n".join(message_parts))
 
-            return path
+        if error is not None:
+            raise error from None
 
     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
         from poetry.core.packages.utils.link import Link

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -18,8 +18,6 @@ from cleo.io.null_io import NullIO
 from poetry.core.packages.utils.link import Link
 
 from poetry.installation.chef import Chef
-from poetry.installation.chef import ChefBuildError
-from poetry.installation.chef import ChefInstallError
 from poetry.installation.chooser import Chooser
 from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall
@@ -34,6 +32,8 @@ from poetry.utils.helpers import get_file_hash
 from poetry.utils.helpers import get_highest_priority_hash_type
 from poetry.utils.helpers import pluralize
 from poetry.utils.helpers import remove_directory
+from poetry.utils.isolated_build import IsolatedBuildError
+from poetry.utils.isolated_build import IsolatedBuildInstallError
 from poetry.utils.pip import pip_install
 
 
@@ -310,7 +310,7 @@ class Executor:
                     trace = ExceptionTrace(e)
                     trace.render(io)
                     pkg = operation.package
-                    if isinstance(e, ChefBuildError):
+                    if isinstance(e, IsolatedBuildError):
                         pip_command = "pip wheel --no-cache-dir --use-pep517"
                         if pkg.develop:
                             requirement = pkg.source_url
@@ -328,7 +328,7 @@ class Executor:
                             f" running '{pip_command} \"{requirement}\"'."
                             "</info>"
                         )
-                    elif isinstance(e, ChefInstallError):
+                    elif isinstance(e, IsolatedBuildInstallError):
                         message = (
                             "<error>"
                             "Cannot install build-system.requires"

--- a/src/poetry/utils/isolated_build.py
+++ b/src/poetry/utils/isolated_build.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+
+from contextlib import contextmanager
+from contextlib import redirect_stdout
+from io import StringIO
+from typing import TYPE_CHECKING
+from typing import Collection
+from typing import Iterator
+
+from build.env import IsolatedEnv as BaseIsolatedEnv
+
+from poetry.utils.env import Env
+from poetry.utils.env import EnvManager
+from poetry.utils.env import ephemeral_environment
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from build import ProjectBuilder
+
+    from poetry.repositories import RepositoryPool
+
+
+class IsolatedBuildBaseError(Exception): ...
+
+
+class IsolatedBuildError(IsolatedBuildBaseError): ...
+
+
+class IsolatedBuildInstallError(IsolatedBuildBaseError):
+    def __init__(self, requirements: Collection[str], output: str, error: str) -> None:
+        message = "\n\n".join(
+            (
+                f"Failed to install {', '.join(requirements)}.",
+                f"Output:\n{output}",
+                f"Error:\n{error}",
+            )
+        )
+        super().__init__(message)
+        self._requirements = requirements
+
+    @property
+    def requirements(self) -> Collection[str]:
+        return self._requirements
+
+
+class IsolatedEnv(BaseIsolatedEnv):
+    def __init__(self, env: Env, pool: RepositoryPool) -> None:
+        self._env = env
+        self._pool = pool
+
+    @property
+    def python_executable(self) -> str:
+        return str(self._env.python)
+
+    def make_extra_environ(self) -> dict[str, str]:
+        path = os.environ.get("PATH")
+        scripts_dir = str(self._env._bin_dir)
+        return {
+            "PATH": (
+                os.pathsep.join([scripts_dir, path])
+                if path is not None
+                else scripts_dir
+            )
+        }
+
+    def install(self, requirements: Collection[str]) -> None:
+        from cleo.io.buffered_io import BufferedIO
+        from poetry.core.packages.dependency import Dependency
+        from poetry.core.packages.project_package import ProjectPackage
+
+        from poetry.config.config import Config
+        from poetry.installation.installer import Installer
+        from poetry.packages.locker import Locker
+        from poetry.repositories.installed_repository import InstalledRepository
+
+        # We build Poetry dependencies from the requirements
+        package = ProjectPackage("__root__", "0.0.0")
+        package.python_versions = ".".join(str(v) for v in self._env.version_info[:3])
+
+        for requirement in requirements:
+            dependency = Dependency.create_from_pep_508(requirement)
+            package.add_dependency(dependency)
+
+        io = BufferedIO()
+
+        installer = Installer(
+            io,
+            self._env,
+            package,
+            Locker(self._env.path.joinpath("poetry.lock"), {}),
+            self._pool,
+            Config.create(),
+            InstalledRepository.load(self._env),
+        )
+        installer.update(True)
+
+        if installer.run() != 0:
+            raise IsolatedBuildInstallError(
+                requirements, io.fetch_output(), io.fetch_error()
+            )
+
+
+@contextmanager
+def isolated_builder(
+    source: Path,
+    distribution: str = "wheel",
+    python_executable: Path | None = None,
+    pool: RepositoryPool | None = None,
+) -> Iterator[ProjectBuilder]:
+    from build import ProjectBuilder
+    from pyproject_hooks import quiet_subprocess_runner  # type: ignore[import-untyped]
+
+    from poetry.factory import Factory
+
+    # we recreate the project's Poetry instance in order to retrieve the correct repository pool
+    # when a pool is not provided
+    pool = pool or Factory().create_poetry().pool
+
+    python_executable = (
+        python_executable or EnvManager.get_system_env(naive=True).python
+    )
+
+    with ephemeral_environment(
+        executable=python_executable,
+        flags={"no-pip": True, "no-setuptools": True, "no-wheel": True},
+    ) as venv:
+        env = IsolatedEnv(venv, pool)
+        stdout = StringIO()
+
+        builder = ProjectBuilder.from_isolated_env(
+            env, source, runner=quiet_subprocess_runner
+        )
+
+        with redirect_stdout(stdout):
+            env.install(builder.build_system_requires)
+
+            # we repeat the build system requirements to avoid poetry installer from removing them
+            env.install(
+                builder.build_system_requires
+                | builder.get_requires_for_build(distribution)
+            )
+
+            yield builder

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1263,7 +1263,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing {package_name} ({package_version} {package_url})
 
-  ChefBuildError
+  IsolatedBuildError
 
   hide the original error
   \
@@ -1409,7 +1409,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing {package_name} ({package_version} {package_url})
 
-  ChefInstallError
+  IsolatedBuildInstallError
 
   Failed to install poetry-core>=1.1.0a7.
   \
@@ -1426,6 +1426,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
     mocker.stopall()  # to get real output
     output = io.fetch_output().strip()
+    print(output)
     assert output.startswith(expected_start)
     assert output.endswith(expected_end)
 

--- a/tests/utils/test_isolated_build.py
+++ b/tests/utils/test_isolated_build.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sys
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from poetry.factory import Factory
+from poetry.puzzle.exceptions import SolverProblemError
+from poetry.puzzle.provider import IncompatibleConstraintsError
+from poetry.repositories import RepositoryPool
+from poetry.repositories.installed_repository import InstalledRepository
+from poetry.utils.env import ephemeral_environment
+from poetry.utils.isolated_build import IsolatedBuildInstallError
+from poetry.utils.isolated_build import IsolatedEnv
+from tests.helpers import get_dependency
+
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+    from pytest_mock import MockerFixture
+
+    from poetry.repositories.pypi_repository import PyPiRepository
+
+
+@pytest.fixture()
+def pool(pypi_repository: PyPiRepository) -> RepositoryPool:
+    pool = RepositoryPool()
+
+    pool.add_repository(pypi_repository)
+
+    return pool
+
+
+@pytest.fixture(autouse=True)
+def setup(mocker: MockerFixture, pool: RepositoryPool) -> None:
+    mocker.patch.object(Factory, "create_pool", return_value=pool)
+
+
+def test_isolated_env_install_success(pool: RepositoryPool) -> None:
+    with ephemeral_environment(Path(sys.executable)) as venv:
+        env = IsolatedEnv(venv, pool)
+        assert not InstalledRepository.load(venv).find_packages(
+            get_dependency("poetry-core")
+        )
+
+        env.install({"poetry-core"})
+        assert InstalledRepository.load(venv).find_packages(
+            get_dependency("poetry-core")
+        )
+
+
+@pytest.mark.parametrize(
+    ("requirements", "exception"),
+    [
+        ({"poetry-core==1.5.0", "poetry-core==1.6.0"}, IncompatibleConstraintsError),
+        ({"black==19.10b0", "attrs==17.4.0"}, SolverProblemError),
+    ],
+)
+def test_isolated_env_install_error(
+    requirements: Collection[str], exception: type[Exception], pool: RepositoryPool
+) -> None:
+    with ephemeral_environment(Path(sys.executable)) as venv:
+        env = IsolatedEnv(venv, pool)
+        with pytest.raises(exception):
+            env.install(requirements)
+
+
+def test_isolated_env_install_failure(
+    pool: RepositoryPool, mocker: MockerFixture
+) -> None:
+    mocker.patch("poetry.installation.installer.Installer.run", return_value=1)
+    with ephemeral_environment(Path(sys.executable)) as venv:
+        env = IsolatedEnv(venv, pool)
+        with pytest.raises(IsolatedBuildInstallError) as e:
+            env.install({"a", "b>1"})
+        assert e.value.requirements == {"a", "b>1"}


### PR DESCRIPTION
Previously, isolated build environments needed for both package installation from sdist and for fallback package metadata  inspection used to rely on inline scripts and delegated management of build  requirements to the build package.

With this change, Poetry manages the build requirements. This enables the use of build requirements from the current projects source, Poetry's configurations and also cache. We also, reduce the use of  subprocesses and thereby increasing speeds of such builds.

Closes: #5650
 