### PR TITLE
chore: fix build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ pytest-github-actions-annotate-failures = "^0.1.7"
 
 
 [build-system]
-requires = ["poetry-core>=1.5.0"]
+requires = ["poetry-core>=2.0"]
 build-backend = "poetry.core.masonry.api"
 
 


### PR DESCRIPTION
With #9937, we need a recent poetry-core.

## Summary by Sourcery

Build:
- Update poetry-core dependency to 2.0