### PR TITLE
Remove fish --init-command, fixes #9463

### DIFF
--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -108,8 +108,6 @@ class Shell:
         with env.temp_environ():
             if self._name == "nu":
                 args = ["-e", cmd]
-            elif self._name == "fish":
-                args = ["-i", "--init-command", cmd]
             else:
                 args = ["-i"]
 
@@ -126,8 +124,8 @@ class Shell:
             c.sendline(f"emulate bash -c {shlex.quote(f'. {quoted_activate_path}')}")
         elif self._name == "xonsh":
             c.sendline(f"vox activate {shlex.quote(str(env.path))}")
-        elif self._name in ["nu", "fish"]:
-            # If this is nu or fish, we don't want to send the activation command to the
+        elif self._name in ["nu"]:
+            # If this is nu, we don't want to send the activation command to the
             # command line since we already ran it via the shell's invocation.
             pass
         else:


### PR DESCRIPTION
Don't use --init-command when starting a fish venv subshell, instead treat it as other shells. The --init--command doesn't work well with python managed by mise. This has an added bonus of removing a few lines of code and some special handling for fish that doesn't seem to be necessary.

# Pull Request Check List

Resolves: python-poetry/poetry-plugin-shell#7

I'm not sure where the tests are for `Shell` but I'm happy to look at writing some for this. It's tricky because the bug being addressed is only for a specific environment (mise and fish shell). What I did to confirm was:

```sh
> poetry install # make a venv
> poetry shell
> which -a python
/path/to/global/mise/python
/path/to/venv/python
> # apply patch
> poetry shell
> which -a python
/path/to/venv/python
/path/to/global/mise/python
```

Hopefully the issue and testing its solution is clear from the issue I submitted.