### PR TITLE
fix(env): ensure all system site paths are used

### DIFF
--- a/src/poetry/utils/env/__init__.py
+++ b/src/poetry/utils/env/__init__.py
@@ -21,7 +21,6 @@ from poetry.utils.env.script_strings import GET_BASE_PREFIX
 from poetry.utils.env.script_strings import GET_ENV_PATH_ONELINER
 from poetry.utils.env.script_strings import GET_ENVIRONMENT_INFO
 from poetry.utils.env.script_strings import GET_PATHS
-from poetry.utils.env.script_strings import GET_PATHS_FOR_GENERIC_ENVS
 from poetry.utils.env.script_strings import GET_PYTHON_VERSION_ONELINER
 from poetry.utils.env.script_strings import GET_SYS_PATH
 from poetry.utils.env.site_packages import SitePackages
@@ -97,7 +96,6 @@ __all__ = [
     "GET_SYS_PATH",
     "GET_ENV_PATH_ONELINER",
     "GET_PYTHON_VERSION_ONELINER",
-    "GET_PATHS_FOR_GENERIC_ENVS",
     "EnvError",
     "EnvCommandError",
     "IncorrectEnvError",

--- a/src/poetry/utils/env/generic_env.py
+++ b/src/poetry/utils/env/generic_env.py
@@ -8,7 +8,7 @@ import subprocess
 from typing import TYPE_CHECKING
 from typing import Any
 
-from poetry.utils.env.script_strings import GET_PATHS_FOR_GENERIC_ENVS
+from poetry.utils.env.script_strings import GET_PATHS
 from poetry.utils.env.virtual_env import VirtualEnv
 
 
@@ -78,7 +78,7 @@ class GenericEnv(VirtualEnv):
                 self._pip_executable = pip_executable
 
     def get_paths(self) -> dict[str, str]:
-        output = self.run_python_script(GET_PATHS_FOR_GENERIC_ENVS)
+        output = self.run_python_script(GET_PATHS)
 
         paths: dict[str, str] = json.loads(output)
         return paths

--- a/src/poetry/utils/env/script_strings.py
+++ b/src/poetry/utils/env/script_strings.py
@@ -92,13 +92,6 @@ print(json.dumps(sys.path))
 
 GET_PATHS = """\
 import json
-import sysconfig
-
-print(json.dumps(sysconfig.get_paths()))
-"""
-
-GET_PATHS_FOR_GENERIC_ENVS = """\
-import json
 import site
 import sysconfig
 

--- a/src/poetry/utils/env/script_strings.py
+++ b/src/poetry/utils/env/script_strings.py
@@ -97,6 +97,11 @@ import sysconfig
 
 paths = sysconfig.get_paths().copy()
 
+paths["fallbacks"] = [
+    p for p in site.getsitepackages()
+    if p and p not in {paths.get("purelib"), paths.get("platlib")}
+]
+
 if site.check_enableusersite():
     paths["usersite"] = site.getusersitepackages()
     paths["userbase"] = site.getuserbase()

--- a/src/poetry/utils/env/site_packages.py
+++ b/src/poetry/utils/env/site_packages.py
@@ -25,7 +25,6 @@ class SitePackages:
         purelib: Path,
         platlib: Path | None = None,
         fallbacks: list[Path] | None = None,
-        skip_write_checks: bool = False,
     ) -> None:
         self._purelib = purelib
         self._platlib = platlib or purelib
@@ -40,7 +39,7 @@ class SitePackages:
             if path not in self._candidates:
                 self._candidates.append(path)
 
-        self._writable_candidates = None if not skip_write_checks else self._candidates
+        self._writable_candidates: list[Path] | None = None
 
     @property
     def path(self) -> Path:

--- a/tests/utils/env/test_env.py
+++ b/tests/utils/env/test_env.py
@@ -309,7 +309,7 @@ def test_env_system_packages_are_relative_to_lib(
 
     # These are the virtual environments' base env packages,
     # in this case the system site packages.
-    for dist in metadata.distributions(path=[str(env.parent_env.site_packages.path)]):
+    for dist in env.parent_env.site_packages.distributions():
         assert (
             env.is_path_relative_to_lib(
                 Path(str(dist._path))  # type: ignore[attr-defined]


### PR DESCRIPTION
With this change, when using newer Python versions (>=3.12), Poetry
correctly detects and considers read-only system site packages when
an environment is loaded.

Resolves: #9878

An example of this scenario is when the OS distributions manages your Python installations,  you can end up with the following.

```
>>> json.dumps(sysconfig.get_paths())
{"stdlib": "/usr/lib64/python3.13", "platstdlib": "/usr/local/lib64/python3.13", "purelib": "/usr/local/lib/python3.13/site-packages", "platlib": "/usr/local/lib64/python3.13/site-packages", "include": "/usr/include/python3.13", "platinclude": "/usr/include/python3.13", "scripts": "/usr/local/bin", "data": "/usr/local"}
>>> 
>>> site.getsitepackages()
['/usr/local/lib64/python3.13/site-packages', '/usr/local/lib/python3.13/site-packages', '/usr/lib64/python3.13/site-packages', '/usr/lib/python3.13/site-packages']
```

You can see that both `platlib` and `purelib` uses the `/usr/local` prefix. While the system installation site uses the `/usr` prefix.

## Summary by Sourcery

Include system site packages when loading a Python environment.

Bug Fixes:
- Fixed an issue where read-only system site packages were not considered when loading an environment in Python 3.12 or later.

Enhancements:
- Improved site package detection to include system site packages that use a different prefix than `purelib` and `platlib`.