### PR TITLE
fix(console): do not fail on warnings on check command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -799,6 +799,7 @@ poetry check
 ### Options
 
 * `--lock`: Verifies that `poetry.lock` exists for the current `pyproject.toml`.
+* `--strict`: Fail if check reports warnings.
 
 ## search
 

--- a/src/poetry/console/commands/check.py
+++ b/src/poetry/console/commands/check.py
@@ -29,6 +29,11 @@ class CheckCommand(Command):
             "Checks that <comment>poetry.lock</> exists for the current"
             " version of <comment>pyproject.toml</>.",
         ),
+        option(
+            "strict",
+            None,
+            "Fail if check reports warnings.",
+        ),
     ]
 
     def _validate_classifiers(
@@ -161,10 +166,15 @@ class CheckCommand(Command):
                 "Run `poetry lock` to fix the lock file."
             ]
 
+        return_code = 0
+
+        if check_result["errors"] or (
+            check_result["warnings"] and self.option("strict")
+        ):
+            return_code = 1
+
         if not check_result["errors"] and not check_result["warnings"]:
             self.info("All set!")
-
-            return 0
 
         for error in check_result["errors"]:
             self.line_error(f"<error>Error: {error}</error>")
@@ -172,4 +182,4 @@ class CheckCommand(Command):
         for error in check_result["warnings"]:
             self.line_error(f"<warning>Warning: {error}</warning>")
 
-        return 1
+        return return_code

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -76,15 +76,26 @@ All set!
     assert tester.io.fetch_output() == expected
 
 
+@pytest.mark.parametrize(
+    ["args", "expected_status"],
+    [
+        ([], 0),
+        (["--strict"], 1),
+    ],
+)
 def test_check_valid_legacy(
-    mocker: MockerFixture, tester: CommandTester, fixture_dir: FixtureDirGetter
+    args: list[str],
+    expected_status: int,
+    mocker: MockerFixture,
+    tester: CommandTester,
+    fixture_dir: FixtureDirGetter,
 ) -> None:
     mocker.patch(
         "poetry.poetry.Poetry.file",
         return_value=TOMLFile(fixture_dir("simple_project_legacy") / "pyproject.toml"),
         new_callable=mocker.PropertyMock,
     )
-    tester.execute()
+    tester.execute(" ".join(args))
 
     expected = (
         "Warning: [tool.poetry.name] is deprecated. Use [project.name] instead.\n"
@@ -125,6 +136,7 @@ def test_check_valid_legacy(
     )
 
     assert tester.io.fetch_error() == expected
+    assert tester.status_code == expected_status
 
 
 def test_check_invalid_dep_name_same_as_project_name(


### PR DESCRIPTION
# Pull Request Check List

Old behavior is retained by new parameter `--strict`.

Resolves: #9971

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Add the `--strict` option to the `check` command to make it fail if warnings are reported. By default, the command will only report warnings and exit with a success code.

New Features:
- Introduce the `--strict` option to the `poetry check` command.

Tests:
- Add tests for the `--strict` option.