### PR TITLE
utils: ensure Downloader defaults to Authenticator

### DIFF
--- a/src/poetry/packages/direct_origin.py
+++ b/src/poetry/packages/direct_origin.py
@@ -9,6 +9,7 @@ from poetry.core.packages.utils.link import Link
 
 from poetry.inspection.info import PackageInfo
 from poetry.inspection.info import PackageInfoError
+from poetry.utils.authenticator import get_default_authenticator
 from poetry.utils.helpers import download_file
 from poetry.utils.helpers import get_file_hash
 from poetry.vcs.git import Git
@@ -56,6 +57,7 @@ def _get_package_from_git(
 class DirectOrigin:
     def __init__(self, artifact_cache: ArtifactCache) -> None:
         self._artifact_cache = artifact_cache
+        self._authenticator = get_default_authenticator()
 
     @classmethod
     def get_package_from_file(cls, file_path: Path) -> Package:
@@ -74,10 +76,13 @@ class DirectOrigin:
     def get_package_from_directory(cls, directory: Path) -> Package:
         return PackageInfo.from_directory(path=directory).to_package(root_dir=directory)
 
+    def _download_file(self, url: str, dest: Path) -> None:
+        download_file(url, dest, session=self._authenticator)
+
     def get_package_from_url(self, url: str) -> Package:
         link = Link(url)
         artifact = self._artifact_cache.get_cached_archive_for_link(
-            link, strict=True, download_func=download_file
+            link, strict=True, download_func=self._download_file
         )
 
         package = self.get_package_from_file(artifact)

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -20,10 +20,9 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import overload
 
-import requests
-
 from requests.utils import atomic_open
 
+from poetry.utils.authenticator import get_default_authenticator
 from poetry.utils.constants import REQUESTS_TIMEOUT
 
 
@@ -171,10 +170,10 @@ class Downloader:
     ):
         self._dest = dest
 
-        get = requests.get if not session else session.get
+        session = session or get_default_authenticator()
         headers = {"Accept-Encoding": "Identity"}
 
-        self._response = get(
+        self._response = session.get(
             url, stream=True, headers=headers, timeout=REQUESTS_TIMEOUT
         )
         self._response.raise_for_status()

--- a/tests/packages/test_direct_origin.py
+++ b/tests/packages/test_direct_origin.py
@@ -44,7 +44,7 @@ def test_direct_origin_does_not_download_url_dependency_when_cached(
     direct_origin = DirectOrigin(artifact_cache)
     url = "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
     download_file = mocker.patch(
-        "poetry.packages.direct_origin.download_file",
+        "poetry.packages.direct_origin.DirectOrigin._download_file",
         side_effect=Exception("download_file should not be called"),
     )
 


### PR DESCRIPTION
This change allows correct usage of http credentials when downloading files.

Resolves: #1444

```sh
poetry config repositories.gh-release-your-org-project https://github.com/your-org/project/releases/download/
poetry config http-basic.gh-release-your-org-project username password
poetry add https://github.com/your-org/project//releases/download/1.1.2/project-1.1.2-py3-none-any.whl
```

### Testing #1444
Modify commands to your specific case.

#### Using pipx
```sh
pipx install --suffix=@9202 'poetry @ git+https://github.com/python-poetry/poetry.git@refs/pull/9202/head'
```

#### Using a container (podman | docker)
```sh
podman run --rm -i --entrypoint bash docker.io/python:3.12 <<EOF
set -xe
python -m pip install --disable-pip-version-check -q git+https://github.com/python-poetry/poetry.git@refs/pull/9202/head

poetry config repositories.gh-release-your-org-project https://github.com/your-org/project/releases/download/
poetry config http-basic.gh-release-your-org-project username password

poetry new foobar
pushd foobar
poetry add [pycowsay](https://github.com/your-org/project//releases/download/1.1.2/project-1.1.2-py3-none-any.whl)
EOF
```