### PR TITLE
chore(ci): reduce cirrus usage

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,14 +8,6 @@ tests_task:
 
   env:
     matrix:
-      - PYTHON: python3.9
-        PYTHON_VERSION: 3.9
-        PYTHON_PACKAGE: python39
-        SQLITE_PACKAGE: py39-sqlite3
-      - PYTHON: python3.10
-        PYTHON_VERSION: 3.10
-        PYTHON_PACKAGE: python310
-        SQLITE_PACKAGE: py310-sqlite3
       - PYTHON: python3.11
         PYTHON_VERSION: 3.11
         PYTHON_PACKAGE: python311
@@ -53,18 +45,11 @@ tests_task:
           format: junit
           type: text/xml
 
-    # TODO: caching
-    - alias: mypy
-      name: "Tests / FreeBSD (Python ${PYTHON_VERSION}) / mypy"
-      skip: "!changesInclude('.cirrus.yml', 'poetry.lock', 'pyproject.toml', 'src/**.py', 'tests/**')"
-      mypy_script: poetry run mypy
-
 status_task:
   name: "Tests / FreeBSD Status"
 
   depends_on:
     - pytest
-    - mypy
 
   container:
     image: alpine:latest


### PR DESCRIPTION
FreeBSD testing was initially introduced when Poetry was distributed in platform specific bundles. This is no longer the case and the value of these tests have reduced significantly, especially when considering newer Python versions (>=3.12) are still not available via ports.

This change reduces the jobs to be more of a smoke test than a full coverage. Mypy tests have been removed along with testing on Python versions <3.11.

## Summary by Sourcery

Reduce the FreeBSD test matrix to a smoke test by removing Mypy tests and support for Python versions below 3.11.

CI:
- Remove Mypy tests from the FreeBSD CI jobs.

Tests:
- Reduce the FreeBSD test matrix to only include Python 3.11 and later.