### PR TITLE
update pytest.mark.network markers

### DIFF
--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -315,7 +315,6 @@ def test_info_setup_simple(mocker: MockerFixture, demo_setup: Path) -> None:
     demo_check_info(info, requires_dist={"package"})
 
 
-@pytest.mark.network
 def test_info_setup_complex(demo_setup_complex: Path) -> None:
     info = PackageInfo.from_directory(demo_setup_complex)
     demo_check_info(info, requires_dist={"package"})
@@ -334,7 +333,6 @@ def test_info_setup_complex_pep517_error(
         PackageInfo.from_directory(demo_setup_complex)
 
 
-@pytest.mark.network
 def test_info_setup_complex_pep517_legacy(
     demo_setup_complex_pep517_legacy: Path,
 ) -> None:
@@ -342,14 +340,12 @@ def test_info_setup_complex_pep517_legacy(
     demo_check_info(info, requires_dist={"package"})
 
 
-@pytest.mark.network
 def test_info_setup_complex_calls_script(demo_setup_complex_calls_script: Path) -> None:
     """Building the project requires calling a script from its build_requires."""
     info = PackageInfo.from_directory(demo_setup_complex_calls_script)
     demo_check_info(info, requires_dist={"package"})
 
 
-@pytest.mark.network
 @pytest.mark.parametrize("missing", ["version", "name"])
 def test_info_setup_missing_mandatory_should_trigger_pep517(
     mocker: MockerFixture, source_dir: Path, missing: str

--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -80,7 +80,6 @@ def test_prepare_directory(
     os.unlink(wheel)
 
 
-@pytest.mark.network
 def test_prepare_directory_with_extensions(
     config: Config,
     config_cache_dir: Path,
@@ -126,7 +125,6 @@ def test_prepare_directory_editable(
     os.unlink(wheel)
 
 
-@pytest.mark.network
 def test_prepare_directory_script(
     config: Config,
     config_cache_dir: Path,

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1547,11 +1547,6 @@ def test_executor_known_hashes(
     io: BufferedIO,
     fixture_dir: FixtureDirGetter,
 ) -> None:
-    # when installing sdist, an isolated build environment is required to extract metadata
-    # this will install any build system requirements into the environment, to avoid failures when
-    # network is not available we enable mock_file_downloads fixture here
-    # see: https://github.com/python-poetry/poetry/issues/9114
-
     package_source_url: Path = (
         fixture_dir("distributions") / "demo-0.1.0.tar.gz"
     ).resolve()


### PR DESCRIPTION
remove unneeded `@pytest.mark.network` markers

remaining network-using tests are:
- all of the `integration` tests; but these already have the `integration` marker
- `test_builder_setup_generation_runs_with_pip_editable`
  - this uses a pip subprocess which I suppose evades all of the `httpretty` stuff