### PR TITLE
fix keyring fixture to comply with KeyringBackend API

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -20,7 +20,7 @@ name = "build"
 version = "1.2.1"
 description = "A simple, correct Python build frontend"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">= 3.8"
 files = [
     {file = "build-1.2.1-py3-none-any.whl", hash = "sha256:75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4"},
     {file = "build-1.2.1.tar.gz", hash = "sha256:526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d"},
@@ -717,13 +717,13 @@ trio = ["async_generator", "trio"]
 
 [[package]]
 name = "keyring"
-version = "25.2.1"
+version = "25.3.0"
 description = "Store and access your passwords safely."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "keyring-25.2.1-py3-none-any.whl", hash = "sha256:2458681cdefc0dbc0b7eb6cf75d0b98e59f9ad9b2d4edd319d18f68bdca95e50"},
-    {file = "keyring-25.2.1.tar.gz", hash = "sha256:daaffd42dbda25ddafb1ad5fec4024e5bbcfe424597ca1ca452b299861e49f1b"},
+    {file = "keyring-25.3.0-py3-none-any.whl", hash = "sha256:8d963da00ccdf06e356acd9bf3b743208878751032d8599c6cc89eb51310ffae"},
+    {file = "keyring-25.3.0.tar.gz", hash = "sha256:8d85a1ea5d6db8515b59e1c5d1d1678b03cf7fc8b8dcfb1651e8c4a524eb42ef"},
 ]
 
 [package.dependencies]
@@ -738,8 +738,8 @@ SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 
 [package.extras]
 completion = ["shtab (>=1.1.0)"]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "more-itertools"
@@ -880,7 +880,7 @@ name = "nodeenv"
 version = "1.9.1"
 description = "Node.js virtual environment builder"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
@@ -986,7 +986,7 @@ name = "poetry-plugin-export"
 version = "1.8.0"
 description = "Poetry plugin to export the dependencies to various formats"
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = ">=3.8,<4.0"
 files = [
     {file = "poetry_plugin_export-1.8.0-py3-none-any.whl", hash = "sha256:adbe232cfa0cc04991ea3680c865cf748bff27593b9abcb1f35fb50ed7ba2c22"},
     {file = "poetry_plugin_export-1.8.0.tar.gz", hash = "sha256:1fa6168a85d59395d835ca564bc19862a7c76061e60c3e7dfaec70d50937fc61"},
@@ -1019,7 +1019,7 @@ name = "psutil"
 version = "6.0.0"
 description = "Cross-platform lib for process and system monitoring in Python."
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
     {file = "psutil-6.0.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a021da3e881cd935e64a3d0a20983bda0bb4cf80e4f74fa9bfcb1bc5785360c6"},
     {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:1287c2b95f1c0a364d23bc6f2ea2365a8d4d9b726a3be7294296ff7ba97c17f0"},

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -5,7 +5,6 @@ import logging
 import re
 import uuid
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -15,6 +14,7 @@ import pytest
 import requests
 
 from cleo.io.null_io import NullIO
+from keyring.credentials import SimpleCredential
 
 from poetry.utils.authenticator import Authenticator
 from poetry.utils.authenticator import RepositoryCertificateConfig
@@ -27,12 +27,6 @@ if TYPE_CHECKING:
 
     from tests.conftest import Config
     from tests.conftest import DummyBackend
-
-
-@dataclass
-class SimpleCredential:
-    username: str
-    password: str
 
 
 @pytest.fixture()
@@ -194,8 +188,9 @@ def test_authenticator_falls_back_to_keyring_url(
         }
     )
 
-    dummy_keyring.set_password(
-        "https://foo.bar/simple/", None, SimpleCredential("foo", "bar")
+    dummy_keyring.set_default_service_credential(
+        "https://foo.bar/simple/",
+        SimpleCredential("foo", "bar"),  # type: ignore[no-untyped-call]
     )
 
     authenticator = Authenticator(config, NullIO())
@@ -220,7 +215,10 @@ def test_authenticator_falls_back_to_keyring_netloc(
         }
     )
 
-    dummy_keyring.set_password("foo.bar", None, SimpleCredential("foo", "bar"))
+    dummy_keyring.set_default_service_credential(
+        "foo.bar",
+        SimpleCredential("foo", "bar"),  # type: ignore[no-untyped-call]
+    )
 
     authenticator = Authenticator(config, NullIO())
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
@@ -483,11 +481,13 @@ def test_authenticator_falls_back_to_keyring_url_matched_by_path(
         }
     )
 
-    dummy_keyring.set_password(
-        "https://foo.bar/alpha/files/simple/", None, SimpleCredential("foo", "bar")
+    dummy_keyring.set_default_service_credential(
+        "https://foo.bar/alpha/files/simple/",
+        SimpleCredential("foo", "bar"),  # type: ignore[no-untyped-call]
     )
-    dummy_keyring.set_password(
-        "https://foo.bar/beta/files/simple/", None, SimpleCredential("foo", "baz")
+    dummy_keyring.set_default_service_credential(
+        "https://foo.bar/beta/files/simple/",
+        SimpleCredential("foo", "baz"),  # type: ignore[no-untyped-call]
     )
 
     authenticator = Authenticator(config, NullIO())


### PR DESCRIPTION
keyring is deprecating empty usernames.  Even before that deprecation, the keyring fixtures in poetry unit tests do not follow the `KeyringBackend` API.

patch that up, and patch up the tests that were relying on using empty usernames by introducing `set_default_service_credential()` on the DummyKeyring.