### PR TITLE
Fix sections in pyproject.toml docs

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -111,8 +111,6 @@ license = { file = "LICENSE" }
 A path to the README file or the content.
 
 ```toml
-[tool.poetry]
-# ...
 readme = "README.md"
 ```
 
@@ -225,7 +223,7 @@ classifiers = [
 The URLs of the project.
 
 ```toml
-[tool.poetry.urls]
+[project.urls]
 homepage = "https://python-poetry.org/"
 repository = "https://github.com/python-poetry/poetry"
 documentation = "https://python-poetry.org/docs/"


### PR DESCRIPTION
Sections for `readme` and `urls` in pyproject.toml docs are fixed.

# Pull Request Check List

Resolves: none

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Documentation:
- Document the correct sections for `readme` and `urls` in `pyproject.toml`.