### PR TITLE
Try finding commit using short SHA if it is not on HEAD

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -430,65 +430,60 @@ files = [
 
 [[package]]
 name = "dulwich"
-version = "0.22.1"
+version = "0.22.6"
 description = "Python Git Library"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 files = [
-    {file = "dulwich-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:892914dc2e80403d16e59a3b440044f6092fde5ffd4ec1fdf36d6ff20a8e624d"},
-    {file = "dulwich-0.22.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b03092399f0f5d3e112405b890128afdb9e1f203eafb812f5d9105b0f5fac9d4"},
-    {file = "dulwich-0.22.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a2c790517ed884bc1b1590806222ab44989eeb7e7f14dfa915561c7ee3b9ac73"},
-    {file = "dulwich-0.22.1-cp310-cp310-win32.whl", hash = "sha256:524d3497a86f79959c9c1d729715d60d8171ed3f71621d45afb4faee5a47e8a1"},
-    {file = "dulwich-0.22.1-cp310-cp310-win_amd64.whl", hash = "sha256:d3146843b972f744aed551e8ac9fac5714baa864393e480586d467b7b4488426"},
-    {file = "dulwich-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:82f26e592e9a36ab33bcdb419c7d53320e26c85dfc254cdb84f5f561a2fcaabf"},
-    {file = "dulwich-0.22.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e90b8a2f24149c5803b733a24f1a016a2943b1f5a9ab2360db545e4638354c35"},
-    {file = "dulwich-0.22.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b069639757b2f287f9cd0daf6765b536558c5e28263bbbb28e3d1925bce75400"},
-    {file = "dulwich-0.22.1-cp311-cp311-win32.whl", hash = "sha256:3ae006498fea11515027a417e6e68b82e1c195d3516188ba2cc08210e3022d14"},
-    {file = "dulwich-0.22.1-cp311-cp311-win_amd64.whl", hash = "sha256:a18d1392eabd02f337dcba23d723a4dcca87274ce8693cf88e6320f38bc3fdcd"},
-    {file = "dulwich-0.22.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:12482e318895da9acabea7c0cc70b35d36833e7cb2def511ab3a63617f5c1af3"},
-    {file = "dulwich-0.22.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dc42afedc8cda4f2fd15a06d2e9e41281074a02cdf31bb2e0dde4d80766a408"},
-    {file = "dulwich-0.22.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3c7774232a2c9b195bde4fb72ad71455e877a9e4e9c0b17a57b1d9bd478838c"},
-    {file = "dulwich-0.22.1-cp312-cp312-win32.whl", hash = "sha256:41dfc52db29a06fe23a5029abc3bc13503e28233b1c3a9614bc1e5c4d6adc1ce"},
-    {file = "dulwich-0.22.1-cp312-cp312-win_amd64.whl", hash = "sha256:9d19f04ecd4628a0e4587b4c4e98e040b87924c1362ae5aa27420435f05d5dd8"},
-    {file = "dulwich-0.22.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0d72a88c7af8fafa14c8743e8923c8d46bd0b850a0b7f5e34eb49201f1ead88e"},
-    {file = "dulwich-0.22.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e36c8a3bb09db5730b3d5014d087bce977e878825cdd7ba8285abcd81c43bc0"},
-    {file = "dulwich-0.22.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd51e77ff1b4ca08bc9b09b85646a3e77f275827b7b30180d76d769ce608e64d"},
-    {file = "dulwich-0.22.1-cp37-cp37m-win32.whl", hash = "sha256:739ef91aeb13fa2aa187d0efd46d0ac168301f54a6ef748565c42876b4b3ce71"},
-    {file = "dulwich-0.22.1-cp37-cp37m-win_amd64.whl", hash = "sha256:91966b7b48ec939e5083b03c9154fc450508056f01650ecb58724095307427f5"},
-    {file = "dulwich-0.22.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:86be1e283d78cc3f7daee1dcd0254122160cde71ca8c5348315156045f8ac2bb"},
-    {file = "dulwich-0.22.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926d671654a2f8cfa0b2fcb6b0c46833af95b5265d27a5c56c49c5a10f3ff3ba"},
-    {file = "dulwich-0.22.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:467ff87fc4c61a23424b32acd952476ba17e7f7eeb8090e5957f68129784a35f"},
-    {file = "dulwich-0.22.1-cp38-cp38-win32.whl", hash = "sha256:f9e10678fe0692c5167553981d97cbe342ed055c49016aef10da336e2962b1f2"},
-    {file = "dulwich-0.22.1-cp38-cp38-win_amd64.whl", hash = "sha256:6386165c64ba5f61c416301f7f32bb899f8200ca575d76888697a42fda8a92d2"},
-    {file = "dulwich-0.22.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:84db8aef08df6431b017cc3abe57b3d6885fd7436eec8d715603c309353b233c"},
-    {file = "dulwich-0.22.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:155124219e6ce4b116d30ed1b9cc63c88021966b29ce761d3ce3caba064f9a13"},
-    {file = "dulwich-0.22.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7579429e89deac6659b4ea70eb3de9063bb40508fd4a8a020fa67b02e0b59f4f"},
-    {file = "dulwich-0.22.1-cp39-cp39-win32.whl", hash = "sha256:454d073e628043dde4f9bd34517736c1889dbe6417099bbae2119873b8d4d5da"},
-    {file = "dulwich-0.22.1-cp39-cp39-win_amd64.whl", hash = "sha256:e1b51d26108a832f151da8856a93676cc1a5cd8dd0bc20f06f4aee5774a7f0f9"},
-    {file = "dulwich-0.22.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4c509e8172b9438536946097768413f297229b03eff064e4e06749cf5c28df78"},
-    {file = "dulwich-0.22.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64eebe1d709539d6e80440fa1185f1eeb260d53bcb6435b1f753b4ce90a65e82"},
-    {file = "dulwich-0.22.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:52a8ddd1d9b5681de216a7af718720f5202d3c093ecc10dd4dfac6d25da605a6"},
-    {file = "dulwich-0.22.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7244b796dd7e191753b822ac0ca871a4b9139b0b850770ac5bd347d5f8c76768"},
-    {file = "dulwich-0.22.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:e7798e842ec506d25f21e825259b70109325ac1c9b43c2e287aad7559455951b"},
-    {file = "dulwich-0.22.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac9fcf7c5cf1e9d0bcc643672f81bf43ec81f6495b99809649f5bfcdff633ab0"},
-    {file = "dulwich-0.22.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e346c1b86c5e5f175ca8f87f3873eea8b2e0eeb5d52033b475cf85641cb200c2"},
-    {file = "dulwich-0.22.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:b2054e1f2c7041857ce129443bde23298ca37592ce82f0fb5ed5704d5f3708dd"},
-    {file = "dulwich-0.22.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3ad3462d070b678fe61d3bdd7c6ac3fdbd25cca66f32b6edf589dd88fff251d2"},
-    {file = "dulwich-0.22.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc6575476539c0b4924abab3896fc76be2f413d5baa6b083c4dfc4abc59329e"},
-    {file = "dulwich-0.22.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3de7a2eba26ff13a79670f78f73fc86fb8c87100508119f3b6bd61451bfdd4bf"},
-    {file = "dulwich-0.22.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:b2c3186cf76d598a9d42b35e09ef35d499118b4197624ba5bba1b3a39ac6a75f"},
-    {file = "dulwich-0.22.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3a366cdba24b8df31ad70b82bae55baa696c453678c1346da8390396a1d5cce4"},
-    {file = "dulwich-0.22.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fb61891b2675664dc89d486eb5199e3659179ae04fc0a863ffc7e16b782b624"},
-    {file = "dulwich-0.22.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0ea4c5feedd35e8bde175a9ab91ef6705c3cef5ee209eeb2f67dd0b59ff1825f"},
-    {file = "dulwich-0.22.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:20f61f6dc0b075ca6459acbfb9527ee0e1ee02dccbed126dc492600bb7310d86"},
-    {file = "dulwich-0.22.1.tar.gz", hash = "sha256:e36d85967cfbf25da1c7bc3d6921adc5baa976969d926aaf1582bd5fd7e94758"},
+    {file = "dulwich-0.22.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:43abc96dabbe79117df3862b35694a52aa0afbe4d68d3e83bcff55ac71c851cb"},
+    {file = "dulwich-0.22.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2085f13dc7a0d7cae06c7fb04b06d3b2f6205029d44c41b65d37a23da0cb67cb"},
+    {file = "dulwich-0.22.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58c91a6409e761f8dd9fd68f28163bcb00bb7a21eebb52655a2adcaf8ee53447"},
+    {file = "dulwich-0.22.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffa95d2d903f387f1a5206adb3d832013803a49e9b04c8749dd369f308f66824"},
+    {file = "dulwich-0.22.6-cp310-cp310-win32.whl", hash = "sha256:06b4fde8d173578a56602dd79b42d5a9121e323ebb8a68102c26a44ce2dd14dc"},
+    {file = "dulwich-0.22.6-cp310-cp310-win_amd64.whl", hash = "sha256:dd8303b570fd439e0facbb7476a658fe865bc985eab04e9a18b7ffc0f5d56d49"},
+    {file = "dulwich-0.22.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:737284cbf4a3de239b1962e5ec2cacf0506d2d0a857b82e9fd2b4a08b913c11e"},
+    {file = "dulwich-0.22.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:308446a339dcda7498a4ed2748f36ecf0e4849875df573613243ac845f781771"},
+    {file = "dulwich-0.22.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25dd3c7217887621cd2d1703329a1e00338bb8839d54137b63e44a6a2d226603"},
+    {file = "dulwich-0.22.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3722b8f09aef30bd30e64a7e4589eba042e530b407d98409350b629da10dd54f"},
+    {file = "dulwich-0.22.6-cp311-cp311-win32.whl", hash = "sha256:de9fccefd61b5098ff755453975021035a8d385896edb57163050251c30ea3b6"},
+    {file = "dulwich-0.22.6-cp311-cp311-win_amd64.whl", hash = "sha256:eb662463f205f106776af499d054c98f408c3753a6c0eaff8612eb3f1cbf6ddb"},
+    {file = "dulwich-0.22.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:db10da1719575b5b113e006b8fc9ed7bbf4fd5488db242e85dcea2191c0d4b99"},
+    {file = "dulwich-0.22.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6684297967833961c81333cbf105b0c2cd3f1a824873b85d60d265ec751fe57"},
+    {file = "dulwich-0.22.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6290edb86155b350a3504582570891b0a7593766d91d6b89cdd24d01061f019f"},
+    {file = "dulwich-0.22.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:75e0c2ad0eb809eda2c1c1253768632e421b099245c12ffddf8a6f109c2fe32e"},
+    {file = "dulwich-0.22.6-cp312-cp312-win32.whl", hash = "sha256:b1a08ad0c6ae572142b7775f6fe028e0e3ac9c01a295344c41049e257c5af980"},
+    {file = "dulwich-0.22.6-cp312-cp312-win_amd64.whl", hash = "sha256:1f0040aa840c9632b973bd98484e584bb21690738c2be1ebd23b0c5af3214b2f"},
+    {file = "dulwich-0.22.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dff11fe1ecd6f9d915b490c660456a467c9150404de5100b3cf112c6bd5c830d"},
+    {file = "dulwich-0.22.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9e75774fe5f219490912931bb8d91a12ec5cc7155f377fd88088fe0f035e1b8"},
+    {file = "dulwich-0.22.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb5f8ff0eb0d6759cebd13cb9e6d7029af5d87f89074bd1a702c7a0943a33d6e"},
+    {file = "dulwich-0.22.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:096a9fe8754bce136e128b7161fca30ff1b2e5859f2324a7e2c8270dcb2ba672"},
+    {file = "dulwich-0.22.6-cp313-cp313-win32.whl", hash = "sha256:115920aff5756cdf02900504fe3c9b941f2f41fab5cea2670130783f02e0ae2c"},
+    {file = "dulwich-0.22.6-cp313-cp313-win_amd64.whl", hash = "sha256:4b84f9a849d64201a8e5cde024bbbf9c56d3138f284eb5cc1a937ee3503f18b0"},
+    {file = "dulwich-0.22.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ec5d376f7f02651301b58e04888bd5d671577fc68cc7dada23793907119c22bd"},
+    {file = "dulwich-0.22.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c8711a00f45d923f8febc047866fa7e845ea19bcdb930f48ddc2a121d1ed8bd"},
+    {file = "dulwich-0.22.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e61b8993d5d5c63682215f67104fc75dcfd9927e214df2be5baff333bafd69a"},
+    {file = "dulwich-0.22.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fda801469f3cbd982898f224696adb4afd72f2f42bbbbfe1ded2632b3a85dba"},
+    {file = "dulwich-0.22.6-cp39-cp39-win32.whl", hash = "sha256:0fca415dc613434a371e9058e1e7f2a1331361a23e41ebae9442b903f553bc3b"},
+    {file = "dulwich-0.22.6-cp39-cp39-win_amd64.whl", hash = "sha256:1b883cd35f755491f79b89c70f082e9e6232361a0281642594f4a2bf8051a7dd"},
+    {file = "dulwich-0.22.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e05edb22519b39f8396e5d36e23e08485d992f04d6acfdd7f4cff2ca3ba5b8c7"},
+    {file = "dulwich-0.22.6-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48e4262bfa68635a97bbe0c2ce4f4092ef903a7f3127b61b8ed634ef2538fdc8"},
+    {file = "dulwich-0.22.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40951f82c80561030175e73f09845f24ebbee88dfd76abda8e4d58d756b95c65"},
+    {file = "dulwich-0.22.6-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4915476feacaeb7e8975942d93d69bf9baf2e87c2a9eab779864aa7319616563"},
+    {file = "dulwich-0.22.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:84ac8d08cbadfb8972de597ab4c0286119409449c7bed207a02f7d62bb5c5b4b"},
+    {file = "dulwich-0.22.6-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cc0810d6e65787ba0f41eb0dbe3e39520d85fd409d8a0e9a15d48cb194b77c6f"},
+    {file = "dulwich-0.22.6-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b18bdf05ed09288b9d8dbbf927a2c3a63fa6192eced25665514959dea92a389b"},
+    {file = "dulwich-0.22.6-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:502cc8ffe2d4f2e7bd347549e8bd1d31a8408dd990f5df2b028853229027baae"},
+    {file = "dulwich-0.22.6-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82039b537ef31dceb04e513f9bc1571e05d283c242fa0aa2c7484ff9dc2ca1ae"},
+    {file = "dulwich-0.22.6-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:fcf1894ac54023266a0cda78d3c997c56328164bdfcd300aab8201e8bcb7decd"},
+    {file = "dulwich-0.22.6-py3-none-any.whl", hash = "sha256:a609c1939b8050c9876d0dd2b15302fef695759f479613c20025fbd4ece32bda"},
+    {file = "dulwich-0.22.6.tar.gz", hash = "sha256:c1f44d599fa5dc59ca43e0789f835b8689b4d831d8de5ae009c442192a1408b5"},
 ]
 
 [package.dependencies]
-setuptools = {version = "*", markers = "python_version >= \"3.12\""}
 urllib3 = ">=1.25"
 
 [package.extras]
+dev = ["mypy (==1.13.0)", "ruff (==0.7.3)"]
 fastimport = ["fastimport"]
 https = ["urllib3 (>=1.24.1)"]
 paramiko = ["paramiko"]
@@ -1472,4 +1467,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "abcf5a628d4f501a0a8c84fbaa96906dd7985317613f176bb2d4eee15e06313d"
+content-hash = "0e5f540f9a7d3ae3c2ddce4240d7ed2faa68beb779e460a73bfff8b52fbe8cc6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ addopts = [ "-n", "logical", "-ra", "--strict-config", "--strict-markers" ]
 testpaths = ["tests"]
 markers = [
     "network: mark tests that require internet access",
-    "skip_git_mock: makrs test should not auto-apply git_mock"
+    "skip_git_mock: mark tests that should not auto-apply git_mock"
 ]
 log_cli_level = "INFO"
 xfail_strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ addopts = [ "-n", "logical", "-ra", "--strict-config", "--strict-markers" ]
 testpaths = ["tests"]
 markers = [
     "network: mark tests that require internet access",
+    "skip_git_mock: makrs test should not auto-apply git_mock"
 ]
 log_cli_level = "INFO"
 xfail_strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ poetry-core = { git = "https://github.com/python-poetry/poetry-core.git", branch
 build = "^1.2.1"
 cachecontrol = { version = "^0.14.0", extras = ["filecache"] }
 cleo = "^2.2.1"
-dulwich = "^0.22.1"
+dulwich = "^0.22.6"
 fastjsonschema = "^2.18.0"
 importlib-metadata = { version = ">=4.4", python = "<3.10" }
 installer = "^0.7.0"

--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -325,18 +325,9 @@ class Git:
                         commit.id,
                     )
                     local.refs[b"HEAD"] = commit.id
-                    try:
-                        with local:
-                            local.reset_index()
-                        short_ref_found = True
-                    except (AssertionError, KeyError) as e:
-                        logger.debug(
-                            "\nRequested ref (<c2>%s</c2>) was not fetched to local copy and"
-                            " cannot be used. The following error was"
-                            " raised:\n\n\t<warning>%s</>",
-                            refspec.key,
-                            e,
-                        )
+                    with local:
+                        local.reset_index()
+                    short_ref_found = True
 
             if not short_ref_found:
                 raise PoetryConsoleError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -613,8 +613,8 @@ def temp_repo(tmp_path: Path) -> TempRepoFixture:
     )
 
     # extra commit
-    (tmp_path / "foo").write_text("foo", encoding="utf-8")
-    repo.stage(["foo"])
+    (tmp_path / "third").write_text("third file", encoding="utf-8")
+    repo.stage(["third"])
 
     head_commit = repo.do_commit(
         committer=b"User <user@example.com>",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 
-import dulwich.repo
 import httpretty
 import keyring
 import pytest
@@ -45,7 +44,6 @@ from tests.helpers import isolated_environment
 from tests.helpers import mock_clone
 from tests.helpers import switch_working_directory
 from tests.helpers import with_working_directory
-from tests.vcs.git.git_fixture import TempRepoFixture
 
 
 if TYPE_CHECKING:
@@ -584,49 +582,3 @@ def set_project_context(
             yield path
 
     return project_context
-
-
-@pytest.fixture()
-def temp_repo(tmp_path: Path) -> TempRepoFixture:
-    """Temporary repository with 2 commits"""
-    repo = dulwich.repo.Repo.init(str(tmp_path))
-
-    # init commit
-    (tmp_path / "foo").write_text("foo", encoding="utf-8")
-    repo.stage(["foo"])
-
-    init_commit = repo.do_commit(
-        committer=b"User <user@example.com>",
-        author=b"User <user@example.com>",
-        message=b"init",
-        no_verify=True,
-    )
-
-    # one commit which is not "head"
-    (tmp_path / "bar").write_text("bar", encoding="utf-8")
-    repo.stage(["bar"])
-    middle_commit = repo.do_commit(
-        committer=b"User <user@example.com>",
-        author=b"User <user@example.com>",
-        message=b"extra",
-        no_verify=True,
-    )
-
-    # extra commit
-    (tmp_path / "third").write_text("third file", encoding="utf-8")
-    repo.stage(["third"])
-
-    head_commit = repo.do_commit(
-        committer=b"User <user@example.com>",
-        author=b"User <user@example.com>",
-        message=b"extra",
-        no_verify=True,
-    )
-
-    return TempRepoFixture(
-        path=tmp_path,
-        repo=repo,
-        init_commit=init_commit.decode(),
-        middle_commit=middle_commit.decode(),
-        head_commit=head_commit.decode(),
-    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -602,7 +602,7 @@ def temp_repo(tmp_path: Path) -> TempRepoFixture:
         no_verify=True,
     )
 
-    # one commit which is not "head
+    # one commit which is not "head"
     (tmp_path / "bar").write_text("bar", encoding="utf-8")
     repo.stage(["bar"])
     middle_commit = repo.do_commit(

--- a/tests/vcs/git/conftest.py
+++ b/tests/vcs/git/conftest.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import dulwich.repo
+import pytest
+
+from tests.vcs.git.git_fixture import TempRepoFixture
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def temp_repo(tmp_path: Path) -> TempRepoFixture:
+    """Temporary repository with 2 commits"""
+    repo = dulwich.repo.Repo.init(str(tmp_path))
+
+    # init commit
+    (tmp_path / "foo").write_text("foo", encoding="utf-8")
+    repo.stage(["foo"])
+
+    init_commit = repo.do_commit(
+        committer=b"User <user@example.com>",
+        author=b"User <user@example.com>",
+        message=b"init",
+        no_verify=True,
+    )
+
+    # one commit which is not "head"
+    (tmp_path / "bar").write_text("bar", encoding="utf-8")
+    repo.stage(["bar"])
+    middle_commit = repo.do_commit(
+        committer=b"User <user@example.com>",
+        author=b"User <user@example.com>",
+        message=b"extra",
+        no_verify=True,
+    )
+
+    # extra commit
+    (tmp_path / "third").write_text("third file", encoding="utf-8")
+    repo.stage(["third"])
+
+    head_commit = repo.do_commit(
+        committer=b"User <user@example.com>",
+        author=b"User <user@example.com>",
+        message=b"extra",
+        no_verify=True,
+    )
+
+    return TempRepoFixture(
+        path=tmp_path,
+        repo=repo,
+        init_commit=init_commit.decode(),
+        middle_commit=middle_commit.decode(),
+        head_commit=head_commit.decode(),
+    )

--- a/tests/vcs/git/git_fixture.py
+++ b/tests/vcs/git/git_fixture.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import shutil
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from pathlib import Path
+
+    import dulwich.repo
+
+
+GIT_NOT_INSTALLLED = shutil.which("git") is None
+
+
+class TempRepoFixture(typing.NamedTuple):
+    path: Path
+    repo: dulwich.repo.Repo
+    init_commit: str
+    middle_commit: str
+    head_commit: str

--- a/tests/vcs/git/git_fixture.py
+++ b/tests/vcs/git/git_fixture.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shutil
 import typing
 
 
@@ -8,9 +7,6 @@ if typing.TYPE_CHECKING:
     from pathlib import Path
 
     import dulwich.repo
-
-
-GIT_NOT_INSTALLLED = shutil.which("git") is None
 
 
 class TempRepoFixture(typing.NamedTuple):

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -11,12 +11,12 @@ from poetry.vcs.git.backend import Git
 from poetry.vcs.git.backend import annotated_tag
 from poetry.vcs.git.backend import is_revision_sha
 from poetry.vcs.git.backend import urlpathjoin
-from tests.vcs.git.git_fixture import GIT_NOT_INSTALLLED
-from tests.vcs.git.git_fixture import TempRepoFixture
 
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from tests.vcs.git.git_fixture import TempRepoFixture
 
 
 VALID_SHA = "c5c7624ef64f34d9f50c3b7e8118f7f652fddbbd"
@@ -84,7 +84,6 @@ def test_urlpathjoin(url: str, expected_result: str) -> None:
     assert result == expected_result
 
 
-@pytest.mark.skipif(GIT_NOT_INSTALLLED, reason="These tests requires git cli")
 class TestBackendGit:
     @pytest.mark.skip_git_mock
     def test_clone_success(self, tmp_path: Path, temp_repo: TempRepoFixture) -> None:

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -84,28 +84,26 @@ def test_urlpathjoin(url: str, expected_result: str) -> None:
     assert result == expected_result
 
 
-class TestBackendGit:
-    @pytest.mark.skip_git_mock
-    def test_clone_success(self, tmp_path: Path, temp_repo: TempRepoFixture) -> None:
-        source_root_dir = tmp_path / "test-repo"
-        Git.clone(
-            url=temp_repo.path.as_uri(), source_root=source_root_dir, name="clone-test"
-        )
+@pytest.mark.skip_git_mock
+def test_clone_success(tmp_path: Path, temp_repo: TempRepoFixture) -> None:
+    source_root_dir = tmp_path / "test-repo"
+    Git.clone(
+        url=temp_repo.path.as_uri(), source_root=source_root_dir, name="clone-test"
+    )
 
-        target_dir = source_root_dir / "clone-test"
-        assert (target_dir / ".git").is_dir()
+    target_dir = source_root_dir / "clone-test"
+    assert (target_dir / ".git").is_dir()
 
-    @pytest.mark.skip_git_mock
-    def test_short_sha_not_in_head(
-        self, tmp_path: Path, temp_repo: TempRepoFixture
-    ) -> None:
-        source_root_dir = tmp_path / "test-repo"
-        Git.clone(
-            url=temp_repo.path.as_uri(),
-            revision=temp_repo.middle_commit[:6],
-            name="clone-test",
-            source_root=source_root_dir,
-        )
 
-        target_dir = source_root_dir / "clone-test"
-        assert (target_dir / ".git").is_dir()
+@pytest.mark.skip_git_mock
+def test_short_sha_not_in_head(tmp_path: Path, temp_repo: TempRepoFixture) -> None:
+    source_root_dir = tmp_path / "test-repo"
+    Git.clone(
+        url=temp_repo.path.as_uri(),
+        revision=temp_repo.middle_commit[:6],
+        name="clone-test",
+        source_root=source_root_dir,
+    )
+
+    target_dir = source_root_dir / "clone-test"
+    assert (target_dir / ".git").is_dir()

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,6 +11,12 @@ from poetry.vcs.git.backend import Git
 from poetry.vcs.git.backend import annotated_tag
 from poetry.vcs.git.backend import is_revision_sha
 from poetry.vcs.git.backend import urlpathjoin
+from tests.vcs.git.git_fixture import GIT_NOT_INSTALLLED
+from tests.vcs.git.git_fixture import TempRepoFixture
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 VALID_SHA = "c5c7624ef64f34d9f50c3b7e8118f7f652fddbbd"
@@ -75,3 +82,31 @@ def test_urlpathjoin(url: str, expected_result: str) -> None:
     path = "../other-repo"
     result = urlpathjoin(url, path)
     assert result == expected_result
+
+
+@pytest.mark.skipif(GIT_NOT_INSTALLLED, reason="These tests requires git cli")
+class TestBackendGit:
+    @pytest.mark.skip_git_mock
+    def test_clone_success(self, tmp_path: Path, temp_repo: TempRepoFixture) -> None:
+        source_root_dir = tmp_path / "test-repo"
+        Git.clone(
+            url=temp_repo.path.as_uri(), source_root=source_root_dir, name="clone-test"
+        )
+
+        target_dir = source_root_dir / "clone-test"
+        assert (target_dir / ".git").is_dir()
+
+    @pytest.mark.skip_git_mock
+    def test_short_sha_not_in_head(
+        self, tmp_path: Path, temp_repo: TempRepoFixture
+    ) -> None:
+        source_root_dir = tmp_path / "test-repo"
+        Git.clone(
+            url=temp_repo.path.as_uri(),
+            revision=temp_repo.middle_commit[:6],
+            name="clone-test",
+            source_root=source_root_dir,
+        )
+
+        target_dir = source_root_dir / "clone-test"
+        assert (target_dir / ".git").is_dir()

--- a/tests/vcs/git/test_system.py
+++ b/tests/vcs/git/test_system.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 import typing
 
 import pytest
 
 from poetry.vcs.git.system import SystemGit
-from tests.vcs.git.git_fixture import GIT_NOT_INSTALLLED
-from tests.vcs.git.git_fixture import TempRepoFixture
 
 
 if typing.TYPE_CHECKING:
     from pathlib import Path
+
+    from tests.vcs.git.git_fixture import TempRepoFixture
+
+GIT_NOT_INSTALLED = shutil.which("git") is None
 
 
 def get_head_sha(cwd: Path) -> str:
@@ -24,7 +27,7 @@ def get_head_sha(cwd: Path) -> str:
     ).strip()
 
 
-@pytest.mark.skipif(GIT_NOT_INSTALLLED, reason="These tests requires git cli")
+@pytest.mark.skipif(GIT_NOT_INSTALLED, reason="These tests requires git cli")
 class TestSystemGit:
     def test_clone_success(self, tmp_path: Path, temp_repo: TempRepoFixture) -> None:
         target_dir = tmp_path / "test-repo"

--- a/tests/vcs/git/test_system.py
+++ b/tests/vcs/git/test_system.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
 import re
-import shutil
 import subprocess
 import typing
 
-import dulwich.repo
 import pytest
 
 from poetry.vcs.git.system import SystemGit
+from tests.vcs.git.git_fixture import GIT_NOT_INSTALLLED
+from tests.vcs.git.git_fixture import TempRepoFixture
 
 
 if typing.TYPE_CHECKING:
     from pathlib import Path
-
-
-GIT_NOT_INSTALLLED = shutil.which("git") is None
 
 
 def get_head_sha(cwd: Path) -> str:
@@ -25,48 +22,6 @@ def get_head_sha(cwd: Path) -> str:
         text=True,
         encoding="utf-8",
     ).strip()
-
-
-class TempRepoFixture(typing.NamedTuple):
-    path: Path
-    repo: dulwich.repo.Repo
-    init_commit: str
-    head_commit: str
-
-
-@pytest.fixture()
-def temp_repo(tmp_path: Path) -> TempRepoFixture:
-    """Temporary repository with 2 commits"""
-    repo = dulwich.repo.Repo.init(str(tmp_path))
-
-    # init commit
-    (tmp_path / "foo").write_text("foo", encoding="utf-8")
-    repo.stage(["foo"])
-
-    init_commit = repo.do_commit(
-        committer=b"User <user@example.com>",
-        author=b"User <user@example.com>",
-        message=b"init",
-        no_verify=True,
-    )
-
-    # extra commit
-    (tmp_path / "foo").write_text("bar", encoding="utf-8")
-    repo.stage(["foo"])
-
-    head_commit = repo.do_commit(
-        committer=b"User <user@example.com>",
-        author=b"User <user@example.com>",
-        message=b"extra",
-        no_verify=True,
-    )
-
-    return TempRepoFixture(
-        path=tmp_path,
-        repo=repo,
-        init_commit=init_commit.decode(),
-        head_commit=head_commit.decode(),
-    )
 
 
 @pytest.mark.skipif(GIT_NOT_INSTALLLED, reason="These tests requires git cli")


### PR DESCRIPTION
# Pull Request Check List

If a dependency specifies a git revision using a short hash, Dulwich does not provide an option to directly address it (see discussion in #9560); however, we can still list revisions and find what we are looking for.

Resolves: #9560

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
