### PR TITLE
feat: improve operation messages and make them stateful 

### DIFF
--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -167,13 +167,13 @@ you can set the "package-mode" to false in your pyproject.toml file.
             return 0
 
         log_install = (
-            "<b>Installing</> the current project:"
+            "<b>{verb}</> the current project:"
             f" <c1>{self.poetry.package.pretty_name}</c1>"
             f" (<{{tag}}>{self.poetry.package.pretty_version}</>)"
         )
         overwrite = self.io.output.is_decorated() and not self.io.is_debug()
         self.line("")
-        self.write(log_install.format(tag="c2"))
+        self.write(log_install.format(verb="Installing", tag="c2"))
         if not overwrite:
             self.line("")
 
@@ -207,7 +207,7 @@ you can set the "package-mode" to false in your pyproject.toml file.
             return 0
 
         if overwrite:
-            self.overwrite(log_install.format(tag="success"))
+            self.overwrite(log_install.format(verb="Installed", tag="success"))
             self.line("")
 
         return 0

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -5,6 +5,7 @@ import functools
 import itertools
 import json
 import threading
+import warnings
 
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait
@@ -393,6 +394,12 @@ class Executor:
         error: bool = False,
         warning: bool = False,
     ) -> str:
+        warnings.warn(
+            "'Executor.get_operation_message()' and its boolean parameters "
+            "are deprecated, please use 'Operation.get_message()' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return operation.get_message()
 
     def _display_summary(self, operations: list[Operation]) -> None:

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -400,7 +400,13 @@ class Executor:
             DeprecationWarning,
             stacklevel=2,
         )
-        return operation.get_message()
+        new_state = {"done": done, "error": error, "warning": warning}
+        old_state = {attr: getattr(operation, attr) for attr in new_state}
+        op_state = vars(operation)
+        op_state.update(new_state)
+        message = operation.get_message()
+        op_state.update(old_state)
+        return message
 
     def _display_summary(self, operations: list[Operation]) -> None:
         installs = 0

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -322,7 +322,7 @@ class Installer:
 
             if updated_lock:
                 self._io.write_line("")
-                self._io.write_line("<info>Writing lock file</>")
+                self._io.write_line("<info>Lock file written</>")
 
     def _execute(self, operations: list[Operation]) -> int:
         return self._executor.execute(operations)

--- a/src/poetry/installation/operations/install.py
+++ b/src/poetry/installation/operations/install.py
@@ -25,9 +25,21 @@ class Install(Operation):
     def job_type(self) -> str:
         return "install"
 
+    @property
+    def message_verb(self) -> str:
+        return "Installed" if self.done else "Installing"
+
+    def get_message(self) -> str:
+        return (
+            f"<{self._message_base_tag}>{self.message_verb} "
+            f"<{self._message_package_color}>{self.package.name}"
+            f"</{self._message_package_color}> "
+            f"(<{self._message_color}>{self.package.full_pretty_version}</>)</>"
+        )
+
     def __str__(self) -> str:
         return (
-            "Installing"
+            f"{self.message_verb}"
             f" {self.package.pretty_name} ({self.format_version(self.package)})"
         )
 

--- a/src/poetry/installation/operations/operation.py
+++ b/src/poetry/installation/operations/operation.py
@@ -5,18 +5,45 @@ from typing import TypeVar
 
 
 if TYPE_CHECKING:
+    from typing import ClassVar
+
     from poetry.core.packages.package import Package
+
 
 T = TypeVar("T", bound="Operation")
 
 
 class Operation:
+    _message_default_color: ClassVar[str] = "c2"
+    _message_package_color: ClassVar[str] = "c1"
+
     def __init__(self, reason: str | None = None, priority: float = 0) -> None:
         self._reason = reason
 
+        self.error = False
+        self.warning = False
+        self.done = False
         self._skipped = False
         self._skip_reason: str | None = None
         self._priority = priority
+
+    @property
+    def _message_base_tag(self) -> str:
+        return "fg=default" + ";options=dark" * self.skipped
+
+    @property
+    def _message_color(self) -> str:
+        color = self._message_default_color
+        if self.error:
+            color = "error"
+        elif self.warning:
+            color = "warning"
+        elif self.done:
+            color = "success"
+        return color + "_dark" * self.skipped
+
+    def get_message(self) -> str:
+        return ""
 
     @property
     def job_type(self) -> str:

--- a/src/poetry/installation/operations/uninstall.py
+++ b/src/poetry/installation/operations/uninstall.py
@@ -28,10 +28,22 @@ class Uninstall(Operation):
     def job_type(self) -> str:
         return "uninstall"
 
+    @property
+    def message_verb(self) -> str:
+        return "Removed" if self.done else "Removing"
+
+    def get_message(self) -> str:
+        return (
+            f"<{self._message_base_tag}>{self.message_verb}"
+            f" <{self._message_package_color}>{self.package.name}"
+            f"</{self._message_package_color}>"
+            f" (<{self._message_color}>{self.package.full_pretty_version}</>)</>"
+        )
+
     def __str__(self) -> str:
         return (
-            "Uninstalling"
-            f" {self.package.pretty_name} ({self.format_version(self._package)})"
+            f"{self.message_verb} "
+            f"{self.package.pretty_name} ({self.format_version(self._package)})"
         )
 
     def __repr__(self) -> str:

--- a/src/poetry/installation/operations/update.py
+++ b/src/poetry/installation/operations/update.py
@@ -6,10 +6,14 @@ from poetry.installation.operations.operation import Operation
 
 
 if TYPE_CHECKING:
+    from typing import ClassVar
+
     from poetry.core.packages.package import Package
 
 
 class Update(Operation):
+    _message_source_operation_color: ClassVar[str] = "c2"
+
     def __init__(
         self,
         initial: Package,
@@ -38,18 +42,38 @@ class Update(Operation):
     def job_type(self) -> str:
         return "update"
 
+    @property
+    def message_verb(self) -> str:
+        initial_version = self.initial_package.version
+        target_version = self.target_package.version
+        if target_version >= initial_version:
+            return "Updated" if self.done else "Updating"
+        return "Downgraded" if self.done else "Downgrading"
+
+    def get_message(self) -> str:
+        return (
+            f"<{self._message_base_tag}>{self.message_verb}"
+            f" <{self._message_package_color}>"
+            f"{self.initial_package.name}</{self._message_package_color}> "
+            f"(<{self._message_source_operation_color}>"
+            f"{self.initial_package.full_pretty_version}"
+            f"</{self._message_source_operation_color}> -> <{self._message_color}>"
+            f"{self.target_package.full_pretty_version}</>)</>"
+        )
+
     def __str__(self) -> str:
-        init_version = self.format_version(self.initial_package)
+        initial_version = self.format_version(self.initial_package)
         target_version = self.format_version(self.target_package)
         return (
-            f"Updating {self.initial_package.pretty_name} ({init_version}) "
-            f"to {self.target_package.pretty_name} ({target_version})"
+            f"{self.message_verb} {self.initial_package.pretty_name} "
+            f"({initial_version}) to {self.target_package.pretty_name} "
+            f"({target_version})"
         )
 
     def __repr__(self) -> str:
-        init_version = self.format_version(self.initial_package)
+        initial_version = self.format_version(self.initial_package)
         target_version = self.format_version(self.target_package)
         return (
-            f"<Update {self.initial_package.pretty_name} ({init_version}) "
+            f"<Update {self.initial_package.pretty_name} ({initial_version}) "
             f"to {self.target_package.pretty_name} ({target_version})>"
         )

--- a/tests/console/commands/self/test_add_plugins.py
+++ b/tests/console/commands/self/test_add_plugins.py
@@ -59,7 +59,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing poetry-plugin (0.1.0)
 
-Writing lock file
+Lock file written
 """
     assert_plugin_add_result(tester, expected, "^0.1.0")
 
@@ -81,7 +81,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing poetry-plugin (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert_plugin_add_result(tester, expected, "^0.2.0")
@@ -104,7 +104,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (2.0.5)
   - Installing poetry-plugin (0.1.2 9cf87a2)
 
-Writing lock file
+Lock file written
 """
 
     assert_plugin_add_result(
@@ -131,7 +131,7 @@ Package operations: 3 installs, 0 updates, 0 removals
   - Installing tomlkit (0.7.0)
   - Installing poetry-plugin (0.1.2 9cf87a2)
 
-Writing lock file
+Lock file written
 """
 
     constraint: dict[str, str | list[str]] = {
@@ -170,7 +170,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (2.0.5)
   - Installing poetry-plugin (0.1.2 9cf87a2)
 
-Writing lock file
+Lock file written
 """
 
     constraint = {
@@ -270,7 +270,7 @@ Package operations: 0 installs, 1 update, 0 removals
 
   - Updating poetry-plugin (1.2.3 -> 2.3.4)
 
-Writing lock file
+Lock file written
 """
 
     assert_plugin_add_result(tester, expected, "^2.3.4")
@@ -307,7 +307,7 @@ Package operations: 1 install, 1 update, 0 removals
   - Updating tomlkit (0.7.1 -> 0.7.2)
   - Installing poetry-plugin (1.2.3)
 
-Writing lock file
+Lock file written
 """
 
     assert_plugin_add_result(tester, expected, "^1.2.3")

--- a/tests/console/commands/self/test_remove_plugins.py
+++ b/tests/console/commands/self/test_remove_plugins.py
@@ -75,7 +75,7 @@ Package operations: 0 installs, 0 updates, 1 removal
 
   - Removing poetry-plugin (1.2.3)
 
-Writing lock file
+Lock file written
 """
     assert tester.io.fetch_output() == expected
 

--- a/tests/console/commands/self/test_update.py
+++ b/tests/console/commands/self/test_update.py
@@ -74,7 +74,7 @@ Package operations: 0 installs, 2 updates, 0 removals
   - Updating cleo (0.8.2 -> 1.0.0)
   - Updating poetry ({__version__} -> {new_version})
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected_output

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -147,7 +147,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing torch (2.4.0+cpu)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -197,7 +197,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
     assert tester.io.fetch_output() == expected
     assert isinstance(tester.command, InstallerCommand)
@@ -218,7 +218,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.1.0)
 
-Writing lock file
+Lock file written
 """
     assert tester.io.fetch_output() == expected
 
@@ -264,7 +264,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.1.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -285,7 +285,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -310,7 +310,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.1.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -331,7 +331,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -359,7 +359,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 9cf87a2)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -393,7 +393,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 9cf87a2)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -424,7 +424,7 @@ Package operations: 4 installs, 0 updates, 0 removals
   - Installing tomlkit (0.5.5)
   - Installing demo (0.1.2 9cf87a2)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output().strip() == expected.strip()
@@ -466,7 +466,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing two (2.0.0 9cf87a2)
 
-Writing lock file
+Lock file written
 """
     assert tester.io.fetch_output().strip() == expected.strip()
     assert isinstance(tester.command, InstallerCommand)
@@ -510,7 +510,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 9cf87a2)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -555,7 +555,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 {demo_path})
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -596,7 +596,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.2 {demo_path})
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -626,7 +626,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.0 {demo_path})
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -662,7 +662,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing pendulum (1.4.4)
   - Installing demo (0.1.0 {demo_path})
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -694,7 +694,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -734,7 +734,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing demo\
  (0.1.0 https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -774,7 +774,7 @@ Package operations: 4 installs, 0 updates, 0 removals
   - Installing demo\
  (0.1.0 https://files.pythonhosted.org/distributions/demo-0.1.0-py2.py3-none-any.whl)
 
-Writing lock file
+Lock file written
 """
     # Order might be different, split into lines and compare the overall output.
     expected_lines = set(expected.splitlines())
@@ -806,7 +806,7 @@ Resolving dependencies...
 
 No dependencies to install or update
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -838,7 +838,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -872,7 +872,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -920,7 +920,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -982,7 +982,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -1030,7 +1030,7 @@ Package operations: 2 installs, 0 updates, 0 removals
   - Installing msgpack-python (0.5.6)
   - Installing cachy (0.2.0)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_error() == warning
@@ -1060,7 +1060,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing pyyaml (3.13)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -1196,7 +1196,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing foo (1.1.2)
 
-Writing lock file
+Lock file written
 """
 
     assert expected in tester.io.fetch_output()
@@ -1226,7 +1226,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing foo (1.2.3b1)
 
-Writing lock file
+Lock file written
 """
     assert expected in tester.io.fetch_output()
 
@@ -1249,7 +1249,7 @@ Package operations: 1 install, 0 updates, 0 removals
 
   - Installing foo (1.2.3)
 
-Writing lock file
+Lock file written
 """
 
     assert expected in tester.io.fetch_output()
@@ -1266,7 +1266,7 @@ Using version ^0.2.0 for cachy
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -1397,7 +1397,7 @@ Package operations: 3 installs, 0 updates, 0 removals
   - Installing redis (3.4.0)
   - Installing cleo (0.6.5)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -407,7 +407,7 @@ def test_install_logs_output_decorated(
         "\x1b[39;1mInstalling\x1b[39;22m the current project: "
         "\x1b[36msimple-project\x1b[39m (\x1b[39;1m1.2.3\x1b[39;22m)"
         "\x1b[1G\x1b[2K"
-        "\x1b[39;1mInstalling\x1b[39;22m the current project: "
+        "\x1b[39;1mInstalled\x1b[39;22m the current project: "
         "\x1b[36msimple-project\x1b[39m (\x1b[32m1.2.3\x1b[39m)"
         "\n"
     )

--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -337,7 +337,7 @@ Package operations: 0 installs, 0 updates, 1 removal
 
   - Removing docker (4.3.1)
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected
@@ -357,7 +357,7 @@ def test_remove_with_lock_does_not_perform_uninstall_op(
 Updating dependencies
 Resolving dependencies...
 
-Writing lock file
+Lock file written
 """
 
     assert tester.io.fetch_output() == expected

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -439,8 +439,8 @@ def test_execute_works_with_ansi_output(
         "\x1b[39;1mPackage operations\x1b[39;22m: \x1b[34m1\x1b[39m install, \x1b[34m0\x1b[39m updates, \x1b[34m0\x1b[39m removals",
         "\x1b[34;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mPending...\x1b[39m",
         "\x1b[34;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mDownloading...\x1b[39m",
-        "\x1b[34;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mInstalling...\x1b[39m",
-        "\x1b[32;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[32m1.0.0a5\x1b[39m\x1b[39m)\x1b[39m",  # finished
+        "\x1b[34;1m-\x1b[39;22m \x1b[39mInstalling \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[39;1m1.0.0a5\x1b[39;22m\x1b[39m)\x1b[39m: \x1b[34mIn progress...\x1b[39m",
+        "\x1b[32;1m-\x1b[39;22m \x1b[39mInstalled \x1b[39m\x1b[36mcleo\x1b[39m\x1b[39m (\x1b[39m\x1b[32m1.0.0a5\x1b[39m\x1b[39m)\x1b[39m",  # finished
     ]
     # fmt: on
 

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -417,6 +417,17 @@ Package operations: 1 install, 0 updates, 0 removals
     assert expected in io.fetch_output()
 
 
+def test_get_operation_message_deprecated(
+    config: Config,
+    pool: RepositoryPool,
+    io_decorated: BufferedIO,
+    env: MockEnv,
+) -> None:
+    executor = Executor(env, pool, config, io_decorated)
+    with pytest.warns(DeprecationWarning):
+        executor.get_operation_message(Install(Package("clikit", "0.2.3")))
+
+
 def test_execute_works_with_ansi_output(
     config: Config,
     pool: RepositoryPool,


### PR DESCRIPTION
# Pull Request Check List
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This PR proposes more meaningful messages on installation operations:
- "Writing lock file" was displayed _after_ writing the lock file. Now the message is "Lock file written", but I'm happy to adapt to a different idea that introduces **past** tense. <details>The key is to convey the true state of the lock file; looking at https://github.com/python-poetry/poetry/blob/fe9f85baa1a533eb66cde1ee8f76fcf5386dbae2/src/poetry/installation/installer.py#L350-L354
one could easily observe that the "Writing lock file" message is written if `updated_lock` is truthy—and can only be _after actually_ completing writing the lock file:
https://github.com/python-poetry/poetry/blob/fe9f85baa1a533eb66cde1ee8f76fcf5386dbae2/src/poetry/packages/locker.py#L251-L259
https://github.com/python-poetry/poetry/blob/fe9f85baa1a533eb66cde1ee8f76fcf5386dbae2/src/poetry/packages/locker.py#L309-L313
Where `TOMLFile.write()` atomically writes to the file.</details>
- In terminals supporting ANSI output, the "Installing the current project" message shifts to "Installed the current project" when finished.
- `Operation` objects were partially stateful (e.g. held the `skipped` attribute) and now are fully stateful (store the information about whether they are in the `done`, `warning` or `error` state). Different attribute names ideas are welcome.
- `Executor.get_operation_message()` was deprecated and polymorphism was utilized in lieu of it. The new implementation was made to be 100% equivalent _except_ that after the relevant operations finish, their messages use past tense in ANSI supporting cases–instead of freezing at "Downgrading" if `Update(...).done` is `True`, "Downgraded" is written eventually, etc.
- Instead of "Removing... (...): Removing..." and similar messages for other job types, one will now read "Removing ... (...): **In progress...**" as long as the operation is in progress. Other ideas welcome.

Before this can eventually be merged, we need a new GIF in the Poetry readme. @neersighted could you help with that?

