### PR TITLE
fix "env use python" to use Python in PATH

### DIFF
--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -230,13 +230,6 @@ class Python:
         return None
 
     @classmethod
-    def from_executable(cls, path: Path | str) -> Python:
-        try:
-            return cls(python=findpython.PythonVersion(executable=Path(path)))
-        except (FileNotFoundError, NotADirectoryError, ValueError):
-            raise ValueError(f"{path} is not a valid Python executable")
-
-    @classmethod
     def get_system_python(cls) -> Python:
         """
         Creates and returns an instance of the class representing the Poetry's Python executable.
@@ -252,10 +245,10 @@ class Python:
 
     @classmethod
     def get_by_name(cls, python_name: str) -> Python | None:
-        if Path(python_name).exists():
-            with contextlib.suppress(ValueError):
-                # if it is a path try assuming it is an executable
-                return cls.from_executable(python_name)
+        # Ignore broken installations.
+        with contextlib.suppress(ValueError):
+            if python := ShutilWhichPythonProvider.find_python_by_name(python_name):
+                return cls(python=python)
 
         if python := findpython.find(python_name):
             return cls(python=python)

--- a/src/poetry/utils/env/python/providers.py
+++ b/src/poetry/utils/env/python/providers.py
@@ -28,9 +28,15 @@ class ShutilWhichPythonProvider(findpython.BaseProvider):  # type: ignore[misc]
         return cls()
 
     def find_pythons(self) -> Iterable[findpython.PythonVersion]:
-        if path := shutil.which("python"):
-            return [findpython.PythonVersion(executable=Path(path))]
+        if python := self.find_python_by_name("python"):
+            return [python]
         return []
+
+    @classmethod
+    def find_python_by_name(cls, name: str) -> findpython.PythonVersion | None:
+        if path := shutil.which(name):
+            return findpython.PythonVersion(executable=Path(path))
+        return None
 
 
 @dataclasses.dataclass

--- a/tests/utils/env/python/test_manager.py
+++ b/tests/utils/env/python/test_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import platform
+import sys
 
 from typing import TYPE_CHECKING
 
@@ -95,3 +96,39 @@ def find_downloadable_versions_include_incompatible() -> None:
     assert len(
         list(Python.find_downloadable_versions(include_incompatible=True))
     ) > len(list(Python.find_downloadable_versions()))
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_minor"),
+    [
+        ("3.9", 9),
+        ("3.10", 10),
+        ("3.11", None),
+    ],
+)
+def test_get_by_name_version(
+    mocked_python_register: MockedPythonRegister, name: str, expected_minor: int | None
+) -> None:
+    mocked_python_register("3.9.1", implementation="CPython", parent="a")
+    mocked_python_register("3.10.3", implementation="CPython", parent="b")
+
+    python = Python.get_by_name(name)
+    if expected_minor is None:
+        assert python is None
+    else:
+        assert python is not None
+        assert python.minor == expected_minor
+
+
+def test_get_by_name_python(without_mocked_findpython: None) -> None:
+    python = Python.get_by_name("python")
+    assert python is not None
+    assert python.version.major == 3
+    assert python.version.minor == sys.version_info.minor
+
+
+def test_get_by_name_path(without_mocked_findpython: None) -> None:
+    python = Python.get_by_name(sys.executable)
+    assert python is not None
+    assert python.version.major == 3
+    assert python.version.minor == sys.version_info.minor

--- a/tests/utils/env/python/test_python_providers.py
+++ b/tests/utils/env/python/test_python_providers.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
+import sys
+
 from typing import TYPE_CHECKING
 
 from poetry.core.constraints.version import Version
 
 from poetry.utils.env.python.providers import PoetryPythonPathProvider
+from poetry.utils.env.python.providers import ShutilWhichPythonProvider
 
 
 if TYPE_CHECKING:
     from tests.types import MockedPoetryPythonRegister
+
+
+def test_shutil_which_python_provider() -> None:
+    provider = ShutilWhichPythonProvider.create()
+    assert provider
+    pythons = list(provider.find_pythons())
+    assert len(pythons) == 1
+    assert pythons[0].minor == sys.version_info.minor
 
 
 def test_poetry_python_path_provider_no_pythons() -> None:


### PR DESCRIPTION
This should use the Python, which is in the PATH, not the latest Python.

# Pull Request Check List

Resolves: #10186

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Fix the `env use python` command to select the Python executable specified in the user's PATH.

Bug Fixes:
- Use the Python executable found in the user's PATH when running `env use python` instead of the latest Python version available.

Tests:
- Add tests to verify that the correct Python executable is selected when using `env use python`.