### PR TITLE
remove deprecated cli options and methods, revoke deprecation of `--dev`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -448,6 +448,7 @@ about dependency groups.
 ### Options
 
 * `--group (-G)`: The group to add the dependency to.
+* `--dev (-D)`: Add package as development dependency. (shortcut for `-G dev`)
 * `--editable (-e)`: Add vcs/path dependencies as editable.
 * `--extras (-E)`: Extras to activate for the dependency. (multiple values allowed)
 * `--optional`: Add as an optional dependency to an extra.
@@ -480,6 +481,7 @@ about dependency groups.
 ### Options
 
 * `--group (-G)`: The group to remove the dependency from.
+* `--dev (-D)`: Removes a package from the development dependencies. (shortcut for `-G dev`)
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
 * `--lock`: Do not perform operations (only update the lockfile).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -158,10 +158,6 @@ the `--without` option.
 poetry install --without test,docs
 ```
 
-{{% note %}}
-The `--no-dev` option is now deprecated. You should use the `--only main` or `--without dev` notation instead.
-{{% /note %}}
-
 You can also select optional dependency groups with the `--with` option.
 
 ```bash
@@ -262,7 +258,6 @@ poetry install --compile
 * `--extras (-E)`: Features to install (multiple values allowed).
 * `--all-extras`: Install all extra features (conflicts with --extras).
 * `--compile`: Compile Python source files to bytecode.
-* `--no-dev`: Do not install dev dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--remove-untracked`: Remove dependencies not presented in the lock file. (**Deprecated**, use `--sync` instead)
 
 {{% note %}}
@@ -301,7 +296,6 @@ You can do this using the `add` command.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
-* `--no-dev` : Do not update the development dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--lock` : Do not perform install (only update the lockfile).
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
 
@@ -454,7 +448,6 @@ about dependency groups.
 ### Options
 
 * `--group (-G)`: The group to add the dependency to.
-* `--dev (-D)`: Add package as development dependency. (**Deprecated**, use `-G dev` instead)
 * `--editable (-e)`: Add vcs/path dependencies as editable.
 * `--extras (-E)`: Extras to activate for the dependency. (multiple values allowed)
 * `--optional`: Add as an optional dependency to an extra.
@@ -487,7 +480,6 @@ about dependency groups.
 ### Options
 
 * `--group (-G)`: The group to remove the dependency from.
-* `--dev (-D)`: Removes a package from the development dependencies. (**Deprecated**, use `-G dev` instead)
 * `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
 * `--lock`: Do not perform operations (only update the lockfile).
 
@@ -524,7 +516,6 @@ required by
 * `--why`: When showing the full list, or a `--tree` for a single package, display whether they are a direct dependency or required by other packages.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
-* `--no-dev`: Do not list the dev dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.
@@ -807,7 +798,6 @@ group defined in `tool.poetry.dependencies` when used without specifying any opt
   Currently, only `constraints.txt` and `requirements.txt` are supported.
 * `--output (-o)`: The name of the output file.  If omitted, print to standard
   output.
-* `--dev`: Include development dependencies. (**Deprecated**, use `--with dev` instead)
 * `--extras (-E)`: Extra sets of dependencies to include.
 * `--without`: The dependency groups to ignore.
 * `--with`: The optional dependency groups to include.

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -40,12 +40,6 @@ class AddCommand(InstallerCommand, InitCommand):
             flag=False,
             default=MAIN_GROUP,
         ),
-        option(
-            "dev",
-            "D",
-            "Add as a development dependency. (<warning>Deprecated</warning>) Use"
-            " --group=dev instead.",
-        ),
         option("editable", "e", "Add vcs/path dependencies as editable."),
         option(
             "extras",
@@ -128,14 +122,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
         from poetry.factory import Factory
 
         packages = self.argument("name")
-        if self.option("dev"):
-            self.line_error(
-                "<warning>The --dev option is deprecated, "
-                "use the `--group dev` notation instead.</warning>"
-            )
-            group = "dev"
-        else:
-            group = self.option("group", self.default_group or MAIN_GROUP)
+        group = self.option("group", self.default_group or MAIN_GROUP)
 
         if self.option("extras") and len(packages) > 1:
             raise ValueError(

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -40,6 +40,11 @@ class AddCommand(InstallerCommand, InitCommand):
             flag=False,
             default=MAIN_GROUP,
         ),
+        option(
+            "dev",
+            "D",
+            "Add as a development dependency. (shortcut for '-G dev')",
+        ),
         option("editable", "e", "Add vcs/path dependencies as editable."),
         option(
             "extras",
@@ -122,7 +127,10 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
         from poetry.factory import Factory
 
         packages = self.argument("name")
-        group = self.option("group", self.default_group or MAIN_GROUP)
+        if self.option("dev"):
+            group = "dev"
+        else:
+            group = self.option("group", self.default_group or MAIN_GROUP)
 
         if self.option("extras") and len(packages) > 1:
             raise ValueError(

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from cleo.helpers import option
-from poetry.core.packages.dependency_group import MAIN_GROUP
 
 from poetry.console.commands.command import Command
 from poetry.console.exceptions import GroupNotFoundError
@@ -81,18 +80,6 @@ class GroupCommand(Command):
                 for group in groups.split(",")
             }
         self._validate_group_options(groups)
-
-        for opt, new, group in [
-            ("no-dev", "only", MAIN_GROUP),
-            ("dev", "with", "dev"),
-        ]:
-            if self.io.input.has_option(opt) and self.option(opt):
-                self.line_error(
-                    f"<warning>The `<fg=yellow;options=bold>--{opt}</>` option is"
-                    f" deprecated, use the `<fg=yellow;options=bold>--{new} {group}</>`"
-                    " notation instead.</warning>"
-                )
-                groups[new].add(group)
 
         if groups["only"] and (groups["with"] or groups["without"]):
             self.line_error(

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -20,12 +20,6 @@ class InstallCommand(InstallerCommand):
     options: ClassVar[list[Option]] = [
         *InstallerCommand._group_dependency_options(),
         option(
-            "no-dev",
-            None,
-            "Do not install the development dependencies."
-            " (<warning>Deprecated</warning>)",
-        ),
-        option(
             "sync",
             None,
             "Synchronize the environment with the locked packages and the specified"
@@ -47,12 +41,6 @@ class InstallCommand(InstallerCommand):
             None,
             "Output the operations but do not execute anything "
             "(implicitly enables --verbose).",
-        ),
-        option(
-            "remove-untracked",
-            None,
-            "Removes packages not present in the lock file."
-            " (<warning>Deprecated</warning>)",
         ),
         option(
             "extras",
@@ -145,14 +133,6 @@ you can set the "package-mode" to false in your pyproject.toml file.
         self.installer.extras(extras)
 
         with_synchronization = self.option("sync")
-        if self.option("remove-untracked"):
-            self.line_error(
-                "<warning>The `<fg=yellow;options=bold>--remove-untracked</>` option is"
-                " deprecated, use the `<fg=yellow;options=bold>--sync</>` option"
-                " instead.</warning>"
-            )
-
-            with_synchronization = True
 
         self.installer.only_groups(self.activated_groups)
         self.installer.skip_directory(self.option("no-directory"))

--- a/src/poetry/console/commands/lock.py
+++ b/src/poetry/console/commands/lock.py
@@ -23,13 +23,6 @@ class LockCommand(InstallerCommand):
             "Ignore existing lock file"
             " and overwrite it with a new lock file created from scratch.",
         ),
-        option(
-            "check",
-            None,
-            "Check that the <comment>poetry.lock</> file corresponds to the current"
-            " version of <comment>pyproject.toml</>. (<warning>Deprecated</>) Use"
-            " <comment>poetry check --lock</> instead.",
-        ),
     ]
 
     help = """
@@ -46,22 +39,6 @@ will not be updated.
     loggers: ClassVar[list[str]] = ["poetry.repositories.pypi_repository"]
 
     def handle(self) -> int:
-        if self.option("check"):
-            self.line_error(
-                "<warning>poetry lock --check is deprecated, use `poetry"
-                " check --lock` instead.</warning>"
-            )
-            if self.poetry.locker.is_locked() and self.poetry.locker.is_fresh():
-                self.line("poetry.lock is consistent with pyproject.toml.")
-                return 0
-            self.line_error(
-                "<error>"
-                "Error: pyproject.toml changed significantly since poetry.lock was last generated. "
-                "Run `poetry lock [--no-update]` to fix the lock file."
-                "</error>"
-            )
-            return 1
-
         self.installer.lock(update=self.option("regenerate"))
 
         return self.installer.run()

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -29,13 +29,6 @@ class RemoveCommand(InstallerCommand):
     options: ClassVar[list[Option]] = [
         option("group", "G", "The group to remove the dependency from.", flag=False),
         option(
-            "dev",
-            "D",
-            "Remove a package from the development dependencies."
-            " (<warning>Deprecated</warning>)"
-            " Use --group=dev instead.",
-        ),
-        option(
             "dry-run",
             None,
             "Output the operations but do not execute anything "
@@ -56,15 +49,7 @@ list of installed packages
 
     def handle(self) -> int:
         packages = self.argument("packages")
-
-        if self.option("dev"):
-            self.line_error(
-                "<warning>The --dev option is deprecated, "
-                "use the `--group dev` notation instead.</warning>"
-            )
-            group = "dev"
-        else:
-            group = self.option("group", self.default_group)
+        group = self.option("group", self.default_group)
 
         content: dict[str, Any] = self.poetry.file.read()
         project_content = content.get("project", {})

--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -29,6 +29,12 @@ class RemoveCommand(InstallerCommand):
     options: ClassVar[list[Option]] = [
         option("group", "G", "The group to remove the dependency from.", flag=False),
         option(
+            "dev",
+            "D",
+            "Remove a package from the development dependencies."
+            " (shortcut for '-G dev')",
+        ),
+        option(
             "dry-run",
             None,
             "Output the operations but do not execute anything "
@@ -49,7 +55,11 @@ list of installed packages
 
     def handle(self) -> int:
         packages = self.argument("packages")
-        group = self.option("group", self.default_group)
+
+        if self.option("dev"):
+            group = "dev"
+        else:
+            group = self.option("group", self.default_group)
 
         content: dict[str, Any] = self.poetry.file.read()
         project_content = content.get("project", {})

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -44,11 +44,6 @@ class ShowCommand(GroupCommand, EnvCommand):
     ]
     options: ClassVar[list[Option]] = [
         *GroupCommand._group_dependency_options(),
-        option(
-            "no-dev",
-            None,
-            "Do not list the development dependencies. (<warning>Deprecated</warning>)",
-        ),
         option("tree", "t", "List the dependencies as a tree."),
         option(
             "why",

--- a/src/poetry/console/commands/update.py
+++ b/src/poetry/console/commands/update.py
@@ -26,12 +26,6 @@ class UpdateCommand(InstallerCommand):
     options: ClassVar[list[Option]] = [
         *InstallerCommand._group_dependency_options(),
         option(
-            "no-dev",
-            None,
-            "Do not update the development dependencies."
-            " (<warning>Deprecated</warning>)",
-        ),
-        option(
             "sync",
             None,
             "Synchronize the environment with the locked packages and the specified"

--- a/src/poetry/repositories/repository_pool.py
+++ b/src/poetry/repositories/repository_pool.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import enum
-import warnings
 
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -19,8 +18,6 @@ if TYPE_CHECKING:
     from poetry.core.constraints.version import Version
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
-
-_SENTINEL = object()
 
 
 class Priority(IntEnum):
@@ -41,7 +38,6 @@ class RepositoryPool(AbstractRepository):
     def __init__(
         self,
         repositories: list[Repository] | None = None,
-        ignore_repository_names: object = _SENTINEL,
         *,
         config: Config | None = None,
     ) -> None:
@@ -56,15 +52,6 @@ class RepositoryPool(AbstractRepository):
         self._artifact_cache = ArtifactCache(
             cache_dir=(config or Config.create()).artifacts_cache_directory
         )
-
-        if ignore_repository_names is not _SENTINEL:
-            warnings.warn(
-                "The 'ignore_repository_names' argument to 'RepositoryPool.__init__' is"
-                " deprecated. It has no effect anymore and will be removed in a future"
-                " version.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     @staticmethod
     def from_packages(packages: list[Package], config: Config | None) -> RepositoryPool:

--- a/src/poetry/toml/file.py
+++ b/src/poetry/toml/file.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import warnings
-
 from typing import TYPE_CHECKING
-from typing import Any
 
 from tomlkit.toml_file import TOMLFile as BaseTOMLFile
 
@@ -35,16 +32,6 @@ class TOMLFile(BaseTOMLFile):
             return super().read()
         except (ValueError, TOMLKitError) as e:
             raise TOMLError(f"Invalid TOML file {self.path.as_posix()}: {e}")
-
-    def __getattr__(self, item: str) -> Any:
-        warnings.warn(
-            "`__getattr__` will be removed from the `TOMLFile` in a future release."
-            "\n\nInstead of accessing properties of the underlying `Path` as "
-            "`tomlfile.whatever`, prefer `tomlfile.path.whatever`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return getattr(self.__path, item)
 
     def __str__(self) -> str:
         return self.__path.as_posix()

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -1099,6 +1099,35 @@ def test_add_creating_poetry_section_does_not_remove_existing_tools(
     assert pyproject["tool"]["foo"]["key"] == "value"
 
 
+def test_add_to_dev_section(app: PoetryTestApplication, tester: CommandTester) -> None:
+    tester.execute("cachy --dev")
+
+    expected = """\
+Using version ^0.2.0 for cachy
+
+Updating dependencies
+Resolving dependencies...
+
+Package operations: 2 installs, 0 updates, 0 removals
+
+  - Installing msgpack-python (0.5.6)
+  - Installing cachy (0.2.0)
+
+Writing lock file
+"""
+
+    assert tester.io.fetch_error() == ""
+    assert tester.io.fetch_output() == expected
+    assert isinstance(tester.command, InstallerCommand)
+    assert tester.command.installer.executor.installations_count == 2
+
+    pyproject: dict[str, Any] = app.poetry.file.read()
+    content = pyproject["tool"]["poetry"]
+
+    assert "cachy" in content["group"]["dev"]["dependencies"]
+    assert content["group"]["dev"]["dependencies"]["cachy"] == "^0.2.0"
+
+
 def test_add_should_not_select_prereleases(
     app: PoetryTestApplication, tester: CommandTester
 ) -> None:

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -1099,41 +1099,6 @@ def test_add_creating_poetry_section_does_not_remove_existing_tools(
     assert pyproject["tool"]["foo"]["key"] == "value"
 
 
-def test_add_to_dev_section_deprecated(
-    app: PoetryTestApplication, tester: CommandTester
-) -> None:
-    tester.execute("cachy --dev")
-
-    warning = """\
-The --dev option is deprecated, use the `--group dev` notation instead.
-"""
-
-    expected = """\
-Using version ^0.2.0 for cachy
-
-Updating dependencies
-Resolving dependencies...
-
-Package operations: 2 installs, 0 updates, 0 removals
-
-  - Installing msgpack-python (0.5.6)
-  - Installing cachy (0.2.0)
-
-Writing lock file
-"""
-
-    assert tester.io.fetch_error() == warning
-    assert tester.io.fetch_output() == expected
-    assert isinstance(tester.command, InstallerCommand)
-    assert tester.command.installer.executor.installations_count == 2
-
-    pyproject: dict[str, Any] = app.poetry.file.read()
-    content = pyproject["tool"]["poetry"]
-
-    assert "cachy" in content["group"]["dev"]["dependencies"]
-    assert content["group"]["dev"]["dependencies"]["cachy"] == "^0.2.0"
-
-
 def test_add_should_not_select_prereleases(
     app: PoetryTestApplication, tester: CommandTester
 ) -> None:

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -109,8 +109,6 @@ def _project_factory(
         ("--without bam", {MAIN_GROUP, "foo", "bar", "baz", "bim"}),
         ("--with bam --without bam", {MAIN_GROUP, "foo", "bar", "baz", "bim"}),
         ("--with foo --without foo", {MAIN_GROUP, "bar", "baz", "bim"}),
-        # deprecated options
-        ("--no-dev", {MAIN_GROUP}),
     ],
 )
 @pytest.mark.parametrize("with_root", [True, False])
@@ -348,22 +346,6 @@ def test_invalid_groups_with_without_only(
                 assert (
                     re.search(rf"{group} \(via .*{opt}.*\)", str(e.value)) is not None
                 )
-
-
-def test_remove_untracked_outputs_deprecation_warning(
-    tester: CommandTester,
-    mocker: MockerFixture,
-) -> None:
-    assert isinstance(tester.command, InstallerCommand)
-    mocker.patch.object(tester.command.installer, "run", return_value=0)
-
-    tester.execute("--remove-untracked")
-
-    assert tester.status_code == 1
-    assert (
-        "The `--remove-untracked` option is deprecated, use the `--sync` option"
-        " instead.\n" in tester.io.fetch_error()
-    )
 
 
 def test_dry_run_populates_installer(

--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -87,54 +87,6 @@ def poetry_with_invalid_lockfile(
     return _project_factory("invalid_lock", project_factory, fixture_dir)
 
 
-def test_lock_check_outdated_legacy(
-    command_tester_factory: CommandTesterFactory,
-    poetry_with_outdated_lockfile: Poetry,
-) -> None:
-    locker = Locker(
-        lock=poetry_with_outdated_lockfile.pyproject.file.path.parent / "poetry.lock",
-        pyproject_data=poetry_with_outdated_lockfile.locker._pyproject_data,
-    )
-    poetry_with_outdated_lockfile.set_locker(locker)
-
-    tester = command_tester_factory("lock", poetry=poetry_with_outdated_lockfile)
-    status_code = tester.execute("--check")
-    expected = (
-        "poetry lock --check is deprecated, use `poetry check --lock` instead.\n"
-        "Error: pyproject.toml changed significantly since poetry.lock was last generated. "
-        "Run `poetry lock [--no-update]` to fix the lock file.\n"
-    )
-
-    assert tester.io.fetch_error() == expected
-
-    # exit with an error
-    assert status_code == 1
-
-
-def test_lock_check_up_to_date_legacy(
-    command_tester_factory: CommandTesterFactory,
-    poetry_with_up_to_date_lockfile: Poetry,
-) -> None:
-    locker = Locker(
-        lock=poetry_with_up_to_date_lockfile.pyproject.file.path.parent / "poetry.lock",
-        pyproject_data=poetry_with_up_to_date_lockfile.locker._pyproject_data,
-    )
-    poetry_with_up_to_date_lockfile.set_locker(locker)
-
-    tester = command_tester_factory("lock", poetry=poetry_with_up_to_date_lockfile)
-    status_code = tester.execute("--check")
-    expected = "poetry.lock is consistent with pyproject.toml.\n"
-    assert tester.io.fetch_output() == expected
-
-    expected_error = (
-        "poetry lock --check is deprecated, use `poetry check --lock` instead.\n"
-    )
-    assert tester.io.fetch_error() == expected_error
-
-    # exit with an error
-    assert status_code == 0
-
-
 def test_lock_does_not_update_if_not_necessary(
     command_tester_factory: CommandTesterFactory,
     poetry_with_old_lockfile: Poetry,

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -206,12 +206,6 @@ cachy 0.1.0 Cachy package
 """,
         ),
         (
-            "--no-dev",
-            """\
-cachy 0.1.0 Cachy package
-""",
-        ),
-        (
             "--with time --without test",
             """\
 cachy    0.1.0 Cachy package

--- a/tests/pyproject/test_pyproject_toml_file.py
+++ b/tests/pyproject/test_pyproject_toml_file.py
@@ -21,9 +21,3 @@ def test_pyproject_toml_file_invalid(pyproject_toml: Path) -> None:
         _ = TOMLFile(pyproject_toml).read()
 
     assert f"Invalid TOML file {pyproject_toml.as_posix()}" in str(excval.value)
-
-
-def test_pyproject_toml_file_getattr(tmp_path: Path, pyproject_toml: Path) -> None:
-    file = TOMLFile(pyproject_toml)
-    with pytest.warns(DeprecationWarning):
-        assert file.parent == tmp_path

--- a/tests/repositories/test_repository_pool.py
+++ b/tests/repositories/test_repository_pool.py
@@ -36,17 +36,6 @@ def test_repository_no_repository() -> None:
         pool.repository("foo")
 
 
-def test_repository_deprecated_ignore_repository_names() -> None:
-    with pytest.warns(DeprecationWarning):
-        RepositoryPool(ignore_repository_names=True)
-    with pytest.warns(DeprecationWarning):
-        RepositoryPool(ignore_repository_names=False)
-    with pytest.warns(DeprecationWarning):
-        RepositoryPool(None, True)
-    with pytest.warns(DeprecationWarning):
-        RepositoryPool(None, False)
-
-
 def test_adding_repositories_with_same_name_twice_raises_value_error() -> None:
     repo1 = Repository("repo")
     repo2 = Repository("repo")


### PR DESCRIPTION
There are at least some users who will miss `--dev/-D`, see https://github.com/orgs/python-poetry/discussions/7530.

Personally, I still tend to remove it.