### PR TITLE
feat(cli): add option to migrate outdated configs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -630,6 +630,7 @@ Without `--` this command will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphe
 * `--unset`: Remove the configuration element named by `setting-key`.
 * `--list`: Show the list of current config variables.
 * `--local`: Set/Get settings that are specific to a project (in the local configuration file `poetry.toml`).
+* `--migrate`: Migrate outdated configuration settings.
 
 ## run
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,6 +114,21 @@ This also works for secret settings, like credentials:
 export POETRY_HTTP_BASIC_MY_REPOSITORY_PASSWORD=secret
 ```
 
+## Migrate outdated configs
+
+If poetry renames or remove config options it might be necessary to migrate explicit set options. This is possible
+by running:
+
+```bash
+poetry config --migrate
+```
+
+If you need to migrate a local config run:
+
+```bash
+poetry config --migrate --local
+```
+
 ## Default Directories
 
 Poetry uses the following default directories:

--- a/src/poetry/config/config_source.py
+++ b/src/poetry/config/config_source.py
@@ -18,3 +18,22 @@ class ConfigSource(ABC):
 
     @abstractmethod
     def remove_property(self, key: str) -> None: ...
+
+
+def drop_empty_config_category(
+    keys: list[str], config: dict[Any, Any]
+) -> dict[Any, Any]:
+    config_ = {}
+
+    for key, value in config.items():
+        if not keys or key != keys[0]:
+            config_[key] = value
+            continue
+        if keys and key == keys[0]:
+            if isinstance(value, dict):
+                value = drop_empty_config_category(keys[1:], value)
+
+            if value != {}:
+                config_[key] = value
+
+    return config_

--- a/src/poetry/config/config_source.py
+++ b/src/poetry/config/config_source.py
@@ -5,7 +5,14 @@ from abc import abstractmethod
 from typing import Any
 
 
+class PropertyNotFoundError(ValueError):
+    pass
+
+
 class ConfigSource(ABC):
+    @abstractmethod
+    def get_property(self, key: str) -> Any: ...
+
     @abstractmethod
     def add_property(self, key: str, value: Any) -> None: ...
 

--- a/src/poetry/config/config_source.py
+++ b/src/poetry/config/config_source.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import dataclasses
+
 from abc import ABC
 from abc import abstractmethod
 from typing import Any
+
+
+UNSET = object()
 
 
 class PropertyNotFoundError(ValueError):
@@ -18,6 +23,28 @@ class ConfigSource(ABC):
 
     @abstractmethod
     def remove_property(self, key: str) -> None: ...
+
+
+@dataclasses.dataclass
+class ConfigSourceMigration:
+    old_key: str
+    new_key: str | None
+    value_migration: dict[Any, Any] = dataclasses.field(default_factory=dict)
+
+    def apply(self, config_source: ConfigSource) -> None:
+        try:
+            old_value = config_source.get_property(self.old_key)
+        except PropertyNotFoundError:
+            return
+
+        new_value = (
+            self.value_migration[old_value] if self.value_migration else old_value
+        )
+
+        config_source.remove_property(self.old_key)
+
+        if self.new_key is not None and new_value is not UNSET:
+            config_source.add_property(self.new_key, new_value)
 
 
 def drop_empty_config_category(

--- a/src/poetry/config/dict_config_source.py
+++ b/src/poetry/config/dict_config_source.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from poetry.config.config_source import ConfigSource
+from poetry.config.config_source import PropertyNotFoundError
 
 
 class DictConfigSource(ConfigSource):
@@ -12,6 +13,19 @@ class DictConfigSource(ConfigSource):
     @property
     def config(self) -> dict[str, Any]:
         return self._config
+
+    def get_property(self, key: str) -> Any:
+        keys = key.split(".")
+        config = self._config
+
+        for i, key in enumerate(keys):
+            if key not in config:
+                raise PropertyNotFoundError(f"Key {'.'.join(keys)} not in config")
+
+            if i == len(keys) - 1:
+                return config[key]
+
+            config = config[key]
 
     def add_property(self, key: str, value: Any) -> None:
         keys = key.split(".")

--- a/src/poetry/config/file_config_source.py
+++ b/src/poetry/config/file_config_source.py
@@ -8,6 +8,7 @@ from tomlkit import document
 from tomlkit import table
 
 from poetry.config.config_source import ConfigSource
+from poetry.config.config_source import PropertyNotFoundError
 
 
 if TYPE_CHECKING:
@@ -29,6 +30,20 @@ class FileConfigSource(ConfigSource):
     @property
     def file(self) -> TOMLFile:
         return self._file
+
+    def get_property(self, key: str) -> Any:
+        keys = key.split(".")
+
+        config = self.file.read() if self.file.exists() else {}
+
+        for i, key in enumerate(keys):
+            if key not in config:
+                raise PropertyNotFoundError(f"Key {'.'.join(keys)} not in config")
+
+            if i == len(keys) - 1:
+                return config[key]
+
+            config = config[key]
 
     def add_property(self, key: str, value: Any) -> None:
         with self.secure() as toml:

--- a/src/poetry/config/file_config_source.py
+++ b/src/poetry/config/file_config_source.py
@@ -9,6 +9,7 @@ from tomlkit import table
 
 from poetry.config.config_source import ConfigSource
 from poetry.config.config_source import PropertyNotFoundError
+from poetry.config.config_source import drop_empty_config_category
 
 
 if TYPE_CHECKING:
@@ -76,6 +77,10 @@ class FileConfigSource(ConfigSource):
                     break
 
                 current_config = current_config[key]
+
+            current_config = drop_empty_config_category(keys=keys[:-1], config=config)
+            config.clear()
+            config.update(current_config)
 
     @contextmanager
     def secure(self) -> Iterator[TOMLDocument]:

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -349,6 +349,12 @@ To remove a repository (repo is a short alias for repositories):
         from poetry.toml.file import TOMLFile
 
         config_file = TOMLFile(CONFIG_DIR / "config.toml")
+
+        if self.option("local"):
+            config_file = TOMLFile(self.poetry.file.path.parent / "poetry.toml")
+            if not config_file.exists():
+                raise RuntimeError("No local config file found")
+
         config_source = FileConfigSource(config_file)
 
         for migration in CONFIG_MIGRATIONS:

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -357,5 +357,9 @@ To remove a repository (repo is a short alias for repositories):
 
         config_source = FileConfigSource(config_file)
 
+        self.io.write_line("Starting config migration ...")
+
         for migration in CONFIG_MIGRATIONS:
-            migration.apply(config_source)
+            migration.apply(config_source, io=self.io)
+
+        self.io.write_line("Config migration successfully done.")

--- a/tests/config/test_config_source.py
+++ b/tests/config/test_config_source.py
@@ -4,7 +4,10 @@ from typing import Any
 
 import pytest
 
+from poetry.config.config_source import UNSET
+from poetry.config.config_source import ConfigSourceMigration
 from poetry.config.config_source import drop_empty_config_category
+from poetry.config.dict_config_source import DictConfigSource
 
 
 @pytest.mark.parametrize(
@@ -51,3 +54,105 @@ def test_drop_empty_config_category(
         )
         == expected
     )
+
+
+def test_config_source_migration_rename_key() -> None:
+    config_data = {
+        "virtualenvs": {
+            "prefer-active-python": True,
+        },
+        "system-git-client": True,
+    }
+
+    config_source = DictConfigSource()
+    config_source._config = config_data
+
+    migration = ConfigSourceMigration(
+        old_key="virtualenvs.prefer-active-python",
+        new_key="virtualenvs.use-poetry-python",
+    )
+
+    migration.apply(config_source)
+
+    config_source._config = {
+        "virtualenvs": {
+            "use-poetry-python": True,
+        },
+        "system-git-client": True,
+    }
+
+
+def test_config_source_migration_remove_key() -> None:
+    config_data = {
+        "virtualenvs": {
+            "prefer-active-python": True,
+        },
+        "system-git-client": True,
+    }
+
+    config_source = DictConfigSource()
+    config_source._config = config_data
+
+    migration = ConfigSourceMigration(
+        old_key="virtualenvs.prefer-active-python",
+        new_key=None,
+    )
+
+    migration.apply(config_source)
+
+    config_source._config = {
+        "virtualenvs": {},
+        "system-git-client": True,
+    }
+
+
+def test_config_source_migration_unset_value() -> None:
+    config_data = {
+        "virtualenvs": {
+            "prefer-active-python": True,
+        },
+        "system-git-client": True,
+    }
+
+    config_source = DictConfigSource()
+    config_source._config = config_data
+
+    migration = ConfigSourceMigration(
+        old_key="virtualenvs.prefer-active-python",
+        new_key="virtualenvs.use-poetry-python",
+        value_migration={True: UNSET, False: True},
+    )
+
+    migration.apply(config_source)
+
+    config_source._config = {
+        "virtualenvs": {},
+        "system-git-client": True,
+    }
+
+
+def test_config_source_migration_complex_migration() -> None:
+    config_data = {
+        "virtualenvs": {
+            "prefer-active-python": True,
+        },
+        "system-git-client": True,
+    }
+
+    config_source = DictConfigSource()
+    config_source._config = config_data
+
+    migration = ConfigSourceMigration(
+        old_key="virtualenvs.prefer-active-python",
+        new_key="virtualenvs.use-poetry-python",
+        value_migration={True: None, False: True},
+    )
+
+    migration.apply(config_source)
+
+    config_source._config = {
+        "virtualenvs": {
+            "use-poetry-python": None,
+        },
+        "system-git-client": True,
+    }

--- a/tests/config/test_config_source.py
+++ b/tests/config/test_config_source.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from poetry.config.config_source import drop_empty_config_category
+
+
+@pytest.mark.parametrize(
+    ["config_data", "expected"],
+    [
+        (
+            {
+                "category_a": {
+                    "category_b": {
+                        "category_c": {},
+                    },
+                },
+                "system-git-client": True,
+            },
+            {"system-git-client": True},
+        ),
+        (
+            {
+                "category_a": {
+                    "category_b": {
+                        "category_c": {},
+                        "category_d": {"some_config": True},
+                    },
+                },
+                "system-git-client": True,
+            },
+            {
+                "category_a": {
+                    "category_b": {
+                        "category_d": {"some_config": True},
+                    }
+                },
+                "system-git-client": True,
+            },
+        ),
+    ],
+)
+def test_drop_empty_config_category(
+    config_data: dict[Any, Any], expected: dict[Any, Any]
+) -> None:
+    assert (
+        drop_empty_config_category(
+            keys=["category_a", "category_b", "category_c"], config=config_data
+        )
+        == expected
+    )

--- a/tests/config/test_dict_config_source.py
+++ b/tests/config/test_dict_config_source.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from poetry.config.config_source import PropertyNotFoundError
+from poetry.config.dict_config_source import DictConfigSource
+
+
+def test_dict_config_source_add_property() -> None:
+    config_source = DictConfigSource()
+    assert config_source._config == {}
+
+    config_source.add_property("system-git-client", True)
+    assert config_source._config == {"system-git-client": True}
+
+    config_source.add_property("virtualenvs.use-poetry-python", False)
+    assert config_source._config == {
+        "virtualenvs": {
+            "use-poetry-python": False,
+        },
+        "system-git-client": True,
+    }
+
+
+def test_dict_config_source_remove_property() -> None:
+    config_data = {
+        "virtualenvs": {
+            "use-poetry-python": False,
+        },
+        "system-git-client": True,
+    }
+
+    config_source = DictConfigSource()
+    config_source._config = config_data
+
+    config_source.remove_property("system-git-client")
+    assert config_source._config == {
+        "virtualenvs": {
+            "use-poetry-python": False,
+        }
+    }
+
+    config_source.remove_property("virtualenvs.use-poetry-python")
+    assert config_source._config == {"virtualenvs": {}}
+
+
+def test_dict_config_source_get_property() -> None:
+    config_data = {
+        "virtualenvs": {
+            "use-poetry-python": False,
+        },
+        "system-git-client": True,
+    }
+
+    config_source = DictConfigSource()
+    config_source._config = config_data
+
+    assert config_source.get_property("virtualenvs.use-poetry-python") is False
+    assert config_source.get_property("system-git-client") is True
+
+
+def test_dict_config_source_get_property_should_raise_if_not_found() -> None:
+    config_source = DictConfigSource()
+
+    with pytest.raises(
+        PropertyNotFoundError, match="Key virtualenvs.use-poetry-python not in config"
+    ):
+        _ = config_source.get_property("virtualenvs.use-poetry-python")

--- a/tests/config/test_file_config_source.py
+++ b/tests/config/test_file_config_source.py
@@ -56,7 +56,7 @@ def test_file_config_source_remove_property(tmp_path: Path) -> None:
     }
 
     config_source.remove_property("virtualenvs.use-poetry-python")
-    assert config_source._file.read() == {"virtualenvs": {}}
+    assert config_source._file.read() == {}
 
 
 def test_file_config_source_get_property(tmp_path: Path) -> None:

--- a/tests/config/test_file_config_source.py
+++ b/tests/config/test_file_config_source.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import tomlkit
+
+from poetry.config.config_source import PropertyNotFoundError
+from poetry.config.file_config_source import FileConfigSource
+from poetry.toml import TOMLFile
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_file_config_source_add_property(tmp_path: Path) -> None:
+    config = tmp_path.joinpath("config.toml")
+    config.touch()
+
+    config_source = FileConfigSource(TOMLFile(config))
+
+    assert config_source._file.read() == {}
+
+    config_source.add_property("system-git-client", True)
+    assert config_source._file.read() == {"system-git-client": True}
+
+    config_source.add_property("virtualenvs.use-poetry-python", False)
+    assert config_source._file.read() == {
+        "virtualenvs": {
+            "use-poetry-python": False,
+        },
+        "system-git-client": True,
+    }
+
+
+def test_file_config_source_remove_property(tmp_path: Path) -> None:
+    config_data = {
+        "virtualenvs": {
+            "use-poetry-python": False,
+        },
+        "system-git-client": True,
+    }
+
+    config = tmp_path.joinpath("config.toml")
+    with config.open(mode="w") as f:
+        f.write(tomlkit.dumps(config_data))
+
+    config_source = FileConfigSource(TOMLFile(config))
+
+    config_source.remove_property("system-git-client")
+    assert config_source._file.read() == {
+        "virtualenvs": {
+            "use-poetry-python": False,
+        }
+    }
+
+    config_source.remove_property("virtualenvs.use-poetry-python")
+    assert config_source._file.read() == {"virtualenvs": {}}
+
+
+def test_file_config_source_get_property(tmp_path: Path) -> None:
+    config_data = {
+        "virtualenvs": {
+            "use-poetry-python": False,
+        },
+        "system-git-client": True,
+    }
+
+    config = tmp_path.joinpath("config.toml")
+    with config.open(mode="w") as f:
+        f.write(tomlkit.dumps(config_data))
+
+    config_source = FileConfigSource(TOMLFile(config))
+
+    assert config_source.get_property("virtualenvs.use-poetry-python") is False
+    assert config_source.get_property("system-git-client") is True
+
+
+def test_file_config_source_get_property_should_raise_if_not_found(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path.joinpath("config.toml")
+    config.touch()
+
+    config_source = FileConfigSource(TOMLFile(config))
+
+    with pytest.raises(
+        PropertyNotFoundError, match="Key virtualenvs.use-poetry-python not in config"
+    ):
+        _ = config_source.get_property("virtualenvs.use-poetry-python")


### PR DESCRIPTION
This PR add a new option `--migrate` to `poetry config`. This option enables users to migrate explicit set configs that have been renamed or changed in other ways in new Poetry versions.

![image](https://github.com/user-attachments/assets/980fbb22-e48b-4756-925c-fb1425677234)

Some question:

Only `FileConfigSource` has been updated in that way, that if a property is removed, it is checked whether the section to which this property belongs is now empty and should be removed from the file. Do we want the same behavior for `DictConfigSource`?

It's probably possible to detect on runtime if the Config contains outdated options. Should we inform users, that they should run `poetry config --migrate` to fix it? (I thinks if yes, I will do it in a separate PR.)

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
