### PR TITLE
Document that package sources are ignored by Pip

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -119,6 +119,18 @@ when publishing a package.
 
 {{% /note %}}
 
+{{% warning %}}
+
+Package sources are a Poetry-specific feature and **not** included in
+[core metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) produced by
+the Poetry build backend.
+
+Consequently, when a Poetry project is e.g. installed using Pip (as a normal package or in editable
+mode), package sources will be ignored and the dependencies in question downloaded from PyPI by
+default.
+
+{{% /warning %}}
+
 ### Project Configuration
 
 These package sources may be managed using the [`source`]({{< relref "cli#source" >}}) command for

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -123,7 +123,7 @@ when publishing a package.
 
 Package sources are a Poetry-specific feature and **not** included in
 [core metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) produced by
-the Poetry build backend.
+the poetry-core build backend.
 
 Consequently, when a Poetry project is e.g. installed using Pip (as a normal package or in editable
 mode), package sources will be ignored and the dependencies in question downloaded from PyPI by


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9934 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

As suggested in #9934, this adds a warning to the [package sources docs](https://python-poetry.org/docs/repositories/#package-sources) that these will be completely ignored by Pip and other tools that get dependency information from core metadata exported by Poetry.