### PR TITLE
tests: replace mock_download with httpretty mock

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,6 @@ from tests.helpers import get_package
 from tests.helpers import http_setup_redirect
 from tests.helpers import isolated_environment
 from tests.helpers import mock_clone
-from tests.helpers import mock_download
 from tests.helpers import switch_working_directory
 from tests.helpers import with_working_directory
 
@@ -278,13 +277,6 @@ def config_dir(tmp_path: Path) -> Path:
 def mock_user_config_dir(mocker: MockerFixture, config_dir: Path) -> None:
     mocker.patch("poetry.locations.CONFIG_DIR", new=config_dir)
     mocker.patch("poetry.config.config.CONFIG_DIR", new=config_dir)
-
-
-@pytest.fixture(autouse=True)
-def download_mock(mocker: MockerFixture) -> None:
-    # Patch download to not download anything but to just copy from fixtures
-    mocker.patch("poetry.utils.helpers.download_file", new=mock_download)
-    mocker.patch("poetry.packages.direct_origin.download_file", new=mock_download)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -734,7 +734,7 @@ def test_add_url_constraint_wheel(
     repo.add_package(get_package("pendulum", "1.4.4"))
 
     tester.execute(
-        "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+        "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
     )
 
     expected = """\
@@ -746,7 +746,7 @@ Package operations: 2 installs, 0 updates, 0 removals
 
   - Installing pendulum (1.4.4)
   - Installing demo\
- (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+ (0.1.0 https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 
 Writing lock file
 """
@@ -760,7 +760,7 @@ Writing lock file
 
     assert "demo" in content["dependencies"]
     assert content["dependencies"]["demo"] == {
-        "url": "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+        "url": "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
     }
 
 
@@ -776,7 +776,7 @@ def test_add_url_constraint_wheel_with_extras(
     repo.add_package(get_package("tomlkit", "0.5.5"))
 
     tester.execute(
-        "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+        "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
         f"[{extra_name},bar]"
     )
 
@@ -791,7 +791,7 @@ Package operations: 4 installs, 0 updates, 0 removals
   - Installing pendulum (1.4.4)
   - Installing tomlkit (0.5.5)
   - Installing demo\
- (0.1.0 https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
+ (0.1.0 https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 
 Writing lock file
 """
@@ -808,7 +808,7 @@ Writing lock file
     assert "demo" in content["dependencies"]
     assert content["dependencies"]["demo"] == {
         "url": (
-            "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+            "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
         ),
         "extras": [extra_name, "bar"],
     }

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -2070,7 +2070,9 @@ def test_url_dependency_is_not_outdated_by_repository_package(
     installed: Repository,
     repo: TestRepository,
 ) -> None:
-    demo_url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    demo_url = (
+        "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    )
     poetry.package.add_dependency(
         Factory.create_dependency(
             "demo",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,6 @@ import contextlib
 import os
 import re
 import shutil
-import urllib.parse
 
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -34,12 +33,10 @@ if TYPE_CHECKING:
     from poetry.core.constraints.version import Version
     from poetry.core.packages.dependency import Dependency
     from pytest_mock import MockerFixture
-    from requests import Session
     from tomlkit.toml_document import TOMLDocument
 
     from poetry.installation.operations.operation import Operation
     from poetry.poetry import Poetry
-    from poetry.utils.authenticator import Authenticator
     from tests.types import HTTPrettyResponse
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures"
@@ -120,21 +117,6 @@ def mock_clone(
 
     copy_path(folder, dest)
     return MockDulwichRepo(dest)
-
-
-def mock_download(
-    url: str,
-    dest: Path,
-    *,
-    session: Authenticator | Session | None = None,
-    chunk_size: int = 1024,
-    raise_accepts_ranges: bool = False,
-) -> None:
-    parts = urllib.parse.urlparse(url)
-
-    fixture = FIXTURE_PATH / parts.path.lstrip("/")
-
-    copy_path(fixture, dest)
 
 
 class TestExecutor(Executor):

--- a/tests/installation/fixtures/with-same-version-url-dependencies.test
+++ b/tests/installation/fixtures/with-same-version-url-dependencies.test
@@ -10,7 +10,7 @@ files = [
 
 [package.source]
 type = "url"
-url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+url = "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
 
 [package.dependencies]
 pendulum = ">=1.4.4"
@@ -30,7 +30,7 @@ files = [
 ]
 [package.source]
 type = "url"
-url = "https://python-poetry.org/distributions/demo-0.1.0.tar.gz"
+url = "https://files.pythonhosted.org/distributions/demo-0.1.0.tar.gz"
 
 [package.dependencies]
 pendulum = ">=1.4.4"

--- a/tests/installation/fixtures/with-url-dependency.test
+++ b/tests/installation/fixtures/with-url-dependency.test
@@ -10,7 +10,7 @@ files = [
 
 [package.source]
 type = "url"
-url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+url = "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
 
 [package.dependencies]
 pendulum = ">=1.4.4"

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -2133,7 +2133,7 @@ def test_installer_can_install_dependencies_from_forced_source(
 def test_run_installs_with_url_file(
     installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
 ) -> None:
-    url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    url = "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
     package.add_dependency(Factory.create_dependency("demo", {"url": url}))
 
     repo.add_package(get_package("pendulum", "1.4.4"))
@@ -2159,9 +2159,9 @@ def test_run_installs_with_same_version_url_files(
     env_platform: str,
 ) -> None:
     urls = {
-        "linux": "https://python-poetry.org/distributions/demo-0.1.0.tar.gz",
+        "linux": "https://files.pythonhosted.org/distributions/demo-0.1.0.tar.gz",
         "win32": (
-            "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+            "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
         ),
     }
     for platform, url in urls.items():
@@ -2727,7 +2727,9 @@ def test_explicit_source_dependency_with_direct_origin_dependency(
     A dependency with explicit source should not be satisfied by
     a direct origin dependency even if there is a version match.
     """
-    demo_url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    demo_url = (
+        "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    )
     package.add_dependency(
         Factory.create_dependency(
             "demo",

--- a/tests/packages/test_direct_origin.py
+++ b/tests/packages/test_direct_origin.py
@@ -26,7 +26,7 @@ def test_direct_origin_get_package_from_file(fixture_dir: FixtureDirGetter) -> N
 def test_direct_origin_caches_url_dependency(tmp_path: Path) -> None:
     artifact_cache = ArtifactCache(cache_dir=tmp_path)
     direct_origin = DirectOrigin(artifact_cache)
-    url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    url = "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
 
     package = direct_origin.get_package_from_url(url)
 
@@ -42,7 +42,7 @@ def test_direct_origin_does_not_download_url_dependency_when_cached(
         return_value=fixture_dir("distributions") / "demo-0.1.2-py2.py3-none-any.whl"
     )
     direct_origin = DirectOrigin(artifact_cache)
-    url = "https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+    url = "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
     download_file = mocker.patch(
         "poetry.packages.direct_origin.download_file",
         side_effect=Exception("download_file should not be called"),

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -863,7 +863,7 @@ def test_locker_dumps_dependency_information_correctly(
     )
     package_a.add_dependency(
         Factory.create_dependency(
-            "E", {"url": "https://python-poetry.org/poetry-1.2.0.tar.gz"}
+            "E", {"url": "https://files.pythonhosted.org/poetry-1.2.0.tar.gz"}
         )
     )
     package_a.add_dependency(
@@ -913,7 +913,7 @@ files = []
 B = {{path = "project_with_extras", develop = true}}
 C = {{path = "directory/project_with_transitive_directory_dependencies"}}
 D = {{path = "distributions/demo-0.1.0.tar.gz"}}
-E = {{url = "https://python-poetry.org/poetry-1.2.0.tar.gz"}}
+E = {{url = "https://files.pythonhosted.org/poetry-1.2.0.tar.gz"}}
 F = {{git = "https://github.com/python-poetry/poetry.git", branch = "foo"}}
 G = {{git = "https://github.com/python-poetry/poetry.git", subdirectory = "bar"}}
 H = {{git = "https://github.com/python-poetry/poetry.git", tag = "baz"}}

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -3906,7 +3906,7 @@ def test_solver_cannot_choose_another_version_for_url_dependencies(
 
     http.register_uri(
         "GET",
-        "https://foo.bar/demo-0.1.0-py2.py3-none-any.whl",
+        "https://files.pythonhosted.org/demo-0.1.0-py2.py3-none-any.whl",
         body=Path(path).read_bytes(),
         streaming=True,
     )
@@ -3921,7 +3921,9 @@ def test_solver_cannot_choose_another_version_for_url_dependencies(
     package.add_dependency(
         Factory.create_dependency(
             "demo",
-            {"url": "https://foo.bar/distributions/demo-0.1.0-py2.py3-none-any.whl"},
+            {
+                "url": "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+            },
         )
     )
     package.add_dependency(Factory.create_dependency("foo", "^1.2.3"))
@@ -3947,7 +3949,7 @@ def test_solver_cannot_choose_url_dependency_for_explicit_source(
             "demo",
             {
                 "markers": "sys_platform != 'darwin'",
-                "url": "https://foo.bar/distributions/demo-0.1.0-py2.py3-none-any.whl",
+                "url": "https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl",
             },
         )
     )
@@ -3968,7 +3970,7 @@ def test_solver_cannot_choose_url_dependency_for_explicit_source(
         "demo",
         "0.1.0",
         source_type="url",
-        source_url="https://foo.bar/distributions/demo-0.1.0-py2.py3-none-any.whl",
+        source_url="https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl",
     )
     # The url demo dependency depends on pendulum.
     repo.add_package(package_pendulum)

--- a/tests/repositories/fixtures/installed/lib/python3.7/site-packages/url_pep_610-1.2.3.dist-info/direct_url.json
+++ b/tests/repositories/fixtures/installed/lib/python3.7/site-packages/url_pep_610-1.2.3.dist-info/direct_url.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://python-poetry.org/distributions/url-pep-610-1.2.3.tar.gz",
+  "url": "https://mock.pythonhosted.org/distributions/url-pep-610-1.2.3.tar.gz",
   "archive_info": {}
 }

--- a/tests/repositories/fixtures/python_hosted.py
+++ b/tests/repositories/fixtures/python_hosted.py
@@ -44,10 +44,21 @@ def mock_files_python_hosted_factory(http: type[httpretty]) -> PythonHostedFileM
 
             return [404, headers, b"Not Found"]
 
+        def mock_file_callback(
+            request: HTTPrettyRequest, uri: str, headers: dict[str, Any]
+        ) -> list[int | dict[str, Any] | bytes | str]:
+            return [200, headers, b""]
+
         http.register_uri(
             http.GET,
             re.compile("^https://files.pythonhosted.org/.*$"),
             body=file_callback,
+        )
+
+        http.register_uri(
+            http.GET,
+            re.compile("^https://mock.pythonhosted.org/.*$"),
+            body=mock_file_callback,
         )
 
     return factory

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -335,7 +335,7 @@ def test_load_pep_610_compliant_url_packages(repository: InstalledRepository) ->
     assert package.source_type == "url"
     assert (
         package.source_url
-        == "https://python-poetry.org/distributions/url-pep-610-1.2.3.tar.gz"
+        == "https://mock.pythonhosted.org/distributions/url-pep-610-1.2.3.tar.gz"
     )
 
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -177,12 +177,12 @@ def test_detect_corrupted_cache_key_file(
 def test_get_cache_directory_for_link(tmp_path: Path) -> None:
     cache = ArtifactCache(cache_dir=tmp_path)
     directory = cache.get_cache_directory_for_link(
-        Link("https://files.python-poetry.org/poetry-1.1.0.tar.gz")
+        Link("https://files.pythonhosted.org/poetry-1.1.0.tar.gz")
     )
 
     expected = Path(
-        f"{tmp_path.as_posix()}/11/4f/a8/"
-        "1c89d75547e4967082d30a28360401c82c83b964ddacee292201bf85f2"
+        f"{tmp_path.as_posix()}/41/9c/6e/"
+        "ef83f08fcf4dac7cd78d843e7974d601a19c90e4bb90bb76b4a7a61548"
     )
 
     assert directory == expected
@@ -225,7 +225,7 @@ def test_get_cached_archives(fixture_dir: FixtureDirGetter) -> None:
     ("link", "strict", "available_packages"),
     [
         (
-            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            "https://files.pythonhosted.org/demo-0.1.0.tar.gz",
             True,
             [
                 Path("/cache/demo-0.1.0-py2.py3-none-any"),
@@ -271,7 +271,7 @@ def test_get_not_found_cached_archive_for_link(
     ("link", "cached", "strict"),
     [
         (
-            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            "https://files.pythonhosted.org/demo-0.1.0.tar.gz",
             "/cache/demo-0.1.0-cp38-cp38-macosx_10_15_x86_64.whl",
             False,
         ),
@@ -281,7 +281,7 @@ def test_get_not_found_cached_archive_for_link(
             False,
         ),
         (
-            "https://files.python-poetry.org/demo-0.1.0.tar.gz",
+            "https://files.pythonhosted.org/demo-0.1.0.tar.gz",
             "/cache/demo-0.1.0.tar.gz",
             True,
         ),
@@ -328,7 +328,7 @@ def test_get_cached_archive_for_link_no_race_condition(
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
     cache = ArtifactCache(cache_dir=tmp_path)
-    link = Link("https://files.python-poetry.org/demo-0.1.0.tar.gz")
+    link = Link("https://files.pythonhosted.org/demo-0.1.0.tar.gz")
 
     def replace_file(_: str, dest: Path) -> None:
         dest.unlink(missing_ok=True)

--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -79,11 +79,11 @@ if TYPE_CHECKING:
         ("../demo", ({"name": "demo", "path": "../demo"},)),
         ("../demo/demo.whl", ({"name": "demo", "path": "../demo/demo.whl"},)),
         (
-            "https://example.com/distributions/demo-0.1.0.tar.gz",
+            "https://files.pythonhosted.org/distributions/demo-0.1.0.tar.gz",
             (
                 {
                     "name": "demo",
-                    "url": "https://example.com/distributions/demo-0.1.0.tar.gz",
+                    "url": "https://files.pythonhosted.org/distributions/demo-0.1.0.tar.gz",
                 },
             ),
         ),


### PR DESCRIPTION
Removes `mock_download` in favour of using socket level mocking. This ensures we can test actual code paths (eg: `poetry.utils.helpers.download_file`) better.

