### PR TITLE
fix: `update`, `add` and `remove` with `--only` shall not uninstall dependencies from all other groups

### DIFF
--- a/src/poetry/puzzle/transaction.py
+++ b/src/poetry/puzzle/transaction.py
@@ -149,10 +149,9 @@ class Transaction:
                     operations.append(Uninstall(package))
 
         if with_uninstalls:
+            result_packages = {package.name for package in self._result_packages}
             for current_package in self._current_packages:
-                if current_package.name not in (
-                    relevant_result_packages | uninstalls
-                ) and (
+                if current_package.name not in (result_packages | uninstalls) and (
                     installed_package := self._installed_packages.get(
                         current_package.name
                     )

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -373,6 +373,8 @@ def _configure_run_install_dev(
 
 
 @pytest.mark.parametrize("lock_version", ("1.1", "2.1"))
+@pytest.mark.parametrize("update", [False, True])
+@pytest.mark.parametrize("requires_synchronization", [False, True])
 @pytest.mark.parametrize(
     ("groups", "installs", "updates", "removals", "with_packages_installed"),
     [
@@ -399,6 +401,8 @@ def test_run_install_with_dependency_groups(
     repo: Repository,
     package: ProjectPackage,
     installed: CustomInstalledRepository,
+    update: bool,
+    requires_synchronization: bool,
     lock_version: str,
 ) -> None:
     _configure_run_install_dev(
@@ -414,10 +418,13 @@ def test_run_install_with_dependency_groups(
     if groups is not None:
         installer.only_groups(groups)
 
-    installer.requires_synchronization(True)
+    installer.update(update)
+    installer.requires_synchronization(requires_synchronization)
     result = installer.run()
     assert result == 0
 
+    if not requires_synchronization:
+        removals = 0
     assert installer.executor.installations_count == installs
     assert installer.executor.updates_count == updates
     assert installer.executor.removals_count == removals


### PR DESCRIPTION
Reintroduce some logic removed in bd3500d07cd0ab0d10d26917fdda3abdd8e67704 and add tests for it. Fix logic with `reresolve = False`, which had the same issue.

- The change in installer is the fix for `reresolve = True` (reintroducing old logic).
- The change in transaction is the fix for `reresolve = False`.

# Pull Request Check List

Resolves: #9950

(Does not resolve the similar issue #9975. This one requires another fix.)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Restore the logic for the --only flag to prevent uninstalling dependencies from other groups, and add tests to cover this behavior.

Bug Fixes:
- Fix an issue where using the `--only` flag with `update`, `add`, and `remove` commands would uninstall dependencies from all other groups.

Tests:
- Add tests to verify the fix for the `--only` flag behavior.