### PR TITLE
Enable GUI scripts

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -366,10 +366,24 @@ This section describes the scripts or executables that will be installed when in
 
 ```toml
 [tool.poetry.scripts]
-my_package_cli = 'my_package.console:run'
+my_package_cli = {reference='my_package.console:run', type='console'}
+my_pachkage_gui = {reference='my_package.gui:run', type='gui'}
 ```
 
 Here, we will have the `my_package_cli` script installed which will execute the `run` function in the `console` module in the `my_package` package.
+
+valid script types:
+
+* console. Usable as a command in a system shell after the package is installed
+* gui. Differs only on windows, where they can be started without a console window, using pythonw instead of python, this means they cannot use standard streams unless application code redirects them. On non windows platforms they are treated as console scripts.
+
+{{% warning %}}
+string defined scripts are deprecated:
+```toml
+[tool.poetry.scripts]
+my_package_cli = 'my_package.console:run'
+```
+{{% /warning %}}
 
 {{% note %}}
 When a script is added or updated, run `poetry install` to make them available in the project's virtualenv.


### PR DESCRIPTION

Resolves: #2310 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

## FEATURE:  ability to define gui scripts 

The implementation is based on the official specification by @abn [#2310](https://github.com/python-poetry/poetry/issues/2310)

### Created a script to be used with Windows gui_scripts, when using poetry install. 

1. The script starts a new window with an empty title "", in this new cmd pythonw is executed with the python script that is created for unix systems as argument (just as in console scripts), any other arguments are forwarded (just as in console scripts), [The start command](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start)
2.  Since pythonw doesn't starts/need a command window only the GUI window is opened, if the python script is defined correctly on the scripts section.
3. After starting pythonw the WINDOWS_GUI_CMD_TEMPLATE finishes, this means that if {script-name}.cmd  was executed by clicking on it this will close the command window that was opened.

**Questions:**
To be able to run pythonw i used string functions [split, replace, join] modifying the python path provided, i don't know if this is correct?
Using pythonw means this only works with the CPython implementation, is this OK?

### Updated documentation corresponding to the scripts section.

Based on [PyPA entry-points specification](https://packaging.python.org/en/latest/specifications/entry-points/) defined console scripts and gui scripts.
Also added a warning deprecation for 

```toml
[tool.poetry.scripts]
my_package_cli = 'my_package.console:run'
```

this is because of a [TODO](https://github.com/python-poetry/poetry-core/blob/06d72bc0f1f05086a1cc0e760075c519af33db5b/src/poetry/core/masonry/builders/builder.py#L301)


### Example

```toml
[tool.poetry.scripts]
my_pachkage_gui = {reference='my_package.gui:run', type='gui'}
```

### testing

- Tested manually with a repository a created with this purpose [DearPyGUI-example-poetry](https://github.com/IgnaciodelaTorreArias/DearPyGUI-example-poetry)
For this testing i also needed to modify poetry-core, i will make a pull request after this one is merged.
 
<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
