### PR TITLE
isolated build: fallback to PyPI only pool

### DIFF
--- a/src/poetry/utils/isolated_build.py
+++ b/src/poetry/utils/isolated_build.py
@@ -116,9 +116,18 @@ def isolated_builder(
 
     from poetry.factory import Factory
 
-    # we recreate the project's Poetry instance in order to retrieve the correct repository pool
-    # when a pool is not provided
-    pool = pool or Factory().create_poetry().pool
+    try:
+        # we recreate the project's Poetry instance in order to retrieve the correct repository pool
+        # when a pool is not provided
+        pool = pool or Factory().create_poetry().pool
+    except RuntimeError:
+        # the context manager is not being called within a Poetry project context
+        # fallback to a default pool using only PyPI as source
+        from poetry.repositories import RepositoryPool
+        from poetry.repositories.pypi_repository import PyPiRepository
+
+        # fallback to using only PyPI
+        pool = RepositoryPool(repositories=[PyPiRepository()])
 
     python_executable = (
         python_executable or EnvManager.get_system_env(naive=True).python


### PR DESCRIPTION
When isolated builder context manager is invoked outside a Poetry project context, fall back to a PyPI only package source.

This is not mandatory as we do not expect isolated builder context to be used outside of a Poetry project, however this is more graceful than throwing a runtime error.
