### PR TITLE
fix: installer.no-binary takes precedence over installer.only-binary

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,6 +221,8 @@ This configuration is ignored when `installer.parallel` is set to `false`.
 
 When set, this configuration allows users to disallow the use of binary distribution format for all, none or specific packages.
 
+If both `installer.no-binary` and `installer.only-binary` configurations match a package, `installer.no-binary` takes precedence.
+
 | Configuration          | Description                                                |
 |------------------------|------------------------------------------------------------|
 | `:all:` or `true`      | Disallow binary distributions for all packages.            |
@@ -268,6 +270,8 @@ across all your projects if incorrectly set.
 
 When set, this configuration allows users to enforce the use of binary distribution format for all, none or
 specific packages.
+
+If both `installer.no-binary` and `installer.only-binary` configurations match a package, `installer.no-binary` takes precedence.
 
 {{% note %}}
 Please refer to [`installer.no-binary`]({{< relref "configuration#installerno-binary" >}}) for information on allowed

--- a/src/poetry/installation/chooser.py
+++ b/src/poetry/installation/chooser.py
@@ -85,14 +85,18 @@ class Chooser:
                 continue
 
             if link.is_sdist and not self._only_binary_policy.allows(package.name):
-                logger.debug(
-                    "Skipping source distribution for %s as requested in only binary policy for"
-                    " package (%s)",
-                    link.filename,
-                    package.name,
-                )
-                sdists_skipped += 1
-                continue
+                if not self._no_binary_policy.allows(package.name):
+                    # no-binary policy takes precedence over only-binary policy
+                    pass
+                else:
+                    logger.debug(
+                        "Skipping source distribution for %s as requested in only binary policy for"
+                        " package (%s)",
+                        link.filename,
+                        package.name,
+                    )
+                    sdists_skipped += 1
+                    continue
 
             links.append(link)
 

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -122,15 +122,16 @@ def test_chooser_only_binary_policy(
 @pytest.mark.parametrize(
     ("no_binary", "only_binary", "filename"),
     [
-        (":all:", ":all:", None),
+        (":all:", ":all:", "pytest-3.5.0.tar.gz"),
         (":none:", ":none:", "pytest-3.5.0-py2.py3-none-any.whl"),
         (":none:", ":all:", "pytest-3.5.0-py2.py3-none-any.whl"),
         (":all:", ":none:", "pytest-3.5.0.tar.gz"),
         ("black", "black", "pytest-3.5.0-py2.py3-none-any.whl"),
         ("black", "pytest", "pytest-3.5.0-py2.py3-none-any.whl"),
         ("pytest", "black", "pytest-3.5.0.tar.gz"),
-        ("pytest", "pytest", None),
-        ("pytest,black", "pytest,black", None),
+        ("pytest", "pytest", "pytest-3.5.0.tar.gz"),
+        ("pytest,black", "pytest,black", "pytest-3.5.0.tar.gz"),
+        ("pytest", ":all:", "pytest-3.5.0.tar.gz"),
     ],
 )
 @pytest.mark.parametrize("source_type", ["", "legacy"])

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -122,16 +122,19 @@ def test_chooser_only_binary_policy(
 @pytest.mark.parametrize(
     ("no_binary", "only_binary", "filename"),
     [
-        (":all:", ":all:", "pytest-3.5.0.tar.gz"),
+        # no `no_binary` for pytest
         (":none:", ":none:", "pytest-3.5.0-py2.py3-none-any.whl"),
         (":none:", ":all:", "pytest-3.5.0-py2.py3-none-any.whl"),
-        (":all:", ":none:", "pytest-3.5.0.tar.gz"),
         ("black", "black", "pytest-3.5.0-py2.py3-none-any.whl"),
         ("black", "pytest", "pytest-3.5.0-py2.py3-none-any.whl"),
+        # `no_binary` but no `only_binary` for pytest
+        (":all:", ":none:", "pytest-3.5.0.tar.gz"),
         ("pytest", "black", "pytest-3.5.0.tar.gz"),
+        # both `no_binary` and `only_binary` for pytest (`no_binary` should take precedence)
         ("pytest", "pytest", "pytest-3.5.0.tar.gz"),
-        ("pytest,black", "pytest,black", "pytest-3.5.0.tar.gz"),
+        (":all:", ":all:", "pytest-3.5.0.tar.gz"),
         ("pytest", ":all:", "pytest-3.5.0.tar.gz"),
+        ("pytest,black", "pytest,black", "pytest-3.5.0.tar.gz"),
     ],
 )
 @pytest.mark.parametrize("source_type", ["", "legacy"])


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10231

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [*] Added **tests** for changed code.
- [*] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
