### PR TITLE
feat(app): add better error for removed commands

### DIFF
--- a/tests/console/test_application_removed_commands.py
+++ b/tests/console/test_application_removed_commands.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cleo.testers.application_tester import ApplicationTester
+
+from poetry.console.application import COMMAND_NOT_FOUND_PREFIX_MESSAGE
+from poetry.console.application import Application
+
+
+if TYPE_CHECKING:
+    from tests.types import CommandFactory
+
+
+@pytest.fixture
+def tester() -> ApplicationTester:
+    return ApplicationTester(Application())
+
+
+def test_application_removed_command_default_message(
+    tester: ApplicationTester,
+) -> None:
+    tester.execute("nonexistent")
+    assert tester.status_code != 0
+
+    stderr = tester.io.fetch_error()
+    assert COMMAND_NOT_FOUND_PREFIX_MESSAGE not in stderr
+    assert 'The command "nonexistent" does not exist.' in stderr
+
+
+@pytest.mark.parametrize(
+    ("command", "message"),
+    [
+        ("shell", "shell command is not installed by default"),
+    ],
+)
+def test_application_removed_command_messages(
+    command: str,
+    message: str,
+    tester: ApplicationTester,
+    command_factory: CommandFactory,
+) -> None:
+    # ensure precondition is met
+    assert not tester.application.has(command)
+
+    # verify that the custom message is returned and command fails
+    tester.execute(command)
+    assert tester.status_code != 0
+
+    stderr = tester.io.fetch_error()
+    assert COMMAND_NOT_FOUND_PREFIX_MESSAGE in stderr
+    assert message in stderr
+
+    # flush any output/error messages to ensure consistency
+    tester.io.clear()
+
+    # add a mock command and verify the command succeeds and no error message is provided
+    message = "The shell command was called"
+    tester.application.add(command_factory(command, command_handler=message))
+    assert tester.application.has(command)
+
+    tester.execute(command)
+    assert tester.status_code == 0
+
+    stdout = tester.io.fetch_output()
+    stderr = tester.io.fetch_error()
+    assert message in stdout
+    assert COMMAND_NOT_FOUND_PREFIX_MESSAGE not in stderr
+    assert stderr == ""

--- a/tests/types.py
+++ b/tests/types.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
     from contextlib import AbstractContextManager
     from pathlib import Path
 
+    from cleo.io.inputs.argument import Argument
+    from cleo.io.inputs.option import Option
     from cleo.io.io import IO
     from cleo.testers.command_tester import CommandTester
     from httpretty.core import HTTPrettyRequest
@@ -17,6 +19,7 @@ if TYPE_CHECKING:
 
     from poetry.config.config import Config
     from poetry.config.source import Source
+    from poetry.console.commands.command import Command
     from poetry.installation import Installer
     from poetry.installation.executor import Executor
     from poetry.poetry import Poetry
@@ -63,6 +66,18 @@ class ProjectFactory(Protocol):
         locker_config: dict[str, Any] | None = None,
         use_test_locker: bool = True,
     ) -> Poetry: ...
+
+
+class CommandFactory(Protocol):
+    def __call__(
+        self,
+        command_name: str,
+        command_arguments: list[Argument] | None = None,
+        command_options: list[Option] | None = None,
+        command_description: str = "",
+        command_help: str = "",
+        command_handler: Callable[[Command], int] | str | None = None,
+    ) -> Command: ...
 
 
 class FixtureDirGetter(Protocol):


### PR DESCRIPTION
In cases like the `shell` command, where it has been moved to a plugin, allow Poetry to provide a better UX when these commands are called.

When rendered this looks like the following.

![image](https://github.com/user-attachments/assets/a4864dd6-0811-4714-b1d5-22b52cc7a8af)

## Summary by Sourcery

Tests:
- Add tests for removed command error messages.