### PR TITLE
chore: PP309: Filter warnings specified

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ markers = [
 ]
 log_cli_level = "INFO"
 xfail_strict = true
+filterwarnings = ["error"]
 
 
 [tool.coverage.report]


### PR DESCRIPTION
Apply repo-review suggestion PP309:
`filterwarnings` must be set (probably to at least `["error"]`). Python will hide important warnings otherwise, like deprecations.

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.