### PR TITLE
env: remove entry in envs.toml if the venv does not exist anymore

### DIFF
--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -276,6 +276,7 @@ class EnvManager:
         ).to_string()
 
         env = None
+        envs = None
         if self.envs_file.exists():
             envs = self.envs_file.read()
             env = envs.get(self.base_env_name)
@@ -310,6 +311,9 @@ class EnvManager:
             venv = venv_path / name
 
             if not venv.exists():
+                if env and envs:
+                    del envs[self.base_env_name]
+                    self.envs_file.write(envs)
                 return self.get_system_env()
 
             return VirtualEnv(venv)


### PR DESCRIPTION
This helps to avoid inconsistent entries when recreating the venv with another Python patch version.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
