### PR TITLE
feat: in `show {package}` output, clarify meaning of 'required by' entries

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -515,7 +515,7 @@ dependencies
  - pytzdata >=2017.2.2
 
 required by
- - calendar requires pendulum >=1.4.0
+ - calendar requires >=1.4.0
 ```
 
 ### Options

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -515,7 +515,7 @@ dependencies
  - pytzdata >=2017.2.2
 
 required by
- - calendar >=1.4.0
+ - calendar requires pendulum >=1.4.0
 ```
 
 ### Options

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -200,7 +200,9 @@ lists all packages available."""
             self.line("")
             self.line("<info>required by</info>")
             for parent, requires_version in required_by.items():
-                self.line(f" - <c1>{parent}</c1> requires {package} <b>{requires_version}</b>")
+                self.line(
+                    f" - <c1>{parent}</c1> requires {package} <b>{requires_version}</b>"
+                )
 
         return 0
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -200,7 +200,7 @@ lists all packages available."""
             self.line("")
             self.line("<info>required by</info>")
             for parent, requires_version in required_by.items():
-                self.line(f" - <c1>{parent}</c1> <b>{requires_version}</b>")
+                self.line(f" - <c1>{parent}</c1> requires {package} <b>{requires_version}</b>")
 
         return 0
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -200,9 +200,7 @@ lists all packages available."""
             self.line("")
             self.line("<info>required by</info>")
             for parent, requires_version in required_by.items():
-                self.line(
-                    f" - <c1>{parent}</c1> requires {package} <b>{requires_version}</b>"
-                )
+                self.line(f" - <c1>{parent}</c1> requires <b>{requires_version}</b>")
 
         return 0
 

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1981,7 +1981,7 @@ dependencies
  - msgpack-python >=0.5 <0.6
 
 required by
- - pendulum >=0.2.0 <0.3.0
+ - pendulum requires cachy >=0.2.0 <0.3.0
 """.splitlines()
     actual = [line.rstrip() for line in tester.io.fetch_output().splitlines()]
     assert actual == expected

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1981,7 +1981,7 @@ dependencies
  - msgpack-python >=0.5 <0.6
 
 required by
- - pendulum requires cachy >=0.2.0 <0.3.0
+ - pendulum requires >=0.2.0 <0.3.0
 """.splitlines()
     actual = [line.rstrip() for line in tester.io.fetch_output().splitlines()]
     assert actual == expected


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9749

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code

Example of actual output before:
```console
> poetry show requests
 name         : requests
 version      : 2.32.3
 description  : Python HTTP for Humans.

dependencies
 - certifi >=2017.4.17
 - charset-normalizer >=2,<4
 - idna >=2.5,<4
 - urllib3 >=1.21.1,<3

required by
 - cachecontrol >=2.16.0
```

After: 
```console 
> poetry show requests
 name         : requests
 version      : 2.32.3
 description  : Python HTTP for Humans.

dependencies
 - certifi >=2017.4.17
 - charset-normalizer >=2,<4
 - idna >=2.5,<4
 - urllib3 >=1.21.1,<3

required by
 - cachecontrol requires requests >=2.16.0
```




