### PR TITLE
fix `--directory` for plugins that access the poetry instance during activation

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -251,11 +251,11 @@ class Application(BaseApplication):
         # display the error cleanly unless the user uses verbose or debug
         self._configure_global_options(io)
 
-        self._load_plugins(io)
-
-        exit_code: int = 1
-
         with directory(self._working_directory):
+            self._load_plugins(io)
+
+            exit_code: int = 1
+
             try:
                 exit_code = super()._run(io)
             except PoetryRuntimeError as e:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -277,10 +277,15 @@ def mock_metadata_entry_points(
     name: str = "my-plugin",
     dist: metadata.Distribution | None = None,
 ) -> None:
+    def patched_entry_points(*args: Any, **kwargs: Any) -> list[metadata.EntryPoint]:
+        if "group" in kwargs and kwargs["group"] != getattr(cls, "group", None):
+            return []
+        return [make_entry_point_from_plugin(name, cls, dist)]
+
     mocker.patch.object(
         metadata,
         "entry_points",
-        return_value=[make_entry_point_from_plugin(name, cls, dist)],
+        side_effect=patched_entry_points,
     )
 
 

--- a/tests/plugins/test_plugin_manager.py
+++ b/tests/plugins/test_plugin_manager.py
@@ -57,6 +57,8 @@ class MyCommandPlugin(ApplicationPlugin):
 
 
 class InvalidPlugin:
+    group = "poetry.plugin"
+
     def activate(self, poetry: Poetry, io: IO) -> None:
         io.write_line("Updating version")
         poetry.package.version = Version.parse("9.9.9")


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/nat-n/poethepoet/issues/288

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Fix the `--directory` option for plugins that access the Poetry instance during activation

Bug Fixes:
- Resolve an issue where plugins accessing the Poetry instance during activation would fail when using the `--directory` option

Enhancements:
- Modify the plugin loading process to ensure correct working directory context during plugin activation

Tests:
- Add test cases to verify the correct behavior of the `--directory` option with plugins that access the Poetry instance early