### PR TITLE
feat: limit build-system to current major version of poetry-core by default

### DIFF
--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import importlib.metadata
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 
 from packaging.utils import canonicalize_name
+from poetry.core.constraints.version import Version
 from poetry.core.utils.helpers import module_name
 from poetry.core.utils.patterns import AUTHOR_REGEX
 from tomlkit import inline_table
@@ -41,8 +44,16 @@ packages = []
 [tool.poetry.group.dev.dependencies]
 """
 
-BUILD_SYSTEM_MIN_VERSION: str | None = None
-BUILD_SYSTEM_MAX_VERSION: str | None = None
+poetry_core_version = Version.parse(importlib.metadata.version("poetry-core"))
+
+BUILD_SYSTEM_MIN_VERSION: str | None = Version.from_parts(
+    major=poetry_core_version.major,
+    minor=poetry_core_version.minor if poetry_core_version.major == 0 else 0,
+    patch=poetry_core_version.patch
+    if (poetry_core_version.major, poetry_core_version.minor) == (0, 0)
+    else 0,
+).to_string()
+BUILD_SYSTEM_MAX_VERSION: str | None = poetry_core_version.next_breaking().to_string()
 
 
 class Layout:

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+import textwrap
 
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -95,6 +96,14 @@ def test_noninteractive(
     assert 'name = "my-package"' in toml_content
     assert '"pytest (>=3.6.0,<4.0.0)"' in toml_content
 
+    expected_build_system = textwrap.dedent("""
+    [build-system]
+    requires = ["poetry-core>=2.0.0,<3.0.0"]
+    build-backend = "poetry.core.masonry.api"
+    """)
+
+    assert expected_build_system in toml_content
+
 
 def test_interactive_with_dependencies(
     tester: CommandTester, repo: TestRepository
@@ -148,6 +157,10 @@ dependencies = [
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^3.6.0"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
 """
 
     assert expected in tester.io.fetch_output()


### PR DESCRIPTION
# Pull Request Check List

Until now when generating a new `pyproject.toml` there is no version range given for `poetry-core` in the `[build-system]` section.

Most people stick to the default. This become a problem as soon as `poetry-core` introduces a breaking change. While users have control over runtime dependencies in case of any incompatibility, it is not possible to tell which version of the build-system requirements should be used.

This is why we should limit the `poetry-core` version in the `[build-system]` section to the current major version of `poetry-core` by default when generating a new `pyproject.toml. 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
