### PR TITLE
Allow parallel uninstalls

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -193,7 +193,7 @@ class Executor:
                 #
                 # We need to explicitly check source type here, see:
                 # https://github.com/python-poetry/poetry-core/pull/98
-                is_parallel_unsafe = operation.job_type == "uninstall" or (
+                is_parallel_unsafe = (
                     operation.package.develop
                     and operation.package.source_type in {"directory", "git"}
                 )


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9263 


I tested this by trying to reproduce via @abn 's [script](https://github.com/python-poetry/poetry/issues/2658#issuecomment-667399312):

```python
#!/usr/bin/env bash -e

TMP_DIR=$(mktemp -d)
TOML=${TMP_DIR}/pyproject.toml

function reset-pyproject() {
  cat >"${TOML}" <<EOF
[tool.poetry]
name = "foobar"
version = "0.1.0"
description = ""
authors = ["Bender Rodriguez <bender@planetexpress.com>"]

[tool.poetry.dependencies]
python = "^3.8"

[tool.poetry.dev-dependencies]
ipython = "*"
EOF
}

mkdir -p "${TMP_DIR}/foobar"
touch "${TMP_DIR}/foobar/__init__.py"

POETRY=$(PWD)/.venv/bin/poetry

pushd "${TMP_DIR}" || exit

for i in $(seq 1 10); do
  reset-pyproject
  "${POETRY}" lock
  "${POETRY}" install
  sed -i '' '/ipython/d' "${TOML}" # On macOS, use 'sed -i '' '...' to edit in-place
  "${POETRY}" lock
  "${POETRY}" install --sync
done

popd || exit
```

I was not able to reproduce the original issue _and_ uninstalls are considerably faster.