### PR TITLE
feat: add strategy=lowest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry"
-version = "1.9.0.dev0"
+version = "1.9.0.dev1"
 description = "Python dependency management and packaging made easy."
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 maintainers = [

--- a/src/poetry/console/commands/lock.py
+++ b/src/poetry/console/commands/lock.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import TYPE_CHECKING
 
 from cleo.helpers import option
 
 from poetry.console.commands.installer_command import InstallerCommand
-
+from poetry.installation.installer import Strategy
 
 if TYPE_CHECKING:
     from cleo.io.inputs.option import Option
@@ -27,6 +27,10 @@ class LockCommand(InstallerCommand):
             " version of <comment>pyproject.toml</>. (<warning>Deprecated</>) Use"
             " <comment>poetry check --lock</> instead.",
         ),
+        option(
+            "strategy", None, "Lock dependencies using a dependency resolution strategy.", value_required=True,
+            default="latest", flag=False
+        )
     ]
 
     help = """
@@ -57,6 +61,15 @@ file.
             )
             return 1
 
+        if strategy := self.option("strategy"):
+            if strategy not in [s.value for s in Strategy]:
+                self.line_error(
+                    f"<error> Invalid strategy '{strategy}'. Valid strategies are: "
+                    f"{', '.join([s.value for s in Strategy])}"
+                    "</error>"
+                )
+                return 1
+            self.installer.strategy = strategy
         self.installer.lock(update=not self.option("no-update"))
 
         return self.installer.run()

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -117,6 +117,7 @@ class Provider:
         *,
         installed: list[Package] | None = None,
         locked: list[Package] | None = None,
+        use_lowest: bool = False,
     ) -> None:
         self._package = package
         self._pool = pool
@@ -133,6 +134,7 @@ class Provider:
         self._direct_origin_packages: dict[str, Package] = {}
         self._locked: dict[NormalizedName, list[DependencyPackage]] = defaultdict(list)
         self._use_latest: Collection[NormalizedName] = []
+        self._use_lowest = use_lowest
 
         self._explicit_sources: dict[str, str] = {}
         for package in locked or []:
@@ -140,9 +142,10 @@ class Provider:
                 DependencyPackage(package.to_dependency(), package)
             )
         for dependency_packages in self._locked.values():
+            # prioritize resolving by lowest versions if use_lowest is True
             dependency_packages.sort(
                 key=lambda p: p.package.version,
-                reverse=True,
+                reverse=not use_lowest,
             )
 
     @property

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -41,15 +41,17 @@ class Solver:
         installed: list[Package],
         locked: list[Package],
         io: IO,
+        use_lowest: bool = False,
     ) -> None:
         self._package = package
         self._pool = pool
         self._installed_packages = installed
         self._locked_packages = locked
         self._io = io
+        self._lowest = use_lowest
 
         self._provider = Provider(
-            self._package, self._pool, self._io, installed=installed, locked=locked
+            self._package, self._pool, self._io, installed=installed, locked=locked, use_lowest=self._lowest
         )
         self._overrides: list[dict[Package, dict[str, Dependency]]] = []
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #3527

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

I have tried to follow the suggestion from [here](https://github.com/python-poetry/poetry/issues/3527#issuecomment-753531696) to come up with an solution. From what I have observed, it does not result in a resolution using the lowest version, but behaves the same as `strategy=highest`.

To reproduce, run `poetry install` then the dev version should be available at `.venv/bin/poetry`. 

Try lock with an experiement project (e.g. with only one dependency, say `requests`):
```shell
.venv/bin/poetry lock --strategy=lowest --directory <some experimental project dir>
```

Then check what the result is, by `poetry show --directory xyz` (either using the dev one or a prod one): 
```shell
certifi            2024.7.4 Python package for providing Mozilla's CA Bundle.
charset-normalizer 3.3.2    The Real First Universal Charset Detector. Open, modern...
idna               3.7      Internationalized Domain Names in Applications (IDNA)
requests           2.32.3   Python HTTP for Humans.
urllib3            2.2.2    HTTP library with thread-safe connection pooling, file ...
```

That means the native approach does not work. As a next step, I would have a deeper look at `version_solver.py` to understand if we could change the heuristics on version solving (not sure if I need to fully understand the Pubgrub algo though). 