### PR TITLE
fix(solver): do not choose a (locked) package from an explicit source for a dependency that does not allow an explicit source

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -30,6 +30,7 @@ from poetry.packages import DependencyPackage
 from poetry.packages.direct_origin import DirectOrigin
 from poetry.packages.package_collection import PackageCollection
 from poetry.puzzle.exceptions import OverrideNeededError
+from poetry.repositories.repository_pool import Priority
 from poetry.utils.helpers import get_file_hash
 
 
@@ -753,6 +754,14 @@ class Provider:
             if package.satisfies(dependency):
                 if explicit_source := self._explicit_sources.get(dependency.name):
                     dependency.source_name = explicit_source
+                elif (
+                    not dependency.source_name
+                    and package.source_type == "legacy"
+                    and package.source_reference
+                    and self._pool.get_priority(package.source_reference)
+                    == Priority.EXPLICIT
+                ):
+                    continue
                 return DependencyPackage(dependency, package)
         return None
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10315

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Improve package source selection logic in the solver to handle complex dependency scenarios with explicit sources

Bug Fixes:
- Prevent choosing a package from an explicit source when the dependency does not explicitly allow it

Tests:
- Add a comprehensive test case to verify package source selection behavior with multiple constraints and locked packages