### PR TITLE
default python requirement to >=

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -173,7 +173,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if not python:
             config = Config.create()
             python = (
-                "^"
+                ">="
                 + EnvManager.get_python_version(
                     precision=2,
                     prefer_active_python=config.get("virtualenvs.prefer-active-python"),

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -216,7 +216,7 @@ authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^{python}"
+python = ">={python}"
 """
     assert expected in tester.io.fetch_output()
 
@@ -1066,7 +1066,7 @@ def test_respect_prefer_active_on_init(
 
     expected = f"""\
 [tool.poetry.dependencies]
-python = "^{python}"
+python = ">={python}"
 """
 
     assert expected in pyproject_file.read_text()

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -225,7 +225,7 @@ def test_respect_prefer_active_on_new(
 
     expected = f"""\
 [tool.poetry.dependencies]
-python = "^{python}"
+python = ">={python}"
 """
 
     assert expected in pyproject_file.read_text()


### PR DESCRIPTION
I'm mostly of the view that there is absolutely no sign of python 4.0 happening in the foreseeable future, so it should make no difference to anyone whether they have this upper bound on their python requirement or not.

However, it continues to be a source of noise that this is a thing: and it is true that - in combination with its own solver - poetry's upper bounds becomes self-propagating.  Which, if nothing else, becomes an opinionated stance - on a matter which I think hardly deserves an opinion.

I expect that the transition may lead to a small bump in that noise, as resolution on new projects will now be more likely to hit conflicts when pulling in dependencies that have the cap.

Still, on the whole I think that no cap here is a better default and the world will be ever so slightly a better place if poetry makes the change.

(Upper bounds on regular dependencies are a whole different kettle of fish, out of scope here).