### PR TITLE
tolerate funky group names at 'poetry add'

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -112,7 +112,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
     def handle(self) -> int:
         from poetry.core.constraints.version import parse_constraint
         from tomlkit import inline_table
-        from tomlkit import parse as parse_toml
+        from tomlkit import nl
         from tomlkit import table
 
         from poetry.factory import Factory
@@ -150,17 +150,17 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
                 poetry_content["group"] = table(is_super_table=True)
 
             groups = poetry_content["group"]
+
             if group not in groups:
-                dependencies_toml: dict[str, Any] = parse_toml(
-                    f"[tool.poetry.group.{group}.dependencies]\n\n"
-                )
-                group_table = dependencies_toml["tool"]["poetry"]["group"][group]
-                poetry_content["group"][group] = group_table
+                groups[group] = table()
+                groups.add(nl())
 
-            if "dependencies" not in poetry_content["group"][group]:
-                poetry_content["group"][group]["dependencies"] = table()
+            this_group = groups[group]
 
-            section = poetry_content["group"][group]["dependencies"]
+            if "dependencies" not in this_group:
+                this_group["dependencies"] = table()
+
+            section = this_group["dependencies"]
 
         existing_packages = self.get_existing_packages_from_input(packages, section)
 
@@ -266,7 +266,6 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
             )
 
         # Refresh the locker
-        content["tool"]["poetry"] = poetry_content
         self.poetry.locker.set_pyproject_data(content)
         self.installer.set_locker(self.poetry.locker)
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -992,13 +992,17 @@ def test_add_constraint_not_found_with_source(
     assert str(e.value) == "Could not find a matching version of package cachy"
 
 
+@pytest.mark.parametrize("group_name", ["dev", "foo.BAR"])
 def test_add_to_section_that_does_not_exist_yet(
-    app: PoetryTestApplication, repo: TestRepository, tester: CommandTester
+    app: PoetryTestApplication,
+    repo: TestRepository,
+    tester: CommandTester,
+    group_name: str,
 ) -> None:
     repo.add_package(get_package("cachy", "0.1.0"))
     repo.add_package(get_package("cachy", "0.2.0"))
 
-    tester.execute("cachy --group dev")
+    tester.execute(f"cachy --group {group_name}")
 
     expected = """\
 Using version ^0.2.0 for cachy
@@ -1020,12 +1024,13 @@ Writing lock file
     pyproject: dict[str, Any] = app.poetry.file.read()
     content = pyproject["tool"]["poetry"]
 
-    assert "cachy" in content["group"]["dev"]["dependencies"]
-    assert content["group"]["dev"]["dependencies"]["cachy"] == "^0.2.0"
+    assert "cachy" in content["group"][group_name]["dependencies"]
+    assert content["group"][group_name]["dependencies"]["cachy"] == "^0.2.0"
 
-    expected = """\
+    escaped_group_name = f'"{group_name}"' if "." in group_name else group_name
+    expected = f"""\
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.{escaped_group_name}.dependencies]
 cachy = "^0.2.0"
 
 """


### PR DESCRIPTION
when adding a dependency to a new group, build up the toml data structure directly - rather than by string parsing (and forgetting to do enough escaping)

fixes #8980