### PR TITLE
fix: do not ignore `installer.max-workers` for implicit PyPI source

### DIFF
--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -154,16 +154,16 @@ class Factory(BaseFactory):
             if repository.name.lower() == "pypi":
                 explicit_pypi = True
 
-        # Only add PyPI if no default repository is configured
+        # Only add PyPI if no primary repository is configured
         if not explicit_pypi:
             if pool.has_primary_repositories():
                 if io.is_debug():
                     io.write_line("Deactivating the PyPI repository")
             else:
-                from poetry.repositories.pypi_repository import PyPiRepository
-
                 pool.add_repository(
-                    PyPiRepository(disable_cache=disable_cache),
+                    cls.create_package_source(
+                        {"name": "pypi"}, config, disable_cache=disable_cache
+                    ),
                     priority=Priority.PRIMARY,
                 )
 


### PR DESCRIPTION
# Pull Request Check List

`installer.max-workers` is considered in `create_package_source()`. However, we did not use this method to create the implicit PyPI source.

Probably not worth a test...

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
