### PR TITLE
Clarify that poetry update only updates main dependencies

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -281,7 +281,7 @@ you should use the `update` command.
 poetry update
 ```
 
-This will resolve all dependencies of the project and write the exact versions into `poetry.lock`.
+This will resolve all main dependencies of the project and write the exact versions into `poetry.lock`.
 
 If you just want to update a few packages and not all, you can list them as such:
 
@@ -308,6 +308,11 @@ You can do this using the `add` command.
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.
+{{% /note %}}
+
+{{% note %}}
+`poetry update` without any options will only update the main dependencies of the project.
+Optional dependency groups are only updated when they are specified through `--with`.
 {{% /note %}}
 
 ## add


### PR DESCRIPTION
Add a note that `--with` is required to let `poetry update` also update optional dependency groups.

This behavior of `poetry update` confused me, so I thought let's try to save other people the trouble by updating the documentation.

I do want to note that I find the behavior strange. If I do `poetry install --with=dev` followed by `poetry update`, then I expect all installed dependencies to be updated, also the dev ones.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
