### PR TITLE
make `allow-prereleases` a tri-state setting to really forbid pre-releases if the setting is `false` and keep default behavior to allow pre-releases only if necessary

### DIFF
--- a/docs/dependency-specification.md
+++ b/docs/dependency-specification.md
@@ -554,3 +554,17 @@ markers = "platform_python_implementation == 'CPython'"
 The same information is still present, and ends up providing the exact
 same specification. It's simply split into multiple, slightly more readable,
 lines.
+
+### Handling of pre-releases
+
+Per default, Poetry will prefer stable releases and only choose a pre-release
+if no stable release satisfies a version constraint. In some cases, this may result in
+a solution containing pre-releases even if another solution without pre-releases exists.
+
+If you want to disallow pre-releases for a specific dependency,
+you can set `allow-prereleases` to `false`. In this case, dependency resolution will
+fail if there is no solution without choosing a pre-release.
+
+If you want to prefer the latest version of a dependency even if it is a pre-release,
+you can set `allow-prereleases` to `true` so that Poetry makes no distinction
+between stable and pre-release versions during dependency resolution.

--- a/poetry.lock
+++ b/poetry.lock
@@ -975,7 +975,7 @@ develop = false
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "main"
-resolved_reference = "589ecb03f28b30d9a604dc13b51fba55f3981ef5"
+resolved_reference = "616d7bfaf018d50bd09bc24c630b697b6368d5a3"
 
 [[package]]
 name = "pre-commit"

--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -219,7 +219,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
 
         requirements = self._determine_requirements(
             packages,
-            allow_prereleases=self.option("allow-prereleases"),
+            allow_prereleases=self.option("allow-prereleases") or None,
             source=self.option("source"),
         )
 

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -303,7 +303,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
     def _determine_requirements(
         self,
         requires: list[str],
-        allow_prereleases: bool = False,
+        allow_prereleases: bool | None = None,
         source: str | None = None,
         is_interactive: bool | None = None,
     ) -> list[dict[str, Any]]:
@@ -440,7 +440,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         self,
         name: str,
         required_version: str | None = None,
-        allow_prereleases: bool = False,
+        allow_prereleases: bool | None = None,
         source: str | None = None,
     ) -> tuple[str, str]:
         from poetry.version.version_selector import VersionSelector

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -546,7 +546,7 @@ lists all packages available."""
                     provider = Provider(root, self.poetry.pool, NullIO())
                     return provider.search_for_direct_origin_dependency(dep)
 
-        allow_prereleases = False
+        allow_prereleases: bool | None = None
         for dep in requires:
             if dep.name == package.name:
                 allow_prereleases = dep.allows_prereleases()

--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -60,6 +60,8 @@ class Repository(AbstractRepository):
             level="debug",
         )
 
+        if allow_prereleases is False:  # in contrast to None!
+            return packages
         return packages or ignored_pre_release_packages
 
     def has_package(self, package: Package) -> bool:

--- a/src/poetry/version/version_selector.py
+++ b/src/poetry/version/version_selector.py
@@ -17,7 +17,7 @@ class VersionSelector:
         self,
         package_name: str,
         target_package_version: str | None = None,
-        allow_prereleases: bool = False,
+        allow_prereleases: bool | None = None,
         source: str | None = None,
     ) -> Package | None:
         """


### PR DESCRIPTION
# Pull Request Check List

Resolves:  #8194
Requires: python-poetry/poetry-core#783

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Values of `allow-prereleases`:
* not set (default): only use pre-release versions if no stable version satisfies the constraint
* `false`: do not allow pre-release versions even if this means there is no solution
* `true`: do not distinguish between stable and pre-release versions

This PR does not change the default behavior or the behavior for `true`, but only the behavior for `false`.