### PR TITLE
Documentation update to mention that project.name config is always required

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -28,7 +28,7 @@ The `project` section of the `pyproject.toml` file according to the
 
 ### name
 
-The name of the package. **Required in package mode**
+The name of the package. **Always required when the `project` section is specified**
 
 This should be a valid name as defined by [PEP 508](https://peps.python.org/pep-0508/#names).
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9988

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

## Summary by Sourcery

Documentation:
- Clarify that the project.name configuration is always required when a project section is specified.