### PR TITLE
Rename ruff ruleset: `TCH` → `TC`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ extend-select = [
     "RUF", # ruff checks
     "SIM", # flake8-simplify
     "T20", # flake8-print
-    "TCH", # flake8-type-checking
+    "TC",  # flake8-type-checking
     "TID", # flake8-tidy-imports
     "UP",  # pyupgrade
 ]
@@ -133,7 +133,7 @@ ignore = [
     "B905", # use explicit 'strict=' parameter with 'zip()'
 ]
 extend-safe-fixes = [
-    "TCH", # move import from and to TYPE_CHECKING blocks
+    "TC",  # move import from and to TYPE_CHECKING blocks
 ]
 unfixable = [
     "ERA", # do not autoremove commented out code


### PR DESCRIPTION
Ruff 0.8.0 changes the error codes for the rules in the [`flake8-type-checking`](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) category from `TCH` to `TC`. This matches changes that were made in the original `flake8-type-checking` plugin from which these rules were originally adapted.

https://astral.sh/blog/ruff-v0.8.0#new-error-codes-for-flake8-type-checking-rules

# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Summary by Sourcery

Chores:
- Update Ruff configuration to use new error code prefix for type-checking rules