### PR TITLE
doc(cli): reorder sections and unify heading

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -223,7 +223,7 @@ See [PEP 440](https://peps.python.org/pep-0440/#local-version-identifiers) for m
 
 ## cache
 
-The `cache` command regroups sub commands to interact with Poetry's cache.
+The `cache` command groups subcommands to interact with Poetry's cache.
 
 ### cache clear
 
@@ -302,7 +302,7 @@ Without `--` this command will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphe
 
 ## env
 
-The `env` command regroups sub commands to interact with the virtualenvs
+The `env` command groups subcommands to interact with the virtualenvs
 associated with a specific project.
 
 See [Managing environments]({{< relref "managing-environments" >}}) for more information about these commands.
@@ -779,7 +779,7 @@ and this [discussion](https://discuss.python.org/t/fastly-interfering-with-pypi-
 
 ## self
 
-The `self` namespace regroups sub commands to manage the Poetry installation itself.
+The `self` namespace groups subcommands to manage the Poetry installation itself.
 
 {{% note %}}
 Use of these commands will create the required `pyproject.toml` and `poetry.lock` files in your
@@ -989,7 +989,7 @@ When `--only` is specified, `--with` and `--without` options are ignored.
 
 ## source
 
-The `source` namespace regroups sub commands to manage repository sources for a Poetry project.
+The `source` namespace groups subcommands to manage repository sources for a Poetry project.
 
 ### source add
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ This chapter documents all the available commands.
 To get help from the command-line, simply call `poetry` to see the complete list of commands,
 then `--help` combined with any of those can give you more information.
 
-## Global options
+## Global Options
 
 * `--verbose (-v|vv|vvv)`: Increase the verbosity of messages: "-v" for normal output, "-vv" for more verbose output and "-vvv" for debug.
 * `--help (-h)` : Display help information.
@@ -32,397 +32,13 @@ then `--help` combined with any of those can give you more information.
 * `--directory=DIRECTORY (-C)`: The working directory for the Poetry command (defaults to the current working directory). All command-line arguments will be resolved relative to the given directory.
 * `--project=PROJECT (-P)`: Specify another path as the project root. All command-line arguments will be resolved relative to the current working directory or directory specified using `--directory` option if used.
 
+## about
 
-## new
-
-This command will help you kickstart your new Python project by creating
-a directory structure suitable for most projects.
+The `about` command displays global information about Poetry, including the current version and version of `poetry-core`.
 
 ```bash
-poetry new my-package
+poetry about
 ```
-
-will create a folder as follows:
-
-```text
-my-package
-├── pyproject.toml
-├── README.md
-├── my_package
-│   └── __init__.py
-└── tests
-    └── __init__.py
-```
-
-If you want to name your project differently than the folder, you can pass
-the `--name` option:
-
-```bash
-poetry new my-folder --name my-package
-```
-
-If you want to use a src folder, you can use the `--src` option:
-
-```bash
-poetry new --src my-package
-```
-
-That will create a folder structure as follows:
-
-```text
-my-package
-├── pyproject.toml
-├── README.md
-├── src
-│   └── my_package
-│       └── __init__.py
-└── tests
-    └── __init__.py
-```
-
-The `--name` option is smart enough to detect namespace packages and create
-the required structure for you.
-
-```bash
-poetry new --src --name my.package my-package
-```
-
-will create the following structure:
-
-```text
-my-package
-├── pyproject.toml
-├── README.md
-├── src
-│   └── my
-│       └── package
-│           └── __init__.py
-└── tests
-    └── __init__.py
-```
-
-### Options
-
-* `--interactive (-i)`: Allow interactive specification of project configuration.
-* `--name`: Set the resulting package name.
-* `--src`: Use the src layout for the project.
-* `--readme`: Specify the readme file extension. Default is `md`. If you intend to publish to PyPI
-  keep the [recommendations for a PyPI-friendly README](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/)
-  in mind.
-* `--description`: Description of the package.
-* `--author`: Author of the package.
-* `--python` Compatible Python versions.
-* `--dependency`: Package to require with a version constraint. Should be in format `foo:1.0.0`.
-* `--dev-dependency`: Development requirements, see `--dependency`.
-
-
-## init
-
-This command will help you create a `pyproject.toml` file interactively
-by prompting you to provide basic information about your package.
-
-It will interactively ask you to fill in the fields, while using some smart defaults.
-
-```bash
-poetry init
-```
-
-### Options
-
-* `--name`: Name of the package.
-* `--description`: Description of the package.
-* `--author`: Author of the package.
-* `--python` Compatible Python versions.
-* `--dependency`: Package to require with a version constraint. Should be in format `foo:1.0.0`.
-* `--dev-dependency`: Development requirements, see `--dependency`.
-
-
-## install
-
-The `install` command reads the `pyproject.toml` file from the current project,
-resolves the dependencies, and installs them.
-
-{{% note %}}
-Normally, you should prefer `poetry sync` to `poetry install` to avoid untracked outdated packages.
-However, if you have set `virtualenvs.create = false` to install dependencies into your system environment,
-which is discouraged, or `virtualenvs.options.system-site-packages = true` to make
-system site-packages available in your virtual environment, you should use `poetry install`
-because `poetry sync` will normally not work well in these cases.
-{{% /note %}}
-
-```bash
-poetry install
-```
-
-If there is a `poetry.lock` file in the current directory,
-it will use the exact versions from there instead of resolving them.
-This ensures that everyone using the library will get the same versions of the dependencies.
-
-If there is no `poetry.lock` file, Poetry will create one after dependency resolution.
-
-If you want to exclude one or more dependency groups for the installation, you can use
-the `--without` option.
-
-```bash
-poetry install --without test,docs
-```
-
-You can also select optional dependency groups with the `--with` option.
-
-```bash
-poetry install --with test,docs
-```
-
-To install all dependency groups including the optional groups, use the ``--all-groups`` flag.
-
-```bash
-poetry install --all-groups
-```
-
-It's also possible to only install specific dependency groups by using the `only` option.
-
-```bash
-poetry install --only test,docs
-```
-
-To only install the project itself with no dependencies, use the `--only-root` flag.
-
-```bash
-poetry install --only-root
-```
-
-See [Dependency groups]({{< relref "managing-dependencies#dependency-groups" >}}) for more information
-about dependency groups.
-
-You can also specify the extras you want installed
-by passing the `-E|--extras` option (See [Extras]({{< relref "pyproject#extras" >}}) for more info).
-Pass `--all-extras` to install all defined extras for a project.
-
-```bash
-poetry install --extras "mysql pgsql"
-poetry install -E mysql -E pgsql
-poetry install --all-extras
-```
-
-Any extras not specified will be kept but not installed:
-
-```bash
-poetry install --extras "A B"  # C is kept if already installed
-```
-
-If you want to remove unspecified extras, use the `sync` command.
-
-By default `poetry` will install your project's package every time you run `install`:
-
-```bash
-$ poetry install
-Installing dependencies from lock file
-
-No dependencies to install or update
-
-  - Installing <your-package-name> (x.x.x)
-```
-
-If you want to skip this installation, use the `--no-root` option.
-
-```bash
-poetry install --no-root
-```
-
-Similar to `--no-root` you can use `--no-directory` to skip directory path dependencies:
-
-```bash
-poetry install --no-directory
-```
-
-This is mainly useful for caching in CI or when building Docker images. See the [FAQ entry]({{< relref "faq#poetry-busts-my-docker-cache-because-it-requires-me-to-copy-my-source-files-in-before-installing-3rd-party-dependencies" >}}) for more information on this option.
-
-By default `poetry` does not compile Python source files to bytecode during installation.
-This speeds up the installation process, but the first execution may take a little more
-time because Python then compiles source files to bytecode automatically.
-If you want to compile source files to bytecode during installation,
-you can use the `--compile` option:
-
-```bash
-poetry install --compile
-```
-
-### Options
-
-* `--without`: The dependency groups to ignore.
-* `--with`: The optional dependency groups to include.
-* `--only`: The only dependency groups to include.
-* `--only-root`: Install only the root project, exclude all dependencies.
-* `--sync`: Synchronize the environment with the locked packages and the specified groups. (**Deprecated**, use `poetry sync` instead)
-* `--no-root`: Do not install the root package (your project).
-* `--no-directory`: Skip all directory path dependencies (including transitive ones).
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
-* `--extras (-E)`: Features to install (multiple values allowed).
-* `--all-extras`: Install all extra features (conflicts with `--extras`).
-* `--all-groups`: Install dependencies from all groups (conflicts with `--only`, `--with`, and `--without`).
-* `--compile`: Compile Python source files to bytecode.
-
-{{% note %}}
-When `--only` is specified, `--with` and `--without` options are ignored.
-{{% /note %}}
-
-
-## sync
-
-The `sync` command makes sure that the project's environment is in sync with the `poetry.lock` file.
-It is similar to `poetry install` but it additionally removes packages that are not tracked in the lock file.
-
-```bash
-poetry sync
-```
-
-If there is a `poetry.lock` file in the current directory,
-it will use the exact versions from there instead of resolving them.
-This ensures that everyone using the library will get the same versions of the dependencies.
-
-If there is no `poetry.lock` file, Poetry will create one after dependency resolution.
-
-If you want to exclude one or more dependency groups for the installation, you can use
-the `--without` option.
-
-```bash
-poetry sync --without test,docs
-```
-
-You can also select optional dependency groups with the `--with` option.
-
-```bash
-poetry sync --with test,docs
-```
-
-To install all dependency groups including the optional groups, use the ``--all-groups`` flag.
-
-```bash
-poetry sync --all-groups
-```
-
-It's also possible to only install specific dependency groups by using the `only` option.
-
-```bash
-poetry sync --only test,docs
-```
-
-To only install the project itself with no dependencies, use the `--only-root` flag.
-
-```bash
-poetry sync --only-root
-```
-
-See [Dependency groups]({{< relref "managing-dependencies#dependency-groups" >}}) for more information
-about dependency groups.
-
-You can also specify the extras you want installed
-by passing the `-E|--extras` option (See [Extras]({{< relref "pyproject#extras" >}}) for more info).
-Pass `--all-extras` to install all defined extras for a project.
-
-```bash
-poetry sync --extras "mysql pgsql"
-poetry sync -E mysql -E pgsql
-poetry sync --all-extras
-```
-
-Any extras not specified will always be removed.
-
-```bash
-poetry sync --extras "A B"  # C is removed
-```
-
-By default `poetry` will install your project's package every time you run `sync`:
-
-```bash
-$ poetry sync
-Installing dependencies from lock file
-
-No dependencies to install or update
-
-  - Installing <your-package-name> (x.x.x)
-```
-
-If you want to skip this installation, use the `--no-root` option.
-
-```bash
-poetry sync --no-root
-```
-
-Similar to `--no-root` you can use `--no-directory` to skip directory path dependencies:
-
-```bash
-poetry sync --no-directory
-```
-
-This is mainly useful for caching in CI or when building Docker images. See the [FAQ entry]({{< relref "faq#poetry-busts-my-docker-cache-because-it-requires-me-to-copy-my-source-files-in-before-installing-3rd-party-dependencies" >}}) for more information on this option.
-
-By default `poetry` does not compile Python source files to bytecode during installation.
-This speeds up the installation process, but the first execution may take a little more
-time because Python then compiles source files to bytecode automatically.
-If you want to compile source files to bytecode during installation,
-you can use the `--compile` option:
-
-```bash
-poetry sync --compile
-```
-
-### Options
-
-* `--without`: The dependency groups to ignore.
-* `--with`: The optional dependency groups to include.
-* `--only`: The only dependency groups to include.
-* `--only-root`: Install only the root project, exclude all dependencies.
-* `--no-root`: Do not install the root package (your project).
-* `--no-directory`: Skip all directory path dependencies (including transitive ones).
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
-* `--extras (-E)`: Features to install (multiple values allowed).
-* `--all-extras`: Install all extra features (conflicts with `--extras`).
-* `--all-groups`: Install dependencies from all groups (conflicts with `--only`, `--with`, and `--without`).
-* `--compile`: Compile Python source files to bytecode.
-
-{{% note %}}
-When `--only` is specified, `--with` and `--without` options are ignored.
-{{% /note %}}
-
-
-## update
-
-In order to get the latest versions of the dependencies and to update the `poetry.lock` file,
-you should use the `update` command.
-
-```bash
-poetry update
-```
-
-This will resolve all dependencies of the project and write the exact versions into `poetry.lock`.
-
-If you just want to update a few packages and not all, you can list them as such:
-
-```bash
-poetry update requests toml
-```
-
-Note that this will not update versions for dependencies outside their
-[version constraints]({{< relref "dependency-specification#version-constraints" >}})
-specified in the `pyproject.toml` file.
-In other terms, `poetry update foo` will be a no-op if the version constraint
-specified for `foo` is `~2.3` or `2.3` and `2.4` is available.
-In order for `foo` to be updated, you must update the constraint, for example `^2.3`.
-You can do this using the `add` command.
-
-### Options
-
-* `--without`: The dependency groups to ignore.
-* `--with`: The optional dependency groups to include.
-* `--only`: The only dependency groups to include.
-* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables `--verbose`).
-* `--lock` : Do not perform install (only update the lockfile).
-* `--sync`: Synchronize the environment with the locked packages and the specified groups.
-
-{{% note %}}
-When `--only` is specified, `--with` and `--without` options are ignored.
-{{% /note %}}
 
 ## add
 
@@ -561,7 +177,7 @@ poetry add mkdocs --group docs
 See [Dependency groups]({{< relref "managing-dependencies#dependency-groups" >}}) for more information
 about dependency groups.
 
-### Options
+#### Options
 
 * `--group (-G)`: The group to add the dependency to.
 * `--dev (-D)`: Add package as development dependency. (shortcut for `-G dev`)
@@ -576,76 +192,6 @@ about dependency groups.
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
 * `--lock`: Do not perform install (only update the lockfile).
 
-
-## remove
-
-The `remove` command removes a package from the current
-list of installed packages.
-
-```bash
-poetry remove pendulum
-```
-
-If you want to remove a package from a specific group of dependencies, you can use the `--group (-G)` option:
-
-```bash
-poetry remove mkdocs --group docs
-```
-
-See [Dependency groups]({{< relref "managing-dependencies#dependency-groups" >}}) for more information
-about dependency groups.
-
-### Options
-
-* `--group (-G)`: The group to remove the dependency from.
-* `--dev (-D)`: Removes a package from the development dependencies. (shortcut for `-G dev`)
-* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables `--verbose`).
-* `--lock`: Do not perform operations (only update the lockfile).
-
-
-## show
-
-To list all the available packages, you can use the `show` command.
-
-```bash
-poetry show
-```
-
-If you want to see the details of a certain package, you can pass the package name.
-
-```bash
-poetry show pendulum
-
-name        : pendulum
-version     : 1.4.2
-description : Python datetimes made easy
-
-dependencies
- - python-dateutil >=2.6.1
- - tzlocal >=1.4
- - pytzdata >=2017.2.2
-
-required by
- - calendar requires >=1.4.0
-```
-
-### Options
-
-* `--without`: The dependency groups to ignore.
-* `--why`: When showing the full list, or a `--tree` for a single package, display whether they are a direct dependency or required by other packages.
-* `--with`: The optional dependency groups to include.
-* `--only`: The only dependency groups to include.
-* `--tree`: List the dependencies as a tree.
-* `--latest (-l)`: Show the latest version.
-* `--outdated (-o)`: Show the latest version but only for packages that are outdated.
-* `--all (-a)`: Show all packages (even those not compatible with current system).
-* `--top-level (-T)`: Only show explicitly defined packages.
-
-{{% note %}}
-When `--only` is specified, `--with` and `--without` options are ignored.
-{{% /note %}}
-
-
 ## build
 
 The `build` command builds the source and wheels archives.
@@ -656,7 +202,7 @@ poetry build
 
 Note that, at the moment, only pure python wheels are supported.
 
-### Options
+#### Options
 
 * `--format (-f)`: Limit the format to either `wheel` or `sdist`.
 * `--clean`: Clean output directory before building.
@@ -675,39 +221,52 @@ used to identify private builds created directly from the project source.
 See [PEP 440](https://peps.python.org/pep-0440/#local-version-identifiers) for more information.
 {{% /warning %}}
 
+## cache
 
-## publish
+The `cache` command regroups sub commands to interact with Poetry's cache.
 
-This command publishes the package, previously built with the [`build`](#build) command, to the remote repository.
+### cache clear
 
-It will automatically register the package before uploading if this is the first time it is submitted.
+The `cache clear` command removes packages from a cached repository.
+
+For example, to clear the whole cache of packages from the `PyPI` repository, run:
 
 ```bash
-poetry publish
+poetry cache clear PyPI --all
 ```
 
-It can also build the package if you pass it the `--build` option.
+To only remove a specific package from a cache, you have to specify the cache entry in the following form `cache:package:version`:
+
+```bash
+poetry cache clear pypi:requests:2.24.0
+```
+
+### cache list
+
+The `cache list` command lists Poetry's available caches.
+
+```bash
+poetry cache list
+```
+
+## check
+
+The `check` command validates the content of the `pyproject.toml` file
+and its consistency with the `poetry.lock` file.
+It returns a detailed report if there are any errors.
 
 {{% note %}}
-See [Publishable Repositories]({{< relref "repositories/#publishable-repositories" >}}) for more information on how to configure and use publishable repositories.
+This command is also available as a pre-commit hook. See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-check">}}) for more information.
 {{% /note %}}
 
-### Options
+```bash
+poetry check
+```
 
-* `--repository (-r)`: The repository to register the package to (default: `pypi`).
-Should match a repository name set by the [`config`](#config) command.
-* `--username (-u)`: The username to access the repository.
-* `--password (-p)`: The password to access the repository.
-* `--cert`: Certificate authority to access the repository.
-* `--client-cert`: Client certificate to access the repository.
-* `--dist-dir`: Dist directory where built artifact are stored. Default is `dist`.
-* `--build`: Build the package before publishing.
-* `--dry-run`: Perform all actions except upload the package.
-* `--skip-existing`: Ignore errors from files already existing in the repository.
+#### Options
 
-{{% note %}}
-See [Configuring Credentials]({{< relref "repositories/#configuring-credentials" >}}) for more information on how to configure credentials.
-{{% /note %}}
+* `--lock`: Verifies that `poetry.lock` exists for the current `pyproject.toml`.
+* `--strict`: Fail if check reports warnings.
 
 ## config
 
@@ -734,154 +293,12 @@ poetry config http-basic.custom-repo gitlab-ci-token -- ${GITLAB_JOB_TOKEN}
 Without `--` this command will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphen.
 {{% /warning%}}
 
-### Options
+#### Options
 
 * `--unset`: Remove the configuration element named by `setting-key`.
 * `--list`: Show the list of current config variables.
 * `--local`: Set/Get settings that are specific to a project (in the local configuration file `poetry.toml`).
 * `--migrate`: Migrate outdated configuration settings.
-
-## run
-
-The `run` command executes the given command inside the project's virtualenv.
-
-```bash
-poetry run python -V
-```
-
-It can also execute one of the scripts defined in `pyproject.toml`.
-
-So, if you have a script defined like this:
-
-{{< tabs tabTotal="2" tabID1="script-project" tabID2=script-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
-
-{{< tab tabID="script-project" >}}
-```toml
-[project]
-# ...
-[project.scripts]
-my-script = "my_module:main"
-```
-{{< /tab >}}
-
-{{< tab tabID="script-poetry" >}}
-```toml
-[tool.poetry.scripts]
-my-script = "my_module:main"
-```
-{{< /tab >}}
-{{< /tabs >}}
-
-You can execute it like so:
-
-```bash
-poetry run my-script
-```
-
-Note that this command has no option.
-
-## shell
-
-The `shell` command was moved to a plugin: [`poetry-plugin-shell`](https://github.com/python-poetry/poetry-plugin-shell)
-
-## check
-
-The `check` command validates the content of the `pyproject.toml` file
-and its consistency with the `poetry.lock` file.
-It returns a detailed report if there are any errors.
-
-{{% note %}}
-This command is also available as a pre-commit hook. See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-check">}}) for more information.
-{{% /note %}}
-
-```bash
-poetry check
-```
-
-### Options
-
-* `--lock`: Verifies that `poetry.lock` exists for the current `pyproject.toml`.
-* `--strict`: Fail if check reports warnings.
-
-## search
-
-This command searches for packages on a remote index.
-
-```bash
-poetry search requests pendulum
-```
-
-{{% note %}}
-PyPI no longer allows for the search of packages without a browser. Please use https://pypi.org/search
-(via a browser) instead.
-
-For more information please see [warehouse documentation](https://warehouse.pypa.io/api-reference/xml-rpc.html#deprecated-methods)
-and this [discussion](https://discuss.python.org/t/fastly-interfering-with-pypi-search/73597/6).
-{{% /note %}}
-
-## lock
-
-This command locks (without installing) the dependencies specified in `pyproject.toml`.
-
-{{% note %}}
-By default, packages that have already been added to the lock file before will not be updated.
-To update all dependencies to the latest available compatible versions, use `poetry update --lock`
-or `poetry lock --regenerate`, which normally produce the same result.
-This command is also available as a pre-commit hook. See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-lock">}}) for more information.
-{{% /note %}}
-
-```bash
-poetry lock
-```
-
-### Options
-
-* `--regenerate`: Ignore existing lock file and overwrite it with a new lock file created from scratch.
-
-## version
-
-This command shows the current version of the project or bumps the version of
-the project and writes the new version back to `pyproject.toml` if a valid
-bump rule is provided.
-
-The new version should be a valid [PEP 440](https://peps.python.org/pep-0440/)
-string or a valid bump rule: `patch`, `minor`, `major`, `prepatch`, `preminor`,
-`premajor`, `prerelease`.
-
-{{% note %}}
-
-If you would like to use semantic versioning for your project, please see
-[here]({{< relref "libraries#versioning" >}}).
-
-{{% /note %}}
-
-The table below illustrates the effect of these rules with concrete examples.
-
-| rule       | before  | after   |
-| ---------- |---------|---------|
-| major      | 1.3.0   | 2.0.0   |
-| minor      | 2.1.4   | 2.2.0   |
-| patch      | 4.1.1   | 4.1.2   |
-| premajor   | 1.0.2   | 2.0.0a0 |
-| preminor   | 1.0.2   | 1.1.0a0 |
-| prepatch   | 1.0.2   | 1.0.3a0 |
-| prerelease | 1.0.2   | 1.0.3a0 |
-| prerelease | 1.0.3a0 | 1.0.3a1 |
-| prerelease | 1.0.3b0 | 1.0.3b1 |
-
-The option `--next-phase` allows the increment of prerelease phase versions.
-
-| rule                    | before   | after    |
-|-------------------------|----------|----------|
-| prerelease --next-phase | 1.0.3a0  | 1.0.3b0  |
-| prerelease --next-phase | 1.0.3b0  | 1.0.3rc0 |
-| prerelease --next-phase | 1.0.3rc0 | 1.0.3    |
-
-### Options
-
-* `--next-phase`: Increment the phase of the current version.
-* `--short (-s)`: Output the version number only.
-* `--dry-run`: Do not update pyproject.toml file.
 
 ## env
 
@@ -942,93 +359,26 @@ The `env use` command activates or creates a new virtualenv for the current proj
 
 * `python`: The python executable to use. This can be a version number (if not on Windows) or a path to the python binary.
 
-## cache
+## export
 
-The `cache` command regroups sub commands to interact with Poetry's cache.
+{{% warning %}}
+This command is provided by the [Export Poetry Plugin](https://github.com/python-poetry/poetry-plugin-export).
+The plugin is no longer installed by default with Poetry 2.0.
 
-### cache list
+See [Using plugins]({{< relref "plugins#using-plugins" >}}) for information on how to install a plugin.
+As described in [Project plugins]({{< relref "plugins#project-plugins" >}}),
+you can also define in your `pyproject.toml` that the plugin is required for the development of your project:
 
-The `cache list` command lists Poetry's available caches.
-
-```bash
-poetry cache list
+```toml
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">=1.8"
 ```
-
-### cache clear
-
-The `cache clear` command removes packages from a cached repository.
-
-For example, to clear the whole cache of packages from the `PyPI` repository, run:
-
-```bash
-poetry cache clear PyPI --all
-```
-
-To only remove a specific package from a cache, you have to specify the cache entry in the following form `cache:package:version`:
-
-```bash
-poetry cache clear pypi:requests:2.24.0
-```
-
-## source
-
-The `source` namespace regroups sub commands to manage repository sources for a Poetry project.
-
-### source add
-
-The `source add` command adds source configuration to the project.
-
-For example, to add the `pypi-test` source, you can run:
-
-```bash
-poetry source add pypi-test https://test.pypi.org/simple/
-```
-
-You cannot use the name `pypi` for a custom repository as it is reserved for use by
-the default PyPI source. However, you can set the priority of PyPI:
-
-```bash
-poetry source add --priority=explicit pypi
-```
-
-#### Options
-
-* `--priority`: Set the priority of this source. Accepted values are: [`supplemental`]({{< relref "repositories#supplemental-package-sources" >}}), and [`explicit`]({{< relref "repositories#explicit-package-sources" >}}). Refer to the dedicated sections in [Repositories]({{< relref "repositories" >}}) for more information.
-
-### source show
-
-The `source show` command displays information on all configured sources for the project.
-
-```bash
-poetry source show
-```
-
-Optionally, you can show information of one or more sources by specifying their names.
-
-```bash
-poetry source show pypi-test
-```
+{{% /warning %}}
 
 {{% note %}}
-This command will only show sources configured via the `pyproject.toml`
-and does not include the implicit default PyPI.
+The `export` command is also available as a pre-commit hook.
+See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-export" >}}) for more information.
 {{% /note %}}
-
-### source remove
-
-The `source remove` command removes a configured source from your `pyproject.toml`.
-
-```bash
-poetry source remove pypi-test
-```
-
-## about
-
-The `about` command displays global information about Poetry, including the current version and version of `poetry-core`.
-
-```bash
-poetry about
-```
 
 ## help
 
@@ -1056,6 +406,155 @@ poetry show --help
 ```
 {{% /note %}}
 
+## init
+
+This command will help you create a `pyproject.toml` file interactively
+by prompting you to provide basic information about your package.
+
+It will interactively ask you to fill in the fields, while using some smart defaults.
+
+```bash
+poetry init
+```
+
+#### Options
+
+* `--name`: Name of the package.
+* `--description`: Description of the package.
+* `--author`: Author of the package.
+* `--python` Compatible Python versions.
+* `--dependency`: Package to require with a version constraint. Should be in format `foo:1.0.0`.
+* `--dev-dependency`: Development requirements, see `--dependency`.
+
+## install
+
+The `install` command reads the `pyproject.toml` file from the current project,
+resolves the dependencies, and installs them.
+
+{{% note %}}
+Normally, you should prefer `poetry sync` to `poetry install` to avoid untracked outdated packages.
+However, if you have set `virtualenvs.create = false` to install dependencies into your system environment,
+which is discouraged, or `virtualenvs.options.system-site-packages = true` to make
+system site-packages available in your virtual environment, you should use `poetry install`
+because `poetry sync` will normally not work well in these cases.
+{{% /note %}}
+
+```bash
+poetry install
+```
+
+If there is a `poetry.lock` file in the current directory,
+it will use the exact versions from there instead of resolving them.
+This ensures that everyone using the library will get the same versions of the dependencies.
+
+If there is no `poetry.lock` file, Poetry will create one after dependency resolution.
+
+If you want to exclude one or more dependency groups for the installation, you can use
+the `--without` option.
+
+```bash
+poetry install --without test,docs
+```
+
+You can also select optional dependency groups with the `--with` option.
+
+```bash
+poetry install --with test,docs
+```
+
+To install all dependency groups including the optional groups, use the ``--all-groups`` flag.
+
+```bash
+poetry install --all-groups
+```
+
+It's also possible to only install specific dependency groups by using the `only` option.
+
+```bash
+poetry install --only test,docs
+```
+
+To only install the project itself with no dependencies, use the `--only-root` flag.
+
+```bash
+poetry install --only-root
+```
+
+See [Dependency groups]({{< relref "managing-dependencies#dependency-groups" >}}) for more information
+about dependency groups.
+
+You can also specify the extras you want installed
+by passing the `-E|--extras` option (See [Extras]({{< relref "pyproject#extras" >}}) for more info).
+Pass `--all-extras` to install all defined extras for a project.
+
+```bash
+poetry install --extras "mysql pgsql"
+poetry install -E mysql -E pgsql
+poetry install --all-extras
+```
+
+Any extras not specified will be kept but not installed:
+
+```bash
+poetry install --extras "A B"  # C is kept if already installed
+```
+
+If you want to remove unspecified extras, use the `sync` command.
+
+By default `poetry` will install your project's package every time you run `install`:
+
+```bash
+$ poetry install
+Installing dependencies from lock file
+
+No dependencies to install or update
+
+  - Installing <your-package-name> (x.x.x)
+```
+
+If you want to skip this installation, use the `--no-root` option.
+
+```bash
+poetry install --no-root
+```
+
+Similar to `--no-root` you can use `--no-directory` to skip directory path dependencies:
+
+```bash
+poetry install --no-directory
+```
+
+This is mainly useful for caching in CI or when building Docker images. See the [FAQ entry]({{< relref "faq#poetry-busts-my-docker-cache-because-it-requires-me-to-copy-my-source-files-in-before-installing-3rd-party-dependencies" >}}) for more information on this option.
+
+By default `poetry` does not compile Python source files to bytecode during installation.
+This speeds up the installation process, but the first execution may take a little more
+time because Python then compiles source files to bytecode automatically.
+If you want to compile source files to bytecode during installation,
+you can use the `--compile` option:
+
+```bash
+poetry install --compile
+```
+
+#### Options
+
+* `--without`: The dependency groups to ignore.
+* `--with`: The optional dependency groups to include.
+* `--only`: The only dependency groups to include.
+* `--only-root`: Install only the root project, exclude all dependencies.
+* `--sync`: Synchronize the environment with the locked packages and the specified groups. (**Deprecated**, use `poetry sync` instead)
+* `--no-root`: Do not install the root package (your project).
+* `--no-directory`: Skip all directory path dependencies (including transitive ones).
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
+* `--extras (-E)`: Features to install (multiple values allowed).
+* `--all-extras`: Install all extra features (conflicts with `--extras`).
+* `--all-groups`: Install dependencies from all groups (conflicts with `--only`, `--with`, and `--without`).
+* `--compile`: Compile Python source files to bytecode.
+
+{{% note %}}
+When `--only` is specified, `--with` and `--without` options are ignored.
+{{% /note %}}
+
 ## list
 
 The `list` command displays all the available Poetry commands.
@@ -1063,6 +562,220 @@ The `list` command displays all the available Poetry commands.
 ```bash
 poetry list
 ```
+
+## lock
+
+This command locks (without installing) the dependencies specified in `pyproject.toml`.
+
+{{% note %}}
+By default, packages that have already been added to the lock file before will not be updated.
+To update all dependencies to the latest available compatible versions, use `poetry update --lock`
+or `poetry lock --regenerate`, which normally produce the same result.
+This command is also available as a pre-commit hook. See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-lock">}}) for more information.
+{{% /note %}}
+
+```bash
+poetry lock
+```
+
+#### Options
+
+* `--regenerate`: Ignore existing lock file and overwrite it with a new lock file created from scratch.
+
+## new
+
+This command will help you kickstart your new Python project by creating
+a directory structure suitable for most projects.
+
+```bash
+poetry new my-package
+```
+
+will create a folder as follows:
+
+```text
+my-package
+├── pyproject.toml
+├── README.md
+├── my_package
+│   └── __init__.py
+└── tests
+    └── __init__.py
+```
+
+If you want to name your project differently than the folder, you can pass
+the `--name` option:
+
+```bash
+poetry new my-folder --name my-package
+```
+
+If you want to use a src folder, you can use the `--src` option:
+
+```bash
+poetry new --src my-package
+```
+
+That will create a folder structure as follows:
+
+```text
+my-package
+├── pyproject.toml
+├── README.md
+├── src
+│   └── my_package
+│       └── __init__.py
+└── tests
+    └── __init__.py
+```
+
+The `--name` option is smart enough to detect namespace packages and create
+the required structure for you.
+
+```bash
+poetry new --src --name my.package my-package
+```
+
+will create the following structure:
+
+```text
+my-package
+├── pyproject.toml
+├── README.md
+├── src
+│   └── my
+│       └── package
+│           └── __init__.py
+└── tests
+    └── __init__.py
+```
+
+#### Options
+
+* `--interactive (-i)`: Allow interactive specification of project configuration.
+* `--name`: Set the resulting package name.
+* `--src`: Use the src layout for the project.
+* `--readme`: Specify the readme file extension. Default is `md`. If you intend to publish to PyPI
+  keep the [recommendations for a PyPI-friendly README](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/)
+  in mind.
+* `--description`: Description of the package.
+* `--author`: Author of the package.
+* `--python` Compatible Python versions.
+* `--dependency`: Package to require with a version constraint. Should be in format `foo:1.0.0`.
+* `--dev-dependency`: Development requirements, see `--dependency`.
+
+## publish
+
+This command publishes the package, previously built with the [`build`](#build) command, to the remote repository.
+
+It will automatically register the package before uploading if this is the first time it is submitted.
+
+```bash
+poetry publish
+```
+
+It can also build the package if you pass it the `--build` option.
+
+{{% note %}}
+See [Publishable Repositories]({{< relref "repositories/#publishable-repositories" >}}) for more information on how to configure and use publishable repositories.
+{{% /note %}}
+
+#### Options
+
+* `--repository (-r)`: The repository to register the package to (default: `pypi`).
+Should match a repository name set by the [`config`](#config) command.
+* `--username (-u)`: The username to access the repository.
+* `--password (-p)`: The password to access the repository.
+* `--cert`: Certificate authority to access the repository.
+* `--client-cert`: Client certificate to access the repository.
+* `--dist-dir`: Dist directory where built artifact are stored. Default is `dist`.
+* `--build`: Build the package before publishing.
+* `--dry-run`: Perform all actions except upload the package.
+* `--skip-existing`: Ignore errors from files already existing in the repository.
+
+{{% note %}}
+See [Configuring Credentials]({{< relref "repositories/#configuring-credentials" >}}) for more information on how to configure credentials.
+{{% /note %}}
+
+## remove
+
+The `remove` command removes a package from the current
+list of installed packages.
+
+```bash
+poetry remove pendulum
+```
+
+If you want to remove a package from a specific group of dependencies, you can use the `--group (-G)` option:
+
+```bash
+poetry remove mkdocs --group docs
+```
+
+See [Dependency groups]({{< relref "managing-dependencies#dependency-groups" >}}) for more information
+about dependency groups.
+
+#### Options
+
+* `--group (-G)`: The group to remove the dependency from.
+* `--dev (-D)`: Removes a package from the development dependencies. (shortcut for `-G dev`)
+* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables `--verbose`).
+* `--lock`: Do not perform operations (only update the lockfile).
+
+## run
+
+The `run` command executes the given command inside the project's virtualenv.
+
+```bash
+poetry run python -V
+```
+
+It can also execute one of the scripts defined in `pyproject.toml`.
+
+So, if you have a script defined like this:
+
+{{< tabs tabTotal="2" tabID1="script-project" tabID2=script-poetry" tabName1="[project]" tabName2="[tool.poetry]">}}
+
+{{< tab tabID="script-project" >}}
+```toml
+[project]
+# ...
+[project.scripts]
+my-script = "my_module:main"
+```
+{{< /tab >}}
+
+{{< tab tabID="script-poetry" >}}
+```toml
+[tool.poetry.scripts]
+my-script = "my_module:main"
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+You can execute it like so:
+
+```bash
+poetry run my-script
+```
+
+Note that this command has no option.
+
+## search
+
+This command searches for packages on a remote index.
+
+```bash
+poetry search requests pendulum
+```
+
+{{% note %}}
+PyPI no longer allows for the search of packages without a browser. Please use https://pypi.org/search
+(via a browser) instead.
+
+For more information please see [warehouse documentation](https://warehouse.pypa.io/api-reference/xml-rpc.html#deprecated-methods)
+and this [discussion](https://discuss.python.org/t/fastly-interfering-with-pypi-search/73597/6).
+{{% /note %}}
 
 ## self
 
@@ -1120,22 +833,23 @@ poetry self add artifacts-keyring
 * `--source`: Name of the source to use to install the package.
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
 
-### self update
+### self install
 
-The `self update` command updates Poetry version in its current runtime environment.
+The `self install` command ensures all additional packages specified are installed in the current
+runtime environment.
 
 {{% note %}}
-The `self update` command works exactly like the [`update` command](#update). However,
-is different in that the packages managed are for Poetry's runtime environment.
+The `self install` command works similar to the [`install` command](#install). However,
+it is different in that the packages managed are for Poetry's runtime environment.
 {{% /note %}}
 
 ```bash
-poetry self update
+poetry self install
 ```
 
 #### Options
 
-* `--preview`: Allow the installation of pre-release versions.
+* `--sync`: Synchronize the environment with the locked packages and the specified groups. (**Deprecated**, use `poetry self sync` instead)
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
 
 ### self lock
@@ -1150,6 +864,18 @@ poetry self lock
 #### Options
 
 * `--regenerate`: Ignore existing lock file and overwrite it with a new lock file created from scratch.
+
+### self remove
+
+The `self remove` command removes an installed addon package.
+
+```bash
+poetry self remove poetry-plugin-export
+```
+
+#### Options
+
+* `--dry-run`: Outputs the operations but will not execute anything (implicitly enables `--verbose`).
 
 ### self show
 
@@ -1179,37 +905,6 @@ The `self show plugins` command lists all the currently installed plugins.
 poetry self show plugins
 ```
 
-### self remove
-
-The `self remove` command removes an installed addon package.
-
-```bash
-poetry self remove poetry-plugin-export
-```
-
-#### Options
-
-* `--dry-run`: Outputs the operations but will not execute anything (implicitly enables `--verbose`).
-
-### self install
-
-The `self install` command ensures all additional packages specified are installed in the current
-runtime environment.
-
-{{% note %}}
-The `self install` command works similar to the [`install` command](#install). However,
-it is different in that the packages managed are for Poetry's runtime environment.
-{{% /note %}}
-
-```bash
-poetry self install
-```
-
-#### Options
-
-* `--sync`: Synchronize the environment with the locked packages and the specified groups. (**Deprecated**, use `poetry self sync` instead)
-* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
-
 ### self sync
 
 The `self sync` command ensures all additional (and no other) packages specified
@@ -1228,23 +923,319 @@ poetry self sync
 
 * `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
 
-## export
+### self update
 
-{{% warning %}}
-This command is provided by the [Export Poetry Plugin](https://github.com/python-poetry/poetry-plugin-export).
-The plugin is no longer installed by default with Poetry 2.0.
-
-See [Using plugins]({{< relref "plugins#using-plugins" >}}) for information on how to install a plugin.
-As described in [Project plugins]({{< relref "plugins#project-plugins" >}}),
-you can also define in your `pyproject.toml` that the plugin is required for the development of your project:
-
-```toml
-[tool.poetry.requires-plugins]
-poetry-plugin-export = ">=1.8"
-```
-{{% /warning %}}
+The `self update` command updates Poetry version in its current runtime environment.
 
 {{% note %}}
-The `export` command is also available as a pre-commit hook.
-See [pre-commit hooks]({{< relref "pre-commit-hooks#poetry-export" >}}) for more information.
+The `self update` command works exactly like the [`update` command](#update). However,
+is different in that the packages managed are for Poetry's runtime environment.
 {{% /note %}}
+
+```bash
+poetry self update
+```
+
+#### Options
+
+* `--preview`: Allow the installation of pre-release versions.
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
+
+## shell
+
+The `shell` command was moved to a plugin: [`poetry-plugin-shell`](https://github.com/python-poetry/poetry-plugin-shell)
+
+## show
+
+To list all the available packages, you can use the `show` command.
+
+```bash
+poetry show
+```
+
+If you want to see the details of a certain package, you can pass the package name.
+
+```bash
+poetry show pendulum
+
+name        : pendulum
+version     : 1.4.2
+description : Python datetimes made easy
+
+dependencies
+ - python-dateutil >=2.6.1
+ - tzlocal >=1.4
+ - pytzdata >=2017.2.2
+
+required by
+ - calendar requires >=1.4.0
+```
+
+#### Options
+
+* `--without`: The dependency groups to ignore.
+* `--why`: When showing the full list, or a `--tree` for a single package, display whether they are a direct dependency or required by other packages.
+* `--with`: The optional dependency groups to include.
+* `--only`: The only dependency groups to include.
+* `--tree`: List the dependencies as a tree.
+* `--latest (-l)`: Show the latest version.
+* `--outdated (-o)`: Show the latest version but only for packages that are outdated.
+* `--all (-a)`: Show all packages (even those not compatible with current system).
+* `--top-level (-T)`: Only show explicitly defined packages.
+
+{{% note %}}
+When `--only` is specified, `--with` and `--without` options are ignored.
+{{% /note %}}
+
+## source
+
+The `source` namespace regroups sub commands to manage repository sources for a Poetry project.
+
+### source add
+
+The `source add` command adds source configuration to the project.
+
+For example, to add the `pypi-test` source, you can run:
+
+```bash
+poetry source add pypi-test https://test.pypi.org/simple/
+```
+
+You cannot use the name `pypi` for a custom repository as it is reserved for use by
+the default PyPI source. However, you can set the priority of PyPI:
+
+```bash
+poetry source add --priority=explicit pypi
+```
+
+#### Options
+
+* `--priority`: Set the priority of this source. Accepted values are: [`supplemental`]({{< relref "repositories#supplemental-package-sources" >}}), and [`explicit`]({{< relref "repositories#explicit-package-sources" >}}). Refer to the dedicated sections in [Repositories]({{< relref "repositories" >}}) for more information.
+
+### source show
+
+The `source show` command displays information on all configured sources for the project.
+
+```bash
+poetry source show
+```
+
+Optionally, you can show information of one or more sources by specifying their names.
+
+```bash
+poetry source show pypi-test
+```
+
+{{% note %}}
+This command will only show sources configured via the `pyproject.toml`
+and does not include the implicit default PyPI.
+{{% /note %}}
+
+### source remove
+
+The `source remove` command removes a configured source from your `pyproject.toml`.
+
+```bash
+poetry source remove pypi-test
+```
+
+## sync
+
+The `sync` command makes sure that the project's environment is in sync with the `poetry.lock` file.
+It is similar to `poetry install` but it additionally removes packages that are not tracked in the lock file.
+
+```bash
+poetry sync
+```
+
+If there is a `poetry.lock` file in the current directory,
+it will use the exact versions from there instead of resolving them.
+This ensures that everyone using the library will get the same versions of the dependencies.
+
+If there is no `poetry.lock` file, Poetry will create one after dependency resolution.
+
+If you want to exclude one or more dependency groups for the installation, you can use
+the `--without` option.
+
+```bash
+poetry sync --without test,docs
+```
+
+You can also select optional dependency groups with the `--with` option.
+
+```bash
+poetry sync --with test,docs
+```
+
+To install all dependency groups including the optional groups, use the ``--all-groups`` flag.
+
+```bash
+poetry sync --all-groups
+```
+
+It's also possible to only install specific dependency groups by using the `only` option.
+
+```bash
+poetry sync --only test,docs
+```
+
+To only install the project itself with no dependencies, use the `--only-root` flag.
+
+```bash
+poetry sync --only-root
+```
+
+See [Dependency groups]({{< relref "managing-dependencies#dependency-groups" >}}) for more information
+about dependency groups.
+
+You can also specify the extras you want installed
+by passing the `-E|--extras` option (See [Extras]({{< relref "pyproject#extras" >}}) for more info).
+Pass `--all-extras` to install all defined extras for a project.
+
+```bash
+poetry sync --extras "mysql pgsql"
+poetry sync -E mysql -E pgsql
+poetry sync --all-extras
+```
+
+Any extras not specified will always be removed.
+
+```bash
+poetry sync --extras "A B"  # C is removed
+```
+
+By default `poetry` will install your project's package every time you run `sync`:
+
+```bash
+$ poetry sync
+Installing dependencies from lock file
+
+No dependencies to install or update
+
+  - Installing <your-package-name> (x.x.x)
+```
+
+If you want to skip this installation, use the `--no-root` option.
+
+```bash
+poetry sync --no-root
+```
+
+Similar to `--no-root` you can use `--no-directory` to skip directory path dependencies:
+
+```bash
+poetry sync --no-directory
+```
+
+This is mainly useful for caching in CI or when building Docker images. See the [FAQ entry]({{< relref "faq#poetry-busts-my-docker-cache-because-it-requires-me-to-copy-my-source-files-in-before-installing-3rd-party-dependencies" >}}) for more information on this option.
+
+By default `poetry` does not compile Python source files to bytecode during installation.
+This speeds up the installation process, but the first execution may take a little more
+time because Python then compiles source files to bytecode automatically.
+If you want to compile source files to bytecode during installation,
+you can use the `--compile` option:
+
+```bash
+poetry sync --compile
+```
+
+#### Options
+
+* `--without`: The dependency groups to ignore.
+* `--with`: The optional dependency groups to include.
+* `--only`: The only dependency groups to include.
+* `--only-root`: Install only the root project, exclude all dependencies.
+* `--no-root`: Do not install the root package (your project).
+* `--no-directory`: Skip all directory path dependencies (including transitive ones).
+* `--dry-run`: Output the operations but do not execute anything (implicitly enables `--verbose`).
+* `--extras (-E)`: Features to install (multiple values allowed).
+* `--all-extras`: Install all extra features (conflicts with `--extras`).
+* `--all-groups`: Install dependencies from all groups (conflicts with `--only`, `--with`, and `--without`).
+* `--compile`: Compile Python source files to bytecode.
+
+{{% note %}}
+When `--only` is specified, `--with` and `--without` options are ignored.
+{{% /note %}}
+
+## update
+
+In order to get the latest versions of the dependencies and to update the `poetry.lock` file,
+you should use the `update` command.
+
+```bash
+poetry update
+```
+
+This will resolve all dependencies of the project and write the exact versions into `poetry.lock`.
+
+If you just want to update a few packages and not all, you can list them as such:
+
+```bash
+poetry update requests toml
+```
+
+Note that this will not update versions for dependencies outside their
+[version constraints]({{< relref "dependency-specification#version-constraints" >}})
+specified in the `pyproject.toml` file.
+In other terms, `poetry update foo` will be a no-op if the version constraint
+specified for `foo` is `~2.3` or `2.3` and `2.4` is available.
+In order for `foo` to be updated, you must update the constraint, for example `^2.3`.
+You can do this using the `add` command.
+
+#### Options
+
+* `--without`: The dependency groups to ignore.
+* `--with`: The optional dependency groups to include.
+* `--only`: The only dependency groups to include.
+* `--dry-run` : Outputs the operations but will not execute anything (implicitly enables `--verbose`).
+* `--lock` : Do not perform install (only update the lockfile).
+* `--sync`: Synchronize the environment with the locked packages and the specified groups.
+
+{{% note %}}
+When `--only` is specified, `--with` and `--without` options are ignored.
+{{% /note %}}
+
+## version
+
+This command shows the current version of the project or bumps the version of
+the project and writes the new version back to `pyproject.toml` if a valid
+bump rule is provided.
+
+The new version should be a valid [PEP 440](https://peps.python.org/pep-0440/)
+string or a valid bump rule: `patch`, `minor`, `major`, `prepatch`, `preminor`,
+`premajor`, `prerelease`.
+
+{{% note %}}
+
+If you would like to use semantic versioning for your project, please see
+[here]({{< relref "libraries#versioning" >}}).
+
+{{% /note %}}
+
+The table below illustrates the effect of these rules with concrete examples.
+
+| rule       | before  | after   |
+| ---------- |---------|---------|
+| major      | 1.3.0   | 2.0.0   |
+| minor      | 2.1.4   | 2.2.0   |
+| patch      | 4.1.1   | 4.1.2   |
+| premajor   | 1.0.2   | 2.0.0a0 |
+| preminor   | 1.0.2   | 1.1.0a0 |
+| prepatch   | 1.0.2   | 1.0.3a0 |
+| prerelease | 1.0.2   | 1.0.3a0 |
+| prerelease | 1.0.3a0 | 1.0.3a1 |
+| prerelease | 1.0.3b0 | 1.0.3b1 |
+
+The option `--next-phase` allows the increment of prerelease phase versions.
+
+| rule                    | before   | after    |
+|-------------------------|----------|----------|
+| prerelease --next-phase | 1.0.3a0  | 1.0.3b0  |
+| prerelease --next-phase | 1.0.3b0  | 1.0.3rc0 |
+| prerelease --next-phase | 1.0.3rc0 | 1.0.3    |
+
+#### Options
+
+* `--next-phase`: Increment the phase of the current version.
+* `--short (-s)`: Output the version number only.
+* `--dry-run`: Do not update pyproject.toml file.


### PR DESCRIPTION
This has been bugging me for a while now. This change attempts the following.

1. Commands and sub-commands are ordered ascending alphabetically.
2. All option sections use `####` headings.

![image](https://github.com/user-attachments/assets/9720ca3a-dbe3-4d98-b42b-9d1d1df30e4c)


## Summary by Sourcery

Documentation:
- Reordered commands and sub-commands alphabetically. Standardized option section headings to `####`.