### PR TITLE
[1.8 backport] handle trailing slash in git url

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -182,7 +182,7 @@ class Git:
 
     @staticmethod
     def get_name_from_source_url(url: str) -> str:
-        return re.sub(r"(.git)?$", "", url.rsplit("/", 1)[-1])
+        return re.sub(r"(.git)?$", "", url.rstrip("/").rsplit("/", 1)[-1])
 
     @classmethod
     def _fetch_remote_refs(cls, url: str, local: Repo) -> FetchPackResult:

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+from poetry.vcs.git.backend import Git
 from poetry.vcs.git.backend import is_revision_sha
 
 
@@ -24,3 +27,17 @@ def test_invalid_revision_sha_min_len() -> None:
 def test_invalid_revision_sha_max_len() -> None:
     result = is_revision_sha(VALID_SHA + "42")
     assert result is False
+
+
+@pytest.mark.parametrize(
+    ("url"),
+    [
+        "git@github.com:python-poetry/poetry.git",
+        "https://github.com/python-poetry/poetry.git",
+        "https://github.com/python-poetry/poetry",
+        "https://github.com/python-poetry/poetry/",
+    ],
+)
+def test_get_name_from_source_url(url: str) -> None:
+    name = Git.get_name_from_source_url(url)
+    assert name == "poetry"


### PR DESCRIPTION
Backport #9205 to 1.8

---

fixes #7326

