### PR TITLE
fix: update error message for deprecated 'shell' command in v2.0

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -293,6 +293,8 @@ class Application(BaseApplication):
                     suggested_names = find_similar_names(
                         command, list(self._commands.keys())
                     )
+                    if command == "shell":
+                        io.write_error_line("poetry shell is not available anymore since v2.0. Please use `poetry env activate` instead.")
                     io.write_error_line(
                         f"The requested command <c1>{command}</> does not exist."
                     )


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

## Summary by Sourcery

Bug Fixes:
- Clarify the error message when users try to use the deprecated `shell` command, suggesting the use of `poetry env activate` instead.