### PR TITLE
tests: adapt tests to cosmetic changes caused by poetry-core#826

### DIFF
--- a/.github/workflows/.tests-matrix.yaml
+++ b/.github/workflows/.tests-matrix.yaml
@@ -103,7 +103,8 @@ jobs:
           persist-credentials: false
           path: poetry-plugin-export
           repository: python-poetry/poetry-plugin-export
-          ref: refs/tags/${{ steps.poetry-plugin-export-version.outputs.version }}
+          # use main for now because of poetry-core#826
+          # ref: refs/tags/${{ steps.poetry-plugin-export-version.outputs.version }}
 
       - name: Use local poetry
         working-directory: poetry-plugin-export

--- a/poetry.lock
+++ b/poetry.lock
@@ -1052,7 +1052,7 @@ develop = false
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "HEAD"
-resolved_reference = "d97577e664d59173482a78f70e8f743cc5468851"
+resolved_reference = "eccf08b5703f20c39282aa8be335d125aa36faab"
 
 [[package]]
 name = "pre-commit"

--- a/tests/installation/fixtures/update-with-locked-extras.test
+++ b/tests/installation/fixtures/update-with-locked-extras.test
@@ -9,7 +9,7 @@ files = []
 
 [package.dependencies]
 "B" = {version = "^1.0", optional = true}
-"C" = {version = "^1.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""}
+"C" = {version = "^1.0", markers = "python_version == \"2.7\""}
 
 [package.extras]
 foo = ["B"]
@@ -30,7 +30,7 @@ description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
-markers = 'python_version < "2.8"'
+markers = 'python_version == "2.7"'
 files = []
 
 [[package]]

--- a/tests/installation/fixtures/with-multiple-updates.test
+++ b/tests/installation/fixtures/with-multiple-updates.test
@@ -10,7 +10,7 @@ files = []
 [package.dependencies]
 B = ">=1.0.1"
 C = [
-    {version = ">=1.0,<2.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\""},
+    {version = ">=1.0,<2.0", markers = "python_version == \"2.7\""},
     {version = ">=2.0,<3.0", markers = "python_version >= \"3.4\" and python_version < \"4.0\""},
 ]
 
@@ -30,7 +30,7 @@ description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
-markers = 'python_version < "2.8"'
+markers = 'python_version == "2.7"'
 files = []
 
 [[package]]

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -1989,71 +1989,37 @@ def test_solver_duplicate_dependencies_with_overlapping_markers_complex(
         ],
     )
     opencv_requires = {dep.to_pep_508() for dep in ops[-1].package.requires}
-    expectation = (
-        {  # concise solution, but too expensive
-            (
-                "numpy (>=1.21.2) ;"
-                ' platform_system == "Darwin" and platform_machine == "arm64"'
-                ' and python_version >= "3.6" or python_version >= "3.10"'
-            ),
-            (
-                'numpy (>=1.19.3) ; python_version >= "3.9" and python_version < "3.10"'
-                ' and platform_system != "Darwin" or platform_system == "Linux"'
-                ' and platform_machine == "aarch64" and python_version < "3.10"'
-                ' and python_version >= "3.6" or python_version >= "3.9"'
-                ' and python_version < "3.10" and platform_machine != "arm64"'
-            ),
-            (
-                'numpy (>=1.17.3) ; python_version >= "3.8" and python_version < "3.9"'
-                ' and (platform_system != "Darwin" or platform_machine != "arm64")'
-                ' and (platform_system != "Linux" or platform_machine != "aarch64")'
-            ),
-            (
-                'numpy (>=1.14.5) ; python_version >= "3.7" and python_version < "3.8"'
-                ' and (platform_system != "Darwin" or platform_machine != "arm64")'
-                ' and (platform_system != "Linux" or platform_machine != "aarch64")'
-            ),
-            (
-                'numpy (>=1.13.3) ; python_version < "3.7"'
-                ' and (python_version < "3.6" or platform_system != "Darwin"'
-                ' or platform_machine != "arm64") and (python_version < "3.6"'
-                ' or platform_system != "Linux" or platform_machine != "aarch64")'
-            ),
-        },
-        {  # current solution
-            (
-                "numpy (>=1.21.2) ;"
-                ' python_version >= "3.6" and platform_system == "Darwin"'
-                ' and platform_machine == "arm64" or python_version >= "3.10"'
-            ),
-            (
-                'numpy (>=1.19.3) ; python_version >= "3.6"'
-                ' and (platform_system == "Linux" or python_version >= "3.9")'
-                ' and python_version < "3.10"'
-                ' and (platform_system != "Darwin" or platform_machine != "arm64")'
-                ' and (platform_machine == "aarch64" or python_version >= "3.9")'
-            ),
-            (
-                'numpy (>=1.17.3) ; python_version < "3.9"'
-                ' and (platform_system != "Darwin" or platform_machine != "arm64")'
-                ' and python_version >= "3.8"'
-                ' and (platform_system != "Linux" or platform_machine != "aarch64")'
-            ),
-            (
-                'numpy (>=1.14.5) ; python_version < "3.8"'
-                ' and (platform_system != "Darwin" or platform_machine != "arm64")'
-                ' and python_version >= "3.7"'
-                ' and (platform_system != "Linux" or platform_machine != "aarch64")'
-            ),
-            (
-                'numpy (>=1.13.3) ; python_version < "3.7"'
-                ' and (python_version < "3.6" or platform_system != "Darwin"'
-                ' or platform_machine != "arm64") and (python_version < "3.6"'
-                ' or platform_system != "Linux" or platform_machine != "aarch64")'
-            ),
-        },
-    )
-    assert opencv_requires in expectation
+
+    assert opencv_requires == {
+        (
+            "numpy (>=1.21.2) ;"
+            ' python_version >= "3.6" and platform_system == "Darwin"'
+            ' and platform_machine == "arm64" or python_version >= "3.10"'
+        ),
+        (
+            'numpy (>=1.19.3) ; platform_system == "Linux"'
+            ' and platform_machine == "aarch64" and python_version < "3.10"'
+            ' and python_version >= "3.6" or python_version == "3.9"'
+            ' and platform_system != "Darwin" or python_version == "3.9"'
+            ' and platform_machine != "arm64"'
+        ),
+        (
+            'numpy (>=1.17.3) ; python_version == "3.8"'
+            ' and (platform_system != "Darwin" or platform_machine != "arm64")'
+            ' and (platform_system != "Linux" or platform_machine != "aarch64")'
+        ),
+        (
+            'numpy (>=1.14.5) ; python_version == "3.7"'
+            ' and (platform_system != "Darwin" or platform_machine != "arm64")'
+            ' and (platform_system != "Linux" or platform_machine != "aarch64")'
+        ),
+        (
+            'numpy (>=1.13.3) ; python_version < "3.7"'
+            ' and (python_version < "3.6" or platform_system != "Darwin"'
+            ' or platform_machine != "arm64") and (python_version < "3.6"'
+            ' or platform_system != "Linux" or platform_machine != "aarch64")'
+        ),
+    }
 
 
 def test_duplicate_path_dependencies(

--- a/tests/puzzle/test_solver_internals.py
+++ b/tests/puzzle/test_solver_internals.py
@@ -450,10 +450,7 @@ def test_merge_override_packages_multiple_deps(package: ProjectPackage) -> None:
     assert len(packages) == 1
     assert packages[a].groups == {"main"}
     assert tm(packages[a]) == {
-        "main": (
-            'python_version < "3.9" and sys_platform == "linux"'
-            ' and python_version >= "3.8"'
-        )
+        "main": 'python_version == "3.8" and sys_platform == "linux"'
     }
 
 


### PR DESCRIPTION
see issue title

The `poetry-plugin-export` failures are caused by cosmetic changes. The tests are fixed in https://github.com/python-poetry/poetry-plugin-export/pull/321. We should probably merge this PR with failing downstream tests and switch from the released poetry-core version to the main branch afterwards. (I changed the CI to use the main branch of `poetry-plugin-export` instead the latest release.)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Tests:
- Adapt tests to match the simplified dependency markers generated by poetry-core.