### PR TITLE
refactor: use `typing_extensions.Self`

### DIFF
--- a/src/poetry/inspection/lazy_wheel.py
+++ b/src/poetry/inspection/lazy_wheel.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import BinaryIO
 from typing import ClassVar
-from typing import TypeVar
 from typing import cast
 from urllib.parse import urlparse
 from zipfile import BadZipFile
@@ -34,6 +33,7 @@ if TYPE_CHECKING:
 
     from packaging.metadata import RawMetadata
     from requests import Session
+    from typing_extensions import Self
 
     from poetry.utils.authenticator import Authenticator
 
@@ -168,9 +168,6 @@ class MergeIntervals:
         yield from self._merge(start, end, left, right)
 
 
-T = TypeVar("T", bound="ReadOnlyIOWrapper")
-
-
 class ReadOnlyIOWrapper(BinaryIO):
     """Implement read-side ``BinaryIO`` methods wrapping an inner ``BinaryIO``.
 
@@ -181,7 +178,7 @@ class ReadOnlyIOWrapper(BinaryIO):
     def __init__(self, inner: BinaryIO) -> None:
         self._file = inner
 
-    def __enter__(self: T) -> T:
+    def __enter__(self) -> Self:
         self._file.__enter__()
         return self
 
@@ -286,9 +283,6 @@ class ReadOnlyIOWrapper(BinaryIO):
         raise NotImplementedError
 
 
-U = TypeVar("U", bound="LazyFileOverHTTP")
-
-
 class LazyFileOverHTTP(ReadOnlyIOWrapper):
     """File-like object representing a fixed-length file over HTTP.
 
@@ -311,7 +305,7 @@ class LazyFileOverHTTP(ReadOnlyIOWrapper):
         self._session = session
         self._url = url
 
-    def __enter__(self: U) -> U:
+    def __enter__(self) -> Self:
         super().__enter__()
         self._setup_content()
         return self

--- a/src/poetry/installation/operations/operation.py
+++ b/src/poetry/installation/operations/operation.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import TypeVar
 
 
 if TYPE_CHECKING:
     from poetry.core.packages.package import Package
-
-T = TypeVar("T", bound="Operation")
+    from typing_extensions import Self
 
 
 class Operation:
@@ -46,7 +44,7 @@ class Operation:
         version: str = package.full_pretty_version
         return version
 
-    def skip(self: T, reason: str) -> T:
+    def skip(self, reason: str) -> Self:
         self._skipped = True
         self._skip_reason = reason
 

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from typing import FrozenSet
 from typing import Tuple
-from typing import TypeVar
 
 from poetry.mixology import resolve_version
 from poetry.mixology.failure import SolveFailure
@@ -27,6 +26,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
     from poetry.core.packages.project_package import ProjectPackage
+    from typing_extensions import Self
 
     from poetry.puzzle.transaction import Transaction
     from poetry.repositories import RepositoryPool
@@ -199,8 +199,6 @@ class Solver:
 
 DFSNodeID = Tuple[str, FrozenSet[str], bool]
 
-T = TypeVar("T", bound="DFSNode")
-
 
 class DFSNode:
     def __init__(self, id: DFSNodeID, name: str, base_name: str) -> None:
@@ -208,7 +206,7 @@ class DFSNode:
         self.name = name
         self.base_name = base_name
 
-    def reachable(self: T) -> Sequence[T]:
+    def reachable(self) -> Sequence[Self]:
         return []
 
     def visit(self, parents: list[PackageNode]) -> None:


### PR DESCRIPTION
Used `typing_extensions.Self` instead of `(self: T, ...) -> T`.
`typing_extensions` has a special stub in typeshed and is seen by mypy even if not installed as a direct/transitive dependency, so there's no need to change anything in dependency specs.
`typing_extensions` was used instead of `typing` because the `Self` type was introduced in 3.11 with PEP 673 and `typing_extensions` offers a backport for 3.8+, which is our case.

`Operation.skip()` and `Operation.unskip()` have an anti-pattern, i.e. they return `Self` despite operating in-place.
This will be addressed in a separate PR; I need an idea how to address the API incompatibility that would bring.
