### PR TITLE
fix: keep lock file eol

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -291,6 +291,8 @@ class Locker:
 
     def _write_lock_data(self, data: TOMLDocument) -> None:
         lockfile = TOMLFile(self.lock)
+        if self.lock.exists():
+            lockfile.read() # get original line ending
         lockfile.write(data)
 
         self._lock_data = None


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/1488 again

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


https://github.com/python-poetry/poetry/issues/1488 once be fixed but it's broken again.

appearly `TOMLFile` need to call `read` method to get line encoding, otherwise it just use default os eol.