### PR TITLE
env: fix check whether path is relative to system site packages

### DIFF
--- a/src/poetry/utils/env/virtual_env.py
+++ b/src/poetry/utils/env/virtual_env.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import sys
 
 from contextlib import contextmanager
 from copy import deepcopy
@@ -17,7 +16,6 @@ from poetry.utils.env.script_strings import GET_BASE_PREFIX
 from poetry.utils.env.script_strings import GET_ENVIRONMENT_INFO
 from poetry.utils.env.script_strings import GET_PATHS
 from poetry.utils.env.script_strings import GET_SYS_PATH
-from poetry.utils.env.system_env import SystemEnv
 
 
 if TYPE_CHECKING:
@@ -145,5 +143,5 @@ class VirtualEnv(Env):
     def is_path_relative_to_lib(self, path: Path) -> bool:
         return super().is_path_relative_to_lib(path) or (
             self.includes_system_site_packages
-            and SystemEnv(Path(sys.prefix)).is_path_relative_to_lib(path)
+            and self.parent_env.is_path_relative_to_lib(path)
         )


### PR DESCRIPTION
We are looking into the wrong environment.

We must not use `SystemEnv`, which is Poetry's own env, but `env.parent_env`, which is the base env.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
