### PR TITLE
Fix test_python_get_preferred_default with Python pre-releases

### DIFF
--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -51,10 +51,11 @@ def test_python_get_system_python() -> None:
 
 def test_python_get_preferred_default(config: Config) -> None:
     python = Python.get_preferred_python(config)
+    version_len = 3 if sys.version_info[3] == "final" else 5
 
     assert python.executable == Path(sys.executable)
     assert python.version == Version.parse(
-        ".".join(str(v) for v in sys.version_info[:3])
+        ".".join(str(v) for v in sys.version_info[:version_len])
     )
 
 


### PR DESCRIPTION
The version we check is now Version.parse("3.14.0.alpha.6") instead of Version.parse("3.14.0").

Fixes https://github.com/python-poetry/poetry/issues/10302

## Summary by Sourcery

Update test case to correctly handle Python pre-release versions by adjusting version parsing

Bug Fixes:
- Fix version parsing for Python pre-release versions to correctly capture the full version string

Tests:
- Modify test_python_get_preferred_default to dynamically adjust version length based on whether the Python version is a final release