### PR TITLE
feat(auth): allow passwords with empty usernames

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -531,7 +531,10 @@ required to set an empty password. This is supported by Poetry.
 poetry config http-basic.foo <TOKEN> ""
 ```
 
-**Note:** Usernames cannot be empty.  Attempting to use an empty username can result in an unpredictable failure.
+**Note:** Empty usernames are discouraged. However, Poetry will honour them if a password is configured without it. This
+is unfortunately commonplace practice, while not best practice, for private indices that use tokens. When a password is
+stored into the system keyring with an empty username, Poetry will use a literal `__poetry_source_empty_username__` as
+the username to circumvent [keyring#687](https://github.com/jaraco/keyring/pull/687).
 {{% /note %}}
 
 ## Certificates

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -27,7 +27,7 @@ class HTTPAuthCredential:
 
 
 class PoetryKeyring:
-    # some private sources expect tokens to be provided as password with that can be empty
+    # some private sources expect tokens to be provided as passwords with empty userames
     # we use a fixed literal to ensure that this can be stored in keyring (jaraco/keyring#687)
     #
     # Note: If this is changed, users with passwords stored with empty usernames will have to

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ from poetry.utils.cache import ArtifactCache
 from poetry.utils.env import EnvManager
 from poetry.utils.env import SystemEnv
 from poetry.utils.env import VirtualEnv
+from poetry.utils.password_manager import PoetryKeyring
 from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import TestLocker
 from tests.helpers import TestRepository
@@ -189,6 +190,11 @@ class ErroneousBackend(FailKeyring):
         username: str | None,
     ) -> Credential | None:
         raise KeyringError()
+
+
+@pytest.fixture()
+def poetry_keyring() -> PoetryKeyring:
+    return PoetryKeyring("poetry-repository")
 
 
 @pytest.fixture()

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
+    from poetry.utils.password_manager import PoetryKeyring
     from tests.conftest import Config
     from tests.conftest import DummyBackend
 
@@ -153,7 +154,7 @@ def test_authenticator_uses_empty_strings_as_default_password(
     assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
-def test_authenticator_ignores_empty_strings_as_default_username(
+def test_authenticator_does_not_ignore_empty_strings_as_default_username(
     config: Config,
     mock_remote: None,
     repo: dict[str, dict[str, str]],
@@ -170,7 +171,7 @@ def test_authenticator_ignores_empty_strings_as_default_username(
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-    assert request.headers["Authorization"] is None
+    assert request.headers["Authorization"] == "Basic OmJhcg=="
 
 
 def test_authenticator_falls_back_to_keyring_url(
@@ -207,6 +208,7 @@ def test_authenticator_falls_back_to_keyring_netloc(
     http: type[httpretty.httpretty],
     with_simple_keyring: None,
     dummy_keyring: DummyBackend,
+    poetry_keyring: PoetryKeyring,
 ) -> None:
     config.merge(
         {

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -171,7 +171,8 @@ def test_authenticator_does_not_ignore_empty_strings_as_default_username(
     authenticator.request("get", "https://foo.bar/files/foo-0.1.0.tar.gz")
 
     request = http.last_request()
-    assert request.headers["Authorization"] == "Basic OmJhcg=="
+    basic_auth = base64.b64encode(b":bar").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_authenticator_falls_back_to_keyring_url(

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import logging
 import os
 
@@ -42,7 +41,7 @@ def test_set_http_password(
     ("username", "password", "is_valid"),
     [
         ("bar", "baz", True),
-        ("", "baz", False),
+        ("", "baz", True),
         ("bar", "", True),
         ("", "", False),
     ],
@@ -53,10 +52,10 @@ def test_get_http_auth(
     is_valid: bool,
     config: Config,
     with_simple_keyring: None,
-    dummy_keyring: DummyBackend,
+    poetry_keyring: PoetryKeyring,
 ) -> None:
-    with contextlib.nullcontext() if username else pytest.warns(DeprecationWarning):
-        dummy_keyring.set_password("poetry-repository-foo", username, password)
+    poetry_keyring.set_password("foo", username, password)
+
     config.auth_config_source.add_property("http-basic.foo", {"username": username})
     manager = PasswordManager(config)
 
@@ -65,8 +64,8 @@ def test_get_http_auth(
 
     if is_valid:
         assert auth is not None
-        assert auth.username == username
-        assert auth.password == password
+        assert auth.username == (username or None)
+        assert auth.password == (password or None)
     else:
         assert auth.username is auth.password is None
 
@@ -137,7 +136,7 @@ def test_set_http_password_with_unavailable_backend(
     ("username", "password", "is_valid"),
     [
         ("bar", "baz", True),
-        ("", "baz", False),
+        ("", "baz", True),
         ("bar", "", True),
         ("", "", False),
     ],
@@ -159,8 +158,8 @@ def test_get_http_auth_with_unavailable_backend(
 
     if is_valid:
         assert auth is not None
-        assert auth.username == username
-        assert auth.password == password
+        assert auth.username == (username or None)
+        assert auth.password == (password or None)
     else:
         assert auth.username is auth.password is None
 


### PR DESCRIPTION
This change largely reverts the decision made in b544ed5 as it seems that it is commonplace, albeit not best practice, for private indices to require or document that users use an empty username. The change in behaviour seems to surprise users migrating from 1.x (#10085).

## Summary by Sourcery

Allow empty usernames for private repositories.

Bug Fixes:
- Fix unexpected behavior when migrating from Poetry 1.x with private indices requiring empty usernames.

Enhancements:
- Improve compatibility with private indices that require or document empty usernames for authentication.