### PR TITLE
ci/docs: fix relative workflow path

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -44,9 +44,9 @@ jobs:
         with:
           hugo-version: '0.83.1'
 
-      - uses: ./.github/actions/bootstrap-poetry
+      - uses: ./poetry/.github/actions/bootstrap-poetry
 
-      - uses: ./.github/actions/poetry-install
+      - uses: ./poetry/.github/actions/poetry-install
         with:
           args: --no-root --only main
 


### PR DESCRIPTION
Actions uses the local checkout for in-repo actions; therefore we have to reference the location of the Poetry checkout.
