### PR TITLE
fix(add): do not pass @latest to parser

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from collections.abc import Mapping
 from contextlib import suppress
 from pathlib import Path
@@ -470,7 +472,10 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             env=self.env if isinstance(self, EnvCommand) else None,
             cwd=cwd,
         )
-        return [parser.parse(requirement) for requirement in requirements]
+        return [
+            parser.parse(re.sub(r"@\s*latest$", "", requirement, flags=re.I))
+            for requirement in requirements
+        ]
 
     def _format_requirements(self, requirements: list[dict[str, str]]) -> Requirements:
         requires: Requirements = {}


### PR DESCRIPTION
We should not pass in front-end specific `@latest` descriptor to the core requirement parser.

Relates-to: #10068

## Summary by Sourcery

Strip out the '@latest' descriptor from requirements before parsing to prevent passing front-end specific descriptors to the core parser, and add a test to verify this behavior.

Bug Fixes:
- Fix the issue where the '@latest' descriptor was incorrectly passed to the core requirement parser by stripping it out before parsing.

Tests:
- Add a test to ensure that the '@latest' descriptor is stripped out before parsing and does not affect the package version selection.