### PR TITLE
Update pipx plugin uninstall docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -202,7 +202,7 @@ pipx inject poetry poetry-plugin
 If you want to uninstall a plugin, you can run:
 
 ```shell
-pipx runpip poetry uninstall poetry-plugin
+pipx uninject poetry poetry-plugin
 ```
 
 ### With `pip`

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -202,7 +202,9 @@ pipx inject poetry poetry-plugin
 If you want to uninstall a plugin, you can run:
 
 ```shell
-pipx uninject poetry poetry-plugin
+pipx uninject poetry poetry-plugin          # For pipx versions >= 1.2.0
+
+pipx runpip poetry uninstall poetry-plugin  # For pipx versions  < 1.2.0
 ```
 
 ### With `pip`


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

As of `pipx` `1.2.0` the `uninject` command was added. This allows you to remove packages that had previously been injected. I updated the docs to reflect that when using `pipx` to manage `poetry` plugins, this is the way to remove a plugin.
