### PR TITLE
feat: allow a folder with a list of wheels to be a repository

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -206,6 +206,15 @@ class Config:
                     "url": os.environ[env_key]
                 }
 
+        pattern = re.compile(r"POETRY_REPOSITORIES_(?P<name>[A-Z_]+)_PATH")
+
+        for env_key in os.environ:
+            match = pattern.match(env_key)
+            if match:
+                repositories[match.group("name").lower().replace("_", "-")] = {
+                    "path": os.environ[env_key]
+                }
+
         return repositories
 
     @property

--- a/src/poetry/config/source.py
+++ b/src/poetry/config/source.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 class Source:
     name: str
     url: str = ""
+    path: str = ""
     priority: Priority = (
         Priority.PRIMARY
     )  # cheating in annotation: str will be converted to Priority in __post_init__

--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -32,12 +32,17 @@ class SourceAddCommand(Command):
         argument(
             "url",
             "Source repository URL."
-            " Required, except for PyPI, for which it is not allowed.",
+            "Required for http repositoy, except for PyPI, for which it is not allowed.",
             optional=True,
         ),
     ]
 
     options: ClassVar[list[Option]] = [
+        option(
+            "path",
+            "Source repository path.",
+            flag=False,
+        ),
         option(
             "priority",
             "p",
@@ -54,6 +59,7 @@ class SourceAddCommand(Command):
         name: str = self.argument("name")
         lower_name = name.lower()
         url: str = self.argument("url")
+        path: str = self.option("path", "")
         priority_str: str | None = self.option("priority", None)
 
         if lower_name == "pypi":
@@ -63,7 +69,7 @@ class SourceAddCommand(Command):
                     "<error>The URL of PyPI is fixed and cannot be set.</error>"
                 )
                 return 1
-        elif not url:
+        elif not url and not path:
             self.line_error(
                 "<error>A custom source cannot be added without a URL.</error>"
             )
@@ -75,7 +81,7 @@ class SourceAddCommand(Command):
             priority = Priority[priority_str.upper()]
 
         sources = AoT([])
-        new_source = Source(name=name, url=url, priority=priority)
+        new_source = Source(name=name, url=url, path=path, priority=priority)
         is_new_source = True
 
         for source in self.poetry.get_sources():

--- a/src/poetry/json/schemas/poetry.json
+++ b/src/poetry/json/schemas/poetry.json
@@ -43,6 +43,10 @@
           "description": "The url of the repository.",
           "format": "uri"
         },
+        "path": {
+          "type": "string",
+          "description": "The path of the repository."
+        },
         "priority": {
           "enum": [
             "primary",

--- a/src/poetry/repositories/wheelhouse_repository.py
+++ b/src/poetry/repositories/wheelhouse_repository.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterator
+from pathlib import Path
+
+from cachecontrol.controller import logger as cache_control_logger
+from poetry.core.packages.package import Package
+from poetry.core.packages.utils.link import Link
+from poetry.repositories.repository import Repository
+from poetry.inspection.info import PackageInfo
+from poetry.core.packages.utils.utils import path_to_url
+
+cache_control_logger.setLevel(logging.ERROR)
+
+logger = logging.getLogger(__name__)
+
+
+class LocalPathRepository(Repository):
+    def __init__(self, name: str, path: str) -> None:
+        self._path = Path(path)
+        if not self._path.is_dir():
+            raise ValueError(f"Path {self._path} is not a directory")
+        
+        super().__init__(name, self._list_packages_in_path())
+
+    @property
+    def path(self) -> str:
+        return self._path
+    
+    def _list_packages_in_path(self) -> Iterator[Package]:
+        for file_path in self._path.iterdir():
+            try:
+                yield PackageInfo.from_path(path=file_path).to_package(root_dir=file_path)
+            except Exception:
+                continue
+
+    def find_links_for_package(self, package: Package) -> list[Link]:
+        return [Link(path_to_url(package.source_type))]


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/5983

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Feature Request

Hi 👋

I submit a PR to allow a folder with a list of wheels (or sdist) to be a repository.  
This is usefull to work offline with wheelhouse, for container or CI stuff.

I work on a POC that allow to set sources, like this:
```toml
[[tool.poetry.source]]
name = "wheelhouse"
path = "./wheelhouse"
```

I'm open to feedback :slightly_smiling_face: 

## Minimal, Reproducible Example 

With a `pyproject.toml`, like:
```toml
[build-system]
requires = ["poetry-core>=2.0.0"]
build-backend = "poetry.core.masonry.api"

[project]
name = "test"
description = ""
version = "1.0.0"

[tool.poetry.dependencies]
python = "~3.12"
mypy = "*"
```

Run these commands to setup a wheelhouse (using poetry):
```shell
$ export WHEELHOUSE_DIR="./wheelhouse"
$ mkdir -p $WHEELHOUSE_DIR
$ poetry lock
$ poetry self add poetry-plugin-export
$ poetry export --format requirements.txt --output $WHEELHOUSE_DIR/requirements.txt
$ poetry run pip wheel --ignore-requires-python --no-deps --wheel-dir $WHEELHOUSE_DIR --requirement $WHEELHOUSE_DIR/$ requirements.txt --require-hashes --only-binary :all:
```

And now regenerate the lockfile with the wheelhouse as source:
```shell
$ poetry source add wheelhouse --path=$WHEELHOUSE_DIR
$ poetry lock
```

This produces a lockfile, like this:
```toml
# This file is automatically @generated by Poetry 2.0.0 and should not be changed by hand.

[[package]]
name = "mypy"
version = "1.14.1"
description = "Optional static typing for Python"
optional = false
python-versions = ">=3.8"
groups = ["main"]
files = []

[package.dependencies]
mypy_extensions = ">=1.0.0"
typing_extensions = ">=4.6.0"

[package.extras]
dmypy = ["psutil (>=4.0)"]
faster-cache = ["orjson"]
install-types = ["pip"]
mypyc = ["setuptools (>=50)"]
reports = ["lxml"]

[package.source]
type = "file"
url = "wheelhouse/mypy-1.14.1-py3-none-any.whl"

[[package]]
name = "mypy-extensions"
version = "1.0.0"
description = "Type system extensions for programs checked with the mypy type checker."
optional = false
python-versions = ">=3.5"
groups = ["main"]
files = []

[package.source]
type = "file"
url = "wheelhouse/mypy_extensions-1.0.0-py3-none-any.whl"

[[package]]
name = "typing_extensions"
version = "4.12.2"
description = "Backported and Experimental Type Hints for Python 3.8+"
optional = false
python-versions = ">=3.8"
groups = ["main"]
files = []

[package.source]
type = "file"
url = "wheelhouse/typing_extensions-4.12.2-py3-none-any.whl"

[metadata]
lock-version = "2.1"
python-versions = "~3.12"
content-hash = "0f9b3c65330adba20ac5fb67def1b4d65e530295b30746dca5acf3d1a996a1a2"

```
And the dependency can normally be installed.
