### PR TITLE
improved error message for env activate

### DIFF
--- a/src/poetry/console/commands/env/activate.py
+++ b/src/poetry/console/commands/env/activate.py
@@ -27,19 +27,20 @@ class EnvActivateCommand(EnvCommand):
 
         env = EnvManager(self.poetry).get()
 
-        if command := self._get_activate_command(env):
-            self.line(command)
-            return 0
-        else:
-            raise ShellNotSupportedError(
-                "Discovered shell doesn't have an activator in virtual environment"
-            )
-
-    def _get_activate_command(self, env: Env) -> str:
         try:
             shell, _ = shellingham.detect_shell()
         except shellingham.ShellDetectionFailure:
             shell = ""
+
+        if command := self._get_activate_command(env, shell):
+            self.line(command)
+            return 0
+
+        raise ShellNotSupportedError(
+            f"Discovered shell '{shell}' doesn't have an activator in virtual environment"
+        )
+
+    def _get_activate_command(self, env: Env, shell: str) -> str:
         if shell == "fish":
             command, filename = "source", "activate.fish"
         elif shell == "nu":


### PR DESCRIPTION
tiny refactoring to give a more useful error message when `poetry env activate` goes wrong

## Summary by Sourcery

Improve the error message when `poetry env activate` fails to find a shell activator script, including the name of the discovered shell in the error message.