### PR TITLE
ci: better and DRYer matrixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,35 +1,81 @@
-freebsd_instance:
-  image_family: freebsd-14-0
-  cpu: 2
-  memory: 4G
+tests_task:
+  # We skip running Cirrus on tags to match GHA.
+  only_if: &not_tag $CIRRUS_TAG == ''
 
-test_task:
-  name: "Tests / FreeBSD / "
-  only_if: $CIRRUS_TAG == ''
-  skip: "!changesInclude('.cirrus.yml', 'poetry.lock', 'pyproject.toml', 'src/**.py', 'tests/**')"
+  # We only use Cirrus CI for FreeBSD at present; the rest of the task will assume FreeBSD.
+  freebsd_instance:
+    image_family: freebsd-14-0
+    # Cirrus has a concurrency limit of 8 vCPUs for FreeBSD. Allow executing 4 tasks in parallel.
+    cpu: 2
+    memory: 2G
+
   env:
-    # `SHELL` environment variable is not set by default, so we explicitly set it to
-    # avoid failures on tests that depend on it.
-    SHELL: sh
     matrix:
       - PYTHON: python3.8
+        PYTHON_VERSION: 3.8
+        PYTHON_PACKAGE: python38
+        SQLITE_PACKAGE: py38-sqlite3
       - PYTHON: python3.9
+        PYTHON_VERSION: 3.9
+        PYTHON_PACKAGE: python39
+        SQLITE_PACKAGE: py39-sqlite3
       - PYTHON: python3.10
+        PYTHON_VERSION: 3.10
+        PYTHON_PACKAGE: python310
+        SQLITE_PACKAGE: py310-sqlite3
       - PYTHON: python3.11
-  install_prereqs_script:
-    - V=$(printf '%s' $PYTHON | tr -d '.[:alpha:]')
-    - pkg install -y python${V} py${V}-sqlite3
-  install_poetry_script:
-    - POETRY_HOME=/opt/poetry
+        PYTHON_VERSION: 3.11
+        PYTHON_PACKAGE: python311
+        SQLITE_PACKAGE: py311-sqlite3
+      # FIXME: Python 3.12 is not available in Ports.
+      # - PYTHON: python3.12
+      #   PYTHON_VERSION: 3.12
+      #   PYTHON_PACKAGE: python312
+      #   SQLITE_PACKAGE: py312-sqlite3
+    # FIXME: use pipx for install. pipx is currently broken in Ports.
+    POETRY_HOME: /opt/poetry
+    # SHELL is not set by default, and we have tests that depend on it.
+    SHELL: sh
+
+  bootstrap_poetry_script:
+    - pkg install -y git $PYTHON_PACKAGE $SQLITE_PACKAGE
     - $PYTHON -m venv $POETRY_HOME
-    - $POETRY_HOME/bin/pip install --upgrade pip setuptools wheel
     - $POETRY_HOME/bin/pip install poetry
-    - echo "PATH=$POETRY_HOME/bin:$PATH" >> $CIRRUS_ENV
-  install_and_test_script:
+    - echo "PATH=${POETRY_HOME}/bin:${PATH}" >> $CIRRUS_ENV
+
+  setup_environment_script:
+    # FIXME: --sync is broken due to a bug with py-sqlite3 packaging.
+    # TODO: caching
     - poetry install
-    - poetry run pytest --junitxml=junit.xml -v
-  on_failure:
-    annotate_failure_artifacts:
-      path: junit.xml
-      format: junit
-      type: text/xml
+    - poetry env info
+    - poetry show
+
+  matrix:
+    - alias: pytest
+      name: "Tests / FreeBSD (Python ${PYTHON_VERSION}) / pytest"
+      skip: "!changesInclude('.cirrus.yml', 'poetry.lock', 'pyproject.toml', 'src/**.py', 'tests/**')"
+      pytest_script: poetry run pytest --integration -v --junitxml=junit.xml
+      on_failure:
+        annotate_failure_artifacts:
+          path: junit.xml
+          format: junit
+          type: text/xml
+
+    # TODO: caching
+    - alias: mypy
+      name: "Tests / FreeBSD (Python ${PYTHON_VERSION}) / mypy"
+      skip: "!changesInclude('.cirrus.yml', 'poetry.lock', 'pyproject.toml', 'src/**.py')"
+      mypy_script: poetry run mypy
+
+status_task:
+  name: "Tests / FreeBSD Status"
+
+  only_if: *not_tag
+  depends_on:
+    - pytest
+    - mypy
+
+  container:
+    image: alpine:latest
+    cpu: 0.5
+    memory: 512M

--- a/.github/actions/bootstrap-poetry/action.yml
+++ b/.github/actions/bootstrap-poetry/action.yml
@@ -1,0 +1,34 @@
+name: Bootstrap Poetry
+description: Configure the environment with the specified Python and Poetry version.
+
+inputs:
+  python-version:
+    description: Desired Python version
+    default: "3.12"
+  python-latest:
+    description: Use an uncached Python if a newer match is available
+    default: 'false'
+  poetry-spec:
+    description: pip-compatible installation specification to use for Poetry
+    default: 'poetry'
+
+runs:
+  using: composite
+  steps:
+    # Enable handling long path names (+260 char) on the Windows platform
+    # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
+    - id: git-config-longpaths
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: git config --system core.longpaths true
+
+    - id: pipx-poetry
+      shell: bash
+      run: pipx install '${{ inputs.poetry-spec }}'
+
+    - id: setup-python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        check-latest: ${{ inputs.python-latest == 'true' }}
+        cache: poetry

--- a/.github/workflows/.tests-matrix.yaml
+++ b/.github/workflows/.tests-matrix.yaml
@@ -1,0 +1,106 @@
+# Reusable workflow consumed by tests.yaml; used to share a single matrix across jobs.
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      run-mypy:
+        required: true
+        type: boolean
+      run-pytest:
+        required: true
+        type: boolean
+      run-pytest-export:
+        required: true
+        type: boolean
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  mypy:
+    name: mypy
+    runs-on: ${{ inputs.runner }}
+    if: inputs.run-mypy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/bootstrap-poetry
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - run: poetry install --sync
+
+      - run: poetry env info
+
+      - run: poetry show
+
+      - uses: actions/cache@v4
+        with:
+          path: .mypy_cache
+          key: mypy-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          restore-keys: |
+            mypy-${{ runner.os }}-${{ env.pythonLocation }}-
+            mypy-${{ runner.os }}-
+
+      - run: poetry run mypy
+
+  pytest:
+    name: pytest
+    runs-on: ${{ inputs.runner }}
+    if: inputs.run-pytest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/bootstrap-poetry
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - run: poetry install --sync --with github-actions
+
+      - run: poetry env info
+
+      - run: poetry show
+
+      - run: poetry run pytest --integration -v
+        env:
+          POETRY_TEST_INTEGRATION_GIT_USERNAME: ${{ github.actor }}
+          POETRY_TEST_INTEGRATION_GIT_PASSWORD: ${{ github.token }}
+
+      - run: git diff --exit-code --stat HEAD
+
+  pytest-export:
+    name: pytest (poetry-plugin-export)
+    runs-on: ${{ inputs.runner }}
+    if: inputs.run-pytest-export
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/bootstrap-poetry
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - run: poetry install --sync --with github-actions
+
+      - run: poetry env info
+
+      - run: poetry show
+
+      - id: poetry-plugin-export
+        run: echo version=$(poetry run pip list --format json | jq -r '.[] | select(.name == "poetry-plugin-export").version') >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          path: poetry-plugin-export
+          repository: python-poetry/poetry-plugin-export
+          ref: refs/tags/${{ steps.poetry-plugin-export.outputs.version }}
+
+      - run: poetry run -C .. pytest -v
+        working-directory: ./poetry-plugin-export
+
+      - run: git -C poetry-plugin-export diff --exit-code --stat HEAD

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -28,12 +28,10 @@ jobs:
         with:
           app-id: ${{ secrets.POETRY_TOKEN_APP_ID }}
           private-key: ${{ secrets.POETRY_TOKEN_APP_KEY }}
-      - name: cherry-pick
+      - name: backport.sh
         env:
             GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          set -euo pipefail
-
           git config --global user.name  "${{ steps.app-token.outputs.slug }}[bot]"
           git config --global user.email "${{ steps.app-token.outputs.slug }}[bot]@users.noreply.github.com"
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,11 +1,11 @@
-name: "Documentation Preview"
+name: Documentation Preview
 
 on:
   pull_request:
     # allow repository maintainers to modify and test workflow
     paths-ignore:
       - "**"
-      - "!.github/workflows/docs.yml"
+      - "!.github/workflows/docs.yaml"
   pull_request_target:
     # enable runs for this workflow when labeled as documentation only
     # prevent execution when the workflow itself is modified from a fork
@@ -28,49 +28,36 @@ jobs:
       (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'impact/docs'))
       || (github.event_name != 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - name: Checkout Website Source
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: python-poetry/website
 
-      - name: Bootstrap poetry
-        run: pipx install poetry
-
-      - name: Checkout Poetry Source
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           path: poetry
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: poetry
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
 
-      - name: Build Assets
-        run: npm ci && npm run prod
-
-      - name: Fetch Documentation
-        run: |
-          poetry install --no-root --only main
-          poetry run python bin/website build --local ./poetry
-
-      - name: Install Hugo
-        uses: peaceiris/actions-hugo@v2
+      - uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.83.1'
 
-      - name: Build
-        run: hugo -v --minify
+      - uses: ./.github/actions/bootstrap-poetry
 
-      - name: Deploy
-        uses: amondnet/vercel-action@v25
+      - run: poetry install --sync --no-root --only main
+
+      - run: |
+          # Rebuild the docs files from the PR checkout.
+          poetry run python bin/website build --local ./poetry
+          # Build website assets (CSS/JS).
+          npm ci && npm run prod
+          # Build the static website.
+          hugo -v --minify
+
+      - uses: amondnet/vercel-action@v25
         id: vercel-action
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -1,9 +1,8 @@
-name: 'Lock Threads'
+name: Lock Threads
 
 on:
   schedule:
-    # at the end of everyday
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # every day at midnight
   workflow_dispatch:
 
 permissions:
@@ -12,10 +11,10 @@ permissions:
   discussions: write
 
 concurrency:
-  group: lock-threads
+  group: ${{ github.workflow }}
 
 jobs:
-  action:
+  lock-threads:
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,17 +10,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: poetry
+      - uses: ./.github/actions/bootstrap-poetry
 
       - name: Build project for distribution
         run: poetry build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -104,6 +104,10 @@ jobs:
 
       - run: poetry install --sync
 
+      - run: poetry env info
+
+      - run: poetry show
+
       - run: poetry run mypy
 
   pytest:
@@ -132,6 +136,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: poetry install --sync --with github-actions
+
+      - run: poetry env info
+
+      - run: poetry show
 
       - run: poetry run pytest --integration -v
         env:
@@ -166,6 +174,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: poetry install --sync --with github-actions
+
+      - run: poetry env info
+
+      - run: poetry show
 
       - id: poetry-plugin-export
         run: echo version=$(poetry run pip list --format json | jq -r '.[] | select(.name == "poetry-plugin-export").version') >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,7 +89,7 @@ jobs:
           - name: Ubuntu
             image: ubuntu-22.04
           - name: macOS
-            image: macos-12
+            image: macos-13
           - name: Windows
             image: windows-2022
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,8 +52,8 @@ jobs:
   lockfile:
     name: Check poetry.lock
     runs-on: ubuntu-latest
-    needs: changes
     if: needs.changes.outputs.project == 'true'
+    needs: changes
     steps:
       - uses: actions/checkout@v4
 
@@ -64,8 +64,8 @@ jobs:
   fixtures-pypi:
     name: Check fixtures (PyPI)
     runs-on: ubuntu-latest
-    needs: changes
     if: needs.changes.outputs.fixtures-pypi == 'true'
+    needs: changes
     steps:
       - uses: actions/checkout@v4
 
@@ -192,3 +192,16 @@ jobs:
         working-directory: ./poetry-plugin-export
 
       - run: git -C poetry-plugin-export diff --exit-code --stat HEAD
+
+  status:
+    name: Status
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - lockfile
+      - fixtures-pypi
+      - mypy
+      - pytest
+      - pytest-export
+    steps:
+      - run: ${{ (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) && 'false' || 'true' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,8 +18,11 @@ jobs:
     name: Detect changed files
     runs-on: ubuntu-latest
     outputs:
+      project: ${{ steps.changes.outputs.project }}
       fixtures-pypi: ${{ steps.changes.outputs.fixtures-pypi }}
+      mypy: ${{ steps.changes.outputs.mypy }}
       pytest: ${{ steps.changes.outputs.pytest }}
+      pytest-export: ${{ steps.changes.outputs.pytest-export }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -28,18 +31,38 @@ jobs:
           filters: |
             workflow: &workflow
               - '.github/workflows/tests.yaml'
-            fixtures-pypi:
-              - *workflow
-              - 'tests/repositories/fixtures/pypi.org/**'
-            pytest:
+            project: &project
               - *workflow
               - 'poetry.lock'
               - 'pyproject.toml'
+            fixtures-pypi:
+              - *workflow
+              - 'tests/repositories/fixtures/pypi.org/**'
+            mypy:
+              - *project
+              - 'src/**.py'
+            pytest:
+              - *project
               - 'src/**.py'
               - 'tests/**'
+            pytest-export:
+              - *project
+              - 'src/**.py'
+
+  lockfile:
+    name: Check poetry.lock
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.project == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/bootstrap-poetry
+
+      - run: poetry check --lock
 
   fixtures-pypi:
-    name: PyPI Fixtures
+    name: Check fixtures (PyPI)
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.fixtures-pypi == 'true'
@@ -55,20 +78,21 @@ jobs:
       - run: git diff --exit-code --stat HEAD tests/repositories/fixtures/pypi.org
 
   pytest:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.image }}
-    needs: changes
+    name: ${{ matrix.os.name }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os.image }}
+    needs:
+      - changes
+      - lockfile
     strategy:
       matrix:
-        os: [Ubuntu, macOS, Windows]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        include:
-          - os: Ubuntu
+        os:
+          - name: Ubuntu
             image: ubuntu-22.04
-          - os: Windows
-            image: windows-2022
-          - os: macOS
+          - name: macOS
             image: macos-12
+          - name: Windows
+            image: windows-2022
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -81,10 +105,6 @@ jobs:
 
       - run: poetry install --sync --with github-actions
         if: needs.changes.outputs.pytest == 'true'
-
-      - name: Check lock file
-        if: needs.changes.outputs.pytest == 'true'
-        run: poetry check --lock
 
       - name: Run mypy
         if: needs.changes.outputs.pytest == 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
   merge_group:
 
 concurrency:
-  group: tests-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
@@ -17,8 +17,6 @@ jobs:
   changes:
     name: Detect changed files
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     outputs:
       fixtures-pypi: ${{ steps.changes.outputs.fixtures-pypi }}
       pytest: ${{ steps.changes.outputs.pytest }}
@@ -48,29 +46,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Bootstrap poetry
-        run: pipx install poetry
+      - uses: ./.github/actions/bootstrap-poetry
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: poetry
+      - run: poetry install --sync --only main,test
 
-      - name: Configure poetry
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry config virtualenvs.options.no-pip true
-          poetry config virtualenvs.options.no-setuptools true
+      - run: poetry run env PYTHONPATH="$GITHUB_WORKSPACE" python tests/repositories/fixtures/pypi.org/generate.py
 
-      - name: Install dependencies
-        run: poetry install --only main,test
-
-      - name: Regenerate PyPI fixtures
-        run: PYTHONPATH="$PWD" poetry run python tests/repositories/fixtures/pypi.org/generate.py
-
-      - name: Check for changed files
-        run: git diff --exit-code --stat HEAD tests/repositories/fixtures/pypi.org
+      - run: git diff --exit-code --stat HEAD tests/repositories/fixtures/pypi.org
 
   pytest:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
@@ -92,37 +74,17 @@ jobs:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.pytest == 'true'
 
-      - name: Bootstrap poetry
-        if: needs.changes.outputs.pytest == 'true'
-        run: pipx install poetry
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/bootstrap-poetry
         if: needs.changes.outputs.pytest == 'true'
         with:
           python-version: ${{ matrix.python-version }}
-          cache: poetry
 
-      - name: Enable long paths for git on Windows
-        if: needs.changes.outputs.pytest == 'true' && matrix.os == 'Windows'
-        # Enable handling long path names (+260 char) on the Windows platform
-        # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
-        run: git config --system core.longpaths true
-
-      - name: Configure poetry
+      - run: poetry install --sync --with github-actions
         if: needs.changes.outputs.pytest == 'true'
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry config virtualenvs.options.no-pip true
-          poetry config virtualenvs.options.no-setuptools true
 
       - name: Check lock file
         if: needs.changes.outputs.pytest == 'true'
         run: poetry check --lock
-
-      - name: Install dependencies
-        if: needs.changes.outputs.pytest == 'true'
-        run: poetry install --with github-actions
 
       - name: Run mypy
         if: needs.changes.outputs.pytest == 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,6 +108,14 @@ jobs:
 
       - run: poetry show
 
+      - uses: actions/cache@v4
+        with:
+          path: .mypy_cache
+          key: mypy-${{ matrix.os.image }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          restore-keys: |
+            mypy-${{ matrix.os.image }}-${{ env.pythonLocation }}-
+            mypy-${{ matrix.os.image }}-
+
       - run: poetry run mypy
 
   pytest:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,9 +77,10 @@ jobs:
 
       - run: git diff --exit-code --stat HEAD tests/repositories/fixtures/pypi.org
 
-  pytest:
-    name: ${{ matrix.os.name }} / ${{ matrix.python-version }}
+  mypy:
+    name: mypy [${{ matrix.os.name }} / Python ${{ matrix.python-version }}]
     runs-on: ${{ matrix.os.image }}
+    if: needs.changes.outputs.mypy == 'true'
     needs:
       - changes
       - lockfile
@@ -96,48 +97,86 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.pytest == 'true'
 
       - uses: ./.github/actions/bootstrap-poetry
-        if: needs.changes.outputs.pytest == 'true'
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: poetry install --sync
+
+      - run: poetry run mypy
+
+  pytest:
+    name: pytest [${{ matrix.os.name }} / Python ${{ matrix.python-version }}]
+    runs-on: ${{ matrix.os.image }}
+    if: needs.changes.outputs.pytest == 'true'
+    needs:
+      - changes
+      - lockfile
+    strategy:
+      matrix:
+        os:
+          - name: Ubuntu
+            image: ubuntu-22.04
+          - name: macOS
+            image: macos-12
+          - name: Windows
+            image: windows-2022
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/bootstrap-poetry
         with:
           python-version: ${{ matrix.python-version }}
 
       - run: poetry install --sync --with github-actions
-        if: needs.changes.outputs.pytest == 'true'
 
-      - name: Run mypy
-        if: needs.changes.outputs.pytest == 'true'
-        run: poetry run mypy
-
-      - name: Run pytest
-        if: needs.changes.outputs.pytest == 'true'
+      - run: poetry run pytest --integration -v
         env:
           POETRY_TEST_INTEGRATION_GIT_USERNAME: ${{ github.actor }}
           POETRY_TEST_INTEGRATION_GIT_PASSWORD: ${{ github.token }}
-        run: poetry run pytest --integration -v
 
-      - name: Get Plugin Version (poetry-plugin-export)
-        id: poetry-plugin-export-version
-        if: needs.changes.outputs.pytest == 'true'
-        run: |
-          echo version=$(poetry show poetry-plugin-export | grep version | cut -d : -f 2 | xargs) >> $GITHUB_OUTPUT
+      - run: git diff --exit-code --stat HEAD
 
-      - name: Checkout Plugin Source (poetry-plugin-export)
-        uses: actions/checkout@v4
-        if: needs.changes.outputs.pytest == 'true'
+  pytest-export:
+    name: pytest (poetry-plugin-export) [${{ matrix.os.name }} / Python ${{ matrix.python-version }}]
+    runs-on: ${{ matrix.os.image }}
+    if: needs.changes.outputs.pytest-export == 'true'
+    needs:
+      - changes
+      - lockfile
+    strategy:
+      matrix:
+        os:
+          - name: Ubuntu
+            image: ubuntu-22.04
+          - name: macOS
+            image: macos-12
+          - name: Windows
+            image: windows-2022
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/bootstrap-poetry
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: poetry install --sync --with github-actions
+
+      - id: poetry-plugin-export
+        run: echo version=$(poetry run pip list --format json | jq -r '.[] | select(.name == "poetry-plugin-export").version') >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
         with:
           path: poetry-plugin-export
           repository: python-poetry/poetry-plugin-export
-          ref: refs/tags/${{ steps.poetry-plugin-export-version.outputs.version }}
+          ref: refs/tags/${{ steps.poetry-plugin-export.outputs.version }}
 
-      - name: Run pytest (poetry-plugin-export)
-        if: needs.changes.outputs.pytest == 'true'
+      - run: poetry run -C .. pytest -v
         working-directory: ./poetry-plugin-export
-        run: poetry run -C .. pytest -v
 
-      - name: Check for clean working tree
-        if: needs.changes.outputs.pytest == 'true'
-        run: |
-          git diff --exit-code --stat HEAD
-          git -C poetry-plugin-export diff --exit-code --stat HEAD
+      - run: git -C poetry-plugin-export diff --exit-code --stat HEAD

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,7 @@ jobs:
           filters: |
             workflow: &workflow
               - '.github/workflows/tests.yaml'
+              - '.github/workflows/.tests-matrix.yaml'
             project: &project
               - *workflow
               - 'poetry.lock'
@@ -77,13 +78,11 @@ jobs:
 
       - run: git diff --exit-code --stat HEAD tests/repositories/fixtures/pypi.org
 
-  mypy:
-    name: mypy [${{ matrix.os.name }} / Python ${{ matrix.python-version }}]
-    runs-on: ${{ matrix.os.image }}
-    if: needs.changes.outputs.mypy == 'true'
+  tests-matrix:
+    name: ${{ matrix.os.name }} (Python ${{ matrix.python-version }})
     needs:
-      - changes
       - lockfile
+      - changes
     strategy:
       matrix:
         os:
@@ -95,111 +94,15 @@ jobs:
             image: windows-2022
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/bootstrap-poetry
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - run: poetry install --sync
-
-      - run: poetry env info
-
-      - run: poetry show
-
-      - uses: actions/cache@v4
-        with:
-          path: .mypy_cache
-          key: mypy-${{ matrix.os.image }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
-          restore-keys: |
-            mypy-${{ matrix.os.image }}-${{ env.pythonLocation }}-
-            mypy-${{ matrix.os.image }}-
-
-      - run: poetry run mypy
-
-  pytest:
-    name: pytest [${{ matrix.os.name }} / Python ${{ matrix.python-version }}]
-    runs-on: ${{ matrix.os.image }}
-    if: needs.changes.outputs.pytest == 'true'
-    needs:
-      - changes
-      - lockfile
-    strategy:
-      matrix:
-        os:
-          - name: Ubuntu
-            image: ubuntu-22.04
-          - name: macOS
-            image: macos-12
-          - name: Windows
-            image: windows-2022
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/bootstrap-poetry
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - run: poetry install --sync --with github-actions
-
-      - run: poetry env info
-
-      - run: poetry show
-
-      - run: poetry run pytest --integration -v
-        env:
-          POETRY_TEST_INTEGRATION_GIT_USERNAME: ${{ github.actor }}
-          POETRY_TEST_INTEGRATION_GIT_PASSWORD: ${{ github.token }}
-
-      - run: git diff --exit-code --stat HEAD
-
-  pytest-export:
-    name: pytest (poetry-plugin-export) [${{ matrix.os.name }} / Python ${{ matrix.python-version }}]
-    runs-on: ${{ matrix.os.image }}
-    if: needs.changes.outputs.pytest-export == 'true'
-    needs:
-      - changes
-      - lockfile
-    strategy:
-      matrix:
-        os:
-          - name: Ubuntu
-            image: ubuntu-22.04
-          - name: macOS
-            image: macos-12
-          - name: Windows
-            image: windows-2022
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/bootstrap-poetry
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - run: poetry install --sync --with github-actions
-
-      - run: poetry env info
-
-      - run: poetry show
-
-      - id: poetry-plugin-export
-        run: echo version=$(poetry run pip list --format json | jq -r '.[] | select(.name == "poetry-plugin-export").version') >> $GITHUB_OUTPUT
-
-      - uses: actions/checkout@v4
-        with:
-          path: poetry-plugin-export
-          repository: python-poetry/poetry-plugin-export
-          ref: refs/tags/${{ steps.poetry-plugin-export.outputs.version }}
-
-      - run: poetry run -C .. pytest -v
-        working-directory: ./poetry-plugin-export
-
-      - run: git -C poetry-plugin-export diff --exit-code --stat HEAD
+    # Use this matrix with multiple jobs defined in a reusable workflow:
+    uses: ./.github/workflows/.tests-matrix.yaml
+    with:
+      runner: ${{ matrix.os.image }}
+      python-version: ${{ matrix.python-version }}
+      run-mypy: ${{ needs.changes.outputs.mypy == 'true' }}
+      run-pytest: ${{ needs.changes.outputs.pytest == 'true' }}
+      run-pytest-export: ${{ needs.changes.outputs.pytest-export == 'true' }}
+    secrets: inherit
 
   status:
     name: Status
@@ -208,8 +111,6 @@ jobs:
     needs:
       - lockfile
       - fixtures-pypi
-      - mypy
-      - pytest
-      - pytest-export
+      - tests-matrix
     steps:
       - run: ${{ (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) && 'false' || 'true' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ ignore_missing_imports = true
 
 
 [tool.pytest.ini_options]
-addopts = "-n auto"
+addopts = "-n logical"
 testpaths = ["tests"]
 markers = [
     "network: mark tests that require internet access",


### PR DESCRIPTION
Hopefully drastically increase the maintainability of our CI workflows by DRYing up common bits, and taking better advantage of parallelism.

Note some big changes:
* The main 'tests' workflow is now much wider and more parallel, and should surface meaningful results faster (e.g. mypy and pytest in parallel)
* We now have a single 'Status' job intended to be used as a required check; this means we no longer need to keep updating branch protection rules
* Likewise, skipped jobs should now actually show that they were skipped in the UI
* pytest-xdist is now using 'logical' CPU cores as well (the distinction is less meaningful with VM vCPUs, so we should use all of them)
* mypy data is cached, resulting in a 5x speedup on Windows
* We're using the 'Poetry managed' venv for now, as this is all that setup-python can cache