### PR TITLE
`--no-truncate` flag in show command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1061,6 +1061,7 @@ required by
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.
 * `--all (-a)`: Show all packages (even those not compatible with current system).
 * `--top-level (-T)`: Only show explicitly defined packages.
+* `--no-truncate`: Do not truncate the output based on the terminal width.
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import math
+import sys
 
 from typing import TYPE_CHECKING
 from typing import ClassVar
@@ -237,7 +237,7 @@ lists all packages available."""
         show_all = self.option("all")
         show_top_level = self.option("top-level")
         width = (
-            math.inf
+            sys.maxsize
             if self.option("no-truncate")
             else shutil.get_terminal_size().columns
         )

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -307,7 +307,8 @@ lists all packages available."""
                     )
 
         if self.option("no-truncate"):
-            write_version = write_latest = write_why = write_description = True
+            write_version = write_latest = write_description = True
+            write_why = self.option("why")
         else:
             write_version = name_length + version_length + 3 <= width
             write_latest = name_length + version_length + latest_length + 3 <= width

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -238,7 +238,7 @@ lists all packages available."""
         show_top_level = self.option("top-level")
         width = (
             math.inf
-            if self.option("--no-truncate")
+            if self.option("no-truncate")
             else shutil.get_terminal_size().columns
         )
         name_length = version_length = latest_length = required_by_length = 0

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
@@ -234,7 +236,11 @@ lists all packages available."""
         show_latest = self.option("latest")
         show_all = self.option("all")
         show_top_level = self.option("top-level")
-        width = shutil.get_terminal_size().columns
+        width = (
+            math.inf
+            if self.option("--no-truncate")
+            else shutil.get_terminal_size().columns
+        )
         name_length = version_length = latest_length = required_by_length = 0
         latest_packages = {}
         latest_statuses = {}
@@ -306,18 +312,14 @@ lists all packages available."""
                         required_by_length, len(" from " + ",".join(required_by.keys()))
                     )
 
-        if self.option("no-truncate"):
-            write_version = write_latest = write_description = True
-            write_why = self.option("why")
-        else:
-            write_version = name_length + version_length + 3 <= width
-            write_latest = name_length + version_length + latest_length + 3 <= width
+        write_version = name_length + version_length + 3 <= width
+        write_latest = name_length + version_length + latest_length + 3 <= width
 
-            why_end_column = (
-                name_length + version_length + latest_length + required_by_length
-            )
-            write_why = self.option("why") and (why_end_column + 3) <= width
-            write_description = (why_end_column + 24) <= width
+        why_end_column = (
+            name_length + version_length + latest_length + required_by_length
+        )
+        write_why = self.option("why") and (why_end_column + 3) <= width
+        write_description = (why_end_column + 24) <= width
 
         requires = root.all_requires
 
@@ -395,9 +397,7 @@ lists all packages available."""
                 if show_latest:
                     remaining -= latest_length
 
-                if len(locked.description) > remaining and not self.option(
-                    "no-truncate"
-                ):
+                if len(locked.description) > remaining:
                     description = description[: remaining - 3] + "..."
 
                 line += " " + description

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -64,6 +64,11 @@ class ShowCommand(GroupCommand, EnvCommand):
             "Show all packages (even those not compatible with current system).",
         ),
         option("top-level", "T", "Show only top-level dependencies."),
+        option(
+            "no-truncate",
+            None,
+            "Do not truncate the output based on the terminal width.",
+        ),
     ]
 
     help = """The show command displays detailed information about a package, or
@@ -301,14 +306,17 @@ lists all packages available."""
                         required_by_length, len(" from " + ",".join(required_by.keys()))
                     )
 
-        write_version = name_length + version_length + 3 <= width
-        write_latest = name_length + version_length + latest_length + 3 <= width
+        if self.option("no-truncate"):
+            write_version = write_latest = write_why = write_description = True
+        else:
+            write_version = name_length + version_length + 3 <= width
+            write_latest = name_length + version_length + latest_length + 3 <= width
 
-        why_end_column = (
-            name_length + version_length + latest_length + required_by_length
-        )
-        write_why = self.option("why") and (why_end_column + 3) <= width
-        write_description = (why_end_column + 24) <= width
+            why_end_column = (
+                name_length + version_length + latest_length + required_by_length
+            )
+            write_why = self.option("why") and (why_end_column + 3) <= width
+            write_description = (why_end_column + 24) <= width
 
         requires = root.all_requires
 
@@ -386,7 +394,9 @@ lists all packages available."""
                 if show_latest:
                     remaining -= latest_length
 
-                if len(locked.description) > remaining:
+                if len(locked.description) > remaining and not self.option(
+                    "no-truncate"
+                ):
                     description = description[: remaining - 3] + "..."
 
                 line += " " + description

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1981,6 +1981,120 @@ required by
     assert actual == expected
 
 
+def test_show_entire_description_with_no_truncate(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.2.0"))
+
+    cachy2 = get_package("cachy", "0.2.0")
+    cachy2.description = (
+        "This is a veeeeeeeery long description that should not be truncated."
+    )
+    cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
+
+    installed.add_package(cachy2)
+
+    assert isinstance(poetry.locker, TestLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.2.0",
+                    "description": "This is a veeeeeeeery long description that should not be truncated.",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"msgpack-python": ">=0.5 <0.6"},
+                },
+                {
+                    "name": "msgpack-python",
+                    "version": "0.5.1",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": [], "msgpack-python": []},
+            },
+        }
+    )
+
+    tester.execute("--no-truncate")
+
+    expected = """\
+cachy              0.2.0 This is a veeeeeeeery long description that should not be truncated.
+msgpack-python (!) 0.5.1"""
+
+    assert tester.io.fetch_output().strip() == expected
+
+
+def test_show_entire_description_with_truncate(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.2.0"))
+
+    cachy2 = get_package("cachy", "0.2.0")
+    cachy2.description = (
+        "This is a veeeeeeeery long description that should be truncated."
+    )
+    cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
+
+    installed.add_package(cachy2)
+
+    assert isinstance(poetry.locker, TestLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.2.0",
+                    "description": "This is a veeeeeeeery long description that should be truncated.",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"msgpack-python": ">=0.5 <0.6"},
+                },
+                {
+                    "name": "msgpack-python",
+                    "version": "0.5.1",
+                    "description": "",
+                    "category": "main",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": [], "msgpack-python": []},
+            },
+        }
+    )
+
+    tester.execute()
+
+    expected = """\
+cachy              0.2.0 This is a veeeeeeeery long description that should...
+msgpack-python (!) 0.5.1"""
+
+    assert tester.io.fetch_output().strip() == expected
+
+
 def test_show_errors_without_lock_file(tester: CommandTester, poetry: Poetry) -> None:
     assert not poetry.locker.lock.exists()
 


### PR DESCRIPTION
Fixes #9597

In order to get a more consistent output from the `poetry show` command, this PR introduces a `--no-truncate` flag to the command. When the flag is set the show command does not take the width of the terminal into account when deciding the level of detail to print.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
