### PR TITLE
fix(config): system-git-client could not be set

### DIFF
--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -69,7 +69,7 @@ To remove a repository (repo is a short alias for repositories):
             "virtualenvs.path": (str, lambda val: str(Path(val))),
             "virtualenvs.prefer-active-python": (boolean_validator, boolean_normalizer),
             "virtualenvs.prompt": (str, str),
-            "experimental.system-git-client": (boolean_validator, boolean_normalizer),
+            "system-git-client": (boolean_validator, boolean_normalizer),
             "requests.max-retries": (lambda val: int(val) >= 0, int_normalizer),
             "installer.parallel": (boolean_validator, boolean_normalizer),
             "installer.max-workers": (lambda val: int(val) > 0, int_normalizer),


### PR DESCRIPTION
Without this fix, trying to set `system-git-client` would result in:

```
Setting system-git-client does not exist
```