### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,11 +26,17 @@ jobs:
       contents: write
     needs: build
     steps:
+      # We need to be in a git repo for gh to work.
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: distfiles
+          path: dist/
 
       - run: gh release upload ${{ github.event.release.tag_name }} dist/*.{tar.gz,whl}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   upload-pypi:
     name: Upload (PyPI)
@@ -45,6 +51,7 @@ jobs:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: distfiles
+          path: dist/
 
       - uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
         with:


### PR DESCRIPTION
I tested the new release workflow - which we probably should have done before merging it - and fixed some bugs:
- `gh` fails without a token
- `gh` does not find the artifacts if we do not put them in the `dist` folder
- `gh` fails when not inside a git repo
- `pypi-publish` does not find the artifacts if we do not put them in the `dist` folder