### PR TITLE
perf: tune heuristics for choosing the next package to solve

### DIFF
--- a/.github/workflows/.tests-matrix.yaml
+++ b/.github/workflows/.tests-matrix.yaml
@@ -112,6 +112,7 @@ jobs:
         # if the plugin still supports a wider range than Poetry itself.
         run: |
           perl -pi -e 's/^python =.*$/python = "~'"${PYTHON_VERSION}"'"/' pyproject.toml
+          poetry remove --lock poetry-core  # use whatever poetry uses
           poetry add --lock --group dev ../poetry
         env:
           PYTHON_VERSION: ${{ inputs.python-version }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1067,7 +1067,7 @@ develop = false
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "HEAD"
-resolved_reference = "eccf08b5703f20c39282aa8be335d125aa36faab"
+resolved_reference = "91542fc8d7220a1830cc73b85bb99f31ea4d5153"
 
 [[package]]
 name = "pre-commit"

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -149,7 +149,7 @@ class Provider:
                 reverse=True,
             )
 
-        self._get_package_from_pool = functools.cache(self._pool.package)
+        self.get_package_from_pool = functools.cache(self._pool.package)
 
     @property
     def pool(self) -> RepositoryPool:
@@ -469,7 +469,7 @@ class Provider:
         else:
             dependency_package = DependencyPackage(
                 dependency,
-                self._get_package_from_pool(
+                self.get_package_from_pool(
                     package.pretty_name,
                     package.version,
                     repository_name=dependency.source_name,

--- a/tests/mixology/version_solver/test_unsolvable.py
+++ b/tests/mixology/version_solver/test_unsolvable.py
@@ -71,9 +71,9 @@ def test_disjoint_constraints(
     add_to_repo(repo, "shared", "4.0.0")
 
     error = """\
-Because bar (1.0.0) depends on shared (>3.0.0)
- and foo (1.0.0) depends on shared (<=2.0.0),\
- bar (1.0.0) is incompatible with foo (1.0.0).
+Because foo (1.0.0) depends on shared (<=2.0.0)
+ and bar (1.0.0) depends on shared (>3.0.0),\
+ foo (1.0.0) is incompatible with bar (1.0.0).
 So, because myapp depends on both foo (1.0.0) and bar (1.0.0), version solving failed.\
 """
 


### PR DESCRIPTION
- Do not consider anymore if a dependency has a specific marker or not, since there is no good explanation for this criterion.
- Consider if a package has dependencies and especially how many dependencies with a constraint with an upper bound, because these are more likely to cause conflicts later.

# Pull Request Check List

Related to: #9956
Requires: python-poetry/poetry-core#833

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This reduces the time to lock the first example from https://github.com/python-poetry/poetry/issues/9956#issuecomment-2629031927 from over 400 s to less than 30 s while not increasing the time for any other example. See https://github.com/python-poetry/poetry/issues/9956#issuecomment-2629469443 for alternative (simpler but less explainable) variants, which all had a negative influence on at least one example.

## Summary by Sourcery

Enhancements:
- Prioritize packages with dependencies, especially those with upper-bound constraints, when selecting the next package to resolve.