### PR TITLE
fix `get_supported_tags` in cases where the target env has a different platform

### DIFF
--- a/src/poetry/utils/env/script_strings.py
+++ b/src/poetry/utils/env/script_strings.py
@@ -1,5 +1,29 @@
 from __future__ import annotations
 
+import packaging.tags
+
+
+GET_PLATFORMS = f"""
+import importlib.util
+import json
+import sys
+
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "packaging", Path(r"{packaging.__file__}")
+)
+packaging = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = packaging
+
+spec = importlib.util.spec_from_file_location(
+    "packaging.tags", Path(r"{packaging.tags.__file__}")
+)
+packaging_tags = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(packaging_tags)
+
+print(json.dumps(list(packaging_tags.platform_tags())))
+"""
 
 GET_ENVIRONMENT_INFO = """\
 import json
@@ -61,6 +85,7 @@ env = {
         implementation_name, implementation_name
     ),
     "interpreter_version": interpreter_version(),
+    "sysconfig_platform": sysconfig.get_platform(),
 }
 
 print(json.dumps(env))


### PR DESCRIPTION
# Pull Request Check List

 #9304 introduced a regression where wheels for the wrong platform were installed in rare cases. This includes:
- using a 32 Bit Python on Windows (and having Poetry installed with a normal 64 Bit Python)
- using an emulated aarch64 Python on an x86_64 Linux (and having Poetry installed "normally")

This fix basically falls back to determine the platform tags inside the target venv if `sysconfig.get_platform()` of the target venv is different from the value from Poetry's own venv.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Ensure correct platform tags are detected for target environments with different platforms or architectures than the host.

Bug Fixes:
- Fix incorrect platform tag detection when the target environment's platform differs from Poetry's host environment (e.g., 32-bit vs 64-bit Windows, x86_64 vs aarch64 Linux), preventing incorrect wheel installations by querying the target environment directly for its platform information when necessary.
- Include the target environment's `sysconfig.get_platform()` value in its markers for comparison.

Tests:
- Add tests to verify correct tag generation in cross-platform and cross-architecture scenarios.