### PR TITLE
fix(console.commands.command.Command): restore the set_poetry instance method (removed in Poetry v2)

### DIFF
--- a/src/poetry/console/commands/command.py
+++ b/src/poetry/console/commands/command.py
@@ -25,6 +25,14 @@ class Command(BaseCommand):
 
         return self._poetry
 
+    def set_poetry(self, poetry: Poetry) -> None:
+        """Explicitly set the current Poetry.
+
+        Useful for Plugins that extends the features of a Poetry CLI Command.
+        """
+
+        self._poetry = poetry
+
     def get_application(self) -> Application:
         from poetry.console.application import Application
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9980 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Bug Fixes:
- Restore the `set_poetry` instance method, addressing compatibility issues with Poetry v2.