### PR TITLE
fix typo

### DIFF
--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -181,6 +181,6 @@ poetry sync --only dev
 
 ## Layering optional groups
 
-When you using `install` command without the `--sync` option, you can install any subset of optional groups without removing
+When using the `install` command without the `--sync` option, you can install any subset of optional groups without removing
 those that are already installed.  This is very useful, for example, in multi-stage
 Docker builds, where you run `poetry install` multiple times in different build stages.


### PR DESCRIPTION
Simple fix

## Summary by Sourcery

Bug Fixes:
- Fixes a typo in the documentation regarding the usage of the `install` command.