### PR TITLE
fix(ux): better error report when no links found

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -305,6 +305,25 @@ Without `--` this command will fail if `${GITLAB_JOB_TOKEN}` starts with a hyphe
 * `--local`: Set/Get settings that are specific to a project (in the local configuration file `poetry.toml`).
 * `--migrate`: Migrate outdated configuration settings.
 
+## debug
+
+The `debug` command groups subcommands that are useful for, as the name suggests, debugging issues you might have
+when using Poetry with your projects.
+
+### debug info
+
+The `debug info` command shows debug information about Poetry and your project's virtual environment.
+
+### debug resolve
+
+The `debug resolve` command helps when debugging dependency resolution issues. The command attempts to resolve your
+dependencies and list the chosen packages and versions.
+
+### debug tags
+
+The `debug tags` command is useful when you want to see the supported packaging tags for your project's active
+virtual environment. This is useful when Poetry cannot install any known binary distributions for a dependency.
+
 ## env
 
 The `env` command groups subcommands to interact with the virtualenvs

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -75,6 +75,7 @@ COMMANDS = [
     # Debug commands
     "debug info",
     "debug resolve",
+    "debug tags",
     # Env commands
     "env activate",
     "env info",

--- a/src/poetry/console/commands/debug/tags.py
+++ b/src/poetry/console/commands/debug/tags.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from poetry.console.commands.env_command import EnvCommand
+
+
+class DebugTagsCommand(EnvCommand):
+    name = "debug tags"
+    description = "Shows compatible tags for your project's current active environment."
+
+    def handle(self) -> int:
+        for tag in self.env.get_supported_tags():
+            self.io.write_line(
+                f"<c1>{tag.interpreter}</>"
+                f"-<c2>{tag.abi}</>"
+                f"-<fg=yellow;options=bold>{tag.platform}</>"
+            )
+        return 0

--- a/src/poetry/console/exceptions.py
+++ b/src/poetry/console/exceptions.py
@@ -170,7 +170,10 @@ class PoetryRuntimeError(PoetryConsoleError):
             text += f"{indent}{message_text}\n{indent}\n"
 
         if has_skipped_debug:
-            text += f"{indent}You can also run your <c1>poetry</> command with <c1>-v</> to see more information.\n{indent}\n"
+            message = ConsoleMessage(
+                f"{indent}You can also run your <c1>poetry</> command with <c1>-v</> to see more information.\n{indent}\n"
+            )
+            text += message.stripped if strip else message.text
 
         return text.rstrip(f"{indent}\n")
 

--- a/tests/installation/conftest.py
+++ b/tests/installation/conftest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from packaging.tags import Tag
+
+from poetry.repositories.legacy_repository import LegacyRepository
+from poetry.repositories.pypi_repository import PyPiRepository
+from poetry.repositories.repository_pool import RepositoryPool
+from poetry.utils.env import MockEnv
+
+
+@pytest.fixture()
+def env() -> MockEnv:
+    return MockEnv(
+        supported_tags=[
+            Tag("cp37", "cp37", "macosx_10_15_x86_64"),
+            Tag("py3", "none", "any"),
+        ]
+    )
+
+
+@pytest.fixture()
+def pool(legacy_repository: LegacyRepository) -> RepositoryPool:
+    pool = RepositoryPool()
+
+    pool.add_repository(PyPiRepository(disable_cache=True))
+    pool.add_repository(
+        LegacyRepository("foo", "https://legacy.foo.bar/simple/", disable_cache=True)
+    )
+    pool.add_repository(
+        LegacyRepository("foo2", "https://legacy.foo2.bar/simple/", disable_cache=True)
+    )
+    return pool

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -11,12 +11,11 @@ from poetry.core.packages.package import Package
 from poetry.console.exceptions import PoetryRuntimeError
 from poetry.installation.chooser import Chooser
 from poetry.repositories.legacy_repository import LegacyRepository
-from poetry.repositories.pypi_repository import PyPiRepository
-from poetry.repositories.repository_pool import RepositoryPool
 from poetry.utils.env import MockEnv
 
 
 if TYPE_CHECKING:
+    from poetry.repositories.repository_pool import RepositoryPool
     from tests.conftest import Config
     from tests.types import DistributionHashGetter
     from tests.types import SpecializedLegacyRepositoryMocker
@@ -26,30 +25,6 @@ JSON_FIXTURES = (
 )
 
 LEGACY_FIXTURES = Path(__file__).parent.parent / "repositories" / "fixtures" / "legacy"
-
-
-@pytest.fixture()
-def env() -> MockEnv:
-    return MockEnv(
-        supported_tags=[
-            Tag("cp37", "cp37", "macosx_10_15_x86_64"),
-            Tag("py3", "none", "any"),
-        ]
-    )
-
-
-@pytest.fixture()
-def pool(legacy_repository: LegacyRepository) -> RepositoryPool:
-    pool = RepositoryPool()
-
-    pool.add_repository(PyPiRepository(disable_cache=True))
-    pool.add_repository(
-        LegacyRepository("foo", "https://legacy.foo.bar/simple/", disable_cache=True)
-    )
-    pool.add_repository(
-        LegacyRepository("foo2", "https://legacy.foo2.bar/simple/", disable_cache=True)
-    )
-    return pool
 
 
 def check_chosen_link_filename(
@@ -75,7 +50,7 @@ def check_chosen_link_filename(
 
     try:
         link = chooser.choose_for(package)
-    except RuntimeError as e:
+    except PoetryRuntimeError as e:
         if filename is None:
             assert (
                 str(e)

--- a/tests/installation/test_chooser_errors.py
+++ b/tests/installation/test_chooser_errors.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from poetry.core.packages.package import Package
+
+from poetry.installation.chooser import Chooser
+
+
+if TYPE_CHECKING:
+    from poetry.repositories.repository_pool import RepositoryPool
+    from poetry.utils.env import MockEnv
+
+
+def test_chooser_no_links_found_error(env: MockEnv, pool: RepositoryPool) -> None:
+    chooser = Chooser(pool, env)
+    package = Package(
+        "demo",
+        "0.1.0",
+        source_type="legacy",
+        source_reference="foo",
+        source_url="https://legacy.foo.bar/simple/",
+    )
+
+    unsupported_wheels = {"demo-0.1.0-py3-none-any.whl"}
+    error = chooser._no_links_found_error(
+        package=package,
+        links_seen=4,
+        wheels_skipped=3,
+        sdists_skipped=1,
+        unsupported_wheels=unsupported_wheels,
+    )
+    assert (
+        error.get_text(debug=True, strip=True)
+        == f"""\
+Unable to find installation candidates for {package.name} ({package.version})
+
+This is likely not a Poetry issue.
+
+  - 4 candidate(s) were identified for the package
+  - 3 wheel(s) were skipped due to your installer.no-binary policy
+  - 1 source distribution(s) were skipped due to your installer.only-binary policy
+  - 1 wheel(s) were skipped as your project's environment does not support the identified abi tags
+
+The following wheel(s) were skipped as the current project environment does not support them due to abi compatibility \
+issues.
+
+  - {"  -".join(unsupported_wheels)}
+
+If you would like to see the supported tags in your project environment, you can execute the following command:
+
+    poetry debug tags
+
+Solutions:
+Make sure the lockfile is up-to-date. You can try one of the following;
+
+    1. Regenerate lockfile: poetry lock --no-cache --regenerate
+    2. Update package     : poetry update --no-cache {package.name}
+
+If neither works, please first check to verify that the {package.name} has published wheels available from your configured \
+source ({package.source_reference}) that are compatible with your environment- ie. operating system, architecture \
+(x86_64, arm64 etc.), python interpreter.\
+"""
+    )
+
+    assert (
+        error.get_text(debug=False, strip=True)
+        == f"""\
+Unable to find installation candidates for {package.name} ({package.version})
+
+This is likely not a Poetry issue.
+
+  - 4 candidate(s) were identified for the package
+  - 3 wheel(s) were skipped due to your installer.no-binary policy
+  - 1 source distribution(s) were skipped due to your installer.only-binary policy
+  - 1 wheel(s) were skipped as your project's environment does not support the identified abi tags
+
+Solutions:
+Make sure the lockfile is up-to-date. You can try one of the following;
+
+    1. Regenerate lockfile: poetry lock --no-cache --regenerate
+    2. Update package     : poetry update --no-cache {package.name}
+
+If neither works, please first check to verify that the {package.name} has published wheels available from your configured \
+source ({package.source_reference}) that are compatible with your environment- ie. operating system, architecture \
+(x86_64, arm64 etc.), python interpreter.
+
+You can also run your poetry command with -v to see more information.\
+"""
+    )


### PR DESCRIPTION
This changes add better error reporting for cases like #10125. See this issue for a "before" example.

The following are coerced examples. The error was forced to trigger with all possible messages enabled.

### Normal
![Screenshot From 2025-01-29 23-38-34](https://github.com/user-attachments/assets/e9bdb6d0-cf9a-4820-9ef4-a8170ff7f0d5)

### Verbose
![Screenshot From 2025-01-29 23-39-34](https://github.com/user-attachments/assets/07813f39-30ac-42b8-a63f-4b4df8c88cd4)

## Summary by Sourcery

Improve the error reporting when no installation candidates are found for a package. Provide more context and potential solutions to help users debug the issue.

Bug Fixes:
- Improve error reporting when no suitable installation candidates are found for a dependency, addressing issues like #10125.

Enhancements:
- Provide more informative error messages when no installation candidates are found, including details about skipped candidates and potential solutions.