### PR TITLE
fix: specify venv activator as init script when starting PowerShell

### DIFF
--- a/src/poetry/utils/shell.py
+++ b/src/poetry/utils/shell.py
@@ -110,6 +110,8 @@ class Shell:
                 args = ["-e", cmd]
             elif self._name == "fish":
                 args = ["-i", "--init-command", cmd]
+            elif self._name in ("powershell", "pwsh"):
+                args = ["-NoExit", "-File", str(activate_path)]
             else:
                 args = ["-i"]
 
@@ -126,9 +128,10 @@ class Shell:
             c.sendline(f"emulate bash -c {shlex.quote(f'. {quoted_activate_path}')}")
         elif self._name == "xonsh":
             c.sendline(f"vox activate {shlex.quote(str(env.path))}")
-        elif self._name in ["nu", "fish"]:
-            # If this is nu or fish, we don't want to send the activation command to the
-            # command line since we already ran it via the shell's invocation.
+        elif self._name in ["nu", "fish", "powershell", "pwsh"]:
+            # If this is nu, fish or PowerShell, we don't want to send the activation
+            # command to the command line since we already ran it via the shell's
+            # invocation.
             pass
         else:
             c.sendline(cmd)


### PR DESCRIPTION
This PR is to fix a bug (not on Windows but at least on Linux): `poetry shell` sends the command line that invokes the venv activator script into a newly spawned PowerShell instance, while the command will not be automatically executed.