### PR TITLE
fix(env): isolated env must validate requirements

### DIFF
--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -329,7 +329,8 @@ def test_info_no_setup_pkg_info_no_deps_dynamic(fixture_dir: FixtureDirGetter) -
 def test_info_setup_simple(mocker: MockerFixture, demo_setup: Path) -> None:
     spy = mocker.spy(VirtualEnv, "run")
     info = PackageInfo.from_directory(demo_setup)
-    assert spy.call_count == 4
+
+    assert spy.call_count == 6
     demo_check_info(info, requires_dist={"package"})
 
 


### PR DESCRIPTION
This change ensures that when an isolated environment is created, the temporary lockfile created does not consider dependencies that are not valid for the environment. This reduces the possibility of constraint errors when building dependencies from source that use complex build-system requirements.

Resolves: #8409

## Summary by Sourcery

Validate dependencies before installing them in an isolated environment. This prevents constraint errors during dependency resolution, especially for complex build systems.

Bug Fixes:
- Fixed an issue where invalid dependencies could cause constraint errors when building in an isolated environment.

Tests:
- Added tests to verify that only valid dependencies are installed in an isolated environment.