### PR TITLE
remove: improve error message when trying to remove a package from a project without any dependencies

### DIFF
--- a/src/poetry/console/commands/remove.py
+++ b/src/poetry/console/commands/remove.py
@@ -68,13 +68,13 @@ list of installed packages
         if group is None:
             # remove from all groups
             removed = set()
-            group_sections = [
-                (
-                    MAIN_GROUP,
-                    project_content.get("dependencies", []),
-                    poetry_content.get("dependencies", {}),
+            group_sections = []
+            project_dependencies = project_content.get("dependencies", [])
+            poetry_dependencies = poetry_content.get("dependencies", {})
+            if project_dependencies or poetry_dependencies:
+                group_sections.append(
+                    (MAIN_GROUP, project_dependencies, poetry_dependencies)
                 )
-            ]
             group_sections.extend(
                 (group_name, [], group_section.get("dependencies", {}))
                 for group_name, group_section in poetry_content.get("group", {}).items()


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Just a special case, I noticed while trying different commands with a pyproject.toml without a `tool.poetry` section.

When trying to remove a package from a project without any dependencies, the following message is displayed for `poetry remove foo`:

without PR: `The dependency group "main" does not exist.`

with PR: `The following packages were not found: foo`
