### PR TITLE
feat(python): use findpython

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -599,6 +599,21 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "p
 typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
+name = "findpython"
+version = "0.6.2"
+description = "A utility to find python versions on your system"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "findpython-0.6.2-py3-none-any.whl", hash = "sha256:bda62477f858ea623ef2269f5e734469a018104a5f6c0fd9317ba238464ddb76"},
+    {file = "findpython-0.6.2.tar.gz", hash = "sha256:e0c75ba9f35a7f9bb4423eb31bd17358cccf15761b6837317719177aeff46723"},
+]
+
+[package.dependencies]
+packaging = ">=20"
+
+[[package]]
 name = "httpretty"
 version = "1.1.4"
 description = "HTTP client mock for Python"
@@ -1739,4 +1754,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "e12eda5cc53996f463234f41ff013a8b0aa972ffbcbe210197327660d88b0af1"
+content-hash = "aa47753624aadb8e4086016ef73a316474c4b83c58d57c0fe978bec0bb00eab6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "trove-classifiers (>=2022.5.19)",
     "virtualenv (>=20.26.6,<21.0.0)",
     "xattr (>=1.0.0,<2.0.0) ; sys_platform == 'darwin'",
+    "findpython (>=0.6.2,<0.7.0)",
 ]
 authors = [
     { name = "Sébastien Eustace", email = "sebastien@eustace.io" }
@@ -182,6 +183,7 @@ warn_unused_ignores = false
 module = [
     'deepdiff.*',
     'fastjsonschema.*',
+    'findpython.*',
     'httpretty.*',
     'requests_toolbelt.*',
     'shellingham.*',

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -17,7 +17,7 @@ from tomlkit import inline_table
 from poetry.console.commands.command import Command
 from poetry.console.commands.env_command import EnvCommand
 from poetry.utils.dependency_specification import RequirementsParser
-from poetry.utils.env.python_manager import Python
+from poetry.utils.env.python import Python
 
 
 if TYPE_CHECKING:

--- a/src/poetry/utils/env/__init__.py
+++ b/src/poetry/utils/env/__init__.py
@@ -11,9 +11,6 @@ from poetry.utils.env.env_manager import EnvManager
 from poetry.utils.env.exceptions import EnvCommandError
 from poetry.utils.env.exceptions import EnvError
 from poetry.utils.env.exceptions import IncorrectEnvError
-from poetry.utils.env.exceptions import InvalidCurrentPythonVersionError
-from poetry.utils.env.exceptions import NoCompatiblePythonVersionFoundError
-from poetry.utils.env.exceptions import PythonVersionNotFoundError
 from poetry.utils.env.generic_env import GenericEnv
 from poetry.utils.env.mock_env import MockEnv
 from poetry.utils.env.null_env import NullEnv
@@ -102,11 +99,8 @@ __all__ = [
     "EnvManager",
     "GenericEnv",
     "IncorrectEnvError",
-    "InvalidCurrentPythonVersionError",
     "MockEnv",
-    "NoCompatiblePythonVersionFoundError",
     "NullEnv",
-    "PythonVersionNotFoundError",
     "SitePackages",
     "SystemEnv",
     "VirtualEnv",

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -24,11 +24,11 @@ from poetry.utils._compat import WINDOWS
 from poetry.utils._compat import encode
 from poetry.utils.env.exceptions import EnvCommandError
 from poetry.utils.env.exceptions import IncorrectEnvError
-from poetry.utils.env.exceptions import InvalidCurrentPythonVersionError
-from poetry.utils.env.exceptions import NoCompatiblePythonVersionFoundError
-from poetry.utils.env.exceptions import PythonVersionNotFoundError
 from poetry.utils.env.generic_env import GenericEnv
-from poetry.utils.env.python_manager import Python
+from poetry.utils.env.python import Python
+from poetry.utils.env.python.exceptions import InvalidCurrentPythonVersionError
+from poetry.utils.env.python.exceptions import NoCompatiblePythonVersionFoundError
+from poetry.utils.env.python.exceptions import PythonVersionNotFoundError
 from poetry.utils.env.script_strings import GET_ENV_PATH_ONELINER
 from poetry.utils.env.script_strings import GET_PYTHON_VERSION_ONELINER
 from poetry.utils.env.system_env import SystemEnv

--- a/src/poetry/utils/env/exceptions.py
+++ b/src/poetry/utils/env/exceptions.py
@@ -31,39 +31,3 @@ class EnvCommandError(EnvError):
         if e.stderr:
             message_parts.append(f"Error output:\n{decode(e.stderr)}")
         super().__init__("\n\n".join(message_parts))
-
-
-class PythonVersionNotFoundError(EnvError):
-    def __init__(self, expected: str) -> None:
-        super().__init__(f"Could not find the python executable {expected}")
-
-
-class NoCompatiblePythonVersionFoundError(EnvError):
-    def __init__(self, expected: str, given: str | None = None) -> None:
-        if given:
-            message = (
-                f"The specified Python version ({given}) "
-                f"is not supported by the project ({expected}).\n"
-                "Please choose a compatible version "
-                "or loosen the python constraint specified "
-                "in the pyproject.toml file."
-            )
-        else:
-            message = (
-                "Poetry was unable to find a compatible version. "
-                "If you have one, you can explicitly use it "
-                'via the "env use" command.'
-            )
-
-        super().__init__(message)
-
-
-class InvalidCurrentPythonVersionError(EnvError):
-    def __init__(self, expected: str, given: str) -> None:
-        message = (
-            f"Current Python version ({given}) "
-            f"is not allowed by the project ({expected}).\n"
-            'Please change python executable via the "env use" command.'
-        )
-
-        super().__init__(message)

--- a/src/poetry/utils/env/python/__init__.py
+++ b/src/poetry/utils/env/python/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from poetry.utils.env.python.manager import Python
+
+
+__all__ = ["Python"]

--- a/src/poetry/utils/env/python/exceptions.py
+++ b/src/poetry/utils/env/python/exceptions.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+
+class PythonVersionError(Exception):
+    pass
+
+
+class PythonVersionNotFoundError(PythonVersionError):
+    def __init__(self, expected: str) -> None:
+        super().__init__(f"Could not find the python executable {expected}")
+
+
+class NoCompatiblePythonVersionFoundError(PythonVersionError):
+    def __init__(self, expected: str, given: str | None = None) -> None:
+        if given:
+            message = (
+                f"The specified Python version ({given}) "
+                f"is not supported by the project ({expected}).\n"
+                "Please choose a compatible version "
+                "or loosen the python constraint specified "
+                "in the pyproject.toml file."
+            )
+        else:
+            message = (
+                "Poetry was unable to find a compatible version. "
+                "If you have one, you can explicitly use it "
+                'via the "env use" command.'
+            )
+
+        super().__init__(message)
+
+
+class InvalidCurrentPythonVersionError(PythonVersionError):
+    def __init__(self, expected: str, given: str) -> None:
+        message = (
+            f"Current Python version ({given}) "
+            f"is not allowed by the project ({expected}).\n"
+            'Please change python executable via the "env use" command.'
+        )
+
+        super().__init__(message)

--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import shutil
 import sys
 
 from functools import cached_property
@@ -17,28 +16,15 @@ from cleo.io.null_io import NullIO
 from cleo.io.outputs.output import Verbosity
 from poetry.core.constraints.version import Version
 
-from poetry.utils.env.exceptions import NoCompatiblePythonVersionFoundError
+from poetry.utils.env.python.exceptions import NoCompatiblePythonVersionFoundError
+from poetry.utils.env.python.providers import ShutilWhichPythonProvider
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from cleo.io.io import IO
-    from typing_extensions import Self
 
     from poetry.config.config import Config
     from poetry.poetry import Poetry
-
-
-class ShutilWhichPythonProvider(findpython.BaseProvider):  # type: ignore[misc]
-    @classmethod
-    def create(cls) -> Self | None:
-        return cls()
-
-    def find_pythons(self) -> Iterable[findpython.PythonVersion]:
-        if path := shutil.which("python"):
-            return [findpython.PythonVersion(executable=Path(path))]
-        return []
 
 
 class Python:

--- a/src/poetry/utils/env/python/providers.py
+++ b/src/poetry/utils/env/python/providers.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import shutil
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import findpython
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from typing_extensions import Self
+
+
+class ShutilWhichPythonProvider(findpython.BaseProvider):  # type: ignore[misc]
+    @classmethod
+    def create(cls) -> Self | None:
+        return cls()
+
+    def find_pythons(self) -> Iterable[findpython.PythonVersion]:
+        if path := shutil.which("python"):
+            return [findpython.PythonVersion(executable=Path(path))]
+        return []

--- a/src/poetry/utils/env/python_manager.py
+++ b/src/poetry/utils/env/python_manager.py
@@ -1,52 +1,85 @@
 from __future__ import annotations
 
+import contextlib
 import shutil
-import subprocess
 import sys
 
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import cast
+from typing import overload
+
+import findpython
+import packaging.version
 
 from cleo.io.null_io import NullIO
 from cleo.io.outputs.output import Verbosity
 from poetry.core.constraints.version import Version
-from poetry.core.constraints.version import parse_constraint
 
-from poetry.utils._compat import decode
 from poetry.utils.env.exceptions import NoCompatiblePythonVersionFoundError
-from poetry.utils.env.script_strings import GET_PYTHON_VERSION_ONELINER
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from cleo.io.io import IO
+    from typing_extensions import Self
 
     from poetry.config.config import Config
     from poetry.poetry import Poetry
 
 
+class ShutilWhichPythonProvider(findpython.BaseProvider):  # type: ignore[misc]
+    @classmethod
+    def create(cls) -> Self | None:
+        return cls()
+
+    def find_pythons(self) -> Iterable[findpython.PythonVersion]:
+        if path := shutil.which("python"):
+            return [findpython.PythonVersion(executable=Path(path))]
+        return []
+
+
 class Python:
-    def __init__(self, executable: str | Path, version: Version | None = None) -> None:
-        self.executable = Path(executable)
-        self._version = version
+    @overload
+    def __init__(self, *, python: findpython.PythonVersion) -> None: ...
+
+    @overload
+    def __init__(
+        self, executable: str | Path, version: Version | None = None
+    ) -> None: ...
+
+    # we overload __init__ to ensure we do not break any downstream plugins
+    # that use the this
+    def __init__(
+        self,
+        executable: str | Path | None = None,
+        version: Version | None = None,
+        python: findpython.PythonVersion | None = None,
+    ) -> None:
+        if python and (executable or version):
+            raise ValueError(
+                "When python is provided, neither executable or version must be specified"
+            )
+
+        if python:
+            self._python = python
+        elif executable:
+            self._python = findpython.PythonVersion(
+                executable=Path(executable),
+                _version=packaging.version.Version(str(version)) if version else None,
+            )
+        else:
+            raise ValueError("Either python or executable must be provided")
+
+    @property
+    def executable(self) -> Path:
+        return cast(Path, self._python.interpreter)
 
     @property
     def version(self) -> Version:
-        if not self._version:
-            if self.executable == Path(sys.executable):
-                python_version = ".".join(str(v) for v in sys.version_info[:3])
-            else:
-                encoding = "locale" if sys.version_info >= (3, 10) else None
-                python_version = decode(
-                    subprocess.check_output(
-                        [str(self.executable), "-c", GET_PYTHON_VERSION_ONELINER],
-                        text=True,
-                        encoding=encoding,
-                    ).strip()
-                )
-            self._version = Version.parse(python_version)
-
-        return self._version
+        return Version.parse(str(self._python.version))
 
     @cached_property
     def patch_version(self) -> Version:
@@ -60,108 +93,117 @@ class Python:
     def minor_version(self) -> Version:
         return Version.from_parts(major=self.version.major, minor=self.version.minor)
 
-    @staticmethod
-    def _full_python_path(python: str) -> Path | None:
-        # eg first find pythonXY.bat on windows.
-        path_python = shutil.which(python)
-        if path_python is None:
-            return None
+    @classmethod
+    def get_active_python(cls) -> Python | None:
+        """
+        Fetches the active Python interpreter from available system paths or falls
+        back to finding the first valid Python executable named "python".
 
+        An "active Python interpreter" in this context is an executable (or a symlink)
+        with the name `python`. This is done so to detect cases where pyenv or
+        alternatives are used.
+
+        This method first uses the `ShutilWhichPythonProvider` to detect Python
+        executables in the path. If no interpreter is found using, it attempts
+        to locate a Python binary named "python" via the `findpython` library.
+
+        :return: An instance representing the detected active Python,
+                 or None if no valid environment is found.
+        """
+        for python in ShutilWhichPythonProvider().find_pythons():
+            return cls(python=python)
+
+        # fallback to findpython, restrict to finding only executables
+        # named "python" as the intention here is just that, nothing more
+        if python := findpython.find("python"):
+            return cls(python=python)
+
+        return None
+
+    @classmethod
+    def from_executable(cls, path: Path | str) -> Python:
         try:
-            encoding = "locale" if sys.version_info >= (3, 10) else None
-            executable = subprocess.check_output(
-                [path_python, "-c", "import sys; print(sys.executable)"],
-                text=True,
-                encoding=encoding,
-            ).strip()
-            return Path(executable)
-
-        except subprocess.CalledProcessError:
-            return None
-
-    @staticmethod
-    def _detect_active_python(io: IO) -> Path | None:
-        io.write_error_line(
-            "Trying to detect current active python executable as specified in"
-            " the config.",
-            verbosity=Verbosity.VERBOSE,
-        )
-
-        executable = Python._full_python_path("python")
-
-        if executable is not None:
-            io.write_error_line(f"Found: {executable}", verbosity=Verbosity.VERBOSE)
-        else:
-            io.write_error_line(
-                "Unable to detect the current active python executable. Falling"
-                " back to default.",
-                verbosity=Verbosity.VERBOSE,
-            )
-
-        return executable
+            return cls(python=findpython.PythonVersion(executable=Path(path)))
+        except (FileNotFoundError, NotADirectoryError, ValueError):
+            raise ValueError(f"{path} is not a valid Python executable")
 
     @classmethod
     def get_system_python(cls) -> Python:
-        return cls(executable=sys.executable)
+        """
+        Creates and returns an instance of the class representing the Poetry's Python executable.
+        """
+        return cls(
+            python=findpython.PythonVersion(
+                executable=Path(sys.executable),
+                _version=packaging.version.Version(
+                    ".".join(str(v) for v in sys.version_info[:3])
+                ),
+            )
+        )
 
     @classmethod
     def get_by_name(cls, python_name: str) -> Python | None:
-        executable = cls._full_python_path(python_name)
-        if not executable:
-            return None
+        if Path(python_name).exists():
+            with contextlib.suppress(ValueError):
+                # if it is a path try assuming it is an executable
+                return cls.from_executable(python_name)
 
-        return cls(executable=executable)
+        if python := findpython.find(python_name):
+            return cls(python=python)
+
+        return None
 
     @classmethod
     def get_preferred_python(cls, config: Config, io: IO | None = None) -> Python:
+        """
+        Determine and return the "preferred" Python interpreter based on the provided
+        configuration and optional input/output stream.
+
+        This method first attempts to get the active Python interpreter if the configuration
+        does not mandate using Poetry's Python. If an active interpreter is found, it is returned.
+        Otherwise, the method defaults to retrieving the Poetry's Python interpreter (System Python).
+
+        This method **does not** attempt to sort versions or determine Python version constraint
+        compatibility.
+        """
         io = io or NullIO()
 
         if not config.get("virtualenvs.use-poetry-python") and (
-            active_python := Python._detect_active_python(io)
+            active_python := Python.get_active_python()
         ):
-            return cls(executable=active_python)
+            io.write_error_line(
+                f"Found: {active_python.executable}", verbosity=Verbosity.VERBOSE
+            )
+            return active_python
 
         return cls.get_system_python()
 
     @classmethod
     def get_compatible_python(cls, poetry: Poetry, io: IO | None = None) -> Python:
+        """
+        Retrieve a compatible Python version based on the given poetry configuration
+        and Python constraints derived from the project.
+
+        This method iterates through all available Python candidates and checks if any
+        match the supported Python constraint as defined in the specified poetry package.
+
+        :param poetry: The poetry configuration containing package information,
+                       including Python constraints.
+        :param io: The input/output stream for error and status messages. Defaults
+                   to a null I/O if not provided.
+        :return: A Python instance representing a compatible Python version.
+        :raises NoCompatiblePythonVersionFoundError: If no Python version matches
+                the supported constraint.
+        """
         io = io or NullIO()
         supported_python = poetry.package.python_constraint
-        python = None
 
-        for suffix in [
-            *sorted(
-                poetry.package.AVAILABLE_PYTHONS,
-                key=lambda v: (v.startswith("3"), -len(v), v),
-                reverse=True,
-            ),
-            "",
-        ]:
-            if len(suffix) == 1:
-                if not parse_constraint(f"^{suffix}.0").allows_any(supported_python):
-                    continue
-            elif suffix and not supported_python.allows_any(
-                parse_constraint(suffix + ".*")
-            ):
-                continue
-
-            python_name = f"python{suffix}"
-            if io.is_debug():
-                io.write_error_line(f"<debug>Trying {python_name}</debug>")
-
-            executable = cls._full_python_path(python_name)
-            if executable is None:
-                continue
-
-            candidate = cls(executable)
-            if supported_python.allows(candidate.patch_version):
-                python = candidate
+        for candidate in findpython.find_all():
+            python = cls(python=candidate)
+            if python.version.allows_any(supported_python):
                 io.write_error_line(
-                    f"Using <c1>{python_name}</c1> ({python.patch_version})"
+                    f"Using <c1>{candidate.name}</c1> ({python.patch_version})"
                 )
-                break
+                return python
 
-        if not python:
-            raise NoCompatiblePythonVersionFoundError(poetry.package.python_versions)
-
-        return python
+        raise NoCompatiblePythonVersionFoundError(poetry.package.python_versions)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ from poetry.utils.env import EnvManager
 from poetry.utils.env import MockEnv
 from poetry.utils.env import SystemEnv
 from poetry.utils.env import VirtualEnv
-from poetry.utils.env.python_manager import Python
+from poetry.utils.env.python import Python
 from poetry.utils.password_manager import PoetryKeyring
 from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import TestLocker
@@ -906,7 +906,7 @@ def mocked_python_register(
 
         if make_system:
             mocker.patch(
-                "poetry.utils.env.python_manager.Python.get_system_python",
+                "poetry.utils.env.python.Python.get_system_python",
                 return_value=Python(python=python),
             )
             mocked_pythons_version_map[""] = python
@@ -959,6 +959,6 @@ def with_mocked_findpython(
 @pytest.fixture
 def with_no_active_python(mocker: MockerFixture) -> MagicMock:
     return mocker.patch(
-        "poetry.utils.env.python_manager.Python.get_active_python",
+        "poetry.utils.env.python.Python.get_active_python",
         return_value=None,
     )

--- a/tests/types.py
+++ b/tests/types.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from poetry.poetry import Poetry
     from poetry.repositories.legacy_repository import LegacyRepository
     from poetry.utils.env import Env
-    from poetry.utils.env.python_manager import Python
+    from poetry.utils.env.python import Python
     from tests.repositories.fixtures.distribution_hashes import DistributionHash
 
     HTTPrettyResponse = tuple[int, dict[str, Any], bytes]  # status code, headers, body

--- a/tests/types.py
+++ b/tests/types.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from poetry.poetry import Poetry
     from poetry.repositories.legacy_repository import LegacyRepository
     from poetry.utils.env import Env
+    from poetry.utils.env.python_manager import Python
     from tests.repositories.fixtures.distribution_hashes import DistributionHash
 
     HTTPrettyResponse = tuple[int, dict[str, Any], bytes]  # status code, headers, body
@@ -137,3 +138,13 @@ class SetProjectContext(Protocol):
     def __call__(
         self, project: str | Path, in_place: bool = False
     ) -> AbstractContextManager[Path]: ...
+
+
+class MockedPythonRegister(Protocol):
+    def __call__(
+        self,
+        version: str,
+        executable_name: str | Path | None = None,
+        parent: str | Path | None = None,
+        make_system: bool = False,
+    ) -> Python: ...

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -18,10 +18,10 @@ from poetry.utils.env import GET_BASE_PREFIX
 from poetry.utils.env import GET_PYTHON_VERSION_ONELINER
 from poetry.utils.env import EnvManager
 from poetry.utils.env import IncorrectEnvError
-from poetry.utils.env import InvalidCurrentPythonVersionError
-from poetry.utils.env import NoCompatiblePythonVersionFoundError
-from poetry.utils.env import PythonVersionNotFoundError
 from poetry.utils.env.env_manager import EnvsFile
+from poetry.utils.env.python.exceptions import InvalidCurrentPythonVersionError
+from poetry.utils.env.python.exceptions import NoCompatiblePythonVersionFoundError
+from poetry.utils.env.python.exceptions import PythonVersionNotFoundError
 from poetry.utils.helpers import remove_directory
 
 
@@ -940,7 +940,7 @@ def test_create_venv_tries_to_find_a_compatible_python_executable_using_specific
     mocked_python_register("3.9.0")
 
     mocker.patch(
-        "poetry.utils.env.python_manager.Python.get_system_python",
+        "poetry.utils.env.python.Python.get_system_python",
         return_value=mocked_python_register("2.7.16", make_system=True),
     )
     mocked_python_register("3.5.3")
@@ -1043,7 +1043,7 @@ def test_create_venv_uses_patch_version_to_detect_compatibility(
         f"{version.major}.{version.minor}.{version.patch + 1}"
     )
     mocker.patch(
-        "poetry.utils.env.python_manager.Python.get_system_python",
+        "poetry.utils.env.python.Python.get_system_python",
         return_value=python,
     )
     m = mocker.patch(

--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -13,7 +13,7 @@ import pytest
 
 from poetry.core.constraints.version import Version
 
-from poetry.utils.env.python_manager import Python
+from poetry.utils.env.python import Python
 
 
 if TYPE_CHECKING:
@@ -62,7 +62,7 @@ def test_get_preferred_python_use_poetry_python_disabled(
     config: Config, mocker: MockerFixture
 ) -> None:
     mocker.patch(
-        "poetry.utils.env.python_manager.Python.get_active_python",
+        "poetry.utils.env.python.Python.get_active_python",
         return_value=Python(
             python=findpython.PythonVersion(
                 executable=Path("/usr/bin/python3.7"),

--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -1,32 +1,34 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
+import textwrap
 
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import findpython
+import packaging.version
 import pytest
 
-from cleo.io.null_io import NullIO
 from poetry.core.constraints.version import Version
 
 from poetry.utils.env.python_manager import Python
-from tests.utils.env.test_env_manager import check_output_wrapper
 
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
     from poetry.config.config import Config
+    from tests.types import MockedPythonRegister
     from tests.types import ProjectFactory
 
 
 def test_python_get_version_on_the_fly() -> None:
-    python = Python(executable=sys.executable)
+    python = Python.get_system_python()
 
-    assert python.executable == Path(sys.executable)
     assert python.version == Version.parse(
         ".".join([str(s) for s in sys.version_info[:3]])
     )
@@ -41,7 +43,7 @@ def test_python_get_version_on_the_fly() -> None:
 def test_python_get_system_python() -> None:
     python = Python.get_system_python()
 
-    assert python.executable == Path(sys.executable)
+    assert python.executable == findpython.find().executable
     assert python.version == Version.parse(
         ".".join(str(v) for v in sys.version_info[:3])
     )
@@ -60,9 +62,16 @@ def test_get_preferred_python_use_poetry_python_disabled(
     config: Config, mocker: MockerFixture
 ) -> None:
     mocker.patch(
-        "subprocess.check_output",
-        side_effect=check_output_wrapper(Version.parse("3.7.1")),
+        "poetry.utils.env.python_manager.Python.get_active_python",
+        return_value=Python(
+            python=findpython.PythonVersion(
+                executable=Path("/usr/bin/python3.7"),
+                _version=packaging.version.Version("3.7.1"),
+                _interpreter=Path("/usr/bin/python3.7"),
+            )
+        ),
     )
+
     config.config["virtualenvs"]["use-poetry-python"] = False
     python = Python.get_preferred_python(config)
 
@@ -71,46 +80,53 @@ def test_get_preferred_python_use_poetry_python_disabled(
 
 
 def test_get_preferred_python_use_poetry_python_disabled_fallback(
-    config: Config, mocker: MockerFixture
+    config: Config, with_no_active_python: MagicMock
 ) -> None:
     config.config["virtualenvs"]["use-poetry-python"] = False
-    mocker.patch(
-        "subprocess.check_output",
-        side_effect=subprocess.CalledProcessError(1, "some command"),
-    )
     python = Python.get_preferred_python(config)
 
+    assert with_no_active_python.call_count == 1
     assert python.executable == Path(sys.executable)
 
 
-def test_fallback_on_detect_active_python(mocker: MockerFixture) -> None:
-    m = mocker.patch(
-        "subprocess.check_output",
-        side_effect=subprocess.CalledProcessError(1, "some command"),
-    )
-
-    active_python = Python._detect_active_python(NullIO())
-
+def test_fallback_on_detect_active_python(with_no_active_python: MagicMock) -> None:
+    active_python = Python.get_active_python()
     assert active_python is None
-    assert m.call_count == 1
+    assert with_no_active_python.call_count == 1
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-def test_detect_active_python_with_bat(tmp_path: Path) -> None:
+def test_detect_active_python_with_bat(
+    tmp_path: Path, without_mocked_findpython: None
+) -> None:
     """On Windows pyenv uses batch files for python management."""
     python_wrapper = tmp_path / "python.bat"
-    wrapped_python = Path(r"C:\SpecialPython\python.exe")
+
     encoding = "locale" if sys.version_info >= (3, 10) else None
     with python_wrapper.open("w", encoding=encoding) as f:
-        f.write(f"@echo {wrapped_python}")
+        f.write(
+            textwrap.dedent(f"""
+            @echo off
+            SET PYTHON_EXE="{sys.executable}"
+            %PYTHON_EXE% %*
+        """)
+        )
     os.environ["PATH"] = str(python_wrapper.parent) + os.pathsep + os.environ["PATH"]
 
-    active_python = Python._detect_active_python(NullIO())
+    python = Python.get_active_python()
+    assert python is not None
 
-    assert active_python == wrapped_python
+    # TODO: Asses if Poetry needs to discover real path in these cases as
+    # this is not a symlink and won't be handled by findpython
+    assert python.executable.as_posix() == Path(sys.executable).as_posix()
+    assert python.version == Version.parse(
+        ".".join(str(v) for v in sys.version_info[:3])
+    )
 
 
-def test_python_find_compatible(project_factory: ProjectFactory) -> None:
+def test_python_find_compatible(
+    project_factory: ProjectFactory, mocked_python_register: MockedPythonRegister
+) -> None:
     # Note: This test may fail on Windows systems using Python from the Microsoft Store,
     # as the executable is named `py.exe`, which is not currently recognized by
     # Python.get_compatible_python. This issue will be resolved in #2117.
@@ -118,6 +134,7 @@ def test_python_find_compatible(project_factory: ProjectFactory) -> None:
     # Python interpreter is used before attempting to find another compatible version.
     fixture = Path(__file__).parent.parent / "fixtures" / "simple_project"
     poetry = project_factory("simple-project", source=fixture)
+    mocked_python_register("3.12")
     python = Python.get_compatible_python(poetry)
 
     assert Version.from_parts(3, 4) <= python.version <= Version.from_parts(4, 0)


### PR DESCRIPTION
With this change Poetry will use [findpython](https://github.com/frostming/findpython) for Python version discovery. This helps remove Poetry's own custom "best effort" Python version discovery and hopefully also resolve a lot of issues related to the discovery of available Python versions in a given environment.

This change largely focuses on the Python Manager and not the Environment Manager. The latter could also be improved once this has landed. 

## Testing
### Using pipx
```sh
pipx install --suffix=@10097 'poetry @ git+https://github.com/python-poetry/poetry.git@refs/pull/10097/head'
alias poetry=poetry@10097
poetry new foobar
cd foobar
poetry install
poetry env use 3.13
```

### Using a container (podman | docker)
```sh
podman run --rm -i --entrypoint bash docker.io/python:latest <<EOF
set -xe 
python -m pip install --disable-pip-version-check -q git+https://github.com/python-poetry/poetry.git@refs/pull/10097/head
poetry new foobar
cd foobar
poetry env use 3.13
EOF
```

## Summary by Sourcery

Tests:
- Use mocked Python versions in tests.

## Summary by Sourcery

Tests:
- Use mocked Python versions in tests.