### PR TITLE
Stop using private pytest API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,10 +49,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from collections.abc import Mapping
 
-    from _pytest.config import Config as PyTestConfig
-    from _pytest.config.argparsing import Parser
-    from _pytest.tmpdir import TempPathFactory
     from keyring.credentials import Credential
+    from pytest import Config as PyTestConfig
+    from pytest import Parser
+    from pytest import TempPathFactory
     from pytest_mock import MockerFixture
 
     from poetry.poetry import Poetry

--- a/tests/console/commands/cache/conftest.py
+++ b/tests/console/commands/cache/conftest.py
@@ -13,7 +13,7 @@ from poetry.utils.cache import FileCache
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from _pytest.monkeypatch import MonkeyPatch
+    from pytest import MonkeyPatch
 
     from tests.conftest import Config
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -24,8 +24,8 @@ from tests.helpers import get_package
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from _pytest.fixtures import FixtureRequest
     from poetry.core.packages.package import Package
+    from pytest import FixtureRequest
     from pytest_mock import MockerFixture
 
     from poetry.config.config import Config

--- a/tests/installation/test_wheel_installer.py
+++ b/tests/installation/test_wheel_installer.py
@@ -14,7 +14,7 @@ from poetry.utils.env import MockEnv
 
 
 if TYPE_CHECKING:
-    from _pytest.tmpdir import TempPathFactory
+    from pytest import TempPathFactory
 
     from tests.types import FixtureDirGetter
 

--- a/tests/integration/test_utils_vcs_git.py
+++ b/tests/integration/test_utils_vcs_git.py
@@ -27,9 +27,9 @@ from poetry.vcs.git.backend import GitRefSpec
 
 
 if TYPE_CHECKING:
-    from _pytest.tmpdir import TempPathFactory
     from dulwich.client import FetchPackResult
     from dulwich.client import GitClient
+    from pytest import TempPathFactory
     from pytest_mock import MockerFixture
 
     from tests.conftest import Config

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -27,7 +27,7 @@ from tests.helpers import get_package
 
 
 if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
+    from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
 
 

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -22,8 +22,8 @@ from tests.helpers import with_working_directory
 
 
 if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
     from poetry.core.packages.package import Package
+    from pytest import LogCaptureFixture
     from pytest_mock.plugin import MockerFixture
 
     from poetry.poetry import Poetry

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -22,7 +22,7 @@ from poetry.repositories.legacy_repository import LegacyRepository
 if TYPE_CHECKING:
     import httpretty
 
-    from _pytest.monkeypatch import MonkeyPatch
+    from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
     from poetry.config.config import Config

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterator
 
-    from _pytest.logging import LogCaptureFixture
+    from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
 
     from poetry.poetry import Poetry

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -21,8 +21,8 @@ from poetry.utils.authenticator import RepositoryCertificateConfig
 
 
 if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
-    from _pytest.monkeypatch import MonkeyPatch
+    from pytest import LogCaptureFixture
+    from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
     from tests.conftest import Config

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -14,7 +14,7 @@ from poetry.utils.password_manager import PoetryKeyringError
 
 
 if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
+    from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
 
     from tests.conftest import Config


### PR DESCRIPTION
Pytest has been exporting those types as public for a few years now.