### PR TITLE
lock: make `--no-update` the default behavior and introduce `--regenerate` for the previous default behavior

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -709,7 +709,9 @@ poetry search requests pendulum
 This command locks (without installing) the dependencies specified in `pyproject.toml`.
 
 {{% note %}}
-By default, this will lock all dependencies to the latest available compatible versions. To only refresh the lock file, use the `--no-update` option.
+By default, packages that have already been added to the lock file before will not be updated.
+To update all dependencies to the latest available compatible versions, use `poetry update --lock`
+or `poetry lock --regenerate`, which normally produce the same result.
 This command is also available as a pre-commit hook. See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-lock">}}) for more information.
 {{% /note %}}
 
@@ -720,7 +722,7 @@ poetry lock
 ### Options
 
 * `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml`. (**Deprecated**) Use `poetry check --lock` instead.
-* `--no-update`: Do not update locked versions, only refresh lock file.
+* `--regenerate`: Ignore existing lock file and overwrite it with a new lock file created from scratch.
 
 ## version
 

--- a/src/poetry/console/commands/lock.py
+++ b/src/poetry/console/commands/lock.py
@@ -18,7 +18,10 @@ class LockCommand(InstallerCommand):
 
     options: ClassVar[list[Option]] = [
         option(
-            "no-update", None, "Do not update locked versions, only refresh lock file."
+            "regenerate",
+            None,
+            "Ignore existing lock file"
+            " and overwrite it with a new lock file created from scratch.",
         ),
         option(
             "check",
@@ -34,6 +37,8 @@ The <info>lock</info> command reads the <comment>pyproject.toml</> file from the
 current directory, processes it, and locks the dependencies in the\
  <comment>poetry.lock</>
 file.
+By default, packages that have already been added to the lock file before
+will not be updated.
 
 <info>poetry lock</info>
 """
@@ -57,6 +62,6 @@ file.
             )
             return 1
 
-        self.installer.lock(update=not self.option("no-update"))
+        self.installer.lock(update=self.option("regenerate"))
 
         return self.installer.run()


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3248
Relates-to: #9136

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

⚠️ Breaking change. Requires a major version bump. ⚠️

The most difficult decision (if we want to let this change happen) is the name of the new option (old default behavior).

**The old flag was `--no-update`. Why not call the new flag `--update`?**

Because it's not exactly what it is. It does not update the locked package versions but ignores the lock file and creates a new one from scratch. The result is the same as an update because our (only) locking strategy is "use-latest" but in case we introduce alternative locking strategies in the future (cf #3527) the result will be different. Further, by not calling it `--update` the difference to `poetry update --lock` becomes clearer.