### PR TITLE
fix(cli): make `poetry env activate` an EnvCommand (#10084)

### DIFF
--- a/src/poetry/console/commands/env/activate.py
+++ b/src/poetry/console/commands/env/activate.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import shellingham
 
-from poetry.console.commands.command import Command
+from poetry.console.commands.env_command import EnvCommand
 from poetry.utils._compat import WINDOWS
 
 
@@ -18,7 +18,7 @@ class ShellNotSupportedError(Exception):
     """Raised when a shell doesn't have an activator in virtual environment"""
 
 
-class EnvActivateCommand(Command):
+class EnvActivateCommand(EnvCommand):
     name = "env activate"
     description = "Print the command to activate a virtual environment."
 


### PR DESCRIPTION
A venv is now created upon calling this command if no one exist yet. This is similar to the behavior of `poetry shell` before.

Without having a venv in place the command would raise an error "Discovered shell doesn't have an activator in virtual environment" which is misleading.

# Pull Request Check List

Resolves: #10084

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Make the `poetry env activate` command create a virtual environment if one does not already exist.

Bug Fixes:
- Resolve an issue where `poetry env activate` would not create a virtual environment if one did not exist.

Enhancements:
- Refactor the `EnvActivateCommand` to inherit from `EnvCommand`.