### PR TITLE
ignore installed packages during solving

### DIFF
--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -56,9 +56,7 @@ class Solver:
         self._locked_packages = locked
         self._io = io
 
-        self._provider = Provider(
-            self._package, self._pool, self._io, installed=installed, locked=locked
-        )
+        self._provider = Provider(self._package, self._pool, self._io, locked=locked)
         self._overrides: list[dict[Package, dict[str, Dependency]]] = []
 
     @property

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -140,7 +140,7 @@ def test_install_non_existing_package_fail(
         solver.solve()
 
 
-def test_install_unpublished_package_does_not_fail(
+def test_install_unpublished_package_fails(
     package: ProjectPackage, repo: Repository, pool: RepositoryPool, io: NullIO
 ) -> None:
     package.add_dependency(Factory.create_dependency("B", "1"))
@@ -151,20 +151,10 @@ def test_install_unpublished_package_does_not_fail(
 
     repo.add_package(package_a)
 
+    # Even though B is installed, it is unpublished and cannot be used during solving.
     solver = Solver(package, pool, [package_b], [], io)
-    transaction = solver.solve()
-
-    check_solver_result(
-        transaction,
-        [
-            {"job": "install", "package": package_a},
-            {
-                "job": "install",
-                "package": package_b,
-                "skipped": True,  # already installed
-            },
-        ],
-    )
+    with pytest.raises(SolverProblemError):
+        solver.solve()
 
 
 def test_solver_with_deps(


### PR DESCRIPTION
fixes #8328, #9774

Currently-installed packages have no place in the locking process.  Folk who are doing development against unreleased projects can and should use a path dependency, or a git dependency, or a dependency on a private index, or a privately built wheel