### PR TITLE
chore(doc): add a heading for git credentials

### DIFF
--- a/docs/dependency-specification.md
+++ b/docs/dependency-specification.md
@@ -368,6 +368,8 @@ pendulum = { git = "git@github.com/sdispater/pendulum.git" }
 {{< /tab >}}
 {{< /tabs >}}
 
+### Credentials for git dependencies
+
 To use HTTP basic authentication with your git repositories, you can configure credentials similar to
 how [repository credentials]({{< relref "repositories#configuring-credentials" >}}) are configured.
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a section about configuring credentials for git dependencies.