### PR TITLE
feat(source/show): notify when PyPI is implicit

### DIFF
--- a/src/poetry/console/commands/source/show.py
+++ b/src/poetry/console/commands/source/show.py
@@ -26,13 +26,25 @@ class SourceShowCommand(Command):
         ),
     ]
 
+    def notify_implicit_pypi(self) -> None:
+        if not self.poetry.pool.has_repository("pypi"):
+            return
+
+        self.line(
+            "<c1><b>PyPI</> is implicitly enabled as a <b>primary</> source. "
+            "If you wish to disable it, or alter its priority please refer to "
+            "<b>https://python-poetry.org/docs/repositories/#package-sources</>.</>"
+        )
+        self.line("")
+
     def handle(self) -> int:
         sources = self.poetry.get_sources()
         names = self.argument("source")
         lower_names = [name.lower() for name in names]
 
         if not sources:
-            self.line("No sources configured for this project.")
+            self.line("No sources configured for this project.\n")
+            self.notify_implicit_pypi()
             return 0
 
         if names and not any(s.name.lower() in lower_names for s in sources):
@@ -42,9 +54,14 @@ class SourceShowCommand(Command):
             )
             return 1
 
+        is_pypi_implicit = True
+
         for source in sources:
             if names and source.name.lower() not in lower_names:
                 continue
+
+            if source.name.lower() == "pypi":
+                is_pypi_implicit = False
 
             table = self.table(style="compact")
             rows: Rows = [["<info>name</>", f" : <c1>{source.name}</>"]]
@@ -54,5 +71,8 @@ class SourceShowCommand(Command):
             table.add_rows(rows)
             table.render()
             self.line("")
+
+        if not names and is_pypi_implicit:
+            self.notify_implicit_pypi()
 
         return 0

--- a/tests/console/commands/source/test_show.py
+++ b/tests/console/commands/source/test_show.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poetry.repositories.pypi_repository import PyPiRepository
+
 
 if TYPE_CHECKING:
     from cleo.testers.command_tester import CommandTester
@@ -175,6 +177,20 @@ def test_source_show_no_sources(tester_no_sources: CommandTester) -> None:
         tester_no_sources.io.fetch_output().strip()
         == "No sources configured for this project."
     )
+    assert tester_no_sources.status_code == 0
+
+
+def test_source_show_no_sources_implicit_pypi(
+    tester_no_sources: CommandTester, poetry_without_source: Poetry
+) -> None:
+    poetry_without_source.pool.add_repository(PyPiRepository())
+    tester_no_sources.execute("")
+
+    output = tester_no_sources.io.fetch_output().strip()
+
+    assert "No sources configured for this project." in output
+    assert "PyPI is implicitly enabled as a primary source." in output
+
     assert tester_no_sources.status_code == 0
 
 


### PR DESCRIPTION
Add a notice when all sources are listed and PyPI is implicitly enabled.

## Summary by Sourcery

Add a notification to inform users when PyPI is implicitly enabled as a primary source and update tests to verify this behavior.

New Features:
- Add a notification feature to inform users when PyPI is implicitly enabled as a primary source.

Tests:
- Introduce a test to verify the notification for implicit PyPI when no sources are configured.