### PR TITLE
docs/cli: Fix typo in `export` section to allow `poetry-plugin-export` at latest version `1.8`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1177,7 +1177,7 @@ you can also define in your `pyproject.toml` that the plugin is required for the
 
 ```toml
 [tool.poetry.requires-plugins]
-poetry-plugin-export = ">1.8"
+poetry-plugin-export = ">=1.8"
 ```
 {{% /warning %}}
 


### PR DESCRIPTION
Resolves #9953

This PR fixes a typo in the `export` section of the CLI (Commands) documentation page, allowing `poetry-plugin-export` to be installed at its latest version, `1.8`.

## Summary by Sourcery

Documentation:
- Correct the minimum required version of the `poetry-plugin-export` plugin in the CLI documentation.