### PR TITLE
tests: resolve paths before comparing

### DIFF
--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -43,7 +43,7 @@ def test_python_get_version_on_the_fly() -> None:
 def test_python_get_system_python() -> None:
     python = Python.get_system_python()
 
-    assert python.executable == findpython.find().executable
+    assert python.executable.resolve() == findpython.find().executable.resolve()
     assert python.version == Version.parse(
         ".".join(str(v) for v in sys.version_info[:3])
     )
@@ -53,7 +53,7 @@ def test_python_get_preferred_default(config: Config) -> None:
     python = Python.get_preferred_python(config)
     version_len = 3 if sys.version_info[3] == "final" else 5
 
-    assert python.executable == Path(sys.executable)
+    assert python.executable.resolve() == Path(sys.executable).resolve()
     assert python.version == Version.parse(
         ".".join(str(v) for v in sys.version_info[:version_len])
     )
@@ -87,7 +87,7 @@ def test_get_preferred_python_use_poetry_python_disabled_fallback(
     python = Python.get_preferred_python(config)
 
     assert with_no_active_python.call_count == 1
-    assert python.executable == Path(sys.executable)
+    assert python.executable.resolve() == Path(sys.executable).resolve()
 
 
 def test_fallback_on_detect_active_python(with_no_active_python: MagicMock) -> None:


### PR DESCRIPTION
# Pull Request Check List

Resolves: `test_python_get_preferred_default` fails because one of the paths being compared is a symlink to the other:
```
______________________ test_python_get_preferred_default _______________________
[gw3] linux -- Python 3.12.8 /nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3.12

config = <tests.conftest.Config object at 0x7fffee6f9760>

    def test_python_get_preferred_default(config: Config) -> None:
        python = Python.get_preferred_python(config)
    
>       assert python.executable == Path(sys.executable)
E       AssertionError: assert PosixPath('/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python') == PosixPath('/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3.12')
E        +  where PosixPath('/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python') = <poetry.utils.env.python_manager.Python object at 0x7fffef07acf0>.executable
E        +  and   PosixPath('/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3.12') = Path('/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3.12')
E        +    where '/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3.12' = sys.executable
```

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
