### PR TITLE
Clarify add command help

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 class AddCommand(InstallerCommand, InitCommand):
     name = "add"
-    description = "Adds a new dependency to <comment>pyproject.toml</>."
+    description = "Adds a new dependency to <comment>pyproject.toml</> and installs it."
 
     arguments: ClassVar[list[Argument]] = [
         argument("name", "The packages to add.", multiple=True)


### PR DESCRIPTION
When we `add` some dependency it is appended in `pyproject.toml` and it is installed in the corresponding virtual environment. I would suggest to incorporate the installation action into the related help so that `poetry list` and `poetry add --help` are harmonized.

# Pull Request Check List

Resolves: none

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
