### PR TITLE
fix(console): self update didn't recognize Poetry's environment

### DIFF
--- a/src/poetry/console/commands/self/update.py
+++ b/src/poetry/console/commands/self/update.py
@@ -46,6 +46,7 @@ environment.
         add_command = application.find("add")
         assert isinstance(add_command, AddCommand)
         add_command.set_env(self.env)
+        add_command.set_poetry(self.poetry)
         application.configure_installer_for_command(add_command, self.io)
 
         argv = ["add", f"poetry@{self.argument('version')}"]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9964

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Bug Fixes:
- Fix an issue where `self update` would not recognize Poetry\'s environment, causing it to fail when adding a package.