### PR TITLE
fix: `update`, `add` and `remove` shall not uninstall extra dependencies

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -204,11 +204,13 @@ poetry install -E mysql -E pgsql
 poetry install --all-extras
 ```
 
-Any extras not specified will always be removed.
+Any extras not specified will be kept but not installed:
 
 ```bash
-poetry install --extras "A B"  # C is removed
+poetry install --extras "A B"  # C is kept if already installed
 ```
+
+If you want to remove unspecified extras, use the `sync` command.
 
 By default `poetry` will install your project's package every time you run `install`:
 

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -1400,6 +1400,7 @@ def test_run_with_different_dependency_extras(
 @pytest.mark.parametrize("is_locked", [False, True])
 @pytest.mark.parametrize("is_installed", [False, True])
 @pytest.mark.parametrize("with_extras", [False, True])
+@pytest.mark.parametrize("do_update", [False, True])
 @pytest.mark.parametrize("do_sync", [False, True])
 def test_run_installs_extras_with_deps_if_requested(
     installer: Installer,
@@ -1410,6 +1411,7 @@ def test_run_installs_extras_with_deps_if_requested(
     is_locked: bool,
     is_installed: bool,
     with_extras: bool,
+    do_update: bool,
     do_sync: bool,
 ) -> None:
     package.extras = {canonicalize_name("foo"): [get_dependency("C")]}
@@ -1443,6 +1445,7 @@ def test_run_installs_extras_with_deps_if_requested(
 
     if with_extras:
         installer.extras(["foo"])
+    installer.update(do_update)
     installer.requires_synchronization(do_sync)
     result = installer.run()
     assert result == 0
@@ -1459,7 +1462,7 @@ def test_run_installs_extras_with_deps_if_requested(
         expected_installations_count = 0 if is_installed else 2
         # We only want to uninstall extras if we do a "poetry install" without extras,
         # not if we do a "poetry update" or "poetry add".
-        expected_removals_count = 2 if is_installed else 0
+        expected_removals_count = 2 if is_installed and do_sync else 0
 
     assert installer.executor.installations_count == expected_installations_count
     assert installer.executor.removals_count == expected_removals_count

--- a/tests/puzzle/test_transaction.py
+++ b/tests/puzzle/test_transaction.py
@@ -433,8 +433,10 @@ def test_calculate_operations_extras(
     if extras:
         ops = [{"job": "install", "package": Package("a", "1"), "skipped": installed}]
     elif installed:
-        # extras are always removed, even if with_uninstalls is False
-        ops = [{"job": "remove", "package": Package("a", "1")}]
+        if with_uninstalls and sync:
+            ops = [{"job": "remove", "package": Package("a", "1")}]
+        else:
+            ops = []
     else:
         ops = [{"job": "install", "package": Package("a", "1"), "skipped": True}]
 
@@ -494,6 +496,7 @@ def test_calculate_operations_extras_no_redundant_uninstall(extra: str) -> None:
 
     check_operations(
         transaction.calculate_operations(
+            synchronize=True,
             extras=set() if not extra else {canonicalize_name(extra)},
         ),
         ops,


### PR DESCRIPTION
With this change unrequested extras dependencies will also be kept when running `install` and are only removed when running `sync`!

# Pull Request Check List

Resolves: #9975
Requires: #10014

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Bug Fixes:
- Dependencies with extras are no longer uninstalled when those extras are not explicitly requested during installation or update.