### PR TITLE
Fix basic usage docs example about environment activation

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -183,7 +183,7 @@ For example, these commands should output the same python path:
 conda activate your_env_name
 which python
 poetry run which python
-poetry shell
+poetry env activate
 which python
 ```
 


### PR DESCRIPTION
Documentation:

Very minor change deprecating `poetry shell` in an example in 'Basic Usage' docs; loosely relates to change https://github.com/python-poetry/poetry/pull/9963.

## Summary by Sourcery

Documentation:
- Clarify the recommended way to activate a project environment in the basic usage documentation.