### PR TITLE
feat(config): installer.build-config-settings.pkg

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,6 +271,49 @@ values, usage instructions and warnings.
 
 Use parallel execution when using the new (`>=1.1.0`) installer.
 
+### `installer.build-config-settings.<package-name>`
+
+**Type**: `Serialised JSON with string or list of string properties`
+
+**Default**: `None`
+
+**Environment Variable**: `POETRY_INSTALLER_BUILD_CONFIG_SETTINGS_<package-name>`
+
+*Introduced in 2.1.0*
+
+{{% warning %}}
+This is an **experimental** configuration and can be subject to changes in upcoming releases until it is considered
+stable.
+{{% /warning %}}
+
+Configure [PEP 517 config settings](https://peps.python.org/pep-0517/#config-settings) to be passed to a package's
+build backend if it has to be built from a directory or vcs source; or a source distribution during installation.
+
+This is only used when a compatible binary distribution (wheel) is not available for a package. This can be used along
+with [`installer.no-binary`]({{< relref "configuration#installerno-binary" >}}) option to force a build with these
+configurations when a dependency of your project with the specified name is being installed.
+
+{{% note %}}
+Poetry does not offer a similar option in the `pyproject.toml` file as these are, in majority of cases, not universal
+and vary depending on the target installation environment.
+
+If you want to use a project specific configuration it is recommended that this configuration be set locally, in your
+project's `poetry.toml` file.
+
+```bash
+poetry config --local installer.build-config-settings.grpcio \
+  '{"CC": "gcc", "--global-option": ["--some-global-option"], "--build-option": ["--build-option1", "--build-option2"]}'
+```
+
+If you want to modify a single key, you can do, by setting the same key again.
+
+```bash
+poetry config --local installer.build-config-settings.grpcio \
+  '{"CC": "g++"}'
+```
+
+{{% /note %}}
+
 ### `requests.max-retries`
 
 **Type**: `int`

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -143,7 +143,7 @@ def test_disabled_keyring_is_unavailable(
         # non-string key
         ('{0: "hello"}', True),
         # non-string value in list
-        ('{"world: ["hello", 0]}', True),
+        ('{"world": ["hello", 0]}', True),
     ],
 )
 def test_config_get_from_environment_variable_build_config_settings(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 
@@ -9,11 +10,14 @@ from typing import Any
 
 import pytest
 
+from deepdiff.diff import DeepDiff
+
 from poetry.config.config import Config
 from poetry.config.config import boolean_normalizer
 from poetry.config.config import int_normalizer
 from poetry.utils.password_manager import PasswordManager
 from tests.helpers import flatten_dict
+from tests.helpers import isolated_environment
 
 
 if TYPE_CHECKING:
@@ -127,3 +131,35 @@ def test_disabled_keyring_is_unavailable(
     config.config["keyring"]["enabled"] = False
     manager = PasswordManager(config)
     assert not manager.use_keyring
+
+
+@pytest.mark.parametrize(
+    ("value", "invalid"),
+    [
+        # non-serialised json
+        ("BAD=VALUE", True),
+        # good value
+        (json.dumps({"CC": "gcc", "--build-option": ["--one", "--two"]}), False),
+        # non-string key
+        ('{0: "hello"}', True),
+        # non-string value in list
+        ('{"world: ["hello", 0]}', True),
+    ],
+)
+def test_config_get_from_environment_variable_build_config_settings(
+    value: str,
+    invalid: bool,
+    config: Config,
+) -> None:
+    with isolated_environment(
+        {
+            "POETRY_INSTALLER_BUILD_CONFIG_SETTINGS_DEMO": value,
+        },
+        clear=True,
+    ):
+        configured_value = config.get("installer.build-config-settings.demo")
+
+        if invalid:
+            assert configured_value is None
+        else:
+            assert not DeepDiff(configured_value, json.loads(value))


### PR DESCRIPTION
This change introduces the `installer.build-config-settings.<pkg>` configuration option to allow for PEP 517 build config settings to be passed to the respective build backends when a dependency is built during installation.

This feature was chosen not to be exposed via an addition to the dependency specification schema as these configurations can differ between environments.

Resolves: #845 #8909
Closes: python-poetry/poetry-core#715

## Examples
```console
$ # Empty values
$ poetry config installer.build-config-settings.pip 
No build config settings configured for pip.
$ poetry config installer.build-config-settings
No packages configured with build config settings.
$
$ # Configuration via env var
$ POETRY_INSTALLER_BUILD_CONFIG_SETTINGS_POD='{"baz" : ["ONE"]}' poetry config installer.build-config-settings
pod.baz = "[ONE]"
$
$ # Configuration via cli
$ poetry config installer.build-config-settings.pip '{"CC": "gcc", "--build-option": ["--build-option1", "--build-option2"]}'
$
$ # Reading env var and toml
$ POETRY_INSTALLER_BUILD_CONFIG_SETTINGS_POD='{"baz" : ["ONE"]}' poetry config installer.build-config-settings
pip.--build-option = "[--build-option1, --build-option2]"
pip.CC = "gcc"
pod.baz = "[ONE]"
$
$ # Env var takes precedence
$ POETRY_INSTALLER_BUILD_CONFIG_SETTINGS_PIP='{"baz" : ["ONE"]}' poetry config installer.build-config-settings
pip.baz = "[ONE]"
$
$ # Show single value
$ poetry config installer.build-config-settings.pip 
{"CC": "gcc", "--build-option": ["--build-option1", "--build-option2"]}
```

## Testing
We can verify that the settings are passed to the builder using the following snippet.

```sh
podman run --rm -i --entrypoint bash docker.io/python:latest <<EOF
set -xe
python -m pip install --disable-pip-version-check -q git+https://github.com/python-poetry/poetry.git@refs/pull/10129/head
poetry new foobar
pushd foobar
cat > poetry.toml <<TOML
[installer.build-config-settings.pygraphviz]
--global-option = ["build_ext", "-I/bad/path/graphviz/include/", "-L/bad/path/lib/"]
TOML
poetry add pygraphviz
EOF
```

The relevant output that shows the correct passing of the config settings are the following.

```console
gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -DSWIG_PYTHON_STRICT_BYTE_CHAR -I/bad/path/graphviz/include/ -I/tmp/tmpy02y2dmo/.venv/include -I/usr/local/include/python3.13 -c pygraphviz/graphviz_wrap.c -o build/temp.linux-x86_64-cpython-313/pygraphviz/graphviz_wrap.o
```


```console
You can verify this by running pip wheel --no-cache-dir --use-pep517 --config-settings='--global-option=build_ext' --config-settings='--global-option=-I/bad/path/graphviz/include/' --config-settings='--global-option=-L/bad/path/lib/' "pygraphviz (==1.14)".
```

<details>
<summary><b>console.output</b></summary>
<p>

```console
Creating virtualenv foobar-lWDpn5M1-py3.13 in /root/.cache/pypoetry/virtualenvs
Using version ^1.14 for pygraphviz

Updating dependencies
Resolving dependencies...

Package operations: 1 install, 0 updates, 0 removals

  - Installing pygraphviz (1.14)

PEP517 build of a dependency failed

Backend subprocess exited when trying to invoke build_wheel

    | Command '['/tmp/tmpy02y2dmo/.venv/bin/python', '/usr/local/lib/python3.13/site-packages/pyproject_hooks/_in_process/_in_process.py', 'build_wheel', '/tmp/tmpokr672bw']' returned non-zero exit status 1.
    | 
    | running build_ext
    | building 'pygraphviz._graphviz' extension
    | creating build/temp.linux-x86_64-cpython-313/pygraphviz
    | gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -DSWIG_PYTHON_STRICT_BYTE_CHAR -I/bad/path/graphviz/include/ -I/tmp/tmpy02y2dmo/.venv/include -I/usr/local/include/python3.13 -c pygraphviz/graphviz_wrap.c -o build/temp.linux-x86_64-cpython-313/pygraphviz/graphviz_wrap.o
    | pygraphviz/graphviz_wrap.c:9: warning: "SWIG_PYTHON_STRICT_BYTE_CHAR" redefined
    |     9 | #define SWIG_PYTHON_STRICT_BYTE_CHAR
    |       | 
    | <command-line>: note: this is the location of the previous definition
    | pygraphviz/graphviz_wrap.c:3023:10: fatal error: graphviz/cgraph.h: No such file or directory
    |  3023 | #include "graphviz/cgraph.h"
    |       |          ^~~~~~~~~~~~~~~~~~~
    | compilation terminated.
    | error: command '/usr/bin/gcc' failed with exit code 1

Note: This error originates from the build backend, and is likely not a problem with poetry but one of the following issues with pygraphviz (1.14)

  - not supporting PEP 517 builds
  - not specifying PEP 517 build requirements correctly
  - the build requirements are incompatible with your operating system or Python version
  - the build requirements are missing system dependencies (eg: compilers, libraries, headers).

You can verify this by running pip wheel --no-cache-dir --use-pep517 --config-settings='--global-option=build_ext' --config-settings='--global-option=-I/bad/path/graphviz/include/' --config-settings='--global-option=-L/bad/path/lib/' "pygraphviz (==1.14)".
```

</p>
</details>

## Summary by Sourcery

Add support for PEP 517 build config settings during package installation. This allows specifying build configuration settings for dependencies that need to be built from source.

New Features:
- Added a new configuration option `installer.build-config-settings.<pkg>` to allow passing PEP 517 build configuration settings to build backends when building dependencies during installation.

Tests:
- Added tests to verify the new build config settings functionality.

## Summary by Sourcery

Add support for PEP 517 build config settings during dependency installation. This allows users to specify build configuration settings for dependencies that need to be built from source using the `installer.build-config-settings.<pkg>` config option.

New Features:
- Added the `installer.build-config-settings.<pkg>` configuration option to allow passing PEP 517 build configuration settings to build backends when building dependencies during installation.

Tests:
- Added tests to verify that build config settings are passed correctly to the builder.