### PR TITLE
ci/release: implement trusted publishing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,3 +75,6 @@ status_task:
     image: alpine:latest
     cpu: 0.5
     memory: 512M
+
+  # No-op the clone.
+  clone_script: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,4 @@
 tests_task:
-  # We skip running Cirrus on tags to match GHA.
-  only_if: &not_tag $CIRRUS_TAG == ''
-
   # We only use Cirrus CI for FreeBSD at present; the rest of the task will assume FreeBSD.
   freebsd_instance:
     image_family: freebsd-14-0
@@ -70,7 +67,6 @@ tests_task:
 status_task:
   name: "Tests / FreeBSD Status"
 
-  only_if: *not_tag
   depends_on:
     - pytest
     - mypy

--- a/.github/actions/bootstrap-poetry/action.yml
+++ b/.github/actions/bootstrap-poetry/action.yml
@@ -17,17 +17,14 @@ runs:
   steps:
     # Enable handling long path names (+260 char) on the Windows platform
     # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
-    - id: git-config-longpaths
+    - run: git config --system core.longpaths true
       if: runner.os == 'Windows'
       shell: pwsh
-      run: git config --system core.longpaths true
 
-    - id: pipx-poetry
+    - run: pipx install '${{ inputs.poetry-spec }}'
       shell: bash
-      run: pipx install '${{ inputs.poetry-spec }}'
 
-    - id: setup-python
-      uses: actions/setup-python@v5
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         check-latest: ${{ inputs.python-latest == 'true' }}

--- a/.github/workflows/.tests-matrix.yaml
+++ b/.github/workflows/.tests-matrix.yaml
@@ -91,14 +91,14 @@ jobs:
 
       - run: poetry show
 
-      - id: poetry-plugin-export
-        run: echo version=$(poetry run pip list --format json | jq -r '.[] | select(.name == "poetry-plugin-export").version') >> $GITHUB_OUTPUT
+      - run: poetry run pip list --format json | jq -r '.[] | "\(.name)=\(.version)"' >> $GITHUB_OUTPUT
+        id: package-versions
 
       - uses: actions/checkout@v4
         with:
           path: poetry-plugin-export
           repository: python-poetry/poetry-plugin-export
-          ref: refs/tags/${{ steps.poetry-plugin-export.outputs.version }}
+          ref: refs/tags/${{ steps.package-versions.outputs.poetry-plugin-export }}
 
       - run: poetry run -C .. pytest -v
         working-directory: ./poetry-plugin-export

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -23,18 +23,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # This workflow requires a non-GHA token in order to trigger downstream CI, and to access the 'fork' repository.
-      - id: app-token
-        uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
           app-id: ${{ secrets.POETRY_TOKEN_APP_ID }}
           private-key: ${{ secrets.POETRY_TOKEN_APP_KEY }}
-      - name: backport.sh
-        env:
-            GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
+      - run: |
           git config --global user.name  "${{ steps.app-token.outputs.slug }}[bot]"
           git config --global user.email "${{ steps.app-token.outputs.slug }}[bot]@users.noreply.github.com"
 
           gh repo fork --remote-name fork
 
           ./.github/scripts/backport.sh --pr ${{ github.event.pull_request.number }} --comment --remote fork
+        name: backport.sh
+        env:
+            GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -57,7 +57,6 @@ jobs:
           hugo -v --minify
 
       - uses: amondnet/vercel-action@v25
-        id: vercel-action
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,17 +16,16 @@ on:
       - "**"
       - "!docs/**"
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   deploy:
     name: Build & Deploy
     runs-on: ubuntu-latest
-    if: |
+    if: >
       (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'impact/docs'))
       || (github.event_name != 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -9,7 +9,21 @@ concurrency:
   group: ${{ github.workflow }}
 
 jobs:
-  lock-threads:
+  lock-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          process-only: issues
+          issue-inactive-days: 30
+          issue-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+
+  lock-prs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -17,14 +31,9 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v5
         with:
-          issue-inactive-days: 30
-          issue-comment: >
-            This issue has been automatically locked since there
-            has not been any recent activity after it was closed.
-            Please open a new issue for related bugs.
+          process-only: prs
           pr-inactive-days: 30
           pr-comment: >
             This pull request has been automatically locked since there
             has not been any recent activity after it was closed.
             Please open a new issue for related bugs.
-          process-only: 'issues, prs'

--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -5,17 +5,15 @@ on:
     - cron: '0 0 * * *' # every day at midnight
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
-  discussions: write
-
 concurrency:
   group: ${{ github.workflow }}
 
 jobs:
   lock-threads:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: dessant/lock-threads@v5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,19 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-  upload:
-    name: Upload
+  upload-github:
+    name: Upload (GitHub)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: distfiles
+
+      - run: gh release upload ${{ github.event.release.tag_name }} dist/*.{tar.gz,whl}
+
+  upload-pypi:
+    name: Upload (PyPI)
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ jobs:
   upload-github:
     name: Upload (GitHub)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: build
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,36 +1,36 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - '*.*.*'
+  release:
+    types: [published]
 
 jobs:
-  release:
-    name: Release
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/bootstrap-poetry
+      - run: pipx run build
 
-      - name: Build project for distribution
-        run: poetry build
-
-      - name: Check Version
-        id: check-version
-        run: |
-          [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo prerelease=true >> $GITHUB_OUTPUT
-
-      - name: Create Release
-        uses: ncipollo/release-action@v1
+      - uses: actions/upload-artifact@v4
         with:
-          artifacts: "dist/*"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: false
-          prerelease: ${{ steps.check-version.outputs.prerelease == 'true' }}
+          name: distfiles
+          path: dist/
+          if-no-files-found: error
 
-      - name: Publish to PyPI
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-        run: poetry publish
+  upload:
+    name: Upload
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: distfiles
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true


### PR DESCRIPTION
Completely rewrite the release workflow. There are a couple key differences now:
* Releases are triggered by GitHub releases; which can refer to an existing tag, or create one on the fly.
* Credentials are no longer needed to perform a release, instead we use the PyPI trusted publishing flow.
* The build and upload tasks are split to ensure the credentials are safeguarded.
* Uploads require approval from one other maintainer (beyond the person who triggered the build).
* We now also upload release artifacts to the GitHub release.

Note that PyPI will only accept uploads from the 'pypi' environment, triggered in this workflow file.