### PR TITLE
Add activate command alias for env commad

### DIFF
--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -86,6 +86,8 @@ The `poetry env activate` command prints the activate command of the virtual env
 You can run the output command manually or feed it to the eval command of your shell to activate the environment.
 This way you won't leave the current shell.
 
+The `poetry activate` command acts an alias for `poetry env activate` and is interchangeable with each other.
+
 {{< tabs tabTotal="3" tabID1="bash-csh-zsh" tabID2="fish" tabID3="powershell" tabName1="Bash/Zsh/Csh" tabName2="Fish" tabName3="Powershell" >}}
 
 {{< tab tabID="bash-csh-zsh" >}}

--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -86,7 +86,7 @@ The `poetry env activate` command prints the activate command of the virtual env
 You can run the output command manually or feed it to the eval command of your shell to activate the environment.
 This way you won't leave the current shell.
 
-The `poetry activate` command acts an alias for `poetry env activate` and is interchangeable with each other.
+The `poetry activate` command acts as an alias for `poetry env activate` and is interchangeable with each other.
 
 {{< tabs tabTotal="3" tabID1="bash-csh-zsh" tabID2="fish" tabID3="powershell" tabName1="Bash/Zsh/Csh" tabName2="Fish" tabName3="Powershell" >}}
 

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -54,6 +54,8 @@ def load_command(name: str) -> Callable[[], Command]:
 COMMANDS = [
     "about",
     "add",
+    # Alias commands
+    "activate",
     "build",
     "check",
     "config",

--- a/src/poetry/console/commands/activate.py
+++ b/src/poetry/console/commands/activate.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from poetry.console.commands.env.activate import EnvActivateCommand
+
+
+class ActivateCommand(EnvActivateCommand):
+    name = "activate"
+    description = "Alias for the env activate command"

--- a/tests/console/commands/test_activate.py
+++ b/tests/console/commands/test_activate.py
@@ -20,6 +20,11 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
     return command_tester_factory("activate")
 
 
+@pytest.fixture
+def env_tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
+    return command_tester_factory("activate")
+
+
 @pytest.mark.parametrize(
     "shell, command, ext",
     (
@@ -32,10 +37,11 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
     ),
 )
 @pytest.mark.skipif(WINDOWS, reason="Only Unix shells")
-def test_env_activate_prints_correct_script(
+def test_activate_prints_correct_script_and_matches_env_activate(
     tmp_venv: VirtualEnv,
     mocker: MockerFixture,
     tester: CommandTester,
+    env_tester: CommandTester,
     shell: str,
     command: str,
     ext: str,
@@ -44,10 +50,14 @@ def test_env_activate_prints_correct_script(
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
 
     tester.execute()
+    env_tester.execute()
 
     line = tester.io.fetch_output().split("\n")[0]
+    env_line = env_tester.io.fetch_output().split("\n")[0]
+
     assert line.startswith(command)
     assert line.endswith(f"activate{ext}")
+    assert line == env_line
 
 
 @pytest.mark.parametrize(
@@ -59,10 +69,11 @@ def test_env_activate_prints_correct_script(
     ),
 )
 @pytest.mark.skipif(not WINDOWS, reason="Only Windows shells")
-def test_env_activate_prints_correct_script_on_windows(
+def test_activate_prints_correct_script_on_windows(
     tmp_venv: VirtualEnv,
     mocker: MockerFixture,
     tester: CommandTester,
+    env_tester: CommandTester,
     shell: str,
     command: str,
     ext: str,
@@ -72,6 +83,10 @@ def test_env_activate_prints_correct_script_on_windows(
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
 
     tester.execute()
+    env_tester.execute()
 
     line = tester.io.fetch_output().split("\n")[0]
+    env_line = env_tester.io.fetch_output().split("\n")[0]
+
     assert line == f'{prefix}"{tmp_venv.bin_dir / ext!s}"'
+    assert line == env_line

--- a/tests/console/commands/test_activate.py
+++ b/tests/console/commands/test_activate.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from poetry.utils._compat import WINDOWS
+
+
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+    from pytest_mock import MockerFixture
+
+    from poetry.utils.env import VirtualEnv
+    from tests.types import CommandTesterFactory
+
+
+@pytest.fixture
+def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
+    return command_tester_factory("activate")
+
+
+@pytest.mark.parametrize(
+    "shell, command, ext",
+    (
+        ("bash", "source", ""),
+        ("zsh", "source", ""),
+        ("fish", "source", ".fish"),
+        ("nu", "overlay use", ".nu"),
+        ("csh", "source", ".csh"),
+        ("tcsh", "source", ".csh"),
+    ),
+)
+@pytest.mark.skipif(WINDOWS, reason="Only Unix shells")
+def test_env_activate_prints_correct_script(
+    tmp_venv: VirtualEnv,
+    mocker: MockerFixture,
+    tester: CommandTester,
+    shell: str,
+    command: str,
+    ext: str,
+) -> None:
+    mocker.patch("shellingham.detect_shell", return_value=(shell, None))
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
+
+    tester.execute()
+
+    line = tester.io.fetch_output().split("\n")[0]
+    assert line.startswith(command)
+    assert line.endswith(f"activate{ext}")
+
+
+@pytest.mark.parametrize(
+    "shell, command, ext, prefix",
+    (
+        ("cmd", ".", "activate.bat", ""),
+        ("pwsh", ".", "activate.ps1", "& "),
+        ("powershell", ".", "activate.ps1", "& "),
+    ),
+)
+@pytest.mark.skipif(not WINDOWS, reason="Only Windows shells")
+def test_env_activate_prints_correct_script_on_windows(
+    tmp_venv: VirtualEnv,
+    mocker: MockerFixture,
+    tester: CommandTester,
+    shell: str,
+    command: str,
+    ext: str,
+    prefix: str,
+) -> None:
+    mocker.patch("shellingham.detect_shell", return_value=(shell, None))
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
+
+    tester.execute()
+
+    line = tester.io.fetch_output().split("\n")[0]
+    assert line == f'{prefix}"{tmp_venv.bin_dir / ext!s}"'


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10266 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This PR adds a new command called activate that acts as an alias for the "env activate" command.

## Summary by Sourcery

Add an alias command 'activate' for the existing 'env activate' command in Poetry

New Features:
- Introduce a new 'activate' command that directly maps to 'poetry env activate', providing a more convenient shorthand for activating virtual environments

Documentation:
- Update documentation to explain the new 'activate' command and its relationship to 'env activate'

Tests:
- Add comprehensive test cases for the new 'activate' command, covering different shell environments and activation scenarios