### PR TITLE
feat(config)!: prefer active python by default

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -87,7 +87,6 @@ we are allowing any version of Python 3 that is greater than `3.7.0`.
 
 When you run `poetry install`, you must have access to some version of a Python interpreter that satisfies this constraint available on your system.
 Poetry will not install a Python interpreter for you.
-If you use a tool like `pyenv`, you can use the experimental configuration value [`virtualenvs.prefer-active-python`]({{< relref "configuration/#virtualenvsprefer-active-python-experimental" >}}).
 
 ### Initialising a pre-existing project
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -423,9 +423,11 @@ This setting controls the global virtual environment storage path. It most likel
 
 **Type**: `boolean`
 
-**Default**: `false`
+**Default**: `true`
 
 **Environment Variable**: `POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON`
+
+*Default changed to `true` in 2.0.0*
 
 *Introduced in 1.2.0*
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,8 +58,8 @@ virtualenvs.options.always-copy = true
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = "{cache-dir}/virtualenvs"  # /path/to/cache/directory/virtualenvs
-virtualenvs.prefer-active-python = false
 virtualenvs.prompt = "{project_name}-py{python_version}"
+virtualenvs.use-poetry-python = false
 ```
 
 ## Displaying a single configuration setting
@@ -419,21 +419,6 @@ Directory where virtual environments will be created.
 This setting controls the global virtual environment storage path. It most likely will not be useful at the local level. To store virtual environments in the project root, see `virtualenvs.in-project`.
 {{% /note %}}
 
-### `virtualenvs.prefer-active-python`
-
-**Type**: `boolean`
-
-**Default**: `true`
-
-**Environment Variable**: `POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON`
-
-*Default changed to `true` in 2.0.0*
-
-*Introduced in 1.2.0*
-
-Use currently activated Python version to create a new virtual environment.
-If set to `false`, Python version used during Poetry installation is used.
-
 ### `virtualenvs.prompt`
 
 **Type**: `string`
@@ -446,6 +431,19 @@ If set to `false`, Python version used during Poetry installation is used.
 
 Format string defining the prompt to be displayed when the virtual environment is activated.
 The variables `project_name` and `python_version` are available for formatting.
+
+### `virtualenvs.use-poetry-python`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+**Environment Variable**: `POETRY_VIRTUALENVS_USE_POETRY_PYTHON`
+
+*Introduced in 2.0.0*
+
+By default, Poetry will use the activated Python version to create a new virtual environment.
+If set to `true`, the Python version used during Poetry installation is used.
 
 ### `repositories.<name>.url`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -419,7 +419,7 @@ Directory where virtual environments will be created.
 This setting controls the global virtual environment storage path. It most likely will not be useful at the local level. To store virtual environments in the project root, see `virtualenvs.in-project`.
 {{% /note %}}
 
-### `virtualenvs.prefer-active-python` (experimental)
+### `virtualenvs.prefer-active-python`
 
 **Type**: `boolean`
 

--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -28,8 +28,8 @@ to activate one explicitly, see [Switching environments](#switching-between-envi
 
 {{% note %}}
 If you use a tool like [pyenv](https://github.com/pyenv/pyenv) to manage different Python versions,
-you can set the experimental `virtualenvs.prefer-active-python` option to `true`. Poetry
-will then try to find the current `python` of your shell.
+you can switch the current `python` of your shell and Poetry will use it to create
+the new environment.
 
 For instance, if your project requires a newer Python than is available with
 your system, a standard workflow would be:

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -116,7 +116,7 @@ class Config:
                 "system-site-packages": False,
                 "no-pip": False,
             },
-            "prefer-active-python": True,
+            "use-poetry-python": False,
             "prompt": "{project_name}-py{python_version}",
         },
         "requests": {
@@ -296,7 +296,7 @@ class Config:
             "virtualenvs.options.always-copy",
             "virtualenvs.options.no-pip",
             "virtualenvs.options.system-site-packages",
-            "virtualenvs.options.prefer-active-python",
+            "virtualenvs.use-poetry-python",
             "installer.parallel",
             "solver.lazy-wheel",
             "system-git-client",

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -116,7 +116,7 @@ class Config:
                 "system-site-packages": False,
                 "no-pip": False,
             },
-            "prefer-active-python": False,
+            "prefer-active-python": True,
             "prompt": "{project_name}-py{python_version}",
         },
         "requests": {

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -67,7 +67,7 @@ To remove a repository (repo is a short alias for repositories):
             ),
             "virtualenvs.options.no-pip": (boolean_validator, boolean_normalizer),
             "virtualenvs.path": (str, lambda val: str(Path(val))),
-            "virtualenvs.prefer-active-python": (boolean_validator, boolean_normalizer),
+            "virtualenvs.use-poetry-python": (boolean_validator, boolean_normalizer),
             "virtualenvs.prompt": (str, str),
             "system-git-client": (boolean_validator, boolean_normalizer),
             "requests.max-retries": (lambda val: int(val) >= 0, int_normalizer),

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -397,9 +397,7 @@ class EnvManager:
 
         create_venv = self._poetry.config.get("virtualenvs.create")
         in_project_venv = self.use_in_project_venv()
-        prefer_active_python = self._poetry.config.get(
-            "virtualenvs.prefer-active-python"
-        )
+        use_poetry_python = self._poetry.config.get("virtualenvs.use-poetry-python")
         venv_prompt = self._poetry.config.get("virtualenvs.prompt")
 
         python = (
@@ -424,7 +422,7 @@ class EnvManager:
             # If an executable has been specified, we stop there
             # and notify the user of the incompatibility.
             # Otherwise, we try to find a compatible Python version.
-            if executable and not prefer_active_python:
+            if executable and use_poetry_python:
                 raise NoCompatiblePythonVersionFoundError(
                     self._poetry.package.python_versions,
                     python.patch_version.to_string(),

--- a/src/poetry/utils/env/python_manager.py
+++ b/src/poetry/utils/env/python_manager.py
@@ -116,7 +116,7 @@ class Python:
     def get_preferred_python(cls, config: Config, io: IO | None = None) -> Python:
         io = io or NullIO()
 
-        if config.get("virtualenvs.prefer-active-python") and (
+        if not config.get("virtualenvs.use-poetry-python") and (
             active_python := Python._detect_active_python(io)
         ):
             return cls(executable=active_python)

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -68,8 +68,8 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+virtualenvs.use-poetry-python = false
 """
 
     assert tester.io.fetch_output() == expected
@@ -99,8 +99,8 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+virtualenvs.use-poetry-python = false
 """
 
     assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
@@ -151,8 +151,8 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+virtualenvs.use-poetry-python = false
 """
     assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
     assert tester.io.fetch_output() == expected
@@ -181,8 +181,8 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+virtualenvs.use-poetry-python = false
 """
     assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
     assert tester.io.fetch_output() == expected
@@ -309,8 +309,8 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+virtualenvs.use-poetry-python = false
 """
 
     assert config.set_config_source.call_count == 1  # type: ignore[attr-defined]
@@ -348,8 +348,8 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
+virtualenvs.use-poetry-python = false
 """
 
     assert tester.io.fetch_output() == expected

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -68,7 +68,7 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = false
+virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
 """
 
@@ -99,7 +99,7 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = false
+virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
 """
 
@@ -151,7 +151,7 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = false
+virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
 """
     assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
@@ -181,7 +181,7 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = false
+virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
 """
     assert config.set_config_source.call_count == 0  # type: ignore[attr-defined]
@@ -309,7 +309,7 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = false
+virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
 """
 
@@ -348,7 +348,7 @@ virtualenvs.options.always-copy = false
 virtualenvs.options.no-pip = false
 virtualenvs.options.system-site-packages = false
 virtualenvs.path = {venv_path}  # {config_cache_dir / 'virtualenvs'}
-virtualenvs.prefer-active-python = false
+virtualenvs.prefer-active-python = true
 virtualenvs.prompt = "{{project_name}}-py{{python_version}}"
 """
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1087,14 +1087,14 @@ def test_package_include(
 
 
 @pytest.mark.parametrize(
-    ["prefer_active", "python"],
+    ["use_poetry_python", "python"],
     [
-        (True, "1.1"),
-        (False, f"{sys.version_info[0]}.{sys.version_info[1]}"),
+        (False, "1.1"),
+        (True, f"{sys.version_info[0]}.{sys.version_info[1]}"),
     ],
 )
-def test_respect_prefer_active_on_init(
-    prefer_active: bool,
+def test_respect_use_poetry_python_on_init(
+    use_poetry_python: bool,
     python: str,
     config: Config,
     mocker: MockerFixture,
@@ -1117,7 +1117,7 @@ def test_respect_prefer_active_on_init(
         "poetry.utils.env.python_manager.Python._full_python_path",
         return_value=Path(f"/usr/bin/python{python}"),
     )
-    config.config["virtualenvs"]["prefer-active-python"] = prefer_active
+    config.config["virtualenvs"]["use-poetry-python"] = use_poetry_python
     pyproject_file = source_dir / "pyproject.toml"
 
     tester.execute(

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -189,14 +189,14 @@ def test_command_new_with_readme(
 
 
 @pytest.mark.parametrize(
-    ["prefer_active", "python"],
+    ["use_poetry_python", "python"],
     [
-        (True, "1.1"),
-        (False, f"{sys.version_info[0]}.{sys.version_info[1]}"),
+        (False, "1.1"),
+        (True, f"{sys.version_info[0]}.{sys.version_info[1]}"),
     ],
 )
-def test_respect_prefer_active_on_new(
-    prefer_active: bool,
+def test_respect_use_poetry_python_on_new(
+    use_poetry_python: bool,
     python: str,
     config: Config,
     mocker: MockerFixture,
@@ -220,7 +220,7 @@ def test_respect_prefer_active_on_new(
         return_value=Path(f"/usr/bin/python{python}"),
     )
 
-    config.config["virtualenvs"]["prefer-active-python"] = prefer_active
+    config.config["virtualenvs"]["use-poetry-python"] = use_poetry_python
 
     package = "package"
     path = tmp_path / package

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -494,6 +494,7 @@ def test_deactivate_non_activated_but_existing(
     mocker: MockerFixture,
     venv_name: str,
 ) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = False
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -521,6 +522,7 @@ def test_deactivate_activated(
     mocker: MockerFixture,
     venv_name: str,
 ) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = False
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -894,6 +896,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
     venv_name: str,
     venv_flags_default: dict[str, bool],
 ) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = False
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -952,6 +955,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     venv_name: str,
     venv_flags_default: dict[str, bool],
 ) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = False
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -987,6 +991,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
 def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
     manager: EnvManager, poetry: Poetry, config: Config, mocker: MockerFixture
 ) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = False
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -1016,6 +1021,7 @@ def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
 def test_create_venv_does_not_try_to_find_compatible_versions_with_executable(
     manager: EnvManager, poetry: Poetry, config: Config, mocker: MockerFixture
 ) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = False
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -1048,6 +1054,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
     venv_name: str,
     venv_flags_default: dict[str, bool],
 ) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = False
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -1151,6 +1158,7 @@ def test_create_venv_project_name_empty_sets_correct_prompt(
     mocker: MockerFixture,
     config_virtualenvs_path: Path,
 ) -> None:
+    config.config["virtualenvs"]["prefer-active-python"] = False
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -494,7 +494,7 @@ def test_deactivate_non_activated_but_existing(
     mocker: MockerFixture,
     venv_name: str,
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = True
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -522,7 +522,7 @@ def test_deactivate_activated(
     mocker: MockerFixture,
     venv_name: str,
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = True
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -896,7 +896,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_generic_
     venv_name: str,
     venv_flags_default: dict[str, bool],
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = True
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -955,7 +955,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     venv_name: str,
     venv_flags_default: dict[str, bool],
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = True
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -991,7 +991,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
 def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
     manager: EnvManager, poetry: Poetry, config: Config, mocker: MockerFixture
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = True
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -1021,7 +1021,7 @@ def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
 def test_create_venv_does_not_try_to_find_compatible_versions_with_executable(
     manager: EnvManager, poetry: Poetry, config: Config, mocker: MockerFixture
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = True
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -1054,7 +1054,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
     venv_name: str,
     venv_flags_default: dict[str, bool],
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = True
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 
@@ -1158,7 +1158,7 @@ def test_create_venv_project_name_empty_sets_correct_prompt(
     mocker: MockerFixture,
     config_virtualenvs_path: Path,
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = True
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 

--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -56,22 +56,24 @@ def test_python_get_preferred_default(config: Config) -> None:
     )
 
 
-def test_python_get_preferred_activated(config: Config, mocker: MockerFixture) -> None:
+def test_get_preferred_python_use_poetry_python_disabled(
+    config: Config, mocker: MockerFixture
+) -> None:
     mocker.patch(
         "subprocess.check_output",
         side_effect=check_output_wrapper(Version.parse("3.7.1")),
     )
-    config.config["virtualenvs"]["prefer-active-python"] = True
+    config.config["virtualenvs"]["use-poetry-python"] = False
     python = Python.get_preferred_python(config)
 
     assert python.executable.as_posix().startswith("/usr/bin/python")
     assert python.version == Version.parse("3.7.1")
 
 
-def test_python_get_preferred_activated_fallback(
+def test_get_preferred_python_use_poetry_python_disabled_fallback(
     config: Config, mocker: MockerFixture
 ) -> None:
-    config.config["virtualenvs"]["prefer-active-python"] = True
+    config.config["virtualenvs"]["use-poetry-python"] = False
     with mocker.patch(
         "subprocess.check_output",
         side_effect=subprocess.CalledProcessError(1, "some command"),


### PR DESCRIPTION
From now on Poetry prefers the currently active Python by default. To restore the old behavior the option `virtualenvs.use-poetry-python` was introduced and must be set to `true` (default: `false`).

`virtualenvs.prefer-active-python` is removed as an option.
