### PR TITLE
Misc cleanup

### DIFF
--- a/src/poetry/console/commands/about.py
+++ b/src/poetry/console/commands/about.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from poetry.console.commands.command import Command
-
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 class AboutCommand(Command):
@@ -17,16 +11,12 @@ class AboutCommand(Command):
     def handle(self) -> int:
         from poetry.utils._compat import metadata
 
-        # The metadata.version that we import for Python 3.7 is untyped, work around
-        # that.
-        version: Callable[[str], str] = metadata.version
-
         self.line(
             f"""\
 <info>Poetry - Package Management for Python
 
-Version: {version('poetry')}
-Poetry-Core Version: {version('poetry-core')}</info>
+Version: {metadata.version('poetry')}
+Poetry-Core Version: {metadata.version('poetry-core')}</info>
 
 <comment>Poetry is a dependency manager tracking local dependencies of your projects\
  and libraries.

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -166,7 +166,7 @@ class HTTPRepository(CachedRepository):
                 response = self.session.get(link.metadata_url)
                 if link.metadata_hashes and (
                     hash_name := get_highest_priority_hash_type(
-                        set(link.metadata_hashes.keys()), f"{link.filename}.metadata"
+                        link.metadata_hashes, f"{link.filename}.metadata"
                     )
                 ):
                     metadata_hash = getattr(hashlib, hash_name)(
@@ -351,9 +351,7 @@ class HTTPRepository(CachedRepository):
                 file_hash = self.calculate_sha256(link)
 
             if file_hash is None and (
-                hash_type := get_highest_priority_hash_type(
-                    set(link.hashes.keys()), link.filename
-                )
+                hash_type := get_highest_priority_hash_type(link.hashes, link.filename)
             ):
                 file_hash = f"{hash_type}:{link.hashes[hash_type]}"
 
@@ -372,9 +370,7 @@ class HTTPRepository(CachedRepository):
 
     def calculate_sha256(self, link: Link) -> str | None:
         with self._cached_or_downloaded_file(link) as filepath:
-            hash_name = get_highest_priority_hash_type(
-                set(link.hashes.keys()), link.filename
-            )
+            hash_name = get_highest_priority_hash_type(link.hashes, link.filename)
             known_hash = None
             with suppress(ValueError, AttributeError):
                 # Handle ValueError here as well since under FIPS environments

--- a/src/poetry/utils/cache.py
+++ b/src/poetry/utils/cache.py
@@ -198,9 +198,7 @@ class ArtifactCache:
     def get_cache_directory_for_link(self, link: Link) -> Path:
         key_parts = {"url": link.url_without_fragment}
 
-        if hash_name := get_highest_priority_hash_type(
-            set(link.hashes.keys()), link.filename
-        ):
+        if hash_name := get_highest_priority_hash_type(link.hashes, link.filename):
             key_parts[hash_name] = link.hashes[hash_name]
 
         if link.subdirectory_fragment:

--- a/src/poetry/utils/env/site_packages.py
+++ b/src/poetry/utils/env/site_packages.py
@@ -112,19 +112,6 @@ class SitePackages:
             return distribution
         return None
 
-    def find_distribution_files_with_suffix(
-        self, distribution_name: str, suffix: str, writable_only: bool = False
-    ) -> Iterable[Path]:
-        for distribution in self.distributions(
-            name=distribution_name, writable_only=writable_only
-        ):
-            files = [] if distribution.files is None else distribution.files
-            for file in files:
-                if file.name.endswith(suffix):
-                    path = distribution.locate_file(file)
-                    assert isinstance(path, Path)
-                    yield path
-
     def find_distribution_files_with_name(
         self, distribution_name: str, name: str, writable_only: bool = False
     ) -> Iterable[Path]:

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -28,6 +28,7 @@ from poetry.utils.constants import REQUESTS_TIMEOUT
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from collections.abc import Collection
     from collections.abc import Iterator
     from types import TracebackType
 
@@ -332,7 +333,7 @@ def get_file_hash(path: Path, hash_name: str = "sha256") -> str:
 
 
 def get_highest_priority_hash_type(
-    hash_types: set[str], archive_name: str
+    hash_types: Collection[str], archive_name: str
 ) -> str | None:
     if not hash_types:
         return None


### PR DESCRIPTION
three small cleanups:
- remove unused code `find_distribution_files_with_suffix()`
- remove python 3.7 accommodation for typing of `metadata.version`
- simplify treatment of `get_highest_priority_hash_type()` - a dictionary is already a collection, no need to take the keys and turn them into a set