### PR TITLE
make tests forward compatible with poetry-core#754 ...

### DIFF
--- a/tests/fixtures/complete.toml
+++ b/tests/fixtures/complete.toml
@@ -32,7 +32,7 @@ pendulum = { version = "^1.4", optional = true }
 [tool.poetry.extras]
 time = [ "pendulum" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^3.0"
 pytest-cov = "^2.4"
 

--- a/tests/fixtures/directory/project_with_transitive_directory_dependencies/pyproject.toml
+++ b/tests/fixtures/directory/project_with_transitive_directory_dependencies/pyproject.toml
@@ -10,4 +10,4 @@ python = "*"
 project-with-extras = {path = "../../project_with_extras/"}
 project-with-transitive-file-dependencies = {path = "../project_with_transitive_file_dependencies/"}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/directory/project_with_transitive_file_dependencies/inner-directory-project/pyproject.toml
+++ b/tests/fixtures/directory/project_with_transitive_file_dependencies/inner-directory-project/pyproject.toml
@@ -8,4 +8,4 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/directory/project_with_transitive_file_dependencies/pyproject.toml
+++ b/tests/fixtures/directory/project_with_transitive_file_dependencies/pyproject.toml
@@ -10,4 +10,4 @@ python = "*"
 demo = {path = "../../distributions/demo-0.1.0-py2.py3-none-any.whl"}
 inner-directory-project = {path = "./inner-directory-project"}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/excluded_subpackage/pyproject.toml
+++ b/tests/fixtures/excluded_subpackage/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^3.0"
 
 [build-system]

--- a/tests/fixtures/git/github.com/demo/poetry-plugin/pyproject.toml
+++ b/tests/fixtures/git/github.com/demo/poetry-plugin/pyproject.toml
@@ -15,4 +15,4 @@ tomlkit = {version = "^0.7.0", optional = true}
 [tool.poetry.extras]
 foo = ["tomlkit"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/git/github.com/demo/poetry-plugin2/subdir/pyproject.toml
+++ b/tests/fixtures/git/github.com/demo/poetry-plugin2/subdir/pyproject.toml
@@ -15,4 +15,4 @@ tomlkit = {version = "^0.7.0", optional = true}
 [tool.poetry.extras]
 foo = ["tomlkit"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/git/github.com/demo/prerelease/pyproject.toml
+++ b/tests/fixtures/git/github.com/demo/prerelease/pyproject.toml
@@ -11,4 +11,4 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.4"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/git/github.com/demo/pyproject-demo/pyproject.toml
+++ b/tests/fixtures/git/github.com/demo/pyproject-demo/pyproject.toml
@@ -12,4 +12,4 @@ license = "MIT"
 python = "~2.7 || ^3.4"
 pendulum = '^1.4'
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/incompatible_lock/pyproject.toml
+++ b/tests/fixtures/incompatible_lock/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Poetry Developer <developer@python-poetry.org>"]
 python = "^3.8"
 sampleproject = ">=1.3.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/fixtures/inspection/demo/pyproject.toml
+++ b/tests/fixtures/inspection/demo/pyproject.toml
@@ -14,5 +14,5 @@ tomlkit = {version = "*", optional = true}
 foo = ["cleo"]
 bar = ["tomlkit"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^3.0"

--- a/tests/fixtures/inspection/demo_poetry_package/pyproject.toml
+++ b/tests/fixtures/inspection/demo_poetry_package/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["John Doe <john@example.com.com>"]
 python = "^3.10"
 pendulum = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/fixtures/inspection/demo_with_obsolete_egg_info/pyproject.toml
+++ b/tests/fixtures/inspection/demo_with_obsolete_egg_info/pyproject.toml
@@ -14,5 +14,5 @@ tomlkit = {version = "*", optional = true}
 foo = ["cleo"]
 bar = ["tomlkit"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^3.0"

--- a/tests/fixtures/invalid_lock/pyproject.toml
+++ b/tests/fixtures/invalid_lock/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Poetry Developer <developer@python-poetry.org>"]
 python = "^3.8"
 sampleproject = ">=1.3.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/fixtures/missing_directory_dependency/pyproject.toml
+++ b/tests/fixtures/missing_directory_dependency/pyproject.toml
@@ -9,5 +9,5 @@ packages = []
 [tool.poetry.dependencies]
 python = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 missing = { path = "./missing" }

--- a/tests/fixtures/missing_file_dependency/pyproject.toml
+++ b/tests/fixtures/missing_file_dependency/pyproject.toml
@@ -9,5 +9,5 @@ packages = []
 [tool.poetry.dependencies]
 python = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 missing = { file = "missing-0.1.0-py2.py3-none-any.whl" }

--- a/tests/fixtures/old_lock/pyproject.toml
+++ b/tests/fixtures/old_lock/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Poetry Developer <developer@python-poetry.org>"]
 python = "^3.8"
 sampleproject = ">=1.3.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/fixtures/old_lock_path_dependency/pyproject.toml
+++ b/tests/fixtures/old_lock_path_dependency/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Poetry Developer <developer@python-poetry.org>"]
 python = "^3.8"
 quix = { path = "./quix", develop = true}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/fixtures/outdated_lock/pyproject.toml
+++ b/tests/fixtures/outdated_lock/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Poetry Developer <developer@python-poetry.org>"]
 python = "^3.8"
 docker = "4.3.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/fixtures/project_with_extras/pyproject.toml
+++ b/tests/fixtures/project_with_extras/pyproject.toml
@@ -13,5 +13,3 @@ cachy = { version = ">=0.2.0", optional = true }
 [tool.poetry.extras]
 extras_a = [ "pendulum" ]
 extras_b = [ "cachy" ]
-
-[tool.poetry.dev-dependencies]

--- a/tests/fixtures/project_with_git_dev_dependency/pyproject.toml
+++ b/tests/fixtures/project_with_git_dev_dependency/pyproject.toml
@@ -24,7 +24,7 @@ python = "~2.7 || ^3.4"
 cachy = "^0.1.0"
 pendulum = "^2.0.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 demo = { git = "https://github.com/demo/demo.git", rev = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24" }
 

--- a/tests/fixtures/project_with_multi_constraints_dependency/pyproject.toml
+++ b/tests/fixtures/project_with_multi_constraints_dependency/pyproject.toml
@@ -16,4 +16,4 @@ pendulum = [
     { version = "^2.0", python = "^3.4" }
 ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/up_to_date_lock/poetry.lock
+++ b/tests/fixtures/up_to_date_lock/poetry.lock
@@ -140,4 +140,4 @@ six = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "67c4543fd4f299cfeeaf82c5846ce720aa576e49811fbf9ccd0463ac8d5b52e4"
+content-hash = "ff2489c48d3c858a11c1ce7463ae5dc1524d9d457826c1bf16fd687a7bc1e819"

--- a/tests/fixtures/up_to_date_lock/pyproject.toml
+++ b/tests/fixtures/up_to_date_lock/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Poetry Developer <developer@python-poetry.org>"]
 python = "^3.8"
 docker = ">=4.3.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/fixtures/with-include/pyproject.toml
+++ b/tests/fixtures/with-include/pyproject.toml
@@ -44,7 +44,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/fixtures/with_default_source/pyproject.toml
+++ b/tests/fixtures/with_default_source/pyproject.toml
@@ -43,7 +43,7 @@ simple-project = { path = "../simple_project/" }
 [tool.poetry.extras]
 db = [ "orator" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 

--- a/tests/fixtures/with_default_source_and_pypi/pyproject.toml
+++ b/tests/fixtures/with_default_source_and_pypi/pyproject.toml
@@ -43,7 +43,7 @@ simple-project = { path = "../simple_project/" }
 [tool.poetry.extras]
 db = [ "orator" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 

--- a/tests/fixtures/with_default_source_legacy/pyproject.toml
+++ b/tests/fixtures/with_default_source_legacy/pyproject.toml
@@ -43,7 +43,7 @@ simple-project = { path = "../simple_project/" }
 [tool.poetry.extras]
 db = [ "orator" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 

--- a/tests/fixtures/with_default_source_pypi/pyproject.toml
+++ b/tests/fixtures/with_default_source_pypi/pyproject.toml
@@ -43,7 +43,7 @@ simple-project = { path = "../simple_project/" }
 [tool.poetry.extras]
 db = [ "orator" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 

--- a/tests/fixtures/with_explicit_pypi_and_other/pyproject.toml
+++ b/tests/fixtures/with_explicit_pypi_and_other/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_explicit_pypi_and_other_explicit/pyproject.toml
+++ b/tests/fixtures/with_explicit_pypi_and_other_explicit/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "explicit"

--- a/tests/fixtures/with_explicit_pypi_no_other/pyproject.toml
+++ b/tests/fixtures/with_explicit_pypi_no_other/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "PyPI"

--- a/tests/fixtures/with_explicit_source/pyproject.toml
+++ b/tests/fixtures/with_explicit_source/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "explicit"

--- a/tests/fixtures/with_local_config/pyproject.toml
+++ b/tests/fixtures/with_local_config/pyproject.toml
@@ -43,7 +43,7 @@ simple-project = { path = "../simple_project/" }
 [tool.poetry.extras]
 db = [ "orator" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 

--- a/tests/fixtures/with_non_default_multiple_secondary_sources/pyproject.toml
+++ b/tests/fixtures/with_non_default_multiple_secondary_sources/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_non_default_multiple_secondary_sources_legacy/pyproject.toml
+++ b/tests/fixtures/with_non_default_multiple_secondary_sources_legacy/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_non_default_multiple_sources/pyproject.toml
+++ b/tests/fixtures/with_non_default_multiple_sources/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_non_default_multiple_sources_legacy/pyproject.toml
+++ b/tests/fixtures/with_non_default_multiple_sources_legacy/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_non_default_multiple_sources_pypi/pyproject.toml
+++ b/tests/fixtures/with_non_default_multiple_sources_pypi/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_non_default_secondary_source/pyproject.toml
+++ b/tests/fixtures/with_non_default_secondary_source/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_non_default_secondary_source_legacy/pyproject.toml
+++ b/tests/fixtures/with_non_default_secondary_source_legacy/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_non_default_source_explicit/pyproject.toml
+++ b/tests/fixtures/with_non_default_source_explicit/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_non_default_source_implicit/pyproject.toml
+++ b/tests/fixtures/with_non_default_source_implicit/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "foo"

--- a/tests/fixtures/with_supplemental_source/pyproject.toml
+++ b/tests/fixtures/with_supplemental_source/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [[tool.poetry.source]]
 name = "supplemental"

--- a/tests/fixtures/with_two_default_sources/pyproject.toml
+++ b/tests/fixtures/with_two_default_sources/pyproject.toml
@@ -43,7 +43,7 @@ simple-project = { path = "../simple_project/" }
 [tool.poetry.extras]
 db = [ "orator" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 

--- a/tests/fixtures/with_two_default_sources_legacy/pyproject.toml
+++ b/tests/fixtures/with_two_default_sources_legacy/pyproject.toml
@@ -43,7 +43,7 @@ simple-project = { path = "../simple_project/" }
 [tool.poetry.extras]
 db = [ "orator" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 

--- a/tests/masonry/builders/fixtures/excluded_subpackage/pyproject.toml
+++ b/tests/masonry/builders/fixtures/excluded_subpackage/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^3.0"
 
 [build-system]

--- a/tests/utils/fixtures/pyproject.toml
+++ b/tests/utils/fixtures/pyproject.toml
@@ -24,5 +24,5 @@ toml = "^0.9"
 cachy = "^0.1.0"
 pip-tools = "^1.11"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"


### PR DESCRIPTION
… and use `tool.poetry.group.dev.dependencies` instead of `tool.poetry.dev-dependencies`

Required for python-poetry/poetry-core#754