### PR TITLE
Fix prerelease parameter's value in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           artifacts: "dist/*"
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
-          prerelease: steps.check-version.outputs.prerelease == 'true'
+          prerelease: ${{ steps.check-version.outputs.prerelease == 'true' }}
 
       - name: Publish to PyPI
         env:


### PR DESCRIPTION
# Pull Request Check List

The current approach makes `prerelease` be equal to `steps.check-version.outputs.prerelease == 'true'` and not be true or false, as expected. You can check the actions logs to see that's the case

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
