### PR TITLE
perf: cache `RepositoryPool.package()` in `Provider`

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -114,10 +114,7 @@ class PackageInfo:
         return cls(cache_version=cache_version, **data)
 
     def to_package(
-        self,
-        name: str | None = None,
-        extras: list[str] | None = None,
-        root_dir: Path | None = None,
+        self, name: str | None = None, root_dir: Path | None = None
     ) -> Package:
         """
         Create a new `poetry.core.packages.package.Package` instance using metadata from

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import itertools
 import logging
 import re
@@ -147,6 +148,8 @@ class Provider:
                 key=lambda p: p.package.version,
                 reverse=True,
             )
+
+        self._get_package_from_pool = functools.cache(self._pool.package)
 
     @property
     def pool(self) -> RepositoryPool:
@@ -446,10 +449,9 @@ class Provider:
         else:
             dependency_package = DependencyPackage(
                 dependency,
-                self._pool.package(
+                self._get_package_from_pool(
                     package.pretty_name,
                     package.version,
-                    extras=list(dependency.extras),
                     repository_name=dependency.source_name,
                 ),
             )

--- a/src/poetry/repositories/abstract_repository.py
+++ b/src/poetry/repositories/abstract_repository.py
@@ -26,9 +26,4 @@ class AbstractRepository(ABC):
     def search(self, query: str | list[str]) -> list[Package]: ...
 
     @abstractmethod
-    def package(
-        self,
-        name: str,
-        version: Version,
-        extras: list[str] | None = None,
-    ) -> Package: ...
+    def package(self, name: str, version: Version) -> Package: ...

--- a/src/poetry/repositories/cached_repository.py
+++ b/src/poetry/repositories/cached_repository.py
@@ -66,12 +66,7 @@ class CachedRepository(Repository, ABC):
 
         return PackageInfo.load(cached)
 
-    def package(
-        self,
-        name: str,
-        version: Version,
-        extras: list[str] | None = None,
-    ) -> Package:
+    def package(self, name: str, version: Version) -> Package:
         return self.get_release_info(canonicalize_name(name), version).to_package(
-            name=name, extras=extras
+            name=name
         )

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -46,9 +46,7 @@ class LegacyRepository(HTTPRepository):
             pool_size=pool_size,
         )
 
-    def package(
-        self, name: str, version: Version, extras: list[str] | None = None
-    ) -> Package:
+    def package(self, name: str, version: Version) -> Package:
         """
         Retrieve the release information.
 
@@ -65,7 +63,7 @@ class LegacyRepository(HTTPRepository):
 
             return self._packages[index]
         except ValueError:
-            package = super().package(name, version, extras)
+            package = super().package(name, version)
             package._source_type = "legacy"
             package._source_url = self._url
             package._source_reference = self.name

--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -102,9 +102,7 @@ class Repository(AbstractRepository):
     def find_links_for_package(self, package: Package) -> list[Link]:
         return []
 
-    def package(
-        self, name: str, version: Version, extras: list[str] | None = None
-    ) -> Package:
+    def package(self, name: str, version: Version) -> Package:
         canonicalized_name = canonicalize_name(name)
         for package in self.packages:
             if canonicalized_name == package.name and package.version == version:

--- a/src/poetry/repositories/repository_pool.py
+++ b/src/poetry/repositories/repository_pool.py
@@ -152,20 +152,14 @@ class RepositoryPool(AbstractRepository):
         return self
 
     def package(
-        self,
-        name: str,
-        version: Version,
-        extras: list[str] | None = None,
-        repository_name: str | None = None,
+        self, name: str, version: Version, repository_name: str | None = None
     ) -> Package:
         if repository_name:
-            return self.repository(repository_name).package(
-                name, version, extras=extras
-            )
+            return self.repository(repository_name).package(name, version)
 
         for repo in self.repositories:
             try:
-                return repo.package(name, version, extras=extras)
+                return repo.package(name, version)
             except PackageNotFoundError:
                 continue
         raise PackageNotFoundError(f"Package {name} ({version}) not found.")


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This should be safe because we do not change the `RepositoryPool` while resolving and the returned package is used read-only.

Testing with the pyproject.toml from https://github.com/python-poetry/poetry/issues/9956#issuecomment-2582451109:

poetry version|lock (--regenerate)|lock (--no-update)
---|---|---
main (with python-poetry/poetry-core#828)|73 s|11.5 s
PR|52 s|5.7 s

## Summary by Sourcery

Cache the `RepositoryPool.package()` method in the `Provider` class to improve performance during dependency resolution.

Enhancements:
- Cache package lookups to improve performance.

Tests:
- Updated tests for the changes.