### PR TITLE
[1.8 backport] env: add support for untagged CPython builds ...

### DIFF
--- a/src/poetry/utils/env/script_strings.py
+++ b/src/poetry/utils/env/script_strings.py
@@ -82,7 +82,7 @@ env = {
     "platform_release": platform.release(),
     "platform_system": platform.system(),
     "platform_version": platform.version(),
-    "python_full_version": platform.python_version(),
+    "python_full_version": platform.python_version().rstrip("+"),
     "platform_python_implementation": platform.python_implementation(),
     "python_version": ".".join(platform.python_version_tuple()[:2]),
     "sys_platform": sys.platform,

--- a/src/poetry/utils/env/system_env.py
+++ b/src/poetry/utils/env/system_env.py
@@ -71,7 +71,8 @@ class SystemEnv(Env):
             "platform_release": platform.release(),
             "platform_system": platform.system(),
             "platform_version": platform.version(),
-            "python_full_version": platform.python_version(),
+            # Workaround for https://github.com/python/cpython/issues/99968
+            "python_full_version": platform.python_version().rstrip("+"),
             "platform_python_implementation": platform.python_implementation(),
             "python_version": ".".join(platform.python_version().split(".")[:2]),
             "sys_platform": sys.platform,

--- a/tests/utils/env/test_system_env.py
+++ b/tests/utils/env/test_system_env.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sys
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from poetry.utils.env import SystemEnv
+
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def test_get_marker_env_untagged_cpython(mocker: MockerFixture) -> None:
+    mocker.patch("platform.python_version", return_value="3.11.9+")
+    env = SystemEnv(Path(sys.prefix))
+    marker_env = env.get_marker_env()
+    assert marker_env["python_full_version"] == "3.11.9"


### PR DESCRIPTION
Backport #9207 to 1.8

---

… where `platform.python_version()` ends with a "+"

works around https://github.com/python/cpython/issues/99968

# Pull Request Check List

Resolves: #6925
Closes: #7462

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
