### PR TITLE
Fix warnings in the test suite

### DIFF
--- a/tests/config/test_file_config_source.py
+++ b/tests/config/test_file_config_source.py
@@ -43,7 +43,7 @@ def test_file_config_source_remove_property(tmp_path: Path) -> None:
     }
 
     config = tmp_path.joinpath("config.toml")
-    with config.open(mode="w") as f:
+    with config.open(mode="w", encoding="utf-8") as f:
         f.write(tomlkit.dumps(config_data))
 
     config_source = FileConfigSource(TOMLFile(config))
@@ -68,7 +68,7 @@ def test_file_config_source_get_property(tmp_path: Path) -> None:
     }
 
     config = tmp_path.joinpath("config.toml")
-    with config.open(mode="w") as f:
+    with config.open(mode="w", encoding="utf-8") as f:
         f.write(tomlkit.dumps(config_data))
 
     config_source = FileConfigSource(TOMLFile(config))

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -603,7 +603,7 @@ def test_config_migrate(
     mocker.patch("poetry.locations.CONFIG_DIR", config_dir)
 
     config_file = Path(config_dir / "config.toml")
-    with config_file.open("w") as fh:
+    with config_file.open("w", encoding="utf-8") as fh:
         fh.write(current_config)
 
     tester.execute("--migrate", inputs=proceed)
@@ -617,7 +617,7 @@ def test_config_migrate(
     output = tester.io.fetch_output()
     assert output.startswith(expected_output)
 
-    with config_file.open("r") as fh:
+    with config_file.open("r", encoding="utf-8") as fh:
         assert fh.read() == expected_config
 
 
@@ -631,7 +631,7 @@ def test_config_migrate_local_config(tester: CommandTester, poetry: Poetry) -> N
     prefer-active-python = false
     """)
 
-    with local_config.open("w") as fh:
+    with local_config.open("w", encoding="utf-8") as fh:
         fh.write(config_data)
 
     tester.execute("--migrate --local", inputs="yes")
@@ -643,7 +643,7 @@ def test_config_migrate_local_config(tester: CommandTester, poetry: Poetry) -> N
         use-poetry-python = true
         """)
 
-    with local_config.open("r") as fh:
+    with local_config.open("r", encoding="utf-8") as fh:
         assert fh.read() == expected_config
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -122,6 +122,9 @@ def mock_clone(
 
 
 class TestExecutor(Executor):
+    # class name begins 'Test': tell pytest that it does not contain testcases.
+    __test__ = False
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -330,7 +330,7 @@ def test_ensure_path_file(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         ensure_path(path=path, is_directory=False)
 
-    path.write_text("foobar")
+    path.write_text("foobar", encoding="utf-8")
     assert ensure_path(path=path, is_directory=False) is path
 
 


### PR DESCRIPTION
The test suite is raising some warnings. This PR fixes the ones that come from our tests.

## Summary by Sourcery

Tests:
- Fix warnings in tests by setting the encoding when opening files.