### PR TITLE
feat(cli): default new command to src layout

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -608,39 +608,14 @@ poetry lock
 
 ## new
 
-This command will help you kickstart your new Python project by creating
-a directory structure suitable for most projects.
+This command will help you kickstart your new Python project by creating a new Poetry project. By default, a `src`
+layout is chosen.
 
 ```bash
 poetry new my-package
 ```
 
 will create a folder as follows:
-
-```text
-my-package
-├── pyproject.toml
-├── README.md
-├── my_package
-│   └── __init__.py
-└── tests
-    └── __init__.py
-```
-
-If you want to name your project differently than the folder, you can pass
-the `--name` option:
-
-```bash
-poetry new my-folder --name my-package
-```
-
-If you want to use a src folder, you can use the `--src` option:
-
-```bash
-poetry new --src my-package
-```
-
-That will create a folder structure as follows:
 
 ```text
 my-package
@@ -653,11 +628,41 @@ my-package
     └── __init__.py
 ```
 
+If you want to name your project differently than the folder, you can pass
+the `--name` option:
+
+```bash
+poetry new my-folder --name my-package
+```
+
+If you want to use a `flat` project layout, you can use the `--flat` option:
+
+```bash
+poetry new --flat my-package
+```
+
+That will create a folder structure as follows:
+
+```text
+my-package
+├── pyproject.toml
+├── README.md
+├── my_package
+│   └── __init__.py
+└── tests
+    └── __init__.py
+```
+
+{{% note %}}
+For an overview of the differences between `flat` and `src` layouts, please see
+[here](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
+{{% /note %}}
+
 The `--name` option is smart enough to detect namespace packages and create
 the required structure for you.
 
 ```bash
-poetry new --src --name my.package my-package
+poetry new --name my.package my-package
 ```
 
 will create the following structure:
@@ -678,7 +683,7 @@ my-package
 
 * `--interactive (-i)`: Allow interactive specification of project configuration.
 * `--name`: Set the resulting package name.
-* `--src`: Use the src layout for the project.
+* `--flat`: Use the flat layout for the project.
 * `--readme`: Specify the readme file extension. Default is `md`. If you intend to publish to PyPI
   keep the [recommendations for a PyPI-friendly README](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/)
   in mind.

--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -29,7 +29,13 @@ class NewCommand(InitCommand):
             flag=True,
         ),
         option("name", None, "Set the resulting package name.", flag=False),
-        option("src", None, "Use the src layout for the project."),
+        option(
+            "src",
+            None,
+            "Use the src layout for the project. "
+            "<warning>Deprecated</>: This is the default option now.",
+        ),
+        option("flat", None, "Use the flat layout for the project."),
         option(
             "readme",
             None,
@@ -72,9 +78,14 @@ class NewCommand(InitCommand):
                 f"Destination <fg=yellow>{path}</> exists and is not empty"
             )
 
+        if self.option("src"):
+            self.line_error(
+                "The <c1>--src</> option is now the default and will be removed in a future version."
+            )
+
         return self._init_pyproject(
             project_path=path,
             allow_interactive=self.option("interactive"),
-            layout_name="src" if self.option("src") else "standard",
+            layout_name="standard" if self.option("flat") else "src",
             readme_format=self.option("readme") or "md",
         )

--- a/tests/console/commands/conftest.py
+++ b/tests/console/commands/conftest.py
@@ -34,3 +34,24 @@ license = {text = "MIT"}
 readme = "README.md"
 requires-python = ">=3.6"
 """
+
+
+@pytest.fixture()
+def new_basic_toml() -> str:
+    return """\
+[project]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = [
+    {name = "Your Name",email = "you@example.com"}
+]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.6"
+dependencies = [
+]
+
+[tool.poetry]
+packages = [{include = "my_package", from = "src"}]
+"""


### PR DESCRIPTION
Resolves: #9390

## Summary by Sourcery

Set the default project layout to "src" when creating new projects using the `poetry new` command. Update the documentation and tests accordingly. Deprecate the `--src` option.

New Features:
- Create new projects with a "src" layout by default.

Tests:
- Update tests to reflect the new default layout.