### PR TITLE
fix(env): use csh activation script for tcsh

### DIFF
--- a/src/poetry/console/commands/env/activate.py
+++ b/src/poetry/console/commands/env/activate.py
@@ -44,7 +44,7 @@ class EnvActivateCommand(EnvCommand):
             command, filename = "source", "activate.fish"
         elif shell == "nu":
             command, filename = "overlay use", "activate.nu"
-        elif shell == "csh":
+        elif shell in ["csh", "tcsh"]:
             command, filename = "source", "activate.csh"
         elif shell in ["powershell", "pwsh"]:
             command, filename = ".", "Activate.ps1"

--- a/tests/console/commands/env/test_activate.py
+++ b/tests/console/commands/env/test_activate.py
@@ -28,6 +28,7 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
         ("fish", "source", ".fish"),
         ("nu", "overlay use", ".nu"),
         ("csh", "source", ".csh"),
+        ("tcsh", "source", ".csh"),
     ),
 )
 @pytest.mark.skipif(WINDOWS, reason="Only Unix shells")


### PR DESCRIPTION
# Pull Request Check List

Resolves: virtualenv activation currently uses Bash script when shell is tcsh, which doesn't work, so this change makes it use the csh activation script

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Bug Fixes:
- Fixes virtualenv activation to use the csh activation script when the shell is tcsh.