### PR TITLE
feat(cli)!: actually switch directory with --directory/-C 

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,8 @@ then `--help` combined with any of those can give you more information.
 * `--no-interaction (-n)`: Do not ask any interactive question.
 * `--no-plugins`: Disables plugins.
 * `--no-cache`: Disables Poetry source caches.
-* `--directory=DIRECTORY (-C)`: The working directory for the Poetry command (defaults to the current working directory).
+* `--directory=DIRECTORY (-C)`: The working directory for the Poetry command (defaults to the current working directory). All command-line arguments will be resolved relative to the given directory.
+* `--project=PROJECT (-P)`: Specify another path as the project root. All command-line arguments will be resolved relative to the current working directory or directory specified using `--directory` option if used.
 
 
 ## new

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -356,12 +356,12 @@ class Application(BaseApplication):
 
         definition.add_option(
             Option(
-                "--directory",
-                "-C",
+                "--project",
+                "-P",
                 flag=False,
                 description=(
-                    "The working directory for the Poetry command (defaults to the"
-                    " current working directory)."
+                    "Specify another path as the project root."
+                    " All command-line arguments will be resolved relative to the current working directory."
                 ),
             )
         )
@@ -370,8 +370,8 @@ class Application(BaseApplication):
 
     @cached_property
     def _directory(self) -> Path:
-        if self._io and self._io.input.option("directory"):
-            return Path(self._io.input.option("directory")).absolute()
+        if self._io and self._io.input.option("project"):
+            return Path(self._io.input.option("project")).absolute()
         return Path.cwd()
 
 

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -74,12 +74,10 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         project_path = Path.cwd()
 
-        if self.io.input.option("directory"):
-            project_path = Path(self.io.input.option("directory"))
+        if self.io.input.option("project"):
+            project_path = Path(self.io.input.option("project"))
             if not project_path.exists() or not project_path.is_dir():
-                self.line_error(
-                    "<error>The --directory path is not a directory.</error>"
-                )
+                self.line_error("<error>The --project path is not a directory.</error>")
                 return 1
 
         return self._init_pyproject(project_path=project_path)

--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -54,9 +54,9 @@ class NewCommand(InitCommand):
     def handle(self) -> int:
         from pathlib import Path
 
-        if self.io.input.option("directory"):
+        if self.io.input.option("project"):
             self.line_error(
-                "<warning>--directory only makes sense with existing projects, and will"
+                "<warning>--project only makes sense with existing projects, and will"
                 " be ignored. You should consider the option --path instead.</warning>"
             )
 

--- a/tests/console/commands/test_build.py
+++ b/tests/console/commands/test_build.py
@@ -206,7 +206,7 @@ def test_build_relative_directory_src_layout(
         # initializes Poetry before passing the directory.
         app = Application()
         tester = ApplicationTester(app)
-        tester.execute("build --directory .")
+        tester.execute("build --project .")
 
         build_dir = tmp_project_path / "dist"
 


### PR DESCRIPTION
# Pull Request Check List

`--directory` now switch the current working folder, so that relative paths are resolved relative to the given folder.

To retain the old behavior the `--project` flag is introduced.

Resolves: #7897

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
