### PR TITLE
[1.8 backport] remove advice re seeding keyring backends

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -532,12 +532,6 @@ Microsoft's [artifacts-keyring](https://pypi.org/project/artifacts-keyring/) get
 valid credentials. It will need to be properly installed into Poetry's virtualenv,
 preferably by installing a plugin.
 
-If you are letting Poetry manage your virtual environments you will want a virtualenv
-seeder installed in Poetry's virtualenv that installs the desired keyring backend
-during `poetry install`. To again use Azure DevOps as an example: [azure-devops-artifacts-helpers](https://pypi.org/project/azure-devops-artifacts-helpers/)
-provides such a seeder. This would of course best achieved by installing a Poetry plugin
-if it exists for you use case instead of doing it yourself.
-
 {{% /note %}}
 
 Alternatively, you can use environment variables to provide the credentials:


### PR DESCRIPTION
Backport #9164 to 1.8

---

I can't make sense of the advice that this pull request removes: so this is an invitation either to remove it or to explain it!

Surely all that matters to poetry is that the relevant keyring backend is in its own virtual environment?  What reason would there be for also seeding the project virtual environment with that backend?

this comes from https://github.com/python-poetry/poetry/pull/4086 so I guess I should tag @Darsstar, though of course three years later it would be completely reasonable to have forgotten or stopped caring.

even if right in principle the doc is not enormously helpful.  As far as I am aware the imagined plug-in remains imaginary - and I would not know from reading this text what I was supposed to do anyway.  So I might encourage removing it in any case.
