### PR TITLE
Fix Relative Links for Single Page Repositories

### DIFF
--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -12,7 +12,7 @@ from poetry.core.packages.package import Package
 from poetry.inspection.info import PackageInfo
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.http_repository import HTTPRepository
-from poetry.repositories.link_sources.html import SimpleRepositoryPage
+from poetry.repositories.link_sources.html import HTMLPage, SimpleRepositoryPage
 from poetry.repositories.link_sources.html import SimpleRepositoryRootPage
 
 
@@ -125,7 +125,7 @@ class LegacyRepository(HTTPRepository):
             ),
         )
 
-    def _get_page(self, name: NormalizedName) -> SimpleRepositoryPage:
+    def _get_page(self, name: NormalizedName) -> HTMLPage:
         if not (response := self._get_response(f"/{name}/")):
             raise PackageNotFound(f"Package [{name}] not found.")
         return SimpleRepositoryPage(response.url, response.text)

--- a/src/poetry/repositories/single_page_repository.py
+++ b/src/poetry/repositories/single_page_repository.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from poetry.repositories.exceptions import PackageNotFound
 from poetry.repositories.legacy_repository import LegacyRepository
-from poetry.repositories.link_sources.html import SimpleRepositoryPage
+from poetry.repositories.link_sources.html import HTMLPage
 
 
 if TYPE_CHECKING:
@@ -12,11 +12,11 @@ if TYPE_CHECKING:
 
 
 class SinglePageRepository(LegacyRepository):
-    def _get_page(self, name: NormalizedName) -> SimpleRepositoryPage:
+    def _get_page(self, name: NormalizedName) -> HTMLPage:
         """
         Single page repositories only have one page irrespective of endpoint.
         """
         response = self._get_response("")
         if not response:
             raise PackageNotFound(f"Package [{name}] not found.")
-        return SimpleRepositoryPage(response.url, response.text)
+        return HTMLPage(response.url, response.text)

--- a/tests/repositories/fixtures/legacy.py
+++ b/tests/repositories/fixtures/legacy.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from packaging.utils import NormalizedName
     from pytest_mock import MockerFixture
 
-    from poetry.repositories.link_sources.html import SimpleRepositoryPage
+    from poetry.repositories.link_sources.html import HTMLPage
     from tests.types import HTTPrettyRequestCallback
     from tests.types import NormalizedNameTransformer
     from tests.types import SpecializedLegacyRepositoryMocker
@@ -129,7 +129,7 @@ def specialized_legacy_repository_mocker(
         )
         original_get_page = specialized_repository._get_page
 
-        def _mocked_get_page(name: NormalizedName) -> SimpleRepositoryPage:
+        def _mocked_get_page(name: NormalizedName) -> HTMLPage:
             return original_get_page(
                 canonicalize_name(f"{name}{transformer_or_suffix}")
                 if isinstance(transformer_or_suffix, str)

--- a/tests/repositories/fixtures/single-page/relative_links.html
+++ b/tests/repositories/fixtures/single-page/relative_links.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
+<body>
+<a href="relative-links-0.1.0.tar.gz">relative-links-0.1.0.tar.gz</a><br>
+</body>
+</html>

--- a/tests/repositories/test_single_page_repository.py
+++ b/tests/repositories/test_single_page_repository.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from requests import Response
+
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.utils.link import Link
 
@@ -17,10 +19,12 @@ if TYPE_CHECKING:
     from packaging.utils import NormalizedName
 
 
-class MockResponse:
+class MockResponse(Response):
     def __init__(self, url: str, content: str):
+        super().__init__()
         self.url = url
-        self.text = content
+        self._content = content.encode("utf-8")
+        self.status_code = 200
 
 
 class MockSinglePageRepository(SinglePageRepository):
@@ -35,7 +39,7 @@ class MockSinglePageRepository(SinglePageRepository):
         )
         self._lazy_wheel = False
 
-    def _get_response(self, endpoint: str):
+    def _get_response(self, endpoint: str) -> MockResponse:
         fixture = self.FIXTURES / (self.url.rsplit("/", 1)[-1] + endpoint)
         if not fixture.exists():
             raise PackageNotFound(f"Package not found.")

--- a/tests/repositories/test_single_page_repository.py
+++ b/tests/repositories/test_single_page_repository.py
@@ -63,6 +63,15 @@ def test_single_page_repository_get_page() -> None:
         assert link.path.startswith("/jax-releases/")
 
 
+def test_single_page_repository_relative_links_get_page() -> None:
+    repo = MockSinglePageRepository("relative_links")
+
+    page = repo.get_page("/ignored")
+    links = list(page.links)
+
+    assert links == [Link(f"{repo.BASE_URL}/relative-links-0.1.0.tar.gz")]
+
+
 def test_single_page_repository_find_packages() -> None:
     repo = MockSinglePageRepository("jax_releases")
 

--- a/tests/repositories/test_single_page_repository.py
+++ b/tests/repositories/test_single_page_repository.py
@@ -36,7 +36,7 @@ class MockSinglePageRepository(SinglePageRepository):
         self._lazy_wheel = False
 
     def _get_response(self, endpoint: str):
-        fixture = self.FIXTURES / self.url.rsplit("/", 1)[-1]
+        fixture = self.FIXTURES / (self.url.rsplit("/", 1)[-1] + endpoint)
         if not fixture.exists():
             raise PackageNotFound(f"Package not found.")
 


### PR DESCRIPTION
## Pull Request Check List

Resolves:
- dmlc/dgl#7494

_just let me know if I need to make a Poetry issue!_

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

## Bug

Relative links on Single Page Repositories are not resolved correctly

#### Steps to Reproduce
For example, take this `pyproject.toml` to install DGL according to [its single-page repo](https://www.dgl.ai/pages/start.html):
```toml
[tool.poetry]
package-mode = false

[tool.poetry.dependencies]
python = "^3.10"
dgl = { version = "2.3.0+cu118", source = "dgl" }

[[tool.poetry.source]]
name = "dgl"
url = "https://data.dgl.ai/wheels/torch-2.3/cu118/repo.html"
priority = "explicit"

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```

#### Expected Behavior
- Poetry installs an appropriate version from the repo.html index page

#### Actual Behavior
```
403 Client Error: Forbidden for url: https://data.dgl.ai/wheels/torch-2.3/cu118/repo.html/dgl-2.3.0%2Bcu118-cp310-cp310-manylinux1_x86_64.whl
```
Poetry tries to locate the `dgl-2.3.0+cu118-cp310-cp310-manylinux1_x86_64.whl` file at `/cu118/repo.html/dgl-2.3.0+cu118-cp310-cp310-manylinux1_x86_64.whl` instead of `/cu118/dgl-2.3.0+cu118-cp310-cp310-manylinux1_x86_64.whl`
