### PR TITLE
remove sp-repo-review pre-commit hook because it does not work on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,3 @@ repos:
     hooks:
       - id: ruff
       - id: ruff-format
-
-  - repo: https://github.com/scientific-python/cookie
-    rev: 2024.04.23
-    hooks:
-      - id: sp-repo-review


### PR DESCRIPTION
Remove the hook as per https://github.com/python-poetry/poetry/pull/9606#issuecomment-2291676090 and https://github.com/python-poetry/poetry/pull/9606#issuecomment-2292278736 because it does not work on Windows.

See https://github.com/scientific-python/cookie/issues/473