### PR TITLE
Fail command install if cannot be installed

### DIFF
--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -200,11 +200,10 @@ you can set the "package-mode" to false in your pyproject.toml file.
                 " use <c1>--no-root</c1>.\n"
                 "If you want to use Poetry only for dependency management"
                 " but not for packaging, you can disable package mode by setting"
-                " <c1>package-mode = false</> in your pyproject.toml file.\n"
-                "In a future version of Poetry this warning will become an error!",
-                style="warning",
+                " <c1>package-mode = false</> in your pyproject.toml file.\n",
+                style="error",
             )
-            return 0
+            return 1
 
         if overwrite:
             self.overwrite(log_install.format(tag="success"))

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -136,7 +136,7 @@ def test_group_options_are_passed_to_the_installer(
 
     status_code = tester.execute(options)
 
-    if options == "--no-root --only-root":
+    if options == "--no-root --only-root" or with_root:
         assert status_code == 1
         return
     else:
@@ -322,7 +322,7 @@ def test_invalid_groups_with_without_only(
 
     if not should_raise:
         tester.execute(cmd_args)
-        assert tester.status_code == 0
+        assert tester.status_code == 1
     else:
         with pytest.raises(GroupNotFound, match=r"^Group\(s\) not found:") as e:
             tester.execute(cmd_args)
@@ -345,7 +345,7 @@ def test_remove_untracked_outputs_deprecation_warning(
 
     tester.execute("--remove-untracked")
 
-    assert tester.status_code == 0
+    assert tester.status_code == 1
     assert (
         "The `--remove-untracked` option is deprecated, use the `--sync` option"
         " instead.\n" in tester.io.fetch_error()
@@ -440,7 +440,11 @@ authors = []
     tester = command_tester_factory("install", poetry=poetry)
     tester.execute("" if with_root else "--no-root")
 
-    assert tester.status_code == 0
+    if error and with_root:
+        assert tester.status_code == 1
+    else:
+        assert tester.status_code == 0
+
     if with_root and error:
         assert "The current project could not be installed: " in tester.io.fetch_error()
     else:


### PR DESCRIPTION
An error code is returned if the installation command fails. Also the style is changed from warning to error.

Tests was updated.

# Pull Request Check List

Resolves: #8637 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
