### PR TITLE
add useful information to error message

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -129,7 +129,7 @@ class PackageInfo:
         name = name or self.name
 
         if not name:
-            raise RuntimeError("Unable to create package with no name")
+            raise RuntimeError(f"Unable to create package with no name for {root_dir}")
 
         if not self.version:
             # The version could not be determined, so we raise an error since it is


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Enhanced error message to provide more context when package creation fails due to missing name