### PR TITLE
canonicalize dependency group names

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1161,12 +1161,16 @@ name = "poetry-core"
 version = "2.1.3"
 description = "Poetry PEP 517 Build Backend"
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = ">=3.9, <4.0"
 groups = ["main"]
-files = [
-    {file = "poetry_core-2.1.3-py3-none-any.whl", hash = "sha256:2c704f05016698a54ca1d327f46ce2426d72eaca6ff614132c8477c292266771"},
-    {file = "poetry_core-2.1.3.tar.gz", hash = "sha256:0522a015477ed622c89aad56a477a57813cace0c8e7ff2a2906b7ef4a2e296a4"},
-]
+files = []
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/python-poetry/poetry-core.git"
+reference = "HEAD"
+resolved_reference = "12f0e00b34f97461709d8d65f9c5ec12d6f71da8"
 
 [[package]]
 name = "pre-commit"
@@ -1990,4 +1994,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "f2793aa20e4a10c4d908f759fb731f32a563497fe0799ba44ef431ff8679dce8"
+content-hash = "0e8181aa29e95d0c347dd3536f5cff519d5b4f0431f4f9ab421f52015e117c75"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.1.3"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.9,<4.0"
 dependencies = [
-    "poetry-core (==2.1.3)",
+    "poetry-core @ git+https://github.com/python-poetry/poetry-core.git",
     "build (>=1.2.1,<2.0.0)",
     "cachecontrol[filecache] (>=0.14.0,<0.15.0)",
     "cleo (>=2.1.0,<3.0.0)",

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -11,6 +11,7 @@ from poetry.plugins.plugin_manager import PluginManager
 
 if TYPE_CHECKING:
     from cleo.io.inputs.option import Option
+    from packaging.utils import NormalizedName
 
 
 class InstallCommand(InstallerCommand):
@@ -83,7 +84,7 @@ you can set the "package-mode" to false in your pyproject.toml file.
     ]
 
     @property
-    def activated_groups(self) -> set[str]:
+    def activated_groups(self) -> set[NormalizedName]:
         if self.option("only-root"):
             return set()
         else:

--- a/src/poetry/console/commands/self/install.py
+++ b/src/poetry/console/commands/self/install.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
+from packaging.utils import NormalizedName
+from packaging.utils import canonicalize_name
 from poetry.core.packages.dependency_group import MAIN_GROUP
 
 from poetry.console.commands.install import InstallCommand
@@ -33,8 +35,8 @@ the <c1>self remove</c1> command.
 """
 
     @property
-    def activated_groups(self) -> set[str]:
-        return {MAIN_GROUP, self.default_group}
+    def activated_groups(self) -> set[NormalizedName]:
+        return {MAIN_GROUP, canonicalize_name(self.default_group)}
 
     @property
     def _alternative_sync_command(self) -> str:

--- a/src/poetry/console/commands/self/self_command.py
+++ b/src/poetry/console/commands/self/self_command.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from packaging.utils import canonicalize_name
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.project_package import ProjectPackage
 
@@ -16,12 +17,14 @@ from poetry.utils.helpers import directory
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
+
     from poetry.poetry import Poetry
     from poetry.utils.env import Env
 
 
 class SelfCommand(InstallerCommand):
-    ADDITIONAL_PACKAGE_GROUP = "additional"
+    ADDITIONAL_PACKAGE_GROUP = canonicalize_name("additional")
 
     @staticmethod
     def get_default_system_pyproject_file() -> Path:
@@ -54,8 +57,8 @@ class SelfCommand(InstallerCommand):
         return self.ADDITIONAL_PACKAGE_GROUP
 
     @property
-    def activated_groups(self) -> set[str]:
-        return {self.default_group}
+    def activated_groups(self) -> set[NormalizedName]:
+        return {canonicalize_name(self.default_group)}
 
     def generate_system_pyproject(self) -> None:
         preserved = {}

--- a/src/poetry/console/commands/self/show/__init__.py
+++ b/src/poetry/console/commands/self/show/__init__.py
@@ -11,6 +11,7 @@ from poetry.console.commands.show import ShowCommand
 
 if TYPE_CHECKING:
     from cleo.io.inputs.option import Option
+    from packaging.utils import NormalizedName
 
 
 class SelfShowCommand(SelfCommand, ShowCommand):
@@ -33,9 +34,8 @@ file.
 """
 
     @property
-    def activated_groups(self) -> set[str]:
+    def activated_groups(self) -> set[NormalizedName]:
         if self.option("addons", False):
             return {SelfCommand.ADDITIONAL_PACKAGE_GROUP}
 
-        groups: set[str] = super(ShowCommand, self).activated_groups
-        return groups
+        return super(ShowCommand, self).activated_groups

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -54,7 +54,7 @@ class Installer:
         self._requires_synchronization = False
         self._update = False
         self._verbose = False
-        self._groups: Iterable[str] | None = None
+        self._groups: Iterable[NormalizedName] | None = None
         self._skip_directory = False
         self._lock = False
 
@@ -127,7 +127,7 @@ class Installer:
     def is_verbose(self) -> bool:
         return self._verbose
 
-    def only_groups(self, groups: Iterable[str]) -> Installer:
+    def only_groups(self, groups: Iterable[NormalizedName]) -> Installer:
         self._groups = groups
 
         return self

--- a/src/poetry/packages/transitive_package_info.py
+++ b/src/poetry/packages/transitive_package_info.py
@@ -10,14 +10,16 @@ from poetry.core.version.markers import EmptyMarker
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from packaging.utils import NormalizedName
+
 
 @dataclass
 class TransitivePackageInfo:
     depth: int  # max depth in the dependency tree
-    groups: set[str]
-    markers: dict[str, BaseMarker]  # group -> marker
+    groups: set[NormalizedName]
+    markers: dict[NormalizedName, BaseMarker]  # group -> marker
 
-    def get_marker(self, groups: Iterable[str]) -> BaseMarker:
+    def get_marker(self, groups: Iterable[NormalizedName]) -> BaseMarker:
         marker: BaseMarker = EmptyMarker()
         for group in groups:
             if group_marker := self.markers.get(group):

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -299,7 +299,7 @@ class PackageNode(DFSNode):
         self.depth = -1
 
         if not previous:
-            self.groups: frozenset[str] = frozenset()
+            self.groups: frozenset[NormalizedName] = frozenset()
             self.optional = True
         elif dep:
             self.groups = dep.groups
@@ -361,7 +361,7 @@ def aggregate_package_nodes(
 ) -> tuple[Package, TransitivePackageInfo]:
     package = nodes[0].package
     depth = max(node.depth for node in nodes)
-    groups: set[str] = set()
+    groups: set[NormalizedName] = set()
     for node in nodes:
         groups.update(node.groups)
 
@@ -395,7 +395,7 @@ def calculate_markers(
         for depth in range(max_depth + 1):
             for package in packages_by_depth[depth]:
                 transitive_info = packages[package]
-                transitive_marker: dict[str, BaseMarker] = {
+                transitive_marker: dict[NormalizedName, BaseMarker] = {
                     group: EmptyMarker() for group in transitive_info.groups
                 }
                 for parent, m in markers[package].items():

--- a/src/poetry/puzzle/transaction.py
+++ b/src/poetry/puzzle/transaction.py
@@ -23,7 +23,7 @@ class Transaction:
         installed_packages: list[Package] | None = None,
         root_package: Package | None = None,
         marker_env: dict[str, Any] | None = None,
-        groups: set[str] | None = None,
+        groups: set[NormalizedName] | None = None,
     ) -> None:
         self._current_packages = current_packages
         self._result_packages = result_packages

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -437,7 +437,7 @@ def test_run_install_with_dependency_groups(
     )
 
     if groups is not None:
-        installer.only_groups(groups)
+        installer.only_groups({canonicalize_name(g) for g in groups})
 
     installer.update(update)
     installer.requires_synchronization(requires_synchronization)

--- a/tests/packages/test_transitive_package_info.py
+++ b/tests/packages/test_transitive_package_info.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import pytest
 
+from packaging.utils import canonicalize_name
+from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.version.markers import parse_marker
 
 from poetry.packages.transitive_package_info import TransitivePackageInfo
+
+
+DEV_GROUP = canonicalize_name("dev")
 
 
 @pytest.mark.parametrize(
@@ -21,10 +26,10 @@ from poetry.packages.transitive_package_info import TransitivePackageInfo
 def test_get_marker(groups: list[str], expected: str) -> None:
     info = TransitivePackageInfo(
         depth=0,
-        groups={"main", "dev"},
+        groups={MAIN_GROUP, DEV_GROUP},
         markers={
-            "main": parse_marker('sys_platform =="linux"'),
-            "dev": parse_marker('python_version < "3.9"'),
+            MAIN_GROUP: parse_marker('sys_platform =="linux"'),
+            DEV_GROUP: parse_marker('python_version < "3.9"'),
         },
     )
-    assert str(info.get_marker(groups)) == expected
+    assert str(info.get_marker([canonicalize_name(g) for g in groups])) == expected

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -5090,8 +5090,12 @@ def test_solver_resolves_conflicting_dependency_in_root_extra(
         ),
     )
     solved_packages = transaction.get_solved_packages()
-    assert solved_packages[package_a1].markers["main"] == parse_marker("extra != 'foo'")
-    assert solved_packages[package_a2].markers["main"] == parse_marker("extra == 'foo'")
+    assert solved_packages[package_a1].markers[MAIN_GROUP] == parse_marker(
+        "extra != 'foo'"
+    )
+    assert solved_packages[package_a2].markers[MAIN_GROUP] == parse_marker(
+        "extra == 'foo'"
+    )
 
 
 def test_solver_resolves_conflicting_dependency_in_root_extras(
@@ -5136,10 +5140,10 @@ def test_solver_resolves_conflicting_dependency_in_root_extras(
         ),
     )
     solved_packages = transaction.get_solved_packages()
-    assert solved_packages[package_a1].markers["main"] == parse_marker(
+    assert solved_packages[package_a1].markers[MAIN_GROUP] == parse_marker(
         "extra != 'bar' and extra == 'foo'"
     )
-    assert solved_packages[package_a2].markers["main"] == parse_marker(
+    assert solved_packages[package_a2].markers[MAIN_GROUP] == parse_marker(
         "extra != 'foo' and extra == 'bar'"
     )
 

--- a/tests/puzzle/test_solver_internals.py
+++ b/tests/puzzle/test_solver_internals.py
@@ -7,6 +7,7 @@ import pytest
 from packaging.utils import canonicalize_name
 from poetry.core.constraints.version import parse_constraint
 from poetry.core.packages.dependency import Dependency
+from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.package import Package
 from poetry.core.version.markers import AnyMarker
 from poetry.core.version.markers import parse_marker
@@ -24,6 +25,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from poetry.core.packages.project_package import ProjectPackage
+
+
+DEV_GROUP = canonicalize_name("dev")
 
 
 def dep(
@@ -369,7 +373,9 @@ def test_merge_override_packages_restricted(package: ProjectPackage) -> None:
                 {package: {"a": dep("b", 'python_version < "3.9"')}},
                 {
                     a: TransitivePackageInfo(
-                        0, {"main"}, {"main": parse_marker("sys_platform == 'win32'")}
+                        0,
+                        {MAIN_GROUP},
+                        {MAIN_GROUP: parse_marker("sys_platform == 'win32'")},
                     )
                 },
             ),
@@ -377,7 +383,9 @@ def test_merge_override_packages_restricted(package: ProjectPackage) -> None:
                 {package: {"a": dep("b", 'python_version >= "3.9"')}},
                 {
                     a: TransitivePackageInfo(
-                        0, {"main"}, {"main": parse_marker("sys_platform == 'linux'")}
+                        0,
+                        {MAIN_GROUP},
+                        {MAIN_GROUP: parse_marker("sys_platform == 'linux'")},
                     )
                 },
             ),
@@ -404,7 +412,9 @@ def test_merge_override_packages_extras(package: ProjectPackage) -> None:
                 {package: {"a": dep("b", 'python_version < "3.9" and extra == "foo"')}},
                 {
                     a: TransitivePackageInfo(
-                        0, {"main"}, {"main": parse_marker("sys_platform == 'win32'")}
+                        0,
+                        {MAIN_GROUP},
+                        {MAIN_GROUP: parse_marker("sys_platform == 'win32'")},
                     )
                 },
             ),
@@ -416,7 +426,9 @@ def test_merge_override_packages_extras(package: ProjectPackage) -> None:
                 },
                 {
                     a: TransitivePackageInfo(
-                        0, {"main"}, {"main": parse_marker("sys_platform == 'linux'")}
+                        0,
+                        {MAIN_GROUP},
+                        {MAIN_GROUP: parse_marker("sys_platform == 'linux'")},
                     )
                 },
             ),
@@ -456,11 +468,11 @@ def test_merge_override_packages_python_constraint(
                         )
                     }
                 },
-                {a: TransitivePackageInfo(0, {"main"}, {"main": AnyMarker()})},
+                {a: TransitivePackageInfo(0, {MAIN_GROUP}, {MAIN_GROUP: AnyMarker()})},
             ),
             (
                 {package: {"a": dep("b", "sys_platform != 'linux'")}},
-                {a: TransitivePackageInfo(0, {"main"}, {"main": AnyMarker()})},
+                {a: TransitivePackageInfo(0, {MAIN_GROUP}, {MAIN_GROUP: AnyMarker()})},
             ),
         ],
         parse_constraint(python_constraint),
@@ -484,7 +496,7 @@ def test_merge_override_packages_multiple_deps(package: ProjectPackage) -> None:
                     },
                     a: {"e": dep("f", 'python_version >= "3.8"')},
                 },
-                {a: TransitivePackageInfo(0, {"main"}, {"main": AnyMarker()})},
+                {a: TransitivePackageInfo(0, {MAIN_GROUP}, {MAIN_GROUP: AnyMarker()})},
             ),
         ],
         parse_constraint("*"),
@@ -507,14 +519,16 @@ def test_merge_override_packages_groups(package: ProjectPackage) -> None:
                 {package: {"a": dep("b", 'python_version < "3.9"')}},
                 {
                     a: TransitivePackageInfo(
-                        0, {"main"}, {"main": parse_marker("sys_platform == 'win32'")}
+                        0,
+                        {MAIN_GROUP},
+                        {MAIN_GROUP: parse_marker("sys_platform == 'win32'")},
                     ),
                     b: TransitivePackageInfo(
                         0,
-                        {"main", "dev"},
+                        {MAIN_GROUP, DEV_GROUP},
                         {
-                            "main": parse_marker("sys_platform == 'win32'"),
-                            "dev": parse_marker("sys_platform == 'linux'"),
+                            MAIN_GROUP: parse_marker("sys_platform == 'win32'"),
+                            DEV_GROUP: parse_marker("sys_platform == 'linux'"),
                         },
                     ),
                 },
@@ -523,14 +537,16 @@ def test_merge_override_packages_groups(package: ProjectPackage) -> None:
                 {package: {"a": dep("b", 'python_version >= "3.9"')}},
                 {
                     a: TransitivePackageInfo(
-                        0, {"dev"}, {"dev": parse_marker("sys_platform == 'linux'")}
+                        0,
+                        {DEV_GROUP},
+                        {DEV_GROUP: parse_marker("sys_platform == 'linux'")},
                     ),
                     b: TransitivePackageInfo(
                         0,
-                        {"main", "dev"},
+                        {MAIN_GROUP, DEV_GROUP},
                         {
-                            "main": parse_marker("platform_machine == 'amd64'"),
-                            "dev": parse_marker("platform_machine == 'aarch64'"),
+                            MAIN_GROUP: parse_marker("platform_machine == 'amd64'"),
+                            DEV_GROUP: parse_marker("platform_machine == 'aarch64'"),
                         },
                     ),
                 },
@@ -573,9 +589,9 @@ def test_merge_override_packages_shortcut(package: ProjectPackage) -> None:
                 {
                     a: TransitivePackageInfo(
                         0,
-                        {"main"},
+                        {MAIN_GROUP},
                         {
-                            "main": parse_marker(
+                            MAIN_GROUP: parse_marker(
                                 f"{override_marker1} and ({common_marker})"
                             )
                         },
@@ -587,9 +603,9 @@ def test_merge_override_packages_shortcut(package: ProjectPackage) -> None:
                 {
                     a: TransitivePackageInfo(
                         0,
-                        {"main"},
+                        {MAIN_GROUP},
                         {
-                            "main": parse_marker(
+                            MAIN_GROUP: parse_marker(
                                 f"{override_marker2} and ({common_marker})"
                             )
                         },


### PR DESCRIPTION
# Pull Request Check List

Requires: python-poetry/poetry-core#868

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Normalize dependency group handling by canonicalizing group names across API, CLI, lock file parsing/dumping, and tests to ensure consistent use of packaging.utils.canonicalize_name.

Bug Fixes:
- Normalize unnormalized dependency group names when loading from lock files

Enhancements:
- Canonicalize dependency group names throughout the codebase using packaging.utils.canonicalize_name
- Switch internal group representations to use NormalizedName in type annotations and data structures
- Normalize CLI-specified and default dependency groups in console commands and installer

Build:
- Update poetry-core dependency to track the latest git revision

Tests:
- Refactor and extend tests to use canonicalized group constants and cover unnormalized group inputs