### PR TITLE
fix calculation of override markers when merging override packages

### DIFF
--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -158,7 +158,9 @@ class Solver:
             new_packages = self._solve()
             override_packages.append((override, new_packages))
 
-        return merge_override_packages(override_packages)
+        return merge_override_packages(
+            override_packages, self._package.python_constraint
+        )
 
     def _solve(self) -> dict[Package, TransitivePackageInfo]:
         if self._provider._overrides:
@@ -419,6 +421,7 @@ def merge_override_packages(
             dict[Package, dict[str, Dependency]], dict[Package, TransitivePackageInfo]
         ]
     ],
+    python_constraint: VersionConstraint,
 ) -> dict[Package, TransitivePackageInfo]:
     result: dict[Package, TransitivePackageInfo] = {}
     all_packages: dict[
@@ -429,6 +432,7 @@ def merge_override_packages(
         for deps in override.values():
             for dep in deps.values():
                 override_marker = override_marker.intersect(dep.marker.without_extras())
+        override_marker = simplify_marker(override_marker, python_constraint)
         for package, info in o_packages.items():
             for group, marker in info.markers.items():
                 # `override_marker` is often a SingleMarker or a MultiMarker,


### PR DESCRIPTION
# Pull Request Check List

Related to: #10237
(Fixes the example of the OP but to fix the issue in general both, this PR and python-poetry/poetry-core#846, are required.)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Tests:
- Adds a test case to verify the correct marker generation based on the project's Python constraint.