### PR TITLE
Add dotpoetry folder override

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,9 +159,9 @@ You can override the Cache directory by setting the `POETRY_CACHE_DIR` environme
 
 ### Project Directory
 
-By default, the Poetry project directory is set to `.poetry/` in the project root. It is used by Poetry for storing project-specific 
-data. For example, the required plugins defined in `pyproject.toml` are installed by default in the `.poetry/plugins/` directory. 
-You can override the Poetry project directory by setting the `POETRY_PROJECT_DIR` environment variable. Note that it must be a relative 
+By default, the Poetry project directory is set to `.poetry/` in the project root. It is used by Poetry for storing project-specific
+data. For example, the required plugins defined in `pyproject.toml` are installed by default in the `.poetry/plugins/` directory.
+You can override the Poetry project directory by setting the `POETRY_PROJECT_DIR` environment variable. Note that it must be a relative
 folder path from the current project root, or an error will be reported.
 
 ## Available settings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,13 @@ You can override the Data directory by setting the `POETRY_DATA_DIR` or `POETRY_
 
 You can override the Cache directory by setting the `POETRY_CACHE_DIR` environment variable.
 
+### Project Directory
+
+By default, the Poetry project directory is set to `.poetry/` in the project root. It is used by Poetry for storing project-specific 
+data. For example, the required plugins defined in `pyproject.toml` are installed by default in the `.poetry/plugins/` directory. 
+You can override the Poetry project directory by setting the `POETRY_PROJECT_DIR` environment variable. Note that it must be a relative 
+folder path from the current project root, or an error will be reported.
+
 ## Available settings
 
 ### `cache-dir`

--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import shutil
 import sys
 
@@ -103,7 +104,7 @@ class PluginManager:
 
 
 class ProjectPluginCache:
-    PATH = Path(".poetry") / "plugins"
+    PATH = Path(os.getenv("POETRY_PLUGIN_DIR", ".poetry")) / "plugins"
 
     def __init__(self, poetry: Poetry, io: IO) -> None:
         self._poetry = poetry

--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -105,6 +105,8 @@ class PluginManager:
 
 class ProjectPluginCache:
     PATH = Path(os.getenv("POETRY_PLUGIN_DIR", ".poetry")) / "plugins"
+    if PATH.is_absolute():
+        raise RuntimeError("POETRY_PLUGIN_DIR env var must represent a relative path from the project directory")
 
     def __init__(self, poetry: Poetry, io: IO) -> None:
         self._poetry = poetry

--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -104,9 +104,9 @@ class PluginManager:
 
 
 class ProjectPluginCache:
-    PATH = Path(os.getenv("POETRY_PLUGIN_DIR", ".poetry")) / "plugins"
+    PATH = Path(os.getenv("POETRY_PROJECT_DIR", ".poetry")) / "plugins"
     if PATH.is_absolute():
-        raise RuntimeError("POETRY_PLUGIN_DIR env var must represent a relative path from the project directory")
+        raise RuntimeError("POETRY_PROJECT_DIR env var must represent a relative path from the project directory")
 
     def __init__(self, poetry: Poetry, io: IO) -> None:
         self._poetry = poetry

--- a/src/poetry/plugins/plugin_manager.py
+++ b/src/poetry/plugins/plugin_manager.py
@@ -106,7 +106,9 @@ class PluginManager:
 class ProjectPluginCache:
     PATH = Path(os.getenv("POETRY_PROJECT_DIR", ".poetry")) / "plugins"
     if PATH.is_absolute():
-        raise RuntimeError("POETRY_PROJECT_DIR env var must represent a relative path from the project directory")
+        raise RuntimeError(
+            "POETRY_PROJECT_DIR env var must represent a relative path from the project directory"
+        )
 
     def __init__(self, poetry: Poetry, io: IO) -> None:
         self._poetry = poetry


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10148

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Allow overriding the default ".poetry" project directory using the POETRY_PROJECT_DIR environment variable.

Enhancements:
- Add support for overriding the default project directory.

Documentation:
- Document the new POETRY_PROJECT_DIR environment variable and its usage.