### PR TITLE
docs: several updates, cleanups and improvements to the docs

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -18,18 +18,10 @@ Poetry offers a lockfile to ensure repeatable installs, and can build your proje
 
 ## System requirements
 
-Poetry requires **Python 3.8+**. It is multi-platform and the goal is to make it work equally well
+Poetry requires **Python 3.9+**. It is multi-platform and the goal is to make it work equally well
 on Linux, macOS and Windows.
 
 ## Installation
-
-{{% warning %}}
-Poetry should always be installed in a dedicated virtual environment to isolate it from the rest of your system.
-It should in no case be installed in the environment of the project that is to be managed by Poetry.
-This ensures that Poetry's own dependencies will not be accidentally upgraded or uninstalled.
-(Each of the following installation methods ensures that Poetry is installed into an isolated environment.)
-In addition, the isolated virtual environment in which poetry is installed should not be activated for running poetry commands.
-{{% /warning %}}
 
 {{% note %}}
 If you are viewing documentation for the development branch, you may wish to install a preview or development version of Poetry.
@@ -71,15 +63,15 @@ source, having multiple versions installed at the same time etc.
 `pipx` can install different versions of Poetry, using the same syntax as pip:
 
 ```bash
-pipx install poetry==1.2.0
+pipx install poetry==1.8.4
 ```
 
 `pipx` can also install versions of Poetry in parallel, which allows for easy testing of alternate or prerelease
 versions. Each version is given a unique, user-specified suffix, which will be used to create a unique binary name:
 
 ```bash
-pipx install --suffix=@1.2.0 poetry==1.2.0
-poetry@1.2.0 --version
+pipx install --suffix=@1.8.4 poetry==1.8.4
+poetry@1.8.4 --version
 ```
 
 ```bash
@@ -127,21 +119,11 @@ and is developed in [its own repository](https://github.com/python-poetry/instal
 The script can be executed directly (i.e. 'curl python') or downloaded and then executed from disk
 (e.g. in a CI environment).
 
-{{% warning %}}
-The `install-poetry.py` installer has been deprecated and removed from the Poetry repository.
-Please migrate from the in-tree version to the standalone version described above.
-{{% /warning %}}
-
 **Linux, macOS, Windows (WSL)**
 
 ```bash
 curl -sSL https://install.python-poetry.org | python3 -
 ```
-
-{{% note %}}
-Note: On some systems, `python` may still refer to Python 2 instead of Python 3. We always suggest the
-`python3` binary to avoid ambiguity.
-{{% /note %}}
 
 **Windows (Powershell)**
 ```powershell
@@ -187,8 +169,8 @@ Similarly, if you want to install a specific version, you can use `--version` op
 environment variable:
 
 ```bash
-curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
-curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.0 python3 -
+curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
+curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.8.4 python3 -
 ```
 
 You can also install Poetry from a `git` repository by using the `--git` option:
@@ -228,7 +210,7 @@ Once Poetry is installed and in your `$PATH`, you can execute the following:
 poetry --version
 ```
 
-If you see something like `Poetry (version 1.2.0)`, your installation is ready to use!
+If you see something like `Poetry (version 2.0.0)`, your installation is ready to use!
 {{< /step >}}
 {{< step >}}
 **Update Poetry**
@@ -254,14 +236,9 @@ And finally, if you want to install a specific version, you can pass it as an ar
 to `self update`.
 
 ```bash
-poetry self update 1.2.0
+poetry self update 1.8.4
 ```
 
-{{% warning %}}
-Poetry `1.1` series releases are not able to update in-place to `1.2` or newer series releases.
-To migrate to newer releases, uninstall using your original install method, and then reinstall
-using the [methods above]({{< ref "#installation" >}} "Installation").
-{{% /warning %}}
 {{< /step >}}
 {{< step >}}
 **Uninstall Poetry**
@@ -274,17 +251,6 @@ the `POETRY_UNINSTALL` environment variable before executing the installer.
 curl -sSL https://install.python-poetry.org | python3 - --uninstall
 curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python3 -
 ```
-
-{{% warning %}}
-If you installed using the deprecated `get-poetry.py` script, you should remove the path it uses manually, e.g.
-
-```bash
-rm -rf "${POETRY_HOME:-~/.poetry}"
-```
-
-Also remove ~/.poetry/bin from your `$PATH` in your shell configuration, if it is present.
-{{% /warning %}}
-
 {{< /step >}}
 {{< /steps >}}
 
@@ -324,7 +290,7 @@ Just as `pipx` is a powerful tool for development use, it is equally useful in a
 and should be one of your top choices for use of Poetry in CI.
 
 ```bash
-pipx install poetry==1.2.0
+pipx install poetry==2.0.0
 ```
 
 **Using install.python-poetry.org**
@@ -345,7 +311,7 @@ Poetry difficult (especially in cases like multi-stage container builds). It is 
 
 ```bash
 export POETRY_HOME=/opt/poetry
-python3 install-poetry.py --version 1.2.0
+python3 install-poetry.py --version 2.0.0
 $POETRY_HOME/bin/poetry --version
 ```
 
@@ -358,7 +324,7 @@ best debugging experience, and leaves you subject to the fewest external tools.
 ```bash
 export POETRY_HOME=/opt/poetry
 python3 -m venv $POETRY_HOME
-$POETRY_HOME/bin/pip install poetry==1.2.0
+$POETRY_HOME/bin/pip install poetry==2.0.0
 $POETRY_HOME/bin/poetry --version
 ```
 
@@ -371,7 +337,13 @@ is likely to upgrade or uninstall its own dependencies (causing hard-to-debug an
 {{< /tab >}}
 {{< /tabs >}}
 
-
+{{% warning %}}
+Poetry should always be installed in a dedicated virtual environment to isolate it from the rest of your system.
+Each of the above described installation methods ensures that.
+It should in no case be installed in the environment of the project that is to be managed by Poetry.
+This ensures that Poetry's own dependencies will not be accidentally upgraded or uninstalled.
+In addition, the isolated virtual environment in which poetry is installed should not be activated for running poetry commands.
+{{% /warning %}}
 
 ## Enable tab completion for Bash, Fish, or Zsh
 

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -46,22 +46,20 @@ authors = [
     {name = "Sébastien Eustace", email = "sebastien@eustace.io"}
 ]
 readme = "README.md"
-requires-python = ">=3.8"
-
-[tool.poetry]
-packages = [{include = "poetry_demo"}]
-
+requires-python = ">=3.9"
+dependencies = [
+]
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 ```
 
-Poetry assumes your package contains a package with the same name as `tool.poetry.name` located in the root of your
+Poetry assumes your package contains a package with the same name as `project.name` located in the root of your
 project. If this is not the case, populate [`tool.poetry.packages`]({{< relref "pyproject#packages" >}}) to specify
 your packages and their locations.
 
-Similarly, the traditional `MANIFEST.in` file is replaced by the `tool.poetry.readme`, `tool.poetry.include`, and
+Similarly, the traditional `MANIFEST.in` file is replaced by the `project.readme`, `tool.poetry.include`, and
 `tool.poetry.exclude` sections. `tool.poetry.exclude` is additionally implicitly populated by your `.gitignore`. For
 full documentation on the project format, see the [pyproject section]({{< relref "pyproject" >}}) of the documentation.
 
@@ -79,11 +77,11 @@ Again, it's important to remember that -- unlike other dependencies -- setting a
 For example, in this `pyproject.toml` file:
 
 ```toml
-[tool.poetry.dependencies]
-python = "^3.7.0"
+[project]
+requires-python = ">=3.9"
 ```
 
-we are allowing any version of Python 3 that is greater than `3.7.0`.
+we are allowing any version of Python 3 that is greater or equal than `3.9.0`.
 
 When you run `poetry install`, you must have access to some version of a Python interpreter that satisfies this constraint available on your system.
 Poetry will not install a Python interpreter for you.
@@ -122,11 +120,8 @@ In the [pyproject section]({{< relref "pyproject" >}}) you can see which fields 
 {{% /note %}}
 
 ### Specifying dependencies
-
 If you want to add dependencies to your project, you can specify them in the
-`project` or `tool.poetry.dependencies` section.
-See the [Dependency specification]({{< relref "dependency-specification" >}})
-for more information.
+`project` section.
 
 ```toml
 [project]
@@ -134,13 +129,6 @@ for more information.
 dependencies = [
     "pendulum (>=2.1,<3.0)"
 ]
-```
-
-or
-
-```toml
-[tool.poetry.dependencies]
-pendulum = "^2.1"
 ```
 
 As you can see, it takes a mapping of **package names** and **version constraints**.
@@ -241,8 +229,8 @@ To deactivate this virtual environment simply use `deactivate`.
 
 ## Version constraints
 
-In our example, we are requesting the `pendulum` package with the version constraint `^2.1`.
-This means any version greater or equal to 2.1.0 and less than 3.0.0 (`>=2.1.0 <3.0.0`).
+In our example, we are requesting the `pendulum` package with the version constraint `>=2.1.0 <3.0.0`.
+This means any version greater or equal to 2.1.0 and less than 3.0.0.
 
 Please read [Dependency specification]({{< relref "dependency-specification" >}} "Dependency specification documentation")
 for more in-depth information on versions, how versions relate to each other, and on the different ways you can specify

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -421,11 +421,6 @@ my-package = {path = "../my/path", develop = true}
 ```
 
 {{% note %}}
-Before poetry 1.1 path dependencies were installed in editable mode by default. You should always set the `develop` attribute explicitly,
-to make sure the behavior is the same for all poetry versions.
-{{% /note %}}
-
-{{% note %}}
 The `develop` attribute is a Poetry-specific feature, so it is not included in the package distribution metadata.
 In other words, it is only considered when using Poetry to install the project.
 {{% /note %}}
@@ -644,10 +639,24 @@ It can also execute one of the scripts defined in `pyproject.toml`.
 
 So, if you have a script defined like this:
 
+{{< tabs tabTotal="2" tabID1="script-project" tabID2=script-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
+
+{{< tab tabID="script-project" >}}
+```toml
+[project]
+# ...
+[project.scripts]
+my-script = "my_module:main"
+```
+{{< /tab >}}
+
+{{< tab tabID="script-poetry" >}}
 ```toml
 [tool.poetry.scripts]
 my-script = "my_module:main"
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 You can execute it like so:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,7 +266,6 @@ poetry install --compile
 * `--all-extras`: Install all extra features (conflicts with `--extras`).
 * `--all-groups`: Install dependencies from all groups (conflicts with `--only`, `--with`, and `--without`).
 * `--compile`: Compile Python source files to bytecode.
-* `--remove-untracked`: Remove dependencies not presented in the lock file. (**Deprecated**, use `--sync` instead)
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.
@@ -705,7 +704,6 @@ poetry lock
 
 ### Options
 
-* `--check`: Verify that `poetry.lock` is consistent with `pyproject.toml`. (**Deprecated**) Use `poetry check --lock` instead.
 * `--regenerate`: Ignore existing lock file and overwrite it with a new lock file created from scratch.
 
 ## version
@@ -752,52 +750,6 @@ The option `--next-phase` allows the increment of prerelease phase versions.
 * `--next-phase`: Increment the phase of the current version.
 * `--short (-s)`: Output the version number only.
 * `--dry-run`: Do not update pyproject.toml file.
-
-## export
-
-{{% warning %}}
-This command is provided by the [Export Poetry Plugin](https://github.com/python-poetry/poetry-plugin-export).
-The plugin is no longer installed by default with Poetry 2.0.
-
-See [Using plugins]({{< relref "plugins#using-plugins" >}}) for information on how to install a plugin.
-As described in [Project plugins]({{< relref "plugins#project-plugins" >}}),
-you can also define in your `pyproject.toml` that the plugin is required for the development of your project:
-
-```toml
-[tool.poetry.requires-plugins]
-poetry-plugin-export = ">1.8"
-```
-{{% /warning %}}
-
-This command exports the lock file to other formats.
-
-```bash
-poetry export -f requirements.txt --output requirements.txt
-```
-
-{{% note %}}
-The `export` command is also available as a pre-commit hook.
-See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-export" >}}) for more information.
-{{% /note %}}
-
-{{% note %}}
-Unlike the `install` command, this command only includes the project's dependencies defined in the implicit `main`
-group defined in `tool.poetry.dependencies` when used without specifying any options.
-{{% /note %}}
-
-### Options
-
-* `--format (-f)`: The format to export to (default: `requirements.txt`).
-  Currently, only `constraints.txt` and `requirements.txt` are supported.
-* `--output (-o)`: The name of the output file.  If omitted, print to standard
-  output.
-* `--extras (-E)`: Extra sets of dependencies to include.
-* `--without`: The dependency groups to ignore.
-* `--with`: The optional dependency groups to include.
-* `--only`: The only dependency groups to include.
-* `--without-hashes`: Exclude hashes from the exported file.
-* `--without-urls`: Exclude source repository urls from the exported file.
-* `--with-credentials`: Include credentials for extra indices.
 
 ## env
 
@@ -1074,3 +1026,24 @@ poetry self install --sync
 
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
+
+## export
+
+{{% warning %}}
+This command is provided by the [Export Poetry Plugin](https://github.com/python-poetry/poetry-plugin-export).
+The plugin is no longer installed by default with Poetry 2.0.
+
+See [Using plugins]({{< relref "plugins#using-plugins" >}}) for information on how to install a plugin.
+As described in [Project plugins]({{< relref "plugins#project-plugins" >}}),
+you can also define in your `pyproject.toml` that the plugin is required for the development of your project:
+
+```toml
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">1.8"
+```
+{{% /warning %}}
+
+{{% note %}}
+The `export` command is also available as a pre-commit hook.
+See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-export" >}}) for more information.
+{{% /note %}}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ export POETRY_HTTP_BASIC_MY_REPOSITORY_PASSWORD=secret
 
 ## Migrate outdated configs
 
-If poetry renames or remove config options it might be necessary to migrate explicit set options. This is possible
+If Poetry renames or remove config options it might be necessary to migrate explicit set options. This is possible
 by running:
 
 ```bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -140,7 +140,7 @@ start a [Discussion][Discussions].
 Poetry is developed using Poetry. Refer to the [documentation] to install Poetry in your local environment.
 
 {{% note %}}
-Poetry's development toolchain requires Python 3.8 or newer.
+Poetry's development toolchain requires Python 3.9 or newer.
 {{% /note %}}
 
 You should first fork the Poetry repository and then clone it locally, so that you can make pull requests against the

--- a/docs/dependency-specification.md
+++ b/docs/dependency-specification.md
@@ -84,31 +84,6 @@ must still be specified in the `tool.poetry` section.
 
 ## Version constraints
 
-{{% warning %}}
-Some of the following constraints can only be used in `tool.poetry.dependencies` and not in `project.dependencies`.
-When using `poetry add` such constraints are automatically converted into an equivalent constraint.
-{{% /warning %}}
-
-### Caret requirements
-
-{{% warning %}}
-Not supported in `project.dependencies`.
-{{% /warning %}}
-
-**Caret requirements** allow [SemVer](https://semver.org/) compatible updates to a specified version. An update is allowed if the new version number does not modify the left-most non-zero digit in the major, minor, patch grouping. For instance, if we previously ran `poetry add requests@^2.13.0` and wanted to update the library and ran `poetry update requests`, poetry would update us to version `2.14.0` if it was available, but would not update us to `3.0.0`. If instead we had specified the version string as `^0.1.13`, poetry would update to `0.1.14` but not `0.2.0`. `0.0.x` is not considered compatible with any other version.
-
-Here are some more examples of caret requirements and the versions that would be allowed with them:
-
-| Requirement | Versions allowed |
-| ----------- | ---------------- |
-| ^1.2.3      | >=1.2.3 <2.0.0   |
-| ^1.2        | >=1.2.0 <2.0.0   |
-| ^1          | >=1.0.0 <2.0.0   |
-| ^0.2.3      | >=0.2.3 <0.3.0   |
-| ^0.0.3      | >=0.0.3 <0.0.4   |
-| ^0.0        | >=0.0.0 <0.1.0   |
-| ^0          | >=0.0.0 <1.0.0   |
-
 ### Compatible release requirements
 
 **Compatible release requirements** specify a minimal version with the ability to update to later versions of the same level.
@@ -121,24 +96,6 @@ If you only specify a major, and minor version, then minor- and patch-level chan
 | ----------- | ---------------- |
 | ~=1.2.3     | >=1.2.3 <1.3.0   |
 | ~=1.2       | >=1.2.0 <2.0.0   |
-
-### Tilde requirements
-
-{{% warning %}}
-Not supported in `project.dependencies`.
-{{% /warning %}}
-
-**Tilde requirements** specify a minimal version with some ability to update.
-If you specify a major, minor, and patch version or only a major and minor version, only patch-level changes are allowed.
-If you only specify a major version, then minor- and patch-level changes are allowed.
-
-`~1.2.3` is an example of a tilde requirement.
-
-| Requirement | Versions allowed |
-| ----------- | ---------------- |
-| ~1.2.3      | >=1.2.3 <1.3.0   |
-| ~1.2        | >=1.2.0 <1.3.0   |
-| ~1          | >=1.0.0 <2.0.0   |
 
 ### Wildcard requirements
 
@@ -182,6 +139,48 @@ Exact versions can also be specified with `==` according to [PEP 440](https://pe
 
 `==1.2.3` is an example of this.
 
+### Caret requirements
+
+{{% warning %}}
+Not supported in `project.dependencies`.
+
+When using `poetry add` such constraints are automatically converted into an equivalent constraint.
+{{% /warning %}}
+
+**Caret requirements** allow [SemVer](https://semver.org/) compatible updates to a specified version. An update is allowed if the new version number does not modify the left-most non-zero digit in the major, minor, patch grouping. For instance, if we previously ran `poetry add requests@^2.13.0` and wanted to update the library and ran `poetry update requests`, poetry would update us to version `2.14.0` if it was available, but would not update us to `3.0.0`. If instead we had specified the version string as `^0.1.13`, poetry would update to `0.1.14` but not `0.2.0`. `0.0.x` is not considered compatible with any other version.
+
+Here are some more examples of caret requirements and the versions that would be allowed with them:
+
+| Requirement | Versions allowed |
+| ----------- | ---------------- |
+| ^1.2.3      | >=1.2.3 <2.0.0   |
+| ^1.2        | >=1.2.0 <2.0.0   |
+| ^1          | >=1.0.0 <2.0.0   |
+| ^0.2.3      | >=0.2.3 <0.3.0   |
+| ^0.0.3      | >=0.0.3 <0.0.4   |
+| ^0.0        | >=0.0.0 <0.1.0   |
+| ^0          | >=0.0.0 <1.0.0   |
+
+### Tilde requirements
+
+{{% warning %}}
+Not supported in `project.dependencies`.
+
+When using `poetry add` such constraints are automatically converted into an equivalent constraint.
+{{% /warning %}}
+
+**Tilde requirements** specify a minimal version with some ability to update.
+If you specify a major, minor, and patch version or only a major and minor version, only patch-level changes are allowed.
+If you only specify a major version, then minor- and patch-level changes are allowed.
+
+`~1.2.3` is an example of a tilde requirement.
+
+| Requirement | Versions allowed |
+| ----------- | ---------------- |
+| ~1.2.3      | >=1.2.3 <1.3.0   |
+| ~1.2        | >=1.2.0 <1.3.0   |
+| ~1          | >=1.0.0 <2.0.0   |
+
 ### Using the `@` operator
 
 When adding dependencies via `poetry add`, you can use the `@` operator.
@@ -189,23 +188,58 @@ This is understood similarly to the `==` syntax, but also allows prefixing any
 specifiers that are valid in `pyproject.toml`. For example:
 
 ```shell
-poetry add django@^4.0.0
+poetry add "django@^4.0.0"
 ```
 
 The above would translate to the following entry in `pyproject.toml`:
+
+{{< tabs tabTotal="2" tabID1="at-project" tabID2="at-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
+
+{{< tab tabID="at-project" >}}
 ```toml
-Django = "^4.0.0"
+[project]
+# ...
+dependencies = [
+    "django (>=4.0.0,<5.0.0)",
+]
 ```
+
+{{< /tab >}}
+
+{{< tab tabID="at-poetry" >}}
+```toml
+[tool.poetry.dependencies]
+django = "^4.0.0"
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 The special keyword `latest` is also understood by the `@` operator:
 ```shell
 poetry add django@latest
 ```
 
-The above would translate to the following entry in `pyproject.toml`, assuming the latest release of `django` is `4.0.5`:
+The above would translate to the following entry in `pyproject.toml`, assuming the latest release of `django` is `5.1.3`:
+
+{{< tabs tabTotal="2" tabID1="at-latest-project" tabID2="at-latest-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
+
+{{< tab tabID="at-latest-project" >}}
 ```toml
-Django = "^4.0.5"
+[project]
+# ...
+dependencies = [
+    "django (>=5.1.3,<6.0.0)",
+]
 ```
+{{< /tab >}}
+
+{{< tab tabID="at-latest-poetry" >}}
+```toml
+[tool.poetry.dependencies]
+django = "^5.1.3"
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 #### Extras
 
@@ -218,42 +252,41 @@ poetry add django[bcrypt]@^4.0.0
 ## `git` dependencies
 
 To depend on a library located in a `git` repository,
-the minimum information you need to specify is the location of the repository with the git key:
+the minimum information you need to specify is the location of the repository:
+
+{{< tabs tabTotal="2" tabID1="git-project" tabID2="git-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
+
+{{< tab tabID="git-project" >}}
+```toml
+[project]
+# ...
+dependencies = [
+    "requests @ git+https://github.com/requests/requests.git",
+]
+```
+{{< /tab >}}
+
+{{< tab tabID="git-poetry" >}}
+In the `tool.poetry` section you use the `git` key:
 
 ```toml
 [tool.poetry.dependencies]
 requests = { git = "https://github.com/requests/requests.git" }
 ```
 
-or in the `project` section:
-
-```toml
-[project]
-# ...
-dependencies = [
-    "requests @ git+https://github.com/requests/requests.git"
-]
-```
+{{< /tab >}}
+{{< /tabs >}}
 
 Since we haven’t specified any other information,
 Poetry assumes that we intend to use the latest commit on the `main` branch
 to build our project.
 
-You can combine the `git` key with the `branch` key to use another branch.
-Alternatively, use `rev` or `tag` to pin a dependency to a specific commit hash
-or tagged ref, respectively. For example:
+You can explicit specify which branch, commit hash or tagged ref should be usd:
 
-```toml
-[tool.poetry.dependencies]
-# Get the latest revision on the branch named "next"
-requests = { git = "https://github.com/kennethreitz/requests.git", branch = "next" }
-# Get a revision by its commit hash
-flask = { git = "https://github.com/pallets/flask.git", rev = "38eb5d3b" }
-# Get a revision by its tag
-numpy = { git = "https://github.com/numpy/numpy.git", tag = "v0.13.2" }
-```
+{{< tabs tabTotal="2" tabID1="git-rev-project" tabID2="git-rev-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
 
-or in the `project` section:
+{{< tab tabID="git-rev-project" >}}
+Append the information to the git url.
 
 ```toml
 [project]
@@ -264,16 +297,50 @@ dependencies = [
     "numpy @ git+https://github.com/numpy/numpy.git@v0.13.2",
 ]
 ```
+{{< /tab >}}
 
-In cases where the package you want to install is located in a subdirectory of the VCS repository, you can use the `subdirectory` option, similarly to what [pip](https://pip.pypa.io/en/stable/topics/vcs-support/#url-fragments) provides:
+{{< tab tabID="git-rev-poetry" >}}
+Combine the `git` key with the `branch`, `rev` or `tag` key respectively.
+
+```toml
+[tool.poetry.dependencies]
+# Get the latest revision on the branch named "next"
+requests = { git = "https://github.com/kennethreitz/requests.git", branch = "next" }
+# Get a revision by its commit hash
+flask = { git = "https://github.com/pallets/flask.git", rev = "38eb5d3b" }
+# Get a revision by its tag
+numpy = { git = "https://github.com/numpy/numpy.git", tag = "v0.13.2" }
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+It's possible to add a package that is located in a subdirectory of the VCS repository.
+
+{{< tabs tabTotal="2" tabID1="git-subdir-project" tabID2="git-subdir-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
+
+{{< tab tabID="git-subdir-project" >}}
+Provide the subdirectory as a URL fragment similarly to what [pip](https://pip.pypa.io/en/stable/topics/vcs-support/#url-fragments) provides.
+```toml
+[project]
+# ...
+dependencies = [
+    "subdir_package @ git+https://github.com/myorg/mypackage_with_subdirs.git#subdirectory=subdir"
+]
+```
+{{< /tab >}}
+
+{{< tab tabID="git-subdir-poetry" >}}
+Use the `subdirectory` key in the `tool.poetry` section:
 
 ```toml
 [tool.poetry.dependencies]
 # Install a package named `subdir_package` from a folder called `subdir` within the repository
 subdir_package = { git = "https://github.com/myorg/mypackage_with_subdirs.git", subdirectory = "subdir" }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
-with the corresponding `add` call:
+The corresponding `add` call looks like this:
 
 ```bash
 poetry add "git+https://github.com/myorg/mypackage_with_subdirs.git#subdirectory=subdir"
@@ -281,10 +348,25 @@ poetry add "git+https://github.com/myorg/mypackage_with_subdirs.git#subdirectory
 
 To use an SSH connection, for example in the case of private repositories, use the following example syntax:
 
+{{< tabs tabTotal="2" tabID1="git-ssh-project" tabID2="git-ssh-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
+
+{{< tab tabID="git-ssh-project" >}}
+```toml
+[project]
+# ...
+dependencies = [
+    "pendulum @ git+ssh://git@github.com/sdispater/pendulum.git"
+]
+```
+{{< /tab >}}
+
+{{< tab tabID="git-ssh-poetry" >}}
 ```toml
 [tool.poetry.dependencies]
-requests = { git = "git@github.com:requests/requests.git" }
+pendulum = { git = "git@github.com/sdispater/pendulum.git" }
 ```
+{{< /tab >}}
+{{< /tabs >}}
 
 To use HTTP basic authentication with your git repositories, you can configure credentials similar to
 how [repository credentials]({{< relref "repositories#configuring-credentials" >}}) are configured.
@@ -296,38 +378,25 @@ poetry add git+https://github.com/org/project.git
 ```
 
 {{% note %}}
-With Poetry 1.2 releases, the default git client used is [Dulwich](https://www.dulwich.io/).
+The default git client used is [Dulwich](https://www.dulwich.io/).
 
 We fall back to legacy system git client implementation in cases where
 [gitcredentials](https://git-scm.com/docs/gitcredentials) is used. This fallback will be removed in
 a future release where `gitcredentials` helpers can be better supported natively.
 
-In cases where you encounter issues with the default implementation that used to work prior to
-Poetry 1.2, you may wish to explicitly configure the use of the system git client via a shell
-subprocess call.
+In cases where you encounter issues with the default implementation, you may wish to
+explicitly configure the use of the system git client via a shell subprocess call.
 
 ```bash
 poetry config system-git-client true
 ```
-
-Keep in mind however, that doing so will surface bugs that existed in versions prior to 1.2 which
-were caused due to the use of the system git client.
 {{% /note %}}
 
 ## `path` dependencies
 
-To depend on a library located in a local directory or file,
-you can use the `path` property:
+{{< tabs tabTotal="2" tabID1="path-project" tabID2="path-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
 
-```toml
-[tool.poetry.dependencies]
-# directory
-my-package = { path = "../my-package/", develop = false }
-
-# file
-my-package = { path = "../my-package/dist/my-package-0.1.0.tar.gz" }
-```
-
+{{< tab tabID="path-project" >}}
 In the `project` section, you can only use absolute paths:
 
 ```toml
@@ -336,26 +405,34 @@ In the `project` section, you can only use absolute paths:
 dependencies = [
     "my-package @ file:///absolute/path/to/my-package/dist/my-package-0.1.0.tar.gz"
 ]
+
 ```
+{{< /tab >}}
 
-{{% note %}}
-Before poetry 1.1 directory path dependencies were installed in editable mode by default. You should set the `develop` attribute explicitly,
-to make sure the behavior is the same for all poetry versions.
-{{% /note %}}
-
-## `url` dependencies
-
-To depend on a library located on a remote archive,
-you can use the `url` property:
+{{< tab tabID="path-poetry" >}}
+To depend on a library located in a local directory or file,
+you can use the `path` property:
 
 ```toml
 [tool.poetry.dependencies]
 # directory
-my-package = { url = "https://example.com/my-package-0.1.0.tar.gz" }
+my-package = { path = "../my-package/", develop = true }
+
+# file
+my-package = { path = "../my-package/dist/my-package-0.1.0.tar.gz" }
 ```
 
-or in the `project` section:
+To install directory path dependencies in editable mode use the `develop` keyword and set it to `true`.
+{{< /tab >}}
+{{< /tabs >}}
 
+## `url` dependencies
+
+`url` dependencies are libraries located on a remote archive.
+
+{{< tabs tabTotal="2" tabID1="url-project" tabID2="url-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
+
+{{< tab tabID="url-project" >}}
 ```toml
 [project]
 # ...
@@ -363,8 +440,20 @@ dependencies = [
     "my-package @ https://example.com/my-package-0.1.0.tar.gz"
 ]
 ```
+{{< /tab >}}
 
-with the corresponding `add` call:
+{{< tab tabID="url-poetry" >}}
+Use the `url` property.
+
+```toml
+[tool.poetry.dependencies]
+# directory
+my-package = { url = "https://example.com/my-package-0.1.0.tar.gz" }
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+The corresponding `add` call is:
 
 ```bash
 poetry add https://example.com/my-package-0.1.0.tar.gz
@@ -375,13 +464,9 @@ poetry add https://example.com/my-package-0.1.0.tar.gz
 You can specify [PEP-508 Extras](https://www.python.org/dev/peps/pep-0508/#extras)
 for a dependency as shown here.
 
-```toml
-[tool.poetry.dependencies]
-gunicorn = { version = "^20.1", extras = ["gevent"] }
-```
+{{< tabs tabTotal="2" tabID1="extras-project" tabID2="extras-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
 
-or in the `project` section:
-
+{{< tab tabID="extras-project" >}}
 ```toml
 [project]
 # ...
@@ -389,6 +474,15 @@ dependencies = [
     "gunicorn[gevent] (>=20.1,<21.0)"
 ]
 ```
+{{< /tab >}}
+
+{{< tab tabID="extras-poetry" >}}
+```toml
+[tool.poetry.dependencies]
+gunicorn = { version = "^20.1", extras = ["gevent"] }
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 {{% note %}}
 These activate extra defined for the dependency, to configure an optional dependency
@@ -396,6 +490,9 @@ for extras in your project refer to [`extras`]({{< relref "pyproject#extras" >}}
 {{% /note %}}
 
 ## `source` dependencies
+{{% note %}}
+It is not possible to define source dependencies in the `project` section.
+{{% /note %}}
 
 To depend on a package from an [alternate repository]({{< relref "repositories#installing-from-private-package-sources" >}}),
 you can use the `source` property:
@@ -421,48 +518,41 @@ In this example, we expect `foo` to be configured correctly. See [using a privat
 for further information.
 {{% /note %}}
 
-{{% note %}}
-It is not possible to define source dependencies in the `project` section.
-{{% /note %}}
-
 ## Python restricted dependencies
 
 You can also specify that a dependency should be installed only for specific Python versions:
 
-```toml
-[tool.poetry.dependencies]
-tomli = { version = "^2.0.1", python = "<3.11" }
-```
+{{< tabs tabTotal="2" tabID1="python-restriction-project" tabID2="python-restriction-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
 
-```toml
-[tool.poetry.dependencies]
-pathlib2 = { version = "^2.2", python = "^3.9" }
-```
-
-or in the `project` section:
-
+{{< tab tabID="python-restriction-project" >}}
 ```toml
 [project]
 # ...
 dependencies = [
-    "tomli (>=2.0.1,<3.11) ; python_version < '3.11'",
+    "tomli (>=2.0.1,<3.0) ; python_version < '3.11'",
     "pathlib2 (>=2.2,<3.0) ; python_version >= '3.9' and python_version < '4.0'"
 ]
 ```
+{{< /tab >}}
+
+{{< tab tabID="python-restriction-poetry" >}}
+
+```toml
+[tool.poetry.dependencies]
+tomli = { version = "^2.0.1", python = "<3.11" }
+pathlib2 = { version = "^2.2", python = "^3.9" }
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Using environment markers
 
 If you need more complex install conditions for your dependencies,
-Poetry supports [environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers)
-via the `markers` property:
+Poetry supports [environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers):
 
-```toml
-[tool.poetry.dependencies]
-pathlib2 = { version = "^2.2", markers = "python_version <= '3.4' or sys_platform == 'win32'" }
-```
+{{< tabs tabTotal="2" tabID1="markers-project" tabID2="markers-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
 
-or in the `project` section:
-
+{{< tab tabID="markers-project" >}}
 ```toml
 [project]
 # ...
@@ -470,6 +560,17 @@ dependencies = [
     "pathlib2 (>=2.2,<3.0) ; python_version <= '3.4' or sys_platform == 'win32'"
 ]
 ```
+{{< /tab >}}
+
+{{< tab tabID="markers-poetry" >}}
+Use the `markers` property:
+
+```toml
+[tool.poetry.dependencies]
+pathlib2 = { version = "^2.2", markers = "python_version <= '3.4' or sys_platform == 'win32'" }
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Multiple constraints dependencies
 
@@ -480,16 +581,9 @@ Let's say you have a dependency on the package `foo` which is only compatible
 with Python 3.6-3.7 up to version 1.9, and compatible with Python 3.8+ from version 2.0:
 you would declare it like so:
 
-```toml
-[tool.poetry.dependencies]
-foo = [
-    {version = "<=1.9", python = ">=3.6,<3.8"},
-    {version = "^2.0", python = ">=3.8"}
-]
-```
+{{< tabs tabTotal="2" tabID1="multiple-constraints-project" tabID2="multiple-constraints-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
 
-or in the `project` section:
-
+{{< tab tabID="multiple-constraints-project" >}}
 ```toml
 [project]
 # ...
@@ -498,6 +592,18 @@ dependencies = [
     "foo (>=2.0,<3.0) ; python_version >= '3.8'"
 ]
 ```
+{{< /tab >}}
+
+{{< tab tabID="multiple-constraints-poetry" >}}
+```toml
+[tool.poetry.dependencies]
+foo = [
+    {version = "<=1.9", python = ">=3.6,<3.8"},
+    {version = "^2.0", python = ">=3.8"}
+]
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 {{% note %}}
 The constraints **must** have different requirements (like `python`)

--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -11,25 +11,26 @@ type: docs
 
 # Managing dependencies
 
-{{% note %}}
-Since Poetry 2.0, main dependencies can be specified in `project.dependencies`
-instead of `tool.poetry.dependencies`.
+Poetry supports specifying main dependencies in the [`project.dependencies`]({{< relref "pyproject#dependencies" >}}) section of your `pyproject.toml`
+according to PEP 621. For legacy reasons and to define additional information that are only used by Poetry
+the [`tool.poetry.dependencies`]({{< relref "pyproject#dependencies-and-dependency-groups" >}}) sections can be used.
+
 See [Dependency specification]({{< relref "dependency-specification" >}}) for more information.
-Only main dependencies can be specified in the `project` section.
-Other groups must still be specified in the `tool.poetry` section.
-{{% /note %}}
 
 ## Dependency groups
 
-Poetry provides a way to **organize** your dependencies by **groups**. For instance, you might have
-dependencies that are only needed to test your project or to build the documentation.
+Poetry provides a way to **organize** your dependencies by **groups**.
+
+The dependencies declared in `project.dependencies` respectively `tool.poetry.dependencies`
+are part of an implicit `main` group. Those dependencies are required by your project during runtime.
+
+Beside the `main` depdendencies, you might have dependencies that are only needed to test your project
+or to build the documentation.
 
 To declare a new dependency group, use a `tool.poetry.group.<group>` section
 where `<group>` is the name of your dependency group (for instance, `test`):
 
 ```toml
-[tool.poetry.group.test]  # This part can be left out
-
 [tool.poetry.group.test.dependencies]
 pytest = "^6.0.0"
 pytest-mock = "*"
@@ -45,34 +46,6 @@ the dependencies logically.
 {{% /note %}}
 
 {{% note %}}
-The dependencies declared in `project.dependencies` respectively `tool.poetry.dependencies`
-are part of an implicit `main` group.
-{{% /note %}}
-
-```toml
-[project]
-# ...
-dependencies = [  # main dependency group
-    "httpx",
-    "pendulum",
-]
-
-[tool.poetry.group.test.dependencies]
-pytest = "^6.0.0"
-pytest-mock = "*"
-```
-
-```toml
-[tool.poetry.dependencies]  # main dependency group
-httpx = "*"
-pendulum = "*"
-
-[tool.poetry.group.test.dependencies]
-pytest = "^6.0.0"
-pytest-mock = "*"
-```
-
-{{% note %}}
 Dependency groups, other than the implicit `main` group, must only contain dependencies you need in your development
 process. Installing them is only possible by using Poetry.
 
@@ -80,32 +53,6 @@ To declare a set of dependencies, which add additional functionality to the proj
 use [extras]({{< relref "pyproject#extras" >}}) instead. Extras can be installed by the end user using `pip`.
 {{% /note %}}
 
-{{% note %}}
-**A note about defining a `dev` dependencies group**
-
-The proper way to define a `dev` dependencies group since Poetry 1.2.0 is the following:
-
-```toml
-[tool.poetry.group.dev.dependencies]
-pytest = "^6.0.0"
-pytest-mock = "*"
-```
-
-This group notation is preferred since Poetry 1.2.0 and not usable in earlier versions.
-For backwards compatibility with older versions of Poetry,
-any dependency declared in the `dev-dependencies` section will automatically be added to the `dev` group.
-So the above and following notations are equivalent:
-
-```toml
-# Poetry pre-1.2.x style, understood by Poetry 1.0–1.2
-[tool.poetry.dev-dependencies]
-pytest = "^6.0.0"
-pytest-mock = "*"
-```
-
-Poetry will slowly transition away from the `dev-dependencies` notation which will soon be deprecated,
-so it's advised to migrate your existing development dependencies to the new `group` notation.
-{{% /note %}}
 
 ### Optional groups
 
@@ -150,9 +97,8 @@ If the group does not already exist, it will be created automatically.
 `poetry install`.
 
 {{% note %}}
-The default set of dependencies for a project includes the implicit `main` group defined in
-`tool.poetry.dependencies` as well as all groups that are not explicitly marked as an
-[optional group]({{< relref "#optional-groups" >}}).
+The default set of dependencies for a project includes the implicit `main` group as well as all
+groups that are not explicitly marked as an [optional group]({{< relref "#optional-groups" >}}).
 {{% /note %}}
 
 You can **exclude** one or more groups with the `--without` option:
@@ -232,10 +178,6 @@ poetry install --without dev --sync
 poetry install --with docs --sync
 poetry install --only dev
 ```
-
-{{% note %}}
-The `--sync` option replaces the `--remove-untracked` option which is now deprecated.
-{{% /note %}}
 
 ## Layering optional groups
 


### PR DESCRIPTION
The main focus was to always provide examples for both `project` and `tool.poetry` sections. the "PEP 621 way" is presented as the "default way".

Outdated Warning boxes were removed.

Some sections were reordered.

The "Basic Usage Guide" focus on PEP 621 only.