### PR TITLE
feat(install): add `--all-groups` flag to install all dependency groups

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -168,6 +168,12 @@ You can also select optional dependency groups with the `--with` option.
 poetry install --with test,docs
 ```
 
+To install all dependency groups including the optional groups, use the ``--all-groups`` flag.
+
+```bash
+poetry install --all-groups
+```
+
 It's also possible to only install specific dependency groups by using the `only` option.
 
 ```bash
@@ -261,12 +267,14 @@ poetry install --compile
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
 * `--extras (-E)`: Features to install (multiple values allowed).
 * `--all-extras`: Install all extra features (conflicts with --extras).
+* `--all-groups`: Install dependencies from all groups (conflicts with --only).
 * `--compile`: Compile Python source files to bytecode.
 * `--no-dev`: Do not install dev dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--remove-untracked`: Remove dependencies not presented in the lock file. (**Deprecated**, use `--sync` instead)
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.
+When `--all-groups` is specified, the `--with` option is ignored.
 {{% /note %}}
 
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -264,10 +264,10 @@ poetry install --compile
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
 * `--no-root`: Do not install the root package (your project).
 * `--no-directory`: Skip all directory path dependencies (including transitive ones).
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
 * `--extras (-E)`: Features to install (multiple values allowed).
-* `--all-extras`: Install all extra features (conflicts with --extras).
-* `--all-groups`: Install dependencies from all groups (conflicts with --only).
+* `--all-extras`: Install all extra features (conflicts with `--extras`).
+* `--all-groups`: Install dependencies from all groups (conflicts with `--only`, `--with`, and `--without`).
 * `--compile`: Compile Python source files to bytecode.
 * `--no-dev`: Do not install dev dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--remove-untracked`: Remove dependencies not presented in the lock file. (**Deprecated**, use `--sync` instead)
@@ -308,7 +308,7 @@ You can do this using the `add` command.
 * `--without`: The dependency groups to ignore.
 * `--with`: The optional dependency groups to include.
 * `--only`: The only dependency groups to include.
-* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
+* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables `--verbose`).
 * `--no-dev` : Do not update the development dependencies. (**Deprecated**, use `--only main` or `--without dev` instead)
 * `--lock` : Do not perform install (only update the lockfile).
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
@@ -470,7 +470,7 @@ about dependency groups.
 * `--platform`: Platforms for which the dependency must be installed.
 * `--source`: Name of the source to use to install the package.
 * `--allow-prereleases`: Accept prereleases.
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
 * `--lock`: Do not perform install (only update the lockfile).
 
 
@@ -496,7 +496,7 @@ about dependency groups.
 
 * `--group (-G)`: The group to remove the dependency from.
 * `--dev (-D)`: Removes a package from the development dependencies. (**Deprecated**, use `-G dev` instead)
-* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables --verbose).
+* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables `--verbose`).
 * `--lock`: Do not perform operations (only update the lockfile).
 
 
@@ -1007,7 +1007,7 @@ poetry self add artifacts-keyring
 * `--extras (-E)`: Extras to activate for the dependency. (multiple values allowed)
 * `--allow-prereleases`: Accept prereleases.
 * `--source`: Name of the source to use to install the package.
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
 
 ### self update
 
@@ -1025,7 +1025,7 @@ poetry self update
 #### Options
 
 * `--preview`: Allow the installation of pre-release versions.
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
 
 ### self lock
 
@@ -1079,7 +1079,7 @@ poetry self remove poetry-plugin-export
 
 #### Options
 
-* `--dry-run`: Outputs the operations but will not execute anything (implicitly enables --verbose).
+* `--dry-run`: Outputs the operations but will not execute anything (implicitly enables `--verbose`).
 
 ### self install
 
@@ -1098,4 +1098,4 @@ poetry self install --sync
 #### Options
 
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables --verbose).
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -269,7 +269,6 @@ poetry install --compile
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.
-When `--all-groups` is specified, the `--with` option is ignored.
 {{% /note %}}
 
 

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -80,6 +80,18 @@ class GroupCommand(Command):
                 for groups in self.option(key, "")
                 for group in groups.split(",")
             }
+
+        if self.option("all-groups"):
+            if self.option("with"):
+                self.line_error(
+                    "<warning>The `<fg=yellow;options=bold>--with</>` option is"
+                    " ignored when using the `<fg=yellow;options=bold>--all-groups</>`"
+                    " option.</warning>"
+                )
+            groups["with"] = self.poetry.package.dependency_group_names(
+                include_optional=True
+            )
+
         self._validate_group_options(groups)
 
         for opt, new, group in [

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -82,12 +82,6 @@ class GroupCommand(Command):
             }
 
         if self.option("all-groups"):
-            if self.option("with"):
-                self.line_error(
-                    "<warning>The `<fg=yellow;options=bold>--with</>` option is"
-                    " ignored when using the `<fg=yellow;options=bold>--all-groups</>`"
-                    " option.</warning>"
-                )
             groups["with"] = self.poetry.package.dependency_group_names(
                 include_optional=True
             )

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -137,10 +137,14 @@ you can set the "package-mode" to false in your pyproject.toml file.
             )
             return 1
 
-        if self.option("only") and self.option("all-groups"):
+        if (
+            self.option("only") or self.option("with") or self.option("without")
+        ) and self.option("all-groups"):
             self.line_error(
-                "<error>You cannot specify `<fg=yellow;options=bold>--all-groups</>`"
-                " when using `<fg=yellow;options=bold>--only</>`.</error>"
+                "<error>You cannot specify `<fg=yellow;options=bold>--with</>`,"
+                " `<fg=yellow;options=bold>--without</>`, or"
+                " `<fg=yellow;options=bold>--only</>` when using"
+                " `<fg=yellow;options=bold>--all-groups</>`.</error>"
             )
             return 1
 

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -62,6 +62,7 @@ class InstallCommand(InstallerCommand):
             multiple=True,
         ),
         option("all-extras", None, "Install all extra dependencies."),
+        option("all-groups", None, "Install dependencies from all groups."),
         option("only-root", None, "Exclude all dependencies."),
         option(
             "compile",
@@ -116,12 +117,14 @@ you can set the "package-mode" to false in your pyproject.toml file.
             return 1
 
         if self.option("only-root") and any(
-            self.option(key) for key in {"with", "without", "only"}
+            self.option(key) for key in {"with", "without", "only", "all-groups"}
         ):
             self.line_error(
                 "<error>The `<fg=yellow;options=bold>--with</>`,"
-                " `<fg=yellow;options=bold>--without</>` and"
-                " `<fg=yellow;options=bold>--only</>` options cannot be used with"
+                " `<fg=yellow;options=bold>--without</>`,"
+                " `<fg=yellow;options=bold>--only</>` and"
+                " `<fg=yellow;options=bold>--all-groups</>`"
+                " options cannot be used with"
                 " the `<fg=yellow;options=bold>--only-root</>`"
                 " option.</error>"
             )
@@ -131,6 +134,13 @@ you can set the "package-mode" to false in your pyproject.toml file.
             self.line_error(
                 "<error>You cannot specify `<fg=yellow;options=bold>--no-root</>`"
                 " when using `<fg=yellow;options=bold>--only-root</>`.</error>"
+            )
+            return 1
+
+        if self.option("only") and self.option("all-groups"):
+            self.line_error(
+                "<error>You cannot specify `<fg=yellow;options=bold>--all-groups</>`"
+                " when using `<fg=yellow;options=bold>--only</>`.</error>"
             )
             return 1
 


### PR DESCRIPTION
This PR adds the `--all-groups` flag to `poetry install` which includes all the dependency groups (including optional groups) for installation. This is a very common use case for projects with multiple optional groups and allows the user to *install everything* without specifying each group.

This feature has been discussed in the past. See e.g. #7605 and #5461. I gave it another shot with an implementation that respects the existing options and flags.

I decided not to go with `--with=all` or similar and instead use the explicit flag `--all-groups`, consistent with the `--all-extras` flag. A naming alternative would be `--with-all`.

Options like
- `--all-groups --without=docs` are supported,
- `--all-groups --with=foo` ignores the `with` with a warning, 
- and `--all-groups --only=foo` results in an error.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.


