### PR TITLE
Fix regression when using empty username/password

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -511,6 +511,17 @@ You can prevent this by adding double dashes to prevent any following argument f
 poetry config -- http-basic.pypi myUsername -myPasswordStartingWithDash
 ```
 
+{{% note %}}
+In some cases like that of [Gemfury](https://gemfury.com/help/errors/repo-url-password/) repositories, it might be
+required to set an empty password. This is supported by Poetry.
+
+```bash
+poetry config http-basic.foo <TOKEN> ""
+```
+
+**Note:** Usernames cannot be empty.  Attempting to use an empty username can result in an unpredictable failure.
+{{% /note %}}
+
 ## Certificates
 
 ### Custom certificate authority and mutual TLS authentication

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -81,9 +81,7 @@ class AuthenticatorRepositoryConfig:
         self, password_manager: PasswordManager
     ) -> HTTPAuthCredential:
         # try with the repository name via the password manager
-        credential = HTTPAuthCredential(
-            **(password_manager.get_http_auth(self.name) or {})
-        )
+        credential = password_manager.get_http_auth(self.name)
 
         if credential.password is not None:
             return credential

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -195,18 +195,25 @@ class PasswordManager:
     def get_http_auth(self, repo_name: str) -> dict[str, str | None] | None:
         username = self._config.get(f"http-basic.{repo_name}.username")
         password = self._config.get(f"http-basic.{repo_name}.password")
-        if not username and not password:
+
+        # we only return None if both values are None or ""
+        # password can be None at this stage with the username ""
+        if (username is password is None) or (username == password == ""):
             return None
 
         if not password:
             if self.use_keyring:
                 password = self.keyring.get_password(repo_name, username)
-            else:
+            elif not username:
+                # at this tage if username is "" or None, auth is invalid
                 return None
 
+        if not username and not password:
+            return None
+
         return {
-            "username": username,
-            "password": password,
+            "username": username or "",
+            "password": password or "",
         }
 
     def set_http_password(self, repo_name: str, username: str, password: str) -> None:

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -153,7 +153,7 @@ def test_authenticator_uses_empty_strings_as_default_password(
     assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
-def test_authenticator_uses_empty_strings_as_default_username(
+def test_authenticator_ignores_empty_strings_as_default_username(
     config: Config,
     mock_remote: None,
     repo: dict[str, dict[str, str]],
@@ -170,8 +170,7 @@ def test_authenticator_uses_empty_strings_as_default_username(
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-    basic_auth = base64.b64encode(b":bar").decode()
-    assert request.headers["Authorization"] == f"Basic {basic_auth}"
+    assert request.headers["Authorization"] is None
 
 
 def test_authenticator_falls_back_to_keyring_url(

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from poetry.utils.password_manager import HTTPAuthCredential
 from poetry.utils.password_manager import PasswordManager
 from poetry.utils.password_manager import PoetryKeyring
 from poetry.utils.password_manager import PoetryKeyringError
@@ -40,7 +41,7 @@ def test_set_http_password(
     ("username", "password", "is_valid"),
     [
         ("bar", "baz", True),
-        ("", "baz", True),
+        ("", "baz", False),
         ("bar", "", True),
         ("", "", False),
     ],
@@ -62,10 +63,10 @@ def test_get_http_auth(
 
     if is_valid:
         assert auth is not None
-        assert auth["username"] == username
-        assert auth["password"] == password
+        assert auth.username == username
+        assert auth.password == password
     else:
-        assert auth is None
+        assert auth.username is auth.password is None
 
 
 def test_delete_http_password(
@@ -134,7 +135,7 @@ def test_set_http_password_with_unavailable_backend(
     ("username", "password", "is_valid"),
     [
         ("bar", "baz", True),
-        ("", "baz", True),
+        ("", "baz", False),
         ("bar", "", True),
         ("", "", False),
     ],
@@ -156,10 +157,10 @@ def test_get_http_auth_with_unavailable_backend(
 
     if is_valid:
         assert auth is not None
-        assert auth["username"] == username
-        assert auth["password"] == password
+        assert auth.username == username
+        assert auth.password == password
     else:
-        assert auth is None
+        assert auth.username is auth.password is None
 
 
 def test_delete_http_password_with_unavailable_backend(
@@ -304,7 +305,7 @@ def test_get_http_auth_from_environment_variables(
     manager = PasswordManager(config)
 
     auth = manager.get_http_auth("foo")
-    assert auth == {"username": "bar", "password": "baz"}
+    assert auth == HTTPAuthCredential(username="bar", password="baz")
 
 
 def test_get_http_auth_does_not_call_keyring_when_credentials_in_environment_variables(
@@ -317,7 +318,7 @@ def test_get_http_auth_does_not_call_keyring_when_credentials_in_environment_var
     manager.keyring = MagicMock()
 
     auth = manager.get_http_auth("foo")
-    assert auth == {"username": "bar", "password": "baz"}
+    assert auth == HTTPAuthCredential(username="bar", password="baz")
     manager.keyring.get_password.assert_not_called()
 
 
@@ -335,7 +336,7 @@ def test_get_http_auth_does_not_call_keyring_when_password_in_environment_variab
     manager.keyring = MagicMock()
 
     auth = manager.get_http_auth("foo")
-    assert auth == {"username": "bar", "password": "baz"}
+    assert auth == HTTPAuthCredential(username="bar", password="baz")
     manager.keyring.get_password.assert_not_called()
 
 

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -36,19 +36,36 @@ def test_set_http_password(
     assert "password" not in auth
 
 
+@pytest.mark.parametrize(
+    ("username", "password", "is_valid"),
+    [
+        ("bar", "baz", True),
+        ("", "baz", True),
+        ("bar", "", True),
+        ("", "", False),
+    ],
+)
 def test_get_http_auth(
-    config: Config, with_simple_keyring: None, dummy_keyring: DummyBackend
+    username: str,
+    password: str,
+    is_valid: bool,
+    config: Config,
+    with_simple_keyring: None,
+    dummy_keyring: DummyBackend,
 ) -> None:
-    dummy_keyring.set_password("poetry-repository-foo", "bar", "baz")
-    config.auth_config_source.add_property("http-basic.foo", {"username": "bar"})
+    dummy_keyring.set_password("poetry-repository-foo", username, password)
+    config.auth_config_source.add_property("http-basic.foo", {"username": username})
     manager = PasswordManager(config)
 
     assert PoetryKeyring.is_available()
     auth = manager.get_http_auth("foo")
-    assert auth is not None
 
-    assert auth["username"] == "bar"
-    assert auth["password"] == "baz"
+    if is_valid:
+        assert auth is not None
+        assert auth["username"] == username
+        assert auth["password"] == password
+    else:
+        assert auth is None
 
 
 def test_delete_http_password(
@@ -113,20 +130,36 @@ def test_set_http_password_with_unavailable_backend(
     assert auth["password"] == "baz"
 
 
+@pytest.mark.parametrize(
+    ("username", "password", "is_valid"),
+    [
+        ("bar", "baz", True),
+        ("", "baz", True),
+        ("bar", "", True),
+        ("", "", False),
+    ],
+)
 def test_get_http_auth_with_unavailable_backend(
-    config: Config, with_fail_keyring: None
+    username: str,
+    password: str,
+    is_valid: bool,
+    config: Config,
+    with_fail_keyring: None,
 ) -> None:
     config.auth_config_source.add_property(
-        "http-basic.foo", {"username": "bar", "password": "baz"}
+        "http-basic.foo", {"username": username, "password": password}
     )
     manager = PasswordManager(config)
 
     assert not PoetryKeyring.is_available()
     auth = manager.get_http_auth("foo")
-    assert auth is not None
 
-    assert auth["username"] == "bar"
-    assert auth["password"] == "baz"
+    if is_valid:
+        assert auth is not None
+        assert auth["username"] == username
+        assert auth["password"] == password
+    else:
+        assert auth is None
 
 
 def test_delete_http_password_with_unavailable_backend(


### PR DESCRIPTION
This change fixes a regression in the password manager that disallowed the use of empty username or password as required by some self-hosted repositories.

Relates-to: #9079 #2538