### PR TITLE
Misc fixes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -17,13 +17,13 @@ testing = ["jaraco.test", "pytest (!=8.0.*)", "pytest (>=6,!=8.1.*)", "pytest-ch
 
 [[package]]
 name = "build"
-version = "1.2.1"
+version = "1.2.2"
 description = "A simple, correct Python build frontend"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">= 3.8"
 files = [
-    {file = "build-1.2.1-py3-none-any.whl", hash = "sha256:75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4"},
-    {file = "build-1.2.1.tar.gz", hash = "sha256:526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d"},
+    {file = "build-1.2.2-py3-none-any.whl", hash = "sha256:277ccc71619d98afdd841a0e96ac9fe1593b823af481d3b0cea748e8894e0613"},
+    {file = "build-1.2.2.tar.gz", hash = "sha256:119b2fb462adef986483438377a13b2f42064a2a3a4161f24a0cca698a07ac8c"},
 ]
 
 [package.dependencies]
@@ -717,13 +717,13 @@ trio = ["async_generator", "trio"]
 
 [[package]]
 name = "keyring"
-version = "25.3.0"
+version = "25.4.1"
 description = "Store and access your passwords safely."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "keyring-25.3.0-py3-none-any.whl", hash = "sha256:8d963da00ccdf06e356acd9bf3b743208878751032d8599c6cc89eb51310ffae"},
-    {file = "keyring-25.3.0.tar.gz", hash = "sha256:8d85a1ea5d6db8515b59e1c5d1d1678b03cf7fc8b8dcfb1651e8c4a524eb42ef"},
+    {file = "keyring-25.4.1-py3-none-any.whl", hash = "sha256:5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf"},
+    {file = "keyring-25.4.1.tar.gz", hash = "sha256:b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b"},
 ]
 
 [package.dependencies]
@@ -737,9 +737,13 @@ pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
 SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 
 [package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
 completion = ["shtab (>=1.1.0)"]
+cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-test = ["pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["pyfakefs", "pytest (>=6,!=8.1.*)"]
+type = ["pygobject-stubs", "pytest-mypy", "shtab", "types-pywin32"]
 
 [[package]]
 name = "more-itertools"
@@ -814,7 +818,6 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
-    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 
@@ -881,7 +884,7 @@ name = "nodeenv"
 version = "1.9.1"
 description = "Node.js virtual environment builder"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
@@ -991,7 +994,7 @@ name = "poetry-plugin-export"
 version = "1.8.0"
 description = "Poetry plugin to export the dependencies to various formats"
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = ">=3.8,<4.0"
 files = [
     {file = "poetry_plugin_export-1.8.0-py3-none-any.whl", hash = "sha256:adbe232cfa0cc04991ea3680c865cf748bff27593b9abcb1f35fb50ed7ba2c22"},
     {file = "poetry_plugin_export-1.8.0.tar.gz", hash = "sha256:1fa6168a85d59395d835ca564bc19862a7c76061e60c3e7dfaec70d50937fc61"},
@@ -1024,7 +1027,7 @@ name = "psutil"
 version = "6.0.0"
 description = "Cross-platform lib for process and system monitoring in Python."
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
     {file = "psutil-6.0.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a021da3e881cd935e64a3d0a20983bda0bb4cf80e4f74fa9bfcb1bc5785360c6"},
     {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:1287c2b95f1c0a364d23bc6f2ea2365a8d4d9b726a3be7294296ff7ba97c17f0"},

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -50,7 +50,7 @@ class Chef:
     ) -> Path:
         from subprocess import CalledProcessError
 
-        distribution: DistributionType = "editable" if editable else "wheel"  # type: ignore[assignment]
+        distribution: DistributionType = "editable" if editable else "wheel"
         error: Exception | None = None
 
         try:

--- a/src/poetry/json/__init__.py
+++ b/src/poetry/json/__init__.py
@@ -30,8 +30,8 @@ def validate_object(obj: dict[str, Any]) -> list[str]:
         (CORE_SCHEMA_DIR / "poetry-schema.json").read_text(encoding="utf-8")
     )
 
-    properties = {*schema["properties"].keys(), *core_schema["properties"].keys()}
-    additional_properties = set(obj.keys()) - properties
+    properties = schema["properties"].keys() | core_schema["properties"].keys()
+    additional_properties = obj.keys() - properties
     for key in additional_properties:
         errors.append(f"Additional properties are not allowed ('{key}' was unexpected)")
 

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -78,7 +78,7 @@ class AuthenticatorRepositoryConfig:
         return RepositoryCertificateConfig.create(self.name, config)
 
     def get_http_credentials(
-        self, password_manager: PasswordManager, username: str | None = None
+        self, password_manager: PasswordManager
     ) -> HTTPAuthCredential:
         # try with the repository name via the password manager
         credential = HTTPAuthCredential(
@@ -268,15 +268,15 @@ class Authenticator:
         return self.request("post", url, **kwargs)
 
     def _get_credentials_for_repository(
-        self, repository: AuthenticatorRepositoryConfig, username: str | None = None
+        self, repository: AuthenticatorRepositoryConfig
     ) -> HTTPAuthCredential:
         # cache repository credentials by repository url to avoid multiple keyring
         # backend queries when packages are being downloaded from the same source
-        key = f"{repository.url}#username={username or ''}"
+        key = repository.url
 
         if key not in self._credentials:
             self._credentials[key] = repository.get_http_credentials(
-                password_manager=self._password_manager, username=username
+                password_manager=self._password_manager
             )
 
         return self._credentials[key]
@@ -346,9 +346,7 @@ class Authenticator:
     def get_pypi_token(self, name: str) -> str | None:
         return self._password_manager.get_pypi_token(name)
 
-    def get_http_auth(
-        self, name: str, username: str | None = None
-    ) -> HTTPAuthCredential | None:
+    def get_http_auth(self, name: str) -> HTTPAuthCredential | None:
         if name == "pypi":
             repository = AuthenticatorRepositoryConfig(
                 name, "https://upload.pypi.org/legacy/"
@@ -358,9 +356,7 @@ class Authenticator:
                 return None
             repository = self.configured_repositories[name]
 
-        return self._get_credentials_for_repository(
-            repository=repository, username=username
-        )
+        return self._get_credentials_for_repository(repository=repository)
 
     def get_certs_for_repository(self, name: str) -> RepositoryCertificateConfig:
         if name.lower() == "pypi" or name not in self.configured_repositories:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,7 +138,7 @@ class DummyBackend(KeyringBackend):
         if password is None:
             return None
 
-        return SimpleCredential(username, password)  # type: ignore[no-untyped-call]
+        return SimpleCredential(username, password)
 
     def delete_password(self, service: str, username: str) -> None:
         if service in self._passwords and username in self._passwords[service]:

--- a/tests/installation/fixtures/with-conditional-dependency.test
+++ b/tests/installation/fixtures/with-conditional-dependency.test
@@ -6,20 +6,6 @@ optional = false
 python-versions = ">=3.5"
 files = []
 
-[package.requirements]
-python = ">=3.5,<4.0"
-
-[[package]]
-name = "A"
-version = "1.0.1"
-description = ""
-optional = false
-python-versions = ">=3.6"
-files = []
-
-[package.requirements]
-python = ">=3.6,<4.0"
-
 [metadata]
 python-versions = "~2.7 || ^3.4"
 lock-version = "2.0"

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1791,9 +1791,6 @@ def test_run_install_duplicate_dependencies_different_constraints_with_lock_upda
     assert installer.executor.removals_count == 0
 
 
-@pytest.mark.skip(
-    "This is not working at the moment due to limitations in the resolver"
-)
 def test_installer_test_solver_finds_compatible_package_for_dependency_python_not_fully_compatible_with_package_python(
     installer: Installer,
     locker: Locker,

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -3811,20 +3811,6 @@ def test_solver_synchronize_single(
     )
 
 
-@pytest.mark.skip(reason="Poetry no longer has critical package requirements")
-def test_solver_with_synchronization_keeps_critical_package(
-    package: ProjectPackage,
-    pool: RepositoryPool,
-    io: NullIO,
-) -> None:
-    package_pip = get_package("setuptools", "1.0")
-
-    solver = Solver(package, pool, [package_pip], [], io)
-    transaction = solver.solve()
-
-    check_solver_result(transaction, [])
-
-
 def test_solver_cannot_choose_another_version_for_directory_dependencies(
     solver: Solver,
     repo: Repository,

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -190,7 +190,7 @@ def test_authenticator_falls_back_to_keyring_url(
 
     dummy_keyring.set_default_service_credential(
         "https://foo.bar/simple/",
-        SimpleCredential("foo", "bar"),  # type: ignore[no-untyped-call]
+        SimpleCredential("foo", "bar"),
     )
 
     authenticator = Authenticator(config, NullIO())
@@ -217,7 +217,7 @@ def test_authenticator_falls_back_to_keyring_netloc(
 
     dummy_keyring.set_default_service_credential(
         "foo.bar",
-        SimpleCredential("foo", "bar"),  # type: ignore[no-untyped-call]
+        SimpleCredential("foo", "bar"),
     )
 
     authenticator = Authenticator(config, NullIO())
@@ -483,11 +483,11 @@ def test_authenticator_falls_back_to_keyring_url_matched_by_path(
 
     dummy_keyring.set_default_service_credential(
         "https://foo.bar/alpha/files/simple/",
-        SimpleCredential("foo", "bar"),  # type: ignore[no-untyped-call]
+        SimpleCredential("foo", "bar"),
     )
     dummy_keyring.set_default_service_credential(
         "https://foo.bar/beta/files/simple/",
-        SimpleCredential("foo", "baz"),  # type: ignore[no-untyped-call]
+        SimpleCredential("foo", "baz"),
     )
 
     authenticator = Authenticator(config, NullIO())


### PR DESCRIPTION
a handful of unimportant fixes tidying up some code

- remove the unused username parameter in code paths that get credentials for repositories
- dictionary `keys()` are already set-like, simplify the code
- take a couple of updates to allow removing some `# type: ignore`
- remove / reinstate skipped tests