### PR TITLE
fix: lock all extra markers in dependencies if package is required by multiple extras

### DIFF
--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -179,16 +179,14 @@ class Solver:
                             if _package.name == dep.name:
                                 continue
 
-                            try:
-                                index = _package.requires.index(dep)
-                            except ValueError:
-                                _package.add_dependency(dep)
-                            else:
-                                _dep = _package.requires[index]
-                                if _dep.marker != dep.marker:
-                                    # marker of feature package is more accurate
-                                    # because it includes relevant extras
-                                    _dep.marker = dep.marker
+                            # Avoid duplication.
+                            if any(
+                                _dep == dep and _dep.marker == dep.marker
+                                for _dep in _package.requires
+                            ):
+                                continue
+
+                            _package.add_dependency(dep)
             else:
                 final_packages.append(package)
                 depths.append(results[package])


### PR DESCRIPTION
fixes #9636 

could do with a testcase really but I doubt that I will have the energy for it.  Maybe you will consider this "obviously correct" and low enough risk to merge anyway, maybe it will have to wait for someone who is more motivated to write that testcase

either way I figured this was more useful as a pull request than not