### PR TITLE
fix: restore code that makes sure that operations concerning pip are executed first

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -148,6 +148,14 @@ class Executor:
         self._sections = {}
         self._yanked_warnings = []
 
+        # pip has to be installed/updated first without parallelism
+        # because we still need it for uninstalls
+        for i, op in enumerate(operations):
+            if op.package.name == "pip":
+                wait([self._executor.submit(self._execute_operation, op)])
+                del operations[i]
+                break
+
         # We group operations by priority
         groups = itertools.groupby(operations, key=lambda o: -o.priority)
         for _, group in groups:


### PR DESCRIPTION
This was removed overzealously in #9392 due to the misleading comment (which has been clarified now).

# Pull Request Check List

Closes: #10091

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

Even if we introduce our own uninstaller, we should probably keep the old way as fallback via a config option (similar to `modern-installation`).

## Summary by Sourcery

Bug Fixes:
- Ensure pip operations are executed first during installation to avoid potential conflicts.