### PR TITLE
feat(config)!: rename experimental.system-git-client to system-git-client

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,22 +158,6 @@ Defaults to one of the following directories:
 - Windows: `C:\Users\<username>\AppData\Local\pypoetry\Cache`
 - Unix:    `~/.cache/pypoetry`
 
-### `experimental.system-git-client`
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-**Environment Variable**: `POETRY_EXPERIMENTAL_SYSTEM_GIT_CLIENT`
-
-*Introduced in 1.2.0*
-
-Use system git client backend for git related tasks.
-
-Poetry uses `dulwich` by default for git related tasks to not rely on the availability of a git client.
-
-If you encounter any problems with it, set to `true` to use the system git backend.
-
 ### `installer.max-workers`
 
 **Type**: `int`
@@ -301,6 +285,24 @@ to only download the METADATA files of wheels.
 Especially with slow network connections this setting can speed up dependency resolution significantly.
 If the cache has already been filled or the server does not support HTTP range requests,
 this setting makes no difference.
+
+### `system-git-client`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+**Environment Variable**: `POETRY_SYSTEM_GIT_CLIENT`
+
+*Renamed to `system-git-client` in 2.0.0*
+
+*Introduced in 1.2.0 as `experimental.system-git-client`*
+
+Use system git client backend for git related tasks.
+
+Poetry uses `dulwich` by default for git related tasks to not rely on the availability of a git client.
+
+If you encounter any problems with it, set to `true` to use the system git backend.
 
 ### `virtualenvs.create`
 

--- a/docs/dependency-specification.md
+++ b/docs/dependency-specification.md
@@ -294,7 +294,7 @@ Poetry 1.2, you may wish to explicitly configure the use of the system git clien
 subprocess call.
 
 ```bash
-poetry config experimental.system-git-client true
+poetry config system-git-client true
 ```
 
 Keep in mind however, that doing so will surface bugs that existed in versions prior to 1.2 which

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -119,9 +119,6 @@ class Config:
             "prefer-active-python": False,
             "prompt": "{project_name}-py{python_version}",
         },
-        "experimental": {
-            "system-git-client": False,
-        },
         "requests": {
             "max-retries": 0,
         },
@@ -134,6 +131,7 @@ class Config:
         "solver": {
             "lazy-wheel": True,
         },
+        "system-git-client": False,
         "keyring": {
             "enabled": True,
         },
@@ -299,9 +297,9 @@ class Config:
             "virtualenvs.options.no-pip",
             "virtualenvs.options.system-site-packages",
             "virtualenvs.options.prefer-active-python",
-            "experimental.system-git-client",
             "installer.parallel",
             "solver.lazy-wheel",
+            "system-git-client",
             "keyring.enabled",
         }:
             return boolean_normalizer

--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -397,9 +397,7 @@ class Git:
     def is_using_legacy_client() -> bool:
         from poetry.config.config import Config
 
-        legacy_client: bool = Config.create().get(
-            "experimental.system-git-client", False
-        )
+        legacy_client: bool = Config.create().get("system-git-client", False)
         return legacy_client
 
     @staticmethod

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -54,7 +54,6 @@ def test_list_displays_default_value_if_not_set(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
-experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -62,6 +61,7 @@ installer.parallel = true
 keyring.enabled = true
 requests.max-retries = 0
 solver.lazy-wheel = true
+system-git-client = false
 virtualenvs.create = true
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
@@ -85,7 +85,6 @@ def test_list_displays_set_get_setting(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
-experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -93,6 +92,7 @@ installer.parallel = true
 keyring.enabled = true
 requests.max-retries = 0
 solver.lazy-wheel = true
+system-git-client = false
 virtualenvs.create = false
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
@@ -137,7 +137,6 @@ def test_unset_setting(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
-experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -145,6 +144,7 @@ installer.parallel = true
 keyring.enabled = true
 requests.max-retries = 0
 solver.lazy-wheel = true
+system-git-client = false
 virtualenvs.create = true
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
@@ -167,7 +167,6 @@ def test_unset_repo_setting(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
-experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -175,6 +174,7 @@ installer.parallel = true
 keyring.enabled = true
 requests.max-retries = 0
 solver.lazy-wheel = true
+system-git-client = false
 virtualenvs.create = true
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
@@ -295,7 +295,6 @@ def test_list_displays_set_get_local_setting(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
-experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -303,6 +302,7 @@ installer.parallel = true
 keyring.enabled = true
 requests.max-retries = 0
 solver.lazy-wheel = true
+system-git-client = false
 virtualenvs.create = false
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false
@@ -333,7 +333,6 @@ def test_list_must_not_display_sources_from_pyproject_toml(
     cache_dir = json.dumps(str(config_cache_dir))
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
-experimental.system-git-client = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -342,6 +341,7 @@ keyring.enabled = true
 repositories.foo.url = "https://foo.bar/simple/"
 requests.max-retries = 0
 solver.lazy-wheel = true
+system-git-client = false
 virtualenvs.create = true
 virtualenvs.in-project = null
 virtualenvs.options.always-copy = false

--- a/tests/integration/test_utils_vcs_git.py
+++ b/tests/integration/test_utils_vcs_git.py
@@ -79,7 +79,7 @@ REF_TO_REVISION_MAP = {
 
 @pytest.fixture
 def use_system_git_client(config: Config) -> None:
-    config.merge({"experimental": {"system-git-client": True}})
+    config.merge({"system-git-client": True})
 
 
 @pytest.fixture(scope="module")
@@ -130,7 +130,7 @@ def remote_default_branch(remote_default_ref: bytes) -> str:
 
 # Regression test for https://github.com/python-poetry/poetry/issues/6722
 def test_use_system_git_client_from_environment_variables() -> None:
-    os.environ["POETRY_EXPERIMENTAL_SYSTEM_GIT_CLIENT"] = "true"
+    os.environ["POETRY_SYSTEM_GIT_CLIENT"] = "true"
 
     assert Git.is_using_legacy_client()
 


### PR DESCRIPTION
`experimental.system-git-client` was introduced in 1.2.0. Let's stop calling it "experimental".