### PR TITLE
fix race condition and KeyError exception in executor

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -104,6 +104,10 @@ class Executor:
         self._shutdown = False
         self._hashes: dict[str, str] = {}
 
+        # Cache whether decorated output is supported.
+        # https://github.com/python-poetry/cleo/issues/423
+        self._decorated_output: bool = self._io.output.is_decorated()
+
     @property
     def installations_count(self) -> int:
         return self._executed["install"]
@@ -121,7 +125,7 @@ class Executor:
         return self._enabled
 
     def supports_fancy_output(self) -> bool:
-        return self._io.output.is_decorated() and not self._dry_run
+        return self._decorated_output and not self._dry_run
 
     def disable(self) -> Executor:
         self._enabled = False


### PR DESCRIPTION
Previously, it was possible that Executor.supports_fancy_output would flip-flop between True and False if a thread was updating a section. This could lead to crashes when an operation got different reponses as it made progress.

Executor.supports_fancy_output reflects the value of the underlying cleo Formatter used by the Output object. The Formatter is shared by any SectionOutputs derived by that Output object.

If a thread (tA) is in the middle of Formatter.remove_format, the flag to show decorator support is temporarily toggled off and then restored, which opens a window of time where another thread could get an "incorrect" answer when queried via `supports_fancy_output`.

If a parallel thread (tB) queries `supports_fancy_output` and sees it's False, the operation would not get added to the Executor's _sections dictionary. If tB's operation progressed after tA has restored the decorator value and attempts to write out progress information it will call `Executor._write`, see that `supports_fancy_output` is now True and attempt to find the operation in the _sections dictionary, however there will not be an entry for that operation due to the earlier query that returned False.

This causes tB to throw a KeyError and causes the install to shutdown.

Now, the Executor queries and caches whether the Output is decorated during init. This value is used in `supports_fancy_output` so as to not be affected by changes to the underlying Formatter object during section updates.

# Pull Request Check List

Resolves: #9334 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
