### PR TITLE
Fix: Documentation/help inconsistency.

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -104,9 +104,9 @@ You can specify a package in the following forms:
  (<b>git+https://github.com/python-poetry/poetry.git#develop</b>)
   - A subdirectory of a git repository\
  (<b>git+https://github.com/python-poetry/poetry.git#subdirectory=tests/fixtures/sample_project</b>)
-  - A git SSH url (<b>git+ssh://github.com/python-poetry/poetry.git</b>)
+  - A git SSH url (<b>git+ssh://git@github.com/python-poetry/poetry.git</b>)
   - A git SSH url with a revision\
- (<b>git+ssh://github.com/python-poetry/poetry.git#develop</b>)
+ (<b>git+ssh://git@github.com/python-poetry/poetry.git#develop</b>)
   - A file path (<b>../my-package/my-package.whl</b>)
   - A directory (<b>../my-package/</b>)
   - A url (<b>https://example.com/packages/my-package-0.1.0.tar.gz</b>)


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6887

- [ **N/A** ] Added **tests** for changed code.
- [ **N/A** ] Updated **documentation** for changed code.

# Description

Ensure that the documentation examples match those printed by the `--help` command.

## Summary by Sourcery

Correct the help examples for the `add` command to accurately reflect the supported URL formats.

Enhancements:
- Standardise URL formats in the documentation and help output.

Documentation:
- Update documentation examples to align with the corrected help output.