### PR TITLE
outputs 'env activate' verbose message on stderr

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -581,7 +581,7 @@ class Application(BaseApplication):
         env = env_manager.create_venv()
 
         if env.is_venv() and io.is_verbose():
-            io.write_line(f"Using virtualenv: <comment>{env.path}</>")
+            io.write_error_line(f"Using virtualenv: <comment>{env.path}</>")
 
         command.set_env(env)
 

--- a/tests/console/commands/env/test_activate.py
+++ b/tests/console/commands/env/test_activate.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from cleo.io.outputs.output import Verbosity
+
 from poetry.utils._compat import WINDOWS
 
 
@@ -43,11 +45,10 @@ def test_env_activate_prints_correct_script(
     mocker.patch("shellingham.detect_shell", return_value=(shell, None))
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
 
-    tester.execute()
+    tester.execute(verbosity=Verbosity.VERBOSE)
 
-    line = tester.io.fetch_output().split("\n")[0]
-    assert line.startswith(command)
-    assert line.endswith(f"activate{ext}")
+    line = tester.io.fetch_output().rstrip("\n")
+    assert line == f"{command} {tmp_venv.bin_dir}/activate{ext}"
 
 
 @pytest.mark.parametrize(
@@ -73,5 +74,5 @@ def test_env_activate_prints_correct_script_on_windows(
 
     tester.execute()
 
-    line = tester.io.fetch_output().split("\n")[0]
+    line = tester.io.fetch_output().rstrip("\n")
     assert line == f'{prefix}"{tmp_venv.bin_dir / ext!s}"'

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -91,7 +91,10 @@ def test_run_passes_args_after_run_before_command_name_conflict(
     path.rename(path.parent / "run")
 
     app_tester.execute(f"{args} python -V", decorated=True)
-    assert app_tester.io.fetch_error() == ""
+    assert (
+        app_tester.io.remove_format(app_tester.io.fetch_error())
+        == f"Using virtualenv: {env.path}\n"
+    )
     assert env.executed == [["python", "-V"]]
 
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10351 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

I don't think it needs a documentation change (this corner case wasn't documented in the first place).

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Modify Poetry's run command to output the virtualenv activation message to stderr instead of stdout when in verbose mode

Bug Fixes:
- Ensure that the virtualenv activation message is printed to stderr when running in verbose mode

Tests:
- Updated test case to verify the virtualenv activation message is now output to stderr