### PR TITLE
tests: make tests forwards compatible with poetry-core#851

### DIFF
--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -2140,7 +2140,8 @@ def test_solver_duplicate_dependencies_with_overlapping_markers_complex(
     )
     opencv_requires = {dep.to_pep_508() for dep in ops[-1].package.requires}
 
-    assert opencv_requires == {
+    # before https://github.com/python-poetry/poetry-core/pull/851
+    expected1 = {
         (
             "numpy (>=1.21.2) ;"
             ' python_version >= "3.6" and platform_system == "Darwin"'
@@ -2170,6 +2171,38 @@ def test_solver_duplicate_dependencies_with_overlapping_markers_complex(
             ' or platform_system != "Linux" or platform_machine != "aarch64")'
         ),
     }
+    # after https://github.com/python-poetry/poetry-core/pull/851
+    expected2 = {
+        (
+            "numpy (>=1.21.2) ;"
+            ' platform_system == "Darwin" and platform_machine == "arm64"'
+            ' and python_version >= "3.6" or python_version >= "3.10"'
+        ),
+        (
+            'numpy (>=1.19.3) ; python_version >= "3.6" and python_version < "3.10"'
+            ' and platform_system == "Linux" and platform_machine == "aarch64"'
+            ' or python_version == "3.9" and platform_machine != "arm64"'
+            ' or python_version == "3.9" and platform_system != "Darwin"'
+        ),
+        (
+            'numpy (>=1.17.3) ; python_version == "3.8"'
+            ' and (platform_system != "Darwin" or platform_machine != "arm64")'
+            ' and (platform_system != "Linux" or platform_machine != "aarch64")'
+        ),
+        (
+            'numpy (>=1.14.5) ; python_version == "3.7"'
+            ' and (platform_system != "Darwin" or platform_machine != "arm64")'
+            ' and (platform_system != "Linux" or platform_machine != "aarch64")'
+        ),
+        (
+            'numpy (>=1.13.3) ; python_version < "3.7"'
+            ' and (python_version < "3.6" or platform_system != "Darwin"'
+            ' or platform_machine != "arm64") and (python_version < "3.6"'
+            ' or platform_system != "Linux" or platform_machine != "aarch64")'
+        ),
+    }
+
+    assert opencv_requires in (expected1, expected2)
 
 
 def test_duplicate_path_dependencies(

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -106,7 +106,7 @@ def test_package(
     ]
     win_inet = package.extras[canonicalize_name("socks")][1]
     assert win_inet.name == "win-inet-pton"
-    assert win_inet.python_versions == "~2.7 || ~2.6"
+    assert win_inet.python_versions in {"~2.7 || ~2.6", ">=2.6 <2.8"}
 
     # Different versions of poetry-core simplify the following marker differently,
     # either is fine.
@@ -118,7 +118,11 @@ def test_package(
         'sys_platform == "win32" and python_version == "2.7" and extra == "socks" or'
         ' sys_platform == "win32" and python_version == "2.6" and extra == "socks"'
     )
-    assert str(win_inet.marker) in {marker1, marker2}
+    marker3 = (
+        'sys_platform == "win32" and python_version >= "2.6" and python_version < '
+        '"2.8" and extra == "socks"'
+    )
+    assert str(win_inet.marker) in {marker1, marker2, marker3}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Make tests forwards compatible with python-poetry/poetry-core#851

The modified markers are equivalent.

## Summary by Sourcery

Tests:
- Make tests forward compatible with poetry-core#851.