### PR TITLE
Pass Install Extras to Markers

### DIFF
--- a/docs/dependency-specification.md
+++ b/docs/dependency-specification.md
@@ -300,6 +300,51 @@ via the `markers` property:
 pathlib2 = { version = "^2.2", markers = "python_version <= '3.4' or sys_platform == 'win32'" }
 ```
 
+### `extra` environment marker
+
+Poetry populates the `extra` marker with each of the selected extras for the parent declaring the dependency. For 
+example, consider the following dependency in your root package:
+```toml
+[tool.poetry.dependencies]
+pathlib2 = { version = "^2.2", markers = "extra == 'paths' and sys_platform == 'win32'", optional = true}
+```
+`pathlib2` will be installed when you install your package with `--extras paths` on a `win32` machine. 
+You'll also need to [define the `paths` extra in your project](./pyproject.md#extras).
+
+#### Exclusive extras
+
+Keep in mind that all combinations of extras available in your project need to be compatible with each other. This 
+means that in order to use differing or incompatible versions across different extras, you need to make your extra 
+markers *exclusive*. For example, the following installs PyTorch from one source repository with CPU versions when 
+the `cpu` extra is specified, while the other installs from another repository with a separate version set for GPUs
+when the `cuda` extra is specified:
+
+```toml
+[tool.poetry.dependencies]
+torch = [
+    { markers = "extra == 'cpu' and extra != 'cuda'", version = "2.3.1+cpu", source = "pytorch-cpu", optional = true},
+    { markers = "extra != 'cpu' and extra == 'cuda'", version = "2.3.1+cu118", source = "pytorch-cu118", optional = true},
+ ]
+
+[tool.poetry.extras]
+cpu = ["torch"]
+cuda = ["torch"]
+
+[[tool.poetry.source]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+priority = "explicit"
+
+[[tool.poetry.source]]
+name = "pytorch-cu118"
+url = "https://download.pytorch.org/whl/cu118"
+priority = "explicit"
+```
+
+For the `cpu` extra marker, we have to specify `"extra == 'cpu' and extra != 'cuda'"` and vice-versa for the `cuda` 
+extra marker. There is no version that satisfies both constraints, so installing with `--extras cpu --extras gpu` 
+would match no cases and not install `torch`.
+
 ## Multiple constraints dependencies
 
 Sometimes, one of your dependency may have different version ranges depending

--- a/docs/dependency-specification.md
+++ b/docs/dependency-specification.md
@@ -313,21 +313,20 @@ You'll also need to [define the `paths` extra in your project](./pyproject.md#ex
 
 #### Exclusive extras
 
-Keep in mind that all combinations of extras available in your project need to be compatible with each other. This 
-means that in order to use differing or incompatible versions across different extras, you need to make your extra 
-markers *exclusive*. For example, the following installs PyTorch from one source repository with CPU versions when 
-the `cpu` extra is specified, while the other installs from another repository with a separate version set for GPUs
-when the `cuda` extra is specified:
+Keep in mind that all combinations of possible extras available in your project need to be compatible with each other. 
+This means that in order to use differing or incompatible versions across different combinations, you need to make your 
+extra markers *exclusive*. For example, the following installs PyTorch from one source repository with CPU versions 
+when the `cuda` extra is *not* specified, while the other installs from another repository with a separate version set 
+for GPUs when the `cuda` extra *is* specified:
 
 ```toml
 [tool.poetry.dependencies]
 torch = [
-    { markers = "extra == 'cpu' and extra != 'cuda'", version = "2.3.1+cpu", source = "pytorch-cpu", optional = true},
-    { markers = "extra != 'cpu' and extra == 'cuda'", version = "2.3.1+cu118", source = "pytorch-cu118", optional = true},
+    { markers = "extra != 'cuda'", version = "2.3.1+cpu", source = "pytorch-cpu", optional = true},
+    { markers = "extra == 'cuda'", version = "2.3.1+cu118", source = "pytorch-cu118", optional = true},
  ]
 
 [tool.poetry.extras]
-cpu = ["torch"]
 cuda = ["torch"]
 
 [[tool.poetry.source]]
@@ -341,9 +340,12 @@ url = "https://download.pytorch.org/whl/cu118"
 priority = "explicit"
 ```
 
-For the `cpu` extra marker, we have to specify `"extra == 'cpu' and extra != 'cuda'"` and vice-versa for the `cuda` 
-extra marker. There is no version that satisfies both constraints, so installing with `--extras cpu --extras gpu` 
-would match no cases and not install `torch`.
+For the CPU case, we have to specify `"extra != 'cuda'"` because the version specified is not compatible with the 
+GPU (`cuda`) version.
+
+This same logic applies when you want either-or extras. If a dependency for `extra-one` and 
+`extra-two` conflict, they will need to be restricted using `markers = "extra == 'extra-one' and extra != 'extra-two'"` 
+and vice versa.
 
 ## Multiple constraints dependencies
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 
     from cleo.io.io import IO
     from packaging.utils import NormalizedName
-    from poetry.core.packages.path_dependency import PathDependency
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.config.config import Config
@@ -287,6 +286,7 @@ class Installer:
             self._installed_repository.packages,
             locked_repository.packages,
             NullIO(),
+            active_root_extras=self._extras,
         )
         # Everything is resolved at this point, so we no longer need
         # to load deferred dependencies (i.e. VCS, URL and path dependencies)

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
     from cleo.io.io import IO
     from packaging.utils import NormalizedName
+    from poetry.core.packages.path_dependency import PathDependency
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.config.config import Config

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -134,7 +134,7 @@ class Provider:
         self._direct_origin_packages: dict[str, Package] = {}
         self._locked: dict[NormalizedName, list[DependencyPackage]] = defaultdict(list)
         self._use_latest: Collection[NormalizedName] = []
-        self._active_root_extras = frozenset(active_root_extras) if active_root_extras is not None else frozenset()
+        self._active_root_extras = frozenset(active_root_extras) if active_root_extras is not None else None
 
         self._explicit_sources: dict[str, str] = {}
         for package in locked or []:

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -962,16 +962,16 @@ class Provider:
         # resolved, there might be new dependencies with the same constraint.
         return self._merge_dependencies_by_constraint(new_dependencies)
 
-    def _marker_values(self, extras: set[NormalizedName] | None = None) -> dict[str, Any]:
+    def _marker_values(self, extras: Collection[NormalizedName] | None = None) -> dict[str, Any]:
         """
         Marker values, per:
         1. marker_env of `self._env`
         2. 'extras' will be added to the 'extra' marker if not already present
         """
-        result = self._env.marker_env.copy()
+        result = self._env.marker_env.copy() if self._env is not None else {}
         if extras is not None:
             if 'extra' not in result.keys():
-                result['extra'] = extras
+                result['extra'] = set(extras)
             else:
                 result['extra'] = set(result['extra']).union(extras)
         return result

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -41,6 +41,7 @@ class Solver:
         installed: list[Package],
         locked: list[Package],
         io: IO,
+        active_root_extras: Collection[NormalizedName] | None = None
     ) -> None:
         self._package = package
         self._pool = pool
@@ -49,7 +50,8 @@ class Solver:
         self._io = io
 
         self._provider = Provider(
-            self._package, self._pool, self._io, installed=installed, locked=locked
+            self._package, self._pool, self._io, installed=installed, locked=locked,
+            active_root_extras=active_root_extras
         )
         self._overrides: list[dict[Package, dict[str, Dependency]]] = []
 

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -50,8 +50,12 @@ class Solver:
         self._io = io
 
         self._provider = Provider(
-            self._package, self._pool, self._io, installed=installed, locked=locked,
-            active_root_extras=active_root_extras
+            self._package,
+            self._pool,
+            self._io,
+            installed=installed,
+            locked=locked,
+            active_root_extras=active_root_extras,
         )
         self._overrides: list[dict[Package, dict[str, Dependency]]] = []
 

--- a/tests/installation/fixtures/with-dependencies-differing-extras.test
+++ b/tests/installation/fixtures/with-dependencies-differing-extras.test
@@ -30,6 +30,10 @@ optional = true
 python-versions = "*"
 files = []
 
+[extras]
+extra-one = ["demo", "demo"]
+extra-two = ["demo", "demo"]
+
 [metadata]
 python-versions = "*"
 lock-version = "2.0"

--- a/tests/installation/fixtures/with-dependencies-differing-extras.test
+++ b/tests/installation/fixtures/with-dependencies-differing-extras.test
@@ -1,0 +1,36 @@
+[[package]]
+name = "demo"
+version = "1.0.0"
+description = ""
+optional = true
+python-versions = "*"
+files = []
+
+[package.extras]
+demo-extra-one = ["transitive-dep-one"]
+demo-extra-two = ["transitive-dep-two"]
+
+[package.dependencies]
+transitive-dep-one = {version = "1.1.0", optional = true}
+transitive-dep-two = {version = "1.2.0", optional = true}
+
+[[package]]
+name = "transitive-dep-one"
+version = "1.1.0"
+description = ""
+optional = true
+python-versions = "*"
+files = []
+
+[[package]]
+name = "transitive-dep-two"
+version = "1.2.0"
+description = ""
+optional = true
+python-versions = "*"
+files = []
+
+[metadata]
+python-versions = "*"
+lock-version = "2.0"
+content-hash = "123456789"

--- a/tests/installation/fixtures/with-exclusive-extras.test
+++ b/tests/installation/fixtures/with-exclusive-extras.test
@@ -1,0 +1,20 @@
+[[package]]
+name = "torch"
+version = "1.11.0+cpu"
+description = ""
+optional = true
+python-versions = "*"
+files = []
+
+[[package]]
+name = "torch"
+version = "1.11.0+cuda"
+description = ""
+optional = true
+python-versions = "*"
+files = []
+
+[metadata]
+python-versions = "*"
+lock-version = "2.0"
+content-hash = "123456789"

--- a/tests/installation/fixtures/with-exclusive-extras.test
+++ b/tests/installation/fixtures/with-exclusive-extras.test
@@ -6,6 +6,11 @@ optional = true
 python-versions = "*"
 files = []
 
+[package.source]
+reference = "pytorch-cpu"
+type = "legacy"
+url = "https://download.pytorch.org/whl/cpu"
+
 [[package]]
 name = "torch"
 version = "1.11.0+cuda"
@@ -13,6 +18,15 @@ description = ""
 optional = true
 python-versions = "*"
 files = []
+
+[package.source]
+reference = "pytorch-cuda"
+type = "legacy"
+url = "https://download.pytorch.org/whl/cuda"
+
+[extras]
+cpu = ["torch", "torch"]
+cuda = ["torch", "torch"]
 
 [metadata]
 python-versions = "*"

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1189,8 +1189,8 @@ def test_run_with_different_dependency_extras(
     package.add_dependency(extra_two_dep)
     # We don't want to cheat by only including the correct dependency in the 'extra' mapping
     package.extras = {
-        "extra-one": [extra_one_dep, extra_two_dep],
-        "extra-two": [extra_one_dep, extra_two_dep],
+        canonicalize_name("extra-one"): [extra_one_dep, extra_two_dep],
+        canonicalize_name("extra-two"): [extra_one_dep, extra_two_dep],
     }
 
     locker.locked(locked)

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1059,6 +1059,51 @@ def test_run_with_exclusive_extras(
     assert locker.written_data == expected
 
 
+def test_run_with_dependencies_different_extras(
+    installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
+) -> None:
+    demo = get_package("demo", "1.0.0")
+    dep_one = get_package("transitive-dep-one", "1.1.0")
+    dep_two = get_package("transitive-dep-two", "1.2.0")
+    demo.extras = {
+        canonicalize_name("demo-extra-one"): [get_dependency("transitive-dep-one")],
+        canonicalize_name("demo-extra-two"): [get_dependency("transitive-dep-two")],
+    }
+    demo.add_dependency(
+        Factory.create_dependency("transitive-dep-one", {"version": "1.1.0", "optional": True})
+    )
+    demo.add_dependency(
+        Factory.create_dependency("transitive-dep-two", {"version": "1.2.0", "optional": True})
+    )
+
+    repo.add_package(demo)
+    repo.add_package(dep_one)
+    repo.add_package(dep_two)
+
+    package.add_dependency(Factory.create_dependency(
+        "demo",
+        {
+            "version": "1.0.0",
+            "markers": "extra == 'extra-one' and extra != 'extra-two'",
+            "extras": ["demo-extra-one"],
+        })
+    )
+    package.add_dependency(Factory.create_dependency(
+        "demo",
+        {
+            "version": "1.0.0",
+            "markers": "extra != 'extra-one' and extra == 'extra-two'",
+            "extras": ["demo-extra-two"],
+        })
+    )
+
+    result = installer.run()
+    assert result == 0
+
+    expected = fixture("with-dependencies-differing-extras")
+    assert locker.written_data == expected
+
+
 @pytest.mark.parametrize("is_locked", [False, True])
 @pytest.mark.parametrize("is_installed", [False, True])
 @pytest.mark.parametrize("with_extras", [False, True])
@@ -2789,6 +2834,74 @@ def test_installer_distinguishes_locked_packages_with_same_version_by_source(
         source_url=source_url,
         source_reference=source_reference,
     )
+
+
+@pytest.mark.parametrize("extra", [None, "extra-one", "extra-two"])
+def test_installer_distinguishes_locked_packages_with_local_version_by_extra(
+    pool: RepositoryPool,
+    locker: Locker,
+    installed: CustomInstalledRepository,
+    config: Config,
+    repo: Repository,
+    package: ProjectPackage,
+    extra: str | None,
+) -> None:
+    """https://github.com/python-poetry/poetry/issues/834"""
+    # 'demo' with extra 'one' when package has 'extra-one' extra and with extra 'two' when 'extra-two'
+    extra_one_dep = Factory.create_dependency(
+            "demo",
+            {
+                "version": "1.0.0",
+                "markers": "extra == 'extra-one' and extra != 'extra-two'",
+                "extras": ["demo-extra-one"]
+            },
+        )
+    extra_two_dep = Factory.create_dependency(
+        "demo",
+        {
+            "version": "1.0.0",
+            "markers": "extra != 'extra-one' and extra == 'extra-two'",
+            "extras": ["demo-extra-two"]
+        },
+    )
+    package.add_dependency(extra_one_dep)
+    package.add_dependency(extra_two_dep)
+    # We don't want to cheat by only including the correct dependency in the 'extra' mapping
+    package.extras = {
+        "extra-one": [extra_one_dep, extra_two_dep],
+        "extra-two": [extra_one_dep, extra_two_dep],
+    }
+
+    # Locking finds packages from extra deps
+    locker.locked(True)
+    locker.mock_lock_data(dict(fixture("with-dependencies-differing-extras")))
+
+    installer = Installer(
+        NullIO(),
+        MockEnv(),
+        package,
+        locker,
+        pool,
+        config,
+        installed=installed,
+        executor=Executor(
+            MockEnv(),
+            pool,
+            config,
+            NullIO(),
+        ),
+    )
+    if extra is not None:
+        installer.extras([extra])
+    result = installer.run()
+    assert result == 0
+
+    # Results of installation are consistent with the 'extra' input
+    assert isinstance(installer.executor, Executor)
+    if extra is None:
+        assert len(installer.executor.installations) == 0
+    else:
+        assert len(installer.executor.installations) == 2
 
 
 @pytest.mark.parametrize("env_platform", ["darwin", "linux"])

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1027,82 +1027,206 @@ def test_run_with_dependencies_nested_extras(
     assert locker.written_data == expected
 
 
-def test_run_with_exclusive_extras(
-    installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
+@pytest.mark.parametrize("locked", [True, False])
+@pytest.mark.parametrize("extra", [None, "cpu", "cuda"])
+def test_run_with_exclusive_extras_different_sources(
+    installer: Installer,
+    locker: Locker,
+    installed: CustomInstalledRepository,
+    config: Config,
+    package: ProjectPackage,
+    extra: str | None,
+    locked: bool,
 ) -> None:
-    """https://github.com/python-poetry/poetry/issues/6409; https://github.com/python-poetry/poetry/issues/6419"""
-    torch_cpu = get_package("torch", "1.11.0+cpu")
-    torch_cuda = get_package("torch", "1.11.0+cuda")
+    """
+    - https://github.com/python-poetry/poetry/issues/6409
+    - https://github.com/python-poetry/poetry/issues/6419
+    - https://github.com/python-poetry/poetry/issues/7748
+    """
+    # Setup repo for each of our sources
+    cpu_repo = Repository("pytorch-cpu")
+    cuda_repo = Repository("pytorch-cuda")
+    pool = RepositoryPool()
+    pool.add_repository(cpu_repo)
+    pool.add_repository(cuda_repo)
+    config.config['repositories'] = {
+        "pytorch-cpu": {"url": "https://download.pytorch.org/whl/cpu"},
+        "pytorch-cuda": {"url": "https://download.pytorch.org/whl/cuda"},
+    }
 
-    repo.add_package(torch_cpu)
-    repo.add_package(torch_cuda)
+    # Configure packages that read from each of the different sources
+    torch_cpu_pkg = get_package("torch", "1.11.0+cpu")
+    torch_cpu_pkg._source_reference = "pytorch-cpu"
+    torch_cpu_pkg._source_type = "legacy"
+    torch_cpu_pkg._source_url = "https://download.pytorch.org/whl/cpu"
+    torch_cuda_pkg = get_package("torch", "1.11.0+cuda")
+    torch_cuda_pkg._source_reference = "pytorch-cuda"
+    torch_cuda_pkg._source_type = "legacy"
+    torch_cuda_pkg._source_url = "https://download.pytorch.org/whl/cuda"
+    cpu_repo.add_package(torch_cpu_pkg)
+    cuda_repo.add_package(torch_cuda_pkg)
 
-    package.add_dependency(Factory.create_dependency(
+    # Depend on each package based on exclusive extras
+    torch_cpu_dep = Factory.create_dependency(
         "torch",
         {
             "version": "1.11.0+cpu",
             "markers": "extra == 'cpu' and extra != 'cuda'",
+            "source": "pytorch-cpu",
         })
-    )
-    package.add_dependency(Factory.create_dependency(
+    torch_cuda_dep = Factory.create_dependency(
         "torch",
         {
             "version": "1.11.0+cuda",
             "markers": "extra != 'cpu' and extra == 'cuda'",
+            "source": "pytorch-cuda",
         })
-    )
+    package.add_dependency(torch_cpu_dep)
+    package.add_dependency(torch_cuda_dep)
+    # We don't want to cheat by only including the correct dependency in the 'extra' mapping
+    package.extras = {
+        canonicalize_name("cpu"): [torch_cpu_dep, torch_cuda_dep],
+        canonicalize_name("cuda"): [torch_cpu_dep, torch_cuda_dep],
+    }
 
+    # Set locker state
+    locker.locked(locked)
+    if locked:
+        locker.mock_lock_data(dict(fixture("with-exclusive-extras")))
+
+    # Perform install
+    installer = Installer(
+        NullIO(),
+        MockEnv(),
+        package,
+        locker,
+        pool,
+        config,
+        installed=installed,
+        executor=Executor(
+            MockEnv(),
+            pool,
+            config,
+            NullIO(),
+        ),
+    )
+    if extra is not None:
+        installer.extras([extra])
     result = installer.run()
     assert result == 0
 
-    expected = fixture("with-exclusive-extras")
-    assert locker.written_data == expected
+    # Results of locking are expected and installation are consistent with the 'extra' input
+    if not locked:
+        expected = fixture("with-exclusive-extras")
+        assert locker.written_data == expected
+    assert isinstance(installer.executor, Executor)
+    if extra is None:
+        assert len(installer.executor.installations) == 0
+    else:
+        assert len(installer.executor.installations) == 1
+        version = f"1.11.0+{extra}"
+        source_url = f"https://download.pytorch.org/whl/{extra}"
+        source_reference = f"pytorch-{extra}"
+        assert installer.executor.installations[0] == Package(
+            "torch",
+            version,
+            source_type="legacy",
+            source_url=source_url,
+            source_reference=source_reference,
+        )
 
 
-def test_run_with_dependencies_different_extras(
-    installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
+@pytest.mark.parametrize("locked", [True, False])
+@pytest.mark.parametrize("extra", [None, "extra-one", "extra-two"])
+def test_run_with_different_dependency_extras(
+    installer: Installer,
+    pool: RepositoryPool,
+    locker: Locker,
+    installed: CustomInstalledRepository,
+    repo: Repository,
+    config: Config,
+    package: ProjectPackage,
+    extra: str | None,
+    locked: bool
 ) -> None:
-    demo = get_package("demo", "1.0.0")
-    dep_one = get_package("transitive-dep-one", "1.1.0")
-    dep_two = get_package("transitive-dep-two", "1.2.0")
-    demo.extras = {
+    """https://github.com/python-poetry/poetry/issues/834"""
+    # Demo package with two optional transitive dependencies, one for each extra
+    demo_pkg = get_package("demo", "1.0.0")
+    transitive_dep_one = get_package("transitive-dep-one", "1.1.0")
+    transitive_dep_two = get_package("transitive-dep-two", "1.2.0")
+    demo_pkg.extras = {
         canonicalize_name("demo-extra-one"): [get_dependency("transitive-dep-one")],
         canonicalize_name("demo-extra-two"): [get_dependency("transitive-dep-two")],
     }
-    demo.add_dependency(
+    demo_pkg.add_dependency(
         Factory.create_dependency("transitive-dep-one", {"version": "1.1.0", "optional": True})
     )
-    demo.add_dependency(
+    demo_pkg.add_dependency(
         Factory.create_dependency("transitive-dep-two", {"version": "1.2.0", "optional": True})
     )
+    repo.add_package(demo_pkg)
+    repo.add_package(transitive_dep_one)
+    repo.add_package(transitive_dep_two)
 
-    repo.add_package(demo)
-    repo.add_package(dep_one)
-    repo.add_package(dep_two)
-
-    package.add_dependency(Factory.create_dependency(
+    # 'demo' with extra 'one' when package has 'extra-one' extra and with extra 'two' when 'extra-two'
+    extra_one_dep = Factory.create_dependency(
         "demo",
         {
             "version": "1.0.0",
             "markers": "extra == 'extra-one' and extra != 'extra-two'",
-            "extras": ["demo-extra-one"],
-        })
+            "extras": ["demo-extra-one"]
+        },
     )
-    package.add_dependency(Factory.create_dependency(
+    extra_two_dep = Factory.create_dependency(
         "demo",
         {
             "version": "1.0.0",
             "markers": "extra != 'extra-one' and extra == 'extra-two'",
-            "extras": ["demo-extra-two"],
-        })
+            "extras": ["demo-extra-two"]
+        },
     )
+    package.add_dependency(extra_one_dep)
+    package.add_dependency(extra_two_dep)
+    # We don't want to cheat by only including the correct dependency in the 'extra' mapping
+    package.extras = {
+        "extra-one": [extra_one_dep, extra_two_dep],
+        "extra-two": [extra_one_dep, extra_two_dep],
+    }
 
+    locker.locked(locked)
+    if locked:
+        locker.mock_lock_data(dict(fixture("with-dependencies-differing-extras")))
+
+    installer = Installer(
+        NullIO(),
+        MockEnv(),
+        package,
+        locker,
+        pool,
+        config,
+        installed=installed,
+        executor=Executor(
+            MockEnv(),
+            pool,
+            config,
+            NullIO(),
+        ),
+    )
+    if extra is not None:
+        installer.extras([extra])
     result = installer.run()
     assert result == 0
 
-    expected = fixture("with-dependencies-differing-extras")
-    assert locker.written_data == expected
+    if not locked:
+        expected = fixture("with-dependencies-differing-extras")
+        assert locker.written_data == expected
 
+    # Results of installation are consistent with the 'extra' input
+    assert isinstance(installer.executor, Executor)
+    if extra is None:
+        assert len(installer.executor.installations) == 0
+    else:
+        assert len(installer.executor.installations) == 2
 
 @pytest.mark.parametrize("is_locked", [False, True])
 @pytest.mark.parametrize("is_installed", [False, True])
@@ -2616,122 +2740,6 @@ def test_installer_distinguishes_locked_packages_with_local_version_by_source(
     )
 
 
-@pytest.mark.parametrize("extra", [None, "cpu", "cuda"])
-def test_installer_distinguishes_locked_packages_with_local_version_by_extra(
-    pool: RepositoryPool,
-    locker: Locker,
-    installed: CustomInstalledRepository,
-    config: Config,
-    repo: Repository,
-    package: ProjectPackage,
-    extra: str | None,
-) -> None:
-    """https://github.com/python-poetry/poetry/issues/6409; https://github.com/python-poetry/poetry/issues/6419"""
-    # Require 1.11.0+cpu from pytorch for when extra is 'cpu', or 1.11.0+cuda when extra is 'cuda'
-    cpu_dep = Factory.create_dependency(
-            "torch",
-            {
-                "version": "1.11.0+cpu",
-                "markers": "extra == 'cpu' and extra != 'cuda'",
-                "source": "pytorch-cpu",
-            },
-        )
-    cuda_dep = Factory.create_dependency(
-        "torch",
-        {
-            "version": "1.11.0+cuda",
-            "markers": "extra != 'cpu' and extra == 'cuda'",
-            "source": "pytorch-cuda",
-        },
-    )
-    package.add_dependency(cpu_dep)
-    package.add_dependency(cuda_dep)
-    # We don't want to cheat by only including the correct dependency in the 'extra' mapping
-    package.extras = {
-        "cpu": [cpu_dep, cuda_dep],
-        "cuda": [cpu_dep, cuda_dep],
-    }
-
-    # Locking finds packages from each pytorch repository
-    locker.locked(True)
-    locker.mock_lock_data(
-        {
-            "package": [
-                {
-                    "name": "torch",
-                    "version": "1.11.0+cpu",
-                    "optional": True,
-                    "files": [],
-                    "python-versions": "*",
-                    "source": {
-                        "type": "legacy",
-                        "url": "https://download.pytorch.org/whl/cpu",
-                        "reference": "pytorch-cpu",
-                    },
-                },
-                {
-                    "name": "torch",
-                    "version": "1.11.0+cuda",
-                    "optional": True,
-                    "files": [],
-                    "python-versions": "*",
-                    "source": {
-                        "type": "legacy",
-                        "url": "https://download.pytorch.org/whl/cuda",
-                        "reference": "pytorch-cuda",
-                    },
-                },
-            ],
-            "metadata": {
-                "python-versions": "*",
-                "platform": "*",
-                "content-hash": "123456789",
-            },
-            "extras": {
-                "cpu": ["torch"],
-                "cuda": ["torch"],
-            }
-        }
-    )
-
-    installer = Installer(
-        NullIO(),
-        MockEnv(),
-        package,
-        locker,
-        pool,
-        config,
-        installed=installed,
-        executor=Executor(
-            MockEnv(),
-            pool,
-            config,
-            NullIO(),
-        ),
-    )
-    if extra is not None:
-        installer.extras([extra])
-    result = installer.run()
-    assert result == 0
-
-    # Results of installation are consistent with the 'extra' input
-    assert isinstance(installer.executor, Executor)
-    if extra is None:
-        assert len(installer.executor.installations) == 0
-    else:
-        assert len(installer.executor.installations) == 1
-        version = f"1.11.0+{extra}"
-        source_url = f"https://download.pytorch.org/whl/{extra}"
-        source_reference = f"pytorch-{extra}"
-        assert installer.executor.installations[0] == Package(
-            "torch",
-            version,
-            source_type="legacy",
-            source_url=source_url,
-            source_reference=source_reference,
-        )
-
-
 @pytest.mark.parametrize("env_platform_machine", ["aarch64", "amd64"])
 def test_installer_distinguishes_locked_packages_with_same_version_by_source(
     pool: RepositoryPool,
@@ -2834,74 +2842,6 @@ def test_installer_distinguishes_locked_packages_with_same_version_by_source(
         source_url=source_url,
         source_reference=source_reference,
     )
-
-
-@pytest.mark.parametrize("extra", [None, "extra-one", "extra-two"])
-def test_installer_distinguishes_locked_packages_with_local_version_by_extra(
-    pool: RepositoryPool,
-    locker: Locker,
-    installed: CustomInstalledRepository,
-    config: Config,
-    repo: Repository,
-    package: ProjectPackage,
-    extra: str | None,
-) -> None:
-    """https://github.com/python-poetry/poetry/issues/834"""
-    # 'demo' with extra 'one' when package has 'extra-one' extra and with extra 'two' when 'extra-two'
-    extra_one_dep = Factory.create_dependency(
-            "demo",
-            {
-                "version": "1.0.0",
-                "markers": "extra == 'extra-one' and extra != 'extra-two'",
-                "extras": ["demo-extra-one"]
-            },
-        )
-    extra_two_dep = Factory.create_dependency(
-        "demo",
-        {
-            "version": "1.0.0",
-            "markers": "extra != 'extra-one' and extra == 'extra-two'",
-            "extras": ["demo-extra-two"]
-        },
-    )
-    package.add_dependency(extra_one_dep)
-    package.add_dependency(extra_two_dep)
-    # We don't want to cheat by only including the correct dependency in the 'extra' mapping
-    package.extras = {
-        "extra-one": [extra_one_dep, extra_two_dep],
-        "extra-two": [extra_one_dep, extra_two_dep],
-    }
-
-    # Locking finds packages from extra deps
-    locker.locked(True)
-    locker.mock_lock_data(dict(fixture("with-dependencies-differing-extras")))
-
-    installer = Installer(
-        NullIO(),
-        MockEnv(),
-        package,
-        locker,
-        pool,
-        config,
-        installed=installed,
-        executor=Executor(
-            MockEnv(),
-            pool,
-            config,
-            NullIO(),
-        ),
-    )
-    if extra is not None:
-        installer.extras([extra])
-    result = installer.run()
-    assert result == 0
-
-    # Results of installation are consistent with the 'extra' input
-    assert isinstance(installer.executor, Executor)
-    if extra is None:
-        assert len(installer.executor.installations) == 0
-    else:
-        assert len(installer.executor.installations) == 2
 
 
 @pytest.mark.parametrize("env_platform", ["darwin", "linux"])

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -5,7 +5,7 @@ import re
 import shutil
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, IO
 from typing import Any
 
 import pytest
@@ -2537,6 +2537,122 @@ def test_installer_distinguishes_locked_packages_with_local_version_by_source(
         source_url=source_url,
         source_reference=source_reference,
     )
+
+
+@pytest.mark.parametrize("extra", [None, "cpu", "cuda"])
+def test_installer_distinguishes_locked_packages_with_local_version_by_extra(
+    pool: RepositoryPool,
+    locker: Locker,
+    installed: CustomInstalledRepository,
+    config: Config,
+    repo: Repository,
+    package: ProjectPackage,
+    extra: str | None,
+) -> None:
+    """https://github.com/python-poetry/poetry/issues/6409; https://github.com/python-poetry/poetry/issues/6419"""
+    # Require 1.11.0+cpu from pytorch for when extra is 'cpu', or 1.11.0+cuda when extra is 'cuda'
+    cpu_dep = Factory.create_dependency(
+            "torch",
+            {
+                "version": "1.11.0+cpu",
+                "markers": "extra == 'cpu' and extra != 'cuda'",
+                "source": "pytorch-cpu",
+            },
+        )
+    cuda_dep = Factory.create_dependency(
+        "torch",
+        {
+            "version": "1.11.0+cuda",
+            "markers": "extra != 'cpu' and extra == 'cuda'",
+            "source": "pytorch-cuda",
+        },
+    )
+    package.add_dependency(cpu_dep)
+    package.add_dependency(cuda_dep)
+    # We don't want to cheat by only including the correct dependency in the 'extra' mapping
+    package.extras = {
+        "cpu": [cpu_dep, cuda_dep],
+        "cuda": [cpu_dep, cuda_dep],
+    }
+
+    # Locking finds packages from each pytorch repository
+    locker.locked(True)
+    locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "torch",
+                    "version": "1.11.0+cpu",
+                    "optional": True,
+                    "files": [],
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://download.pytorch.org/whl/cpu",
+                        "reference": "pytorch-cpu",
+                    },
+                },
+                {
+                    "name": "torch",
+                    "version": "1.11.0+cuda",
+                    "optional": True,
+                    "files": [],
+                    "python-versions": "*",
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://download.pytorch.org/whl/cuda",
+                        "reference": "pytorch-cuda",
+                    },
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+            },
+            "extras": {
+                "cpu": ["torch"],
+                "cuda": ["torch"],
+            }
+        }
+    )
+
+    installer = Installer(
+        NullIO(),
+        MockEnv(),
+        package,
+        locker,
+        pool,
+        config,
+        installed=installed,
+        executor=Executor(
+            MockEnv(),
+            pool,
+            config,
+            NullIO(),
+        ),
+    )
+    if extra is not None:
+        installer.extras([extra])
+    result = installer.run()
+    assert result == 0
+
+    # Results of installation are consistent with the 'extra' input
+    assert isinstance(installer.executor, Executor)
+    if extra is None:
+        assert len(installer.executor.installations) == 0
+    else:
+        assert len(installer.executor.installations) == 1
+        version = f"1.11.0+{extra}"
+        source_url = f"https://download.pytorch.org/whl/{extra}"
+        source_reference = f"pytorch-{extra}"
+        assert installer.executor.installations[0] == Package(
+            "torch",
+            version,
+            source_type="legacy",
+            source_url=source_url,
+            source_reference=source_reference,
+        )
 
 
 @pytest.mark.parametrize("env_platform_machine", ["aarch64", "amd64"])


### PR DESCRIPTION
# Pull Request Check List

Resolves:
- #834 
- #6409 
- #6419
- #7748  
- #9537 

This PR exposes the `extras` supplied at install to the 'extra' marker for dependencies, taking up @radoering's [offer](https://github.com/python-poetry/poetry/issues/6409#issuecomment-1799026967) to create a PR implementing this functionality to allow switching torch installation versions based on a `cuda` extra.

It is a duplicate of the feature in #613 but it appears that PR is no longer active, with the last updates in August 2023 and an unanswered question about timeline from March 2024.

See issues and unit tests for more details but the idea is to, among other things, enable exclusive extras like so:
```toml
[tool.poetry]
package-mode = false

[tool.poetry.dependencies]
python = "^3.10"
click = [
    { markers = "extra == 'one' and extra != 'two' and extra != 'three'", version = "8.1.1", optional = true},
    { markers = "extra != 'one' and extra == 'two' and extra != 'three'", version = "8.1.2", optional = true},
    { markers = "extra != 'one' and extra != 'two' and extra == 'three'", version = "8.1.3", optional = true}
 ]

[tool.poetry.extras]
one = ["click"]
two = ["click"]
three = ["click"]
```

@radoering it looks like you're very familiar with this issue, would you be the right person to review? :pray:  
I'm sure I'm missing something here but look forward to iterating!

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
