### PR TITLE
fix: clarify error message in `install`

### DIFF
--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -204,7 +204,7 @@ you can set the "package-mode" to false in your pyproject.toml file.
             # No need for an editable install in this case.
             self.line("")
             self.line_error(
-                f"Warning: The current project could not be installed: {e}\n"
+                f"Error: The current project could not be installed: {e}\n"
                 "If you do not want to install the current project"
                 " use <c1>--no-root</c1>.\n"
                 "If you want to use Poetry only for dependency management"


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

In previous versions of Poetry, this was only a warning. However, the exit code has now been changed to 1, while the error message still states that it's just a warning. This inconsistency could be misleading in certain situations.