### PR TITLE
release: bump version to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [2.1.1] - 2025-02-16
+
+### Fixed
+
+- Fix an issue where `poetry env use python` does not choose the Python from the PATH ([#10187](https://github.com/python-poetry/poetry/pull/10187)).
+
+### poetry-core ([`2.1.1`](https://github.com/python-poetry/poetry-core/releases/tag/2.1.1))
+
+- Fix an issue where simplifying a `python_version` marker resulted in an invalid marker ([#838](https://github.com/python-poetry/poetry-core/pull/838)).
+
+
 ## [2.1.0] - 2025-02-15
 
 ### Added
@@ -2445,7 +2456,8 @@ Initial release
 
 
 
-[Unreleased]: https://github.com/python-poetry/poetry/compare/2.1.0...main
+[Unreleased]: https://github.com/python-poetry/poetry/compare/2.1.1...main
+[2.1.1]: https://github.com/python-poetry/poetry/releases/tag/2.1.1
 [2.1.0]: https://github.com/python-poetry/poetry/releases/tag/2.1.0
 [2.0.1]: https://github.com/python-poetry/poetry/releases/tag/2.0.1
 [2.0.0]: https://github.com/python-poetry/poetry/releases/tag/2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry"
-version = "2.1.0"
+version = "2.1.1"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.9,<4.0"
 dependencies = [


### PR DESCRIPTION
### Fixed

- Fix an issue where `poetry env use python` does not choose the Python from the PATH ([#10187](https://github.com/python-poetry/poetry/pull/10187)).

### poetry-core ([`2.1.1`](https://github.com/python-poetry/poetry-core/releases/tag/2.1.1))

- Fix an issue where simplifying a `python_version` marker resulted in an invalid marker ([#838](https://github.com/python-poetry/poetry-core/pull/838)).

## Summary by Sourcery

Prepare for the 2.1.1 release by fixing a bug in `poetry env use python` and an issue with simplifying `python_version` markers. Update the changelog and bump the version to 2.1.1.

Bug Fixes:
- Fix an issue where `poetry env use python` does not choose the Python from the PATH.
- Fix an issue where simplifying a `python_version` marker resulted in an invalid marker

Documentation:
- Update changelog for 2.1.1 release

Chores:
- Bump version to 2.1.1