### PR TITLE
fix(keyring): make keyring unlock thread safe

### DIFF
--- a/src/poetry/console/commands/installer_command.py
+++ b/src/poetry/console/commands/installer_command.py
@@ -4,9 +4,12 @@ from typing import TYPE_CHECKING
 
 from poetry.console.commands.env_command import EnvCommand
 from poetry.console.commands.group_command import GroupCommand
+from poetry.utils.password_manager import PoetryKeyring
 
 
 if TYPE_CHECKING:
+    from cleo.io.io import IO
+
     from poetry.installation.installer import Installer
 
 
@@ -30,3 +33,7 @@ class InstallerCommand(GroupCommand, EnvCommand):
 
     def set_installer(self, installer: Installer) -> None:
         self._installer = installer
+
+    def execute(self, io: IO) -> int:
+        PoetryKeyring.preflight_check(io, self.poetry.config)
+        return super().execute(io)

--- a/src/poetry/utils/threading.py
+++ b/src/poetry/utils/threading.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import functools
+import threading
+
+from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import overload
+from weakref import WeakKeyDictionary
+
+
+if TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+
+
+T = TypeVar("T")
+C = TypeVar("C", bound=object)
+
+
+class AtomicCachedProperty(functools.cached_property[T]):
+    def __init__(self, func: Callable[[C], T]) -> None:
+        super().__init__(func)
+        self._semaphore = threading.BoundedSemaphore()
+        self._locks: WeakKeyDictionary[object, threading.Lock] = WeakKeyDictionary()
+
+    @overload
+    def __get__(
+        self, instance: None, owner: type[Any] | None = ...
+    ) -> AtomicCachedProperty[T]: ...
+    @overload
+    def __get__(self, instance: object, owner: type[Any] | None = ...) -> T: ...
+
+    def __get__(
+        self, instance: C | None, owner: type[Any] | None = None
+    ) -> AtomicCachedProperty[T] | T:
+        # If there's no instance, return the descriptor itself
+        if instance is None:
+            return self
+
+        if instance not in self._locks:
+            with self._semaphore:
+                # we double-check the lock has not been created by another thread
+                if instance not in self._locks:
+                    self._locks[instance] = threading.Lock()
+
+        # Use a thread-safe lock to ensure the property is computed only once
+        with self._locks[instance]:
+            return super().__get__(instance, owner)
+
+
+def atomic_cached_property(func: Callable[[C], T]) -> AtomicCachedProperty[T]:
+    """
+    A thread-safe implementation of functools.cached_property that ensures lazily-computed
+    properties are calculated only once, even in multithreaded environments.
+
+    This property decorator works similar to functools.cached_property but employs
+    thread locks and a bounded semaphore to handle concurrent access safely.
+
+    The computed value is cached on the instance itself and is reused for subsequent
+    accesses unless explicitly invalidated. The added thread-safety makes it ideal for
+    situations where multiple threads might access and compute the property simultaneously.
+
+    Note:
+    - The cache is stored in the instance dictionary just like `functools.cached_property`.
+
+    :param func: The function to be turned into a thread-safe cached property.
+    """
+    return AtomicCachedProperty(func)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ from tests.helpers import get_package
 from tests.helpers import http_setup_redirect
 from tests.helpers import isolated_environment
 from tests.helpers import mock_clone
+from tests.helpers import set_keyring_backend
 from tests.helpers import switch_working_directory
 from tests.helpers import with_working_directory
 
@@ -204,29 +205,29 @@ def dummy_keyring() -> DummyBackend:
 
 @pytest.fixture()
 def with_simple_keyring(dummy_keyring: DummyBackend) -> None:
-    keyring.set_keyring(dummy_keyring)
+    set_keyring_backend(dummy_keyring)
 
 
 @pytest.fixture()
 def with_fail_keyring() -> None:
-    keyring.set_keyring(FailKeyring())  # type: ignore[no-untyped-call]
+    set_keyring_backend(FailKeyring())  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture()
 def with_locked_keyring() -> None:
-    keyring.set_keyring(LockedBackend())  # type: ignore[no-untyped-call]
+    set_keyring_backend(LockedBackend())  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture()
 def with_erroneous_keyring() -> None:
-    keyring.set_keyring(ErroneousBackend())  # type: ignore[no-untyped-call]
+    set_keyring_backend(ErroneousBackend())  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture()
 def with_null_keyring() -> None:
     from keyring.backends.null import Keyring
 
-    keyring.set_keyring(Keyring())  # type: ignore[no-untyped-call]
+    set_keyring_backend(Keyring())  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture()
@@ -237,7 +238,7 @@ def with_chained_fail_keyring(mocker: MockerFixture) -> None:
     )
     from keyring.backends.chainer import ChainerBackend
 
-    keyring.set_keyring(ChainerBackend())  # type: ignore[no-untyped-call]
+    set_keyring_backend(ChainerBackend())  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture()
@@ -250,7 +251,7 @@ def with_chained_null_keyring(mocker: MockerFixture) -> None:
     )
     from keyring.backends.chainer import ChainerBackend
 
-    keyring.set_keyring(ChainerBackend())  # type: ignore[no-untyped-call]
+    set_keyring_backend(ChainerBackend())  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture
@@ -633,3 +634,8 @@ def command_factory() -> CommandFactory:
         return MockCommand()
 
     return _command_factory
+
+
+@pytest.fixture(autouse=True)
+def default_keyring(with_null_keyring: None) -> None:
+    pass

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,6 +8,8 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import keyring
+
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.vcs.git import ParsedUrl
@@ -20,6 +22,7 @@ from poetry.packages import Locker
 from poetry.repositories import Repository
 from poetry.repositories.exceptions import PackageNotFoundError
 from poetry.utils._compat import metadata
+from poetry.utils.password_manager import PoetryKeyring
 
 
 if TYPE_CHECKING:
@@ -30,6 +33,7 @@ if TYPE_CHECKING:
     import httpretty
 
     from httpretty.core import HTTPrettyRequest
+    from keyring.backend import KeyringBackend
     from poetry.core.constraints.version import Version
     from poetry.core.packages.dependency import Dependency
     from pytest_mock import MockerFixture
@@ -356,3 +360,9 @@ def with_working_directory(source: Path, target: Path | None = None) -> Iterator
 
     with switch_working_directory(target or source, remove=use_copy) as path:
         yield path
+
+
+def set_keyring_backend(backend: KeyringBackend) -> None:
+    """Clears availability cache and sets the specified keyring backend."""
+    PoetryKeyring.is_available.cache_clear()
+    keyring.set_keyring(backend)

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -285,16 +285,18 @@ def test_fail_keyring_should_be_unavailable(
     assert not key_ring.is_available()
 
 
-def test_locked_keyring_should_be_available(with_locked_keyring: None) -> None:
+def test_locked_keyring_should_not_be_available(with_locked_keyring: None) -> None:
     key_ring = PoetryKeyring("poetry")
 
-    assert key_ring.is_available()
+    assert not key_ring.is_available()
 
 
-def test_erroneous_keyring_should_be_available(with_erroneous_keyring: None) -> None:
+def test_erroneous_keyring_should_not_be_available(
+    with_erroneous_keyring: None,
+) -> None:
     key_ring = PoetryKeyring("poetry")
 
-    assert key_ring.is_available()
+    assert not key_ring.is_available()
 
 
 def test_get_http_auth_from_environment_variables(

--- a/tests/utils/test_threading.py
+++ b/tests/utils/test_threading.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import sys
+import time
+
+from concurrent.futures import wait
+from concurrent.futures.thread import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+import pytest
+
+from poetry.utils.threading import AtomicCachedProperty
+from poetry.utils.threading import atomic_cached_property
+
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
+
+
+WORKER_COUNT = (os.cpu_count() or 1) + 4
+EXPECTED_VALUE = sum(range(1_00_000))
+IS_PY_312 = (sys.version_info.major, sys.version_info.minor) >= (3, 12)
+
+
+class Example:
+    def __init__(self, value: int = 0, name: str = "default") -> None:
+        self.value = value
+        self._name = name
+
+    @classmethod
+    def compute_value(cls, name: str, ts: float) -> int:
+        logging.getLogger().info(
+            "Example compute_value called with name=%s time=%f", name, ts
+        )
+        return sum(range(1_00_000))
+
+    def _compute_value(self) -> int:
+        # we block the thread here to ensure contention
+        time.sleep(0.05)
+        return self.compute_value(self._name, time.time())
+
+    @functools.cached_property
+    def value_functools_cached_property(self) -> int:
+        return self._compute_value() + self.value
+
+    @property
+    @functools.cache  # noqa: B019
+    def value_functools_cache(self) -> int:
+        return self._compute_value() + self.value
+
+    @atomic_cached_property
+    def value_atomic_cached_property(self) -> int:
+        return self._compute_value() + self.value
+
+
+@pytest.fixture(autouse=True)
+def capture_logging(caplog: LogCaptureFixture) -> Generator[None]:
+    with caplog.at_level(logging.DEBUG):
+        yield
+
+
+def test_threading_property_types() -> None:
+    assert isinstance(Example.value_atomic_cached_property, AtomicCachedProperty)
+    assert isinstance(
+        Example.value_functools_cached_property, functools.cached_property
+    )
+    assert isinstance(Example.value_functools_cache, property)
+
+
+def test_threading_single_thread_safe() -> None:
+    instance = Example()
+    assert (
+        instance.value_functools_cached_property
+        == instance.value_atomic_cached_property
+        == EXPECTED_VALUE
+    )
+
+
+def run_in_threads(instance: Example, property_name: str) -> None:
+    results = []
+
+    def access_property() -> None:
+        results.append(instance.__getattribute__(property_name))
+
+    executor = ThreadPoolExecutor(max_workers=WORKER_COUNT)
+    futures = [executor.submit(access_property) for _ in range(WORKER_COUNT)]
+
+    wait(futures)
+    assert len(results) == WORKER_COUNT
+    assert all(result == (EXPECTED_VALUE + instance.value) for result in results)
+
+
+@pytest.mark.parametrize(
+    ["property_name", "expected_call_count"],
+    [
+        ("value_atomic_cached_property", 1),
+        # prior to Python 3.12, cached_property did have a thread lock
+        ("value_functools_cached_property", WORKER_COUNT if IS_PY_312 else 1),
+        ("value_functools_cache", WORKER_COUNT),
+    ],
+)
+def test_threading_property_caching(
+    property_name: str,
+    expected_call_count: int,
+    mocker: MockerFixture,
+    caplog: LogCaptureFixture,
+) -> None:
+    compute_value_spy = mocker.spy(Example, "compute_value")
+    run_in_threads(Example(), property_name)
+    assert compute_value_spy.call_count == len(caplog.messages) == expected_call_count
+
+
+@pytest.mark.parametrize(
+    ["property_name", "expected_call_count"],
+    [
+        ("value_atomic_cached_property", 2),
+        # prior to Python 3.12, cached_property did have a thread lock
+        ("value_functools_cached_property", (WORKER_COUNT if IS_PY_312 else 1) * 2),
+        ("value_functools_cache", WORKER_COUNT * 2),
+    ],
+)
+def test_threading_atomic_cached_property_different_instances(
+    property_name: str,
+    expected_call_count: int,
+    mocker: MockerFixture,
+    caplog: LogCaptureFixture,
+) -> None:
+    compute_value_spy = mocker.spy(Example, "compute_value")
+
+    instance1 = Example(10, "one")
+    instance2 = Example(20, "two")
+
+    run_in_threads(instance1, property_name)
+    run_in_threads(instance2, property_name)
+
+    assert compute_value_spy.call_count == len(caplog.messages) == expected_call_count
+
+    assert instance1.__getattribute__(property_name) == EXPECTED_VALUE + 10
+    assert instance2.__getattribute__(property_name) == EXPECTED_VALUE + 20


### PR DESCRIPTION
When using `poetry install`, Poetry executor prefers to execute  operations using a `concurrent.futures.ThreadPoolExecutor`. This can lead to multiple credential store unlock requests to be dispatched simultaneously.

If the credential store is locked, and a user either intentionally or unintentionally dismisses the prompt to provide the store password; or the dbus messages fail to launch the prompter the Poetry user can experience, what can appear as a "hang". This in fact can be several threads competing with each other waiting for a dbus event indefinitely; this is a consequence of how Poetry uses keyring.

This change introduces the following:

- pre-flight check for installer commands that ensures keyring unlocks only once for the duration of the command
- improved logging of keyring unlock event and/or failure
- thread safe caching of `PasswordManager.<use_keyring|keyring>`
- the `@atomic_cached_property` decorator

This change does not address the following:

- handling cases where dbus message fails or prompter is blocked
- authentication of a locked keyring in a non-tty session

I am also open to consider an alternative for `@atomic_cached_property` as I am not so comfortable having to implement something like this unless we really need it.

Resolves: #8623

## Summary by Sourcery

Make keyring unlock thread-safe and improve logging.

Bug Fixes:
- Fix a hang that could occur when multiple threads attempt to unlock the keyring simultaneously.

Enhancements:
- Add a pre-flight check to ensure keyring unlocks only once during a command.
- Improve logging of keyring unlock events and failures.
- Introduce thread-safe caching for `PasswordManager` properties.

Tests:
- Update tests to reflect changes in keyring handling.