### PR TITLE
Avoid race conditions when installing multiple dependencies from the same git repository.

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -160,13 +160,11 @@ class Executor:
                     operation.package.develop
                     and operation.package.source_type in {"directory", "git"}
                 )
-
+                # Skipped operations are safe to execute in parallel
                 if operation.skipped:
-                    # Skipped operations are safe to execute in parallel
-                    tasks.append(
-                        self._executor.submit(self._execute_operation, operation)
-                    )
-                elif is_parallel_unsafe:
+                    is_parallel_unsafe = False
+
+                if is_parallel_unsafe:
                     serial_operations.append(operation)
                 elif operation.package.source_type == "git":
                     # Git operations on the same repository should be executed serially

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -176,15 +176,14 @@ class Executor:
                         self._executor.submit(self._execute_operation, operation)
                     )
 
+            def _serialize(
+                repository_serial_operations: list[Operation],
+            ) -> None:
+                for operation in repository_serial_operations:
+                    self._execute_operation(operation)
+
             # For each git repository, execute all operations serially
             for repository_git_operations in serial_git_operations.values():
-
-                def _serialize(
-                    repository_serial_operations: list[Operation],
-                ) -> None:
-                    for operation in repository_serial_operations:
-                        self._execute_operation(operation)
-
                 tasks.append(
                     self._executor.submit(
                         _serialize,

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -178,10 +178,17 @@ class Executor:
 
             # For each git repository, execute all operations serially
             for repository_git_operations in serial_git_operations.values():
+
+                def _serialize(
+                    repository_serial_operations: list[Operation],
+                ) -> None:
+                    for operation in repository_serial_operations:
+                        self._execute_operation(operation)
+
                 tasks.append(
                     self._executor.submit(
-                        self._serialize_operations,
-                        serial_operations=repository_git_operations,
+                        _serialize,
+                        repository_serial_operations=repository_git_operations,
                     )
                 )
 
@@ -876,11 +883,3 @@ class Executor:
             archive_info["hashes"] = {algorithm: value}
 
         return archive_info
-
-    def _serialize_operations(
-        self,
-        serial_operations: list[Operation],
-    ) -> None:
-        """Execute operations serialy"""
-        for operation in serial_operations:
-            self._execute_operation(operation)

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -139,13 +139,12 @@ class Executor:
         self._sections = {}
         self._yanked_warnings = []
 
-        git_repositories_to_clone = set()
-
         # We group operations by priority
         groups = itertools.groupby(operations, key=lambda o: -o.priority)
         for _, group in groups:
             tasks = []
             serial_operations = []
+            git_repositories_to_clone = set()
             for operation in group:
                 if self._shutdown:
                     break

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -189,10 +189,8 @@ class Executor:
 
                 tasks.append(
                     self._executor.submit(
-                        functools.partial(
-                            _serialize,
-                            repository_serial_operations=repository_git_operations,
-                        )
+                        _serialize,
+                        repository_serial_operations=repository_git_operations,
                     )
                 )
 

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -178,17 +178,10 @@ class Executor:
 
             # For each git repository, execute all operations serially
             for repository_git_operations in serial_git_operations.values():
-
-                def _serialize(
-                    repository_serial_operations: list[Operation],
-                ) -> None:
-                    for operation in repository_serial_operations:
-                        self._execute_operation(operation)
-
                 tasks.append(
                     self._executor.submit(
-                        _serialize,
-                        repository_serial_operations=repository_git_operations,
+                        self._serialize_operations,
+                        serial_operations=repository_git_operations,
                     )
                 )
 
@@ -883,3 +876,11 @@ class Executor:
             archive_info["hashes"] = {algorithm: value}
 
         return archive_info
+
+    def _serialize_operations(
+        self,
+        serial_operations: list[Operation],
+    ) -> None:
+        """Execute operations serialy"""
+        for operation in serial_operations:
+            self._execute_operation(operation)

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1081,6 +1081,49 @@ def test_executor_should_append_subdirectory_for_git(
     assert archive_arg == tmp_venv.path / "src/demo/subdirectories/two"
 
 
+def test_executor_should_install_multiple_packages_from_same_git_repository(
+    mocker: MockerFixture,
+    tmp_venv: VirtualEnv,
+    pool: RepositoryPool,
+    config: Config,
+    artifact_cache: ArtifactCache,
+    io: BufferedIO,
+    wheel: Path,
+) -> None:
+    package_a = Package(
+        "package_a",
+        "0.1.2",
+        source_type="git",
+        source_reference="master",
+        source_resolved_reference="123456",
+        source_url="https://github.com/demo/subdirectories.git",
+        source_subdirectory="package_a",
+    )
+    package_b = Package(
+        "package_b",
+        "0.1.2",
+        source_type="git",
+        source_reference="master",
+        source_resolved_reference="123456",
+        source_url="https://github.com/demo/subdirectories.git",
+        source_subdirectory="package_b",
+    )
+
+    chef = Chef(artifact_cache, tmp_venv, Factory.create_pool(config))
+    chef.set_directory_wheel(wheel)
+    spy = mocker.spy(chef, "prepare")
+
+    executor = Executor(tmp_venv, pool, config, io)
+    executor._chef = chef
+    executor.execute([Install(package_a), Install(package_b)])
+
+    archive_arg = spy.call_args_list[0][0][0]
+    assert archive_arg == tmp_venv.path / "src/demo/subdirectories/package_a"
+
+    archive_arg = spy.call_args_list[1][0][0]
+    assert archive_arg == tmp_venv.path / "src/demo/subdirectories/package_b"
+
+
 def test_executor_should_write_pep610_url_references_for_git_with_subdirectories(
     tmp_venv: VirtualEnv,
     pool: RepositoryPool,


### PR DESCRIPTION
Multiple installs from the same git repository causes a race condition when the repository is cloned.
This change only allows one operation per repository to be executed by the parallel workers.
Any extra operation on the same git repository will be performed serially.
Since the git repository is cached after the first operation, this is fast.

Building on the [setup](https://github.com/python-poetry/poetry/issues/6958#issuecomment-2229914607) of @JonathanRayner, I was able to consistently reproduce the error in [this repository](https://github.com/gustavgransbo/some_other_repo).

Thank you @JonathanRayner for the hard work!

# Pull Request Check List

Resolves: #6958 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.

The race condition occurs inside [poetry.vcs.git.Git.clone](https://github.com/python-poetry/poetry/blob/5d19ab0d8e9b734e3452c6e1210a7f2501709397/src/poetry/vcs/git/backend.py#L412), this method is mocked in all tests: [conftest.py](https://github.com/python-poetry/poetry/blob/5d19ab0d8e9b734e3452c6e1210a7f2501709397/tests/conftest.py#L328).
This makes the actual race condition hard to test.

Also, since the race condition required quite a bit of external setup, I think it could be challenging to add a good test for this.

- [ ] Updated **documentation** for changed code.
This change should not require any new documentation.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
