### PR TITLE
Apply new repo-review suggestion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ extend-exclude = [
 ]
 fix = true
 line-length = 88
-src = ["src"]
 target-version = "py38"
 
 [tool.ruff.lint]

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -30,9 +30,9 @@ from poetry.utils.env import ephemeral_environment
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
-    from tests.types import FixtureDirGetter
 
     from poetry.poetry import Poetry
+    from tests.types import FixtureDirGetter
 
 
 @pytest.fixture()

--- a/tests/repositories/fixtures/pypi.org/generate.py
+++ b/tests/repositories/fixtures/pypi.org/generate.py
@@ -53,14 +53,14 @@ from typing import Iterator
 from packaging.metadata import parse_email
 from poetry.core.masonry.builders.sdist import SdistBuilder
 from poetry.core.packages.package import Package
+
+from poetry.repositories.pypi_repository import PyPiRepository
 from tests.helpers import FIXTURE_PATH
 from tests.helpers import FIXTURE_PATH_DISTRIBUTIONS
 from tests.helpers import FIXTURE_PATH_INSTALLATION
 from tests.helpers import FIXTURE_PATH_REPOSITORIES
 from tests.helpers import FIXTURE_PATH_REPOSITORIES_LEGACY
 from tests.helpers import FIXTURE_PATH_REPOSITORIES_PYPI
-
-from poetry.repositories.pypi_repository import PyPiRepository
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
RF003: src directory doesn't need to be specified anymore (0.6+)

Ruff now (0.6+) looks in the src directory by default. The src setting doesn't need to be specified if it's just set to `["src"]`.

https://learn.scientific-python.org/development/guides/repo-review/?repo=python-poetry%2Fpoetry&branch=main

CAVEAT: Removing `src = ["src"]` results in changes related to the **`I`** rules, as suggested by the [0.6.0 release announcement](https://astral.sh/blog/ruff-v0.6.0#migrating-to-v06);
> By default, our `isort` rules now search inside `src/` directories when determining the list of package names that are likely to represent first-party code. This was always configurable, but it was suprising for many users that Ruff didn't understand this common project structure "out of the box".
> 
> This change may result in some of your imports being reordered or recategorised, as import statements that these rules previously considered to be third-party imports will now be correctly understood as first-party.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
