### PR TITLE
fix `transitive_marker` handling

### DIFF
--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -514,6 +514,8 @@ class VersionSolver:
 
                 complete_name = dependency.complete_name
                 return complete_name
+
+            package.dependency.transitive_marker = dependency.transitive_marker
         else:
             package = locked
 


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Without this fix, `test_solver_should_not_raise_errors_for_irrelevant_transitive_python_constraints` wrongly chooses the later `importlib-resources` version even though it is not compatible with the project's python constraint depending on which is resolved first, `virtualenv` or `pre-commit`, because the transitive marker of the other's dependency on `importlib-resources` is ignored.

The first commit is just refactoring to facilitate the test, added in the second commit.

## Summary by Sourcery

Fix handling of transitive markers during dependency resolution. This addresses an issue where incompatible transitive dependencies could be selected due to incorrect marker handling.

Bug Fixes:
- Fix an issue where `test_solver_should_not_raise_errors_for_irrelevant_transitive_python_constraints` would select an incompatible `importlib-resources` version.

Tests:
- Add a test to verify the fix for transitive marker handling.