### PR TITLE
tests: `contextlib.suppress` does not return anything

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -333,16 +333,13 @@ def switch_working_directory(path: Path, remove: bool = False) -> Iterator[Path]
     original_cwd = Path.cwd()
     os.chdir(path)
 
-    with contextlib.suppress(Exception) as exception:
+    try:
         yield path
+    finally:
+        os.chdir(original_cwd)
 
-    os.chdir(original_cwd)
-
-    if remove:
-        shutil.rmtree(path, ignore_errors=True)
-
-    if exception is not None:
-        raise exception
+        if remove:
+            shutil.rmtree(path, ignore_errors=True)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
While writing a test, I noticed that it passed although it was supposed to fail. The `AssertionError` was swallowed in the `switch_working_directory` context manager. I found no reference that `contextlib.suppress` returns anything. Therefore, I replaced this bogus expection handling.