### PR TITLE
Correct "introduced in <version>" docs for `requests.max-retries`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -337,7 +337,7 @@ poetry config --local installer.build-config-settings.grpcio \
 
 **Environment Variable**: `POETRY_REQUESTS_MAX_RETRIES`
 
-*Introduced in 1.9.0*
+*Introduced in 2.0.0*
 
 Set the maximum number of retries in an unstable network.
 This setting has no effect if the server does not support HTTP range requests.


### PR DESCRIPTION
The `requests.max-retries` option was added in Poetry 2.0.0, not 1.9.0:
https://github.com/python-poetry/poetry/pull/9422
https://github.com/python-poetry/poetry/blob/2.0.0/CHANGELOG.md?plain=1#L17

## Summary by Sourcery

Documentation:
- Correct the documentation to reflect that the `requests.max-retries` configuration option was introduced in Poetry version 2.0.0, not 1.9.0.