### PR TITLE
docs: add additional information on specifying required python versions

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -708,6 +708,7 @@ python = "^3.7"
 
 {{% note %}}
 If you specify the compatible python versions in both `tool.poetry.dependencies` and in `project.requires-python`, then Poetry will use the information in `tool.poetry.dependencies` for locking, but the python versions must be a subset of those allowed by `project.requires-python`.
+
 For example, the following is invalid and will result in an error, because versions `4.0` and greater are allowed by `tool.poetry.dependencies`, but not by `project.requires-python`.
 
 ```toml

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -699,6 +699,27 @@ If you have multiple repositories configured, you can explicitly tell poetry whe
 requests = { version = "^2.13.0", source = "private" }
 ```
 
+You may also specify your project's compatible python versions in this section, instead of or in addition to `project.requires-python`.
+
+```toml
+[tool.poetry.dependencies]
+python = "^3.7"
+```
+
+{{% note %}}
+If you specify the compatible python versions in both `tool.poetry.dependencies` and in `project.requires-python`, then Poetry will use the information in `tool.poetry.dependencies` for locking, but the python versions must be a subset of those allowed by `project.requires-python`.
+For example, the following is invalid and will result in an error, because version `3.14` is allowed by `tool.poetry.dependencies`, but not by `project.requires-python`.
+
+```toml
+[project]
+# ...
+requires-python = ">=3.8,<4.0"
+
+[tool.poetry.dependencies]
+python = ">=3.8"
+```
+{{% /note %}}
+
 You can organize your dependencies in [groups]({{< relref "managing-dependencies#dependency-groups" >}})
 to manage them in a more granular way.
 

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -708,7 +708,7 @@ python = "^3.7"
 
 {{% note %}}
 If you specify the compatible python versions in both `tool.poetry.dependencies` and in `project.requires-python`, then Poetry will use the information in `tool.poetry.dependencies` for locking, but the python versions must be a subset of those allowed by `project.requires-python`.
-For example, the following is invalid and will result in an error, because version `3.14` is allowed by `tool.poetry.dependencies`, but not by `project.requires-python`.
+For example, the following is invalid and will result in an error, because versions `4.0` and greater are allowed by `tool.poetry.dependencies`, but not by `project.requires-python`.
 
 ```toml
 [project]
@@ -716,7 +716,7 @@ For example, the following is invalid and will result in an error, because versi
 requires-python = ">=3.8,<4.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.8" # not valid!
 ```
 {{% /note %}}
 

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -699,16 +699,6 @@ If you have multiple repositories configured, you can explicitly tell poetry whe
 requests = { version = "^2.13.0", source = "private" }
 ```
 
-{{% note %}}
-Be aware that declaring the python version for which your package
-is compatible is mandatory:
-
-```toml
-[tool.poetry.dependencies]
-python = "^3.7"
-```
-{{% /note %}}
-
 You can organize your dependencies in [groups]({{< relref "managing-dependencies#dependency-groups" >}})
 to manage them in a more granular way.
 


### PR DESCRIPTION
The docs say that the python version must be declared in the `tool.poetry.dependencies` section

> Be aware that declaring the python version for which your package is compatible is mandatory:

This is no longer true, as the version can be declared in `project.requires-python` only.
I just removed the note saying it is mandatory.

# Pull Request Check List

Resolves: #10103

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Documentation:
- Remove the note stating that declaring the Python version in `tool.poetry.dependencies` is mandatory.