### PR TITLE
chore(cli): deprecate default source priority

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1003,7 +1003,7 @@ The `source add` command adds source configuration to the project.
 For example, to add the `pypi-test` source, you can run:
 
 ```bash
-poetry source add pypi-test https://test.pypi.org/simple/
+poetry source add --priority supplemental pypi-test https://test.pypi.org/simple/
 ```
 
 You cannot use the name `pypi` for a custom repository as it is reserved for use by
@@ -1015,7 +1015,7 @@ poetry source add --priority=explicit pypi
 
 #### Options
 
-* `--priority`: Set the priority of this source. Accepted values are: [`supplemental`]({{< relref "repositories#supplemental-package-sources" >}}), and [`explicit`]({{< relref "repositories#explicit-package-sources" >}}). Refer to the dedicated sections in [Repositories]({{< relref "repositories" >}}) for more information.
+* `--priority`: Set the priority of this source. Accepted values are: [`primary`]({{< relref "repositories#primary-package-sources" >}}), [`supplemental`]({{< relref "repositories#supplemental-package-sources" >}}), and [`explicit`]({{< relref "repositories#explicit-package-sources" >}}). Refer to the dedicated sections in [Repositories]({{< relref "repositories" >}}) for more information.
 
 ### source show
 

--- a/src/poetry/console/commands/source/add.py
+++ b/src/poetry/console/commands/source/add.py
@@ -43,7 +43,8 @@ class SourceAddCommand(Command):
             "p",
             "Set the priority of this source. One of:"
             f" {', '.join(p.name.lower() for p in Priority)}. Defaults to"
-            f" {Priority.PRIMARY.name.lower()}.",
+            f" {Priority.PRIMARY.name.lower()}, but will switch to "
+            f"{Priority.SUPPLEMENTAL.name.lower()} in a later release.",
             flag=False,
         ),
     ]
@@ -70,6 +71,10 @@ class SourceAddCommand(Command):
             return 1
 
         if priority_str is None:
+            self.io.write_error_line(
+                f"<warning>The default priority will change to <b>{Priority.SUPPLEMENTAL.name.lower()}</> "
+                f"in a future release.</>"
+            )
             priority = Priority.PRIMARY
         else:
             priority = Priority[priority_str.upper()]

--- a/tests/console/commands/source/test_add.py
+++ b/tests/console/commands/source/test_add.py
@@ -30,11 +30,14 @@ def assert_source_added(
     added_source: Source,
     existing_sources: Iterable[Source] = (),
 ) -> None:
-    assert tester.io.fetch_error().strip() == ""
-    assert (
-        tester.io.fetch_output().strip()
-        == f"Adding source with name {added_source.name}."
-    )
+    expected_error = ""
+    if tester.io.input.option("priority") is None:
+        expected_error = f"The default priority will change to supplemental in a future release.\n{expected_error}"
+    assert tester.io.fetch_error().strip() == expected_error.strip()
+
+    expected_output = f"Adding source with name {added_source.name}."
+    assert tester.io.fetch_output().strip() == expected_output
+
     poetry.pyproject.reload()
     sources = poetry.get_sources()
     assert sources == [*existing_sources, added_source]


### PR DESCRIPTION
Relates-to: #9908

## Summary by Sourcery

Deprecate the default source priority for `poetry source add` from "primary" to "supplemental".  Emit a warning when using the default priority to inform users of the upcoming change.

Enhancements:
- Update the help text of the `poetry source add` command to reflect the deprecation of the default source priority and the future change to "supplemental".

Documentation:
- Document the `--priority` option for the `poetry source add` command and mention the possible values: primary, supplemental, and explicit.