### PR TITLE
feat(env): prefer embedded pip for poetry use

### DIFF
--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -269,11 +269,11 @@ class Env(ABC):
     @abstractmethod
     def get_marker_env(self) -> dict[str, Any]: ...
 
-    def get_pip_command(self, embedded: bool = False) -> list[str]:
-        if embedded or not Path(self._bin(self._pip_executable)).exists():
-            return [str(self.python), str(self.pip_embedded)]
-        # run as module so that pip can update itself on Windows
-        return [str(self.python), "-m", "pip"]
+    def get_pip_command(self, prefer_in_env: bool = False) -> list[str]:
+        if prefer_in_env and Path(self._bin(self._pip_executable)).exists():
+            # we run pip as module so that pip can update itself on Windows
+            return [str(self.python), "-m", "pip"]
+        return [str(self.python), str(self.pip_embedded)]
 
     @abstractmethod
     def get_supported_tags(self) -> list[Tag]: ...
@@ -295,7 +295,7 @@ class Env(ABC):
         if bin == "pip":
             # when pip is required we need to ensure that we fall back to
             # embedded pip when pip is not available in the environment
-            return self.get_pip_command()
+            return self.get_pip_command(prefer_in_env=True)
 
         return [self._bin(bin)]
 


### PR DESCRIPTION
Presently, when Poetry dispatches pip commands for uninstallation, this uses the pip version installed in the active virtual environment. This can potentially cause issues like #10089.

This change, switches to preferring the embedded pip wheel and makes preferring the in-env version the exception, while preferring it when a user uses `poetry run pip`.

See-also: #4011

## Summary by Sourcery

Bug Fixes:
- Fixes potential issues caused by using the virtual environment's pip version when uninstalling packages via Poetry.