### PR TITLE
install: make `--sync` compatible with `virtualenvs.options.system-site-packages = true`

### DIFF
--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -39,7 +39,7 @@ class Installer:
         locker: Locker,
         pool: RepositoryPool,
         config: Config,
-        installed: Repository | None = None,
+        installed: InstalledRepository | None = None,
         executor: Executor | None = None,
         disable_cache: bool = False,
     ) -> None:
@@ -332,6 +332,9 @@ class Installer:
             synchronize=self._requires_synchronization,
             skip_directory=self._skip_directory,
             extras=set(self._extras),
+            system_site_packages={
+                p.name for p in self._installed_repository.system_site_packages
+            },
         )
 
         # Validate the dependencies

--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -19,7 +19,6 @@ from poetry.installation import Installer
 from poetry.packages import Locker
 from poetry.plugins.application_plugin import ApplicationPlugin
 from poetry.plugins.plugin import Plugin
-from poetry.repositories import Repository
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.toml import TOMLFile
 from poetry.utils._compat import metadata
@@ -288,7 +287,7 @@ class ProjectPluginCache:
             self._poetry.config,
             # Build installed repository from locked packages so that plugins
             # that may be overwritten are not included.
-            Repository("poetry-repo", locked_packages),
+            InstalledRepository(locked_packages),
         )
         installer.update(True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,8 @@ from poetry.config.dict_config_source import DictConfigSource
 from poetry.factory import Factory
 from poetry.layouts import layout
 from poetry.packages.direct_origin import _get_package_from_git
-from poetry.repositories import Repository
 from poetry.repositories import RepositoryPool
+from poetry.repositories.installed_repository import InstalledRepository
 from poetry.utils.cache import ArtifactCache
 from poetry.utils.env import EnvManager
 from poetry.utils.env import SystemEnv
@@ -379,8 +379,8 @@ def tmp_venv(tmp_path: Path) -> Iterator[VirtualEnv]:
 
 
 @pytest.fixture
-def installed() -> Repository:
-    return Repository("installed")
+def installed() -> InstalledRepository:
+    return InstalledRepository()
 
 
 @pytest.fixture(scope="session")
@@ -412,7 +412,7 @@ def project_factory(
     tmp_path: Path,
     config: Config,
     repo: TestRepository,
-    installed: Repository,
+    installed: InstalledRepository,
     default_python: str,
     load_required_fixtures: None,
 ) -> ProjectFactory:


### PR DESCRIPTION
# Pull Request Check List

More or less required for #9855

Without this fix, we try to uninstall untracked system site packages when running `poetry install --sync`.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
