### PR TITLE
remove local version specifier at poetry add

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -459,7 +459,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             # TODO: find similar
             raise ValueError(f"Could not find a matching version of package {name}")
 
-        return package.pretty_name, f"^{package.version.to_string()}"
+        version = package.version.without_local()
+        return package.pretty_name, f"^{version.to_string()}"
 
     def _parse_requirements(self, requirements: list[str]) -> list[dict[str, Any]]:
         from poetry.core.pyproject.exceptions import PyProjectException

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -103,6 +103,7 @@ def repo_add_default_packages(repo: TestRepository) -> None:
     repo.add_package(get_package("tomlkit", "0.5.5"))
     repo.add_package(get_package("pyyaml", "3.13"))
     repo.add_package(get_package("pyyaml", "4.2b2"))
+    repo.add_package(get_package("torch", "2.4.0+cpu"))
 
 
 def test_add_no_constraint(app: PoetryTestApplication, tester: CommandTester) -> None:
@@ -131,6 +132,33 @@ Writing lock file
 
     assert "cachy" in content["dependencies"]
     assert content["dependencies"]["cachy"] == "^0.2.0"
+
+
+def test_add_local_version(app: PoetryTestApplication, tester: CommandTester) -> None:
+    tester.execute("torch")
+
+    expected = """\
+Using version ^2.4.0 for torch
+
+Updating dependencies
+Resolving dependencies...
+
+Package operations: 1 install, 0 updates, 0 removals
+
+  - Installing torch (2.4.0+cpu)
+
+Writing lock file
+"""
+
+    assert tester.io.fetch_output() == expected
+    assert isinstance(tester.command, InstallerCommand)
+    assert tester.command.installer.executor.installations_count == 1
+
+    pyproject: dict[str, Any] = app.poetry.file.read()
+    content = pyproject["tool"]["poetry"]
+
+    assert "torch" in content["dependencies"]
+    assert content["dependencies"]["torch"] == "^2.4.0"
 
 
 def test_add_non_package_mode_no_name(


### PR DESCRIPTION
```shell
$ poetry source add torch https://download.pytorch.org/whl/cpu
Adding source with name torch.

$ poetry add --lock --source torch torch
Using version ^2.4.0+cpu for torch
```
but `^2.4.0+cpu` is not a valid constraint: or anyway it is not valid once it has been converted into a regular version specifier (eg when written to METADATA).  Because per PEP440 on [inclusive ordered comparison](https://peps.python.org/pep-0440/#inclusive-ordered-comparison)

> Local version identifiers are NOT permitted in this version specifier