### PR TITLE
feat: allow specifying build constraints for dependencies

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -924,6 +924,28 @@ my-plugin = ">=1.0,<2.0"
 
 See [Project plugins]({{< relref "plugins#project-plugins" >}}) for more information.
 
+### build-constraints
+
+In this section, you can specify additional constraints to apply when creating the build
+environment for a dependency. This is useful if a package does not provide wheels
+(or shall be built from source for other reasons)
+and specifies too loose build requirements (without an upper bound)
+and is not compatible with current versions of one of its build requirements.
+
+For example, if your project depends on `some-package`, which only provides an sdist
+and defines its build requirements as `build-requires = ["setuptools"]`,
+but is incompatible with `setuptools >= 78`, building the package will probably fail
+because per default the latest setuptools will be chosen. In this case, you can
+work around this issue of `some-package` as follows:
+
+```toml
+[tool.poetry.build-constraints]
+some-package = { setuptools = "<78" }
+```
+
+The syntax for specifying constraints is the same as for specifying dependencies
+in the `tool.poetry` section.
+
 ## Poetry and PEP-517
 
 [PEP-517](https://www.python.org/dev/peps/pep-0517/) introduces a standard way

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -616,6 +616,7 @@ class Application(BaseApplication):
             poetry.pool,
             poetry.config,
             disable_cache=poetry.disable_cache,
+            build_constraints=poetry.build_constraints,
         )
         command.set_installer(installer)
 

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from build import DistributionType
+    from poetry.core.packages.dependency import Dependency
 
     from poetry.repositories import RepositoryPool
     from poetry.utils.cache import ArtifactCache
@@ -40,6 +41,7 @@ class Chef:
         *,
         editable: bool = False,
         config_settings: Mapping[str, str | Sequence[str]] | None = None,
+        build_constraints: list[Dependency] | None = None,
     ) -> Path:
         if not self._should_prepare(archive):
             return archive
@@ -51,10 +53,14 @@ class Chef:
                 destination=destination,
                 editable=editable,
                 config_settings=config_settings,
+                build_constraints=build_constraints,
             )
 
         return self._prepare_sdist(
-            archive, destination=output_dir, config_settings=config_settings
+            archive,
+            destination=output_dir,
+            config_settings=config_settings,
+            build_constraints=build_constraints,
         )
 
     def _prepare(
@@ -64,6 +70,7 @@ class Chef:
         *,
         editable: bool = False,
         config_settings: Mapping[str, str | Sequence[str]] | None = None,
+        build_constraints: list[Dependency] | None = None,
     ) -> Path:
         distribution: DistributionType = "editable" if editable else "wheel"
         with isolated_builder(
@@ -71,6 +78,7 @@ class Chef:
             distribution=distribution,
             python_executable=self._env.python,
             pool=self._pool,
+            build_constraints=build_constraints,
         ) as builder:
             return Path(
                 builder.build(
@@ -85,6 +93,7 @@ class Chef:
         archive: Path,
         destination: Path | None = None,
         config_settings: Mapping[str, str | Sequence[str]] | None = None,
+        build_constraints: list[Dependency] | None = None,
     ) -> Path:
         from poetry.core.packages.utils.link import Link
 
@@ -115,6 +124,7 @@ class Chef:
                 sdist_dir,
                 destination,
                 config_settings=config_settings,
+                build_constraints=build_constraints,
             )
 
     def _should_prepare(self, archive: Path) -> bool:

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -16,9 +16,11 @@ from poetry.repositories.lockfile_repository import LockfileRepository
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from collections.abc import Mapping
 
     from cleo.io.io import IO
     from packaging.utils import NormalizedName
+    from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.package import Package
     from poetry.core.packages.path_dependency import PathDependency
     from poetry.core.packages.project_package import ProjectPackage
@@ -42,6 +44,8 @@ class Installer:
         installed: InstalledRepository | None = None,
         executor: Executor | None = None,
         disable_cache: bool = False,
+        *,
+        build_constraints: Mapping[NormalizedName, list[Dependency]] | None = None,
     ) -> None:
         self._io = io
         self._env = env
@@ -64,7 +68,12 @@ class Installer:
 
         if executor is None:
             executor = Executor(
-                self._env, self._pool, config, self._io, disable_cache=disable_cache
+                self._env,
+                self._pool,
+                config,
+                self._io,
+                disable_cache=disable_cache,
+                build_constraints=build_constraints,
             )
 
         self._executor = executor

--- a/src/poetry/json/schemas/poetry.json
+++ b/src/poetry/json/schemas/poetry.json
@@ -24,6 +24,15 @@
       "items": {
         "$ref": "#/definitions/repository"
       }
+    },
+    "build-constraints": {
+      "type": "object",
+      "description": "This is a dict of package name (keys) and version constraints (values) to restrict build requirements for a package.",
+      "patternProperties": {
+        "^[a-zA-Z-_.0-9]+$": {
+          "$ref": "#/definitions/dependencies"
+        }
+      }
     }
   },
   "definitions": {

--- a/src/poetry/poetry.py
+++ b/src/poetry/poetry.py
@@ -12,8 +12,11 @@ from poetry.pyproject.toml import PyProjectTOML
 
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
+    from packaging.utils import NormalizedName
+    from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.config.config import Config
@@ -34,6 +37,8 @@ class Poetry(BasePoetry):
         locker: Locker,
         config: Config,
         disable_cache: bool = False,
+        *,
+        build_constraints: Mapping[NormalizedName, list[Dependency]] | None = None,
     ) -> None:
         from poetry.repositories.repository_pool import RepositoryPool
 
@@ -44,6 +49,7 @@ class Poetry(BasePoetry):
         self._pool = RepositoryPool(config=config)
         self._plugin_manager: PluginManager | None = None
         self._disable_cache = disable_cache
+        self._build_constraints = build_constraints or {}
 
     @property
     def pyproject(self) -> PyProjectTOML:
@@ -69,6 +75,10 @@ class Poetry(BasePoetry):
     @property
     def disable_cache(self) -> bool:
         return self._disable_cache
+
+    @property
+    def build_constraints(self) -> Mapping[NormalizedName, list[Dependency]]:
+        return self._build_constraints
 
     def set_locker(self, locker: Locker) -> Poetry:
         self._locker = locker

--- a/tests/fixtures/build_constraints/pyproject.toml
+++ b/tests/fixtures/build_constraints/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "build-constraints"
+version = "0.1.0"
+
+[tool.poetry.build-constraints]
+Legacy-Lib = { setuptools = "<75" }
+no-constraints = {}
+
+[tool.poetry.build-constraints.c-ext-lib]
+Cython = { version = "<3.1", source = "pypi" }
+setuptools = [
+    { version = ">=60,<75", python = "<3.9" },
+    { version = ">=75", python = ">=3.8" }
+]

--- a/tests/fixtures/build_constraints_empty/pyproject.toml
+++ b/tests/fixtures/build_constraints_empty/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "build-constraints"
+version = "0.1.0"
+
+[tool.poetry.build-constraints]

--- a/tests/json/fixtures/build_constraints.toml
+++ b/tests/json/fixtures/build_constraints.toml
@@ -1,0 +1,14 @@
+[project]
+name = "build-constraints"
+version = "0.1.0"
+
+[tool.poetry.build-constraints]
+Legacy-Lib = { setuptools = "<75" }
+no-constraints = {}
+
+[tool.poetry.build-constraints.c-ext-lib]
+Cython = { version = "<3.1", source = "pypi" }
+setuptools = [
+    { version = ">=60,<75", python = "<3.9" },
+    { version = ">=75", python = ">=3.8" }
+]

--- a/tests/json/test_schema.py
+++ b/tests/json/test_schema.py
@@ -57,6 +57,11 @@ def test_self_invalid_plugin() -> None:
     }
 
 
+def test_build_constraints() -> None:
+    toml: dict[str, Any] = TOMLFile(FIXTURE_DIR / "build_constraints.toml").read()
+    assert Factory.validate(toml) == {"errors": [], "warnings": []}
+
+
 def test_dependencies_is_consistent_to_poetry_core_schema() -> None:
     with SCHEMA_FILE.open(encoding="utf-8") as f:
         schema = json.load(f)


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10299

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Example:

```toml
[tool.poetry.build-constraints]
some-package = { setuptools = "<78" }
```

At some point, I wondered if build constraints should be part of the pyproject.toml or part of the [configuration](https://python-poetry.org/docs/configuration/). I stuck with the pyproject.toml because it is easier to implement.

A small shortcoming is that the constraints are only applied when installing dependencies - not when building a package to extract metadata. I think we can live with that for the time being.

Another shortcoming is that the constraints are not really constraints but implemented as dependencies of an optional group, which is not installed. In most cases, this will not make a difference but in rare cases it could result in unnecessary solver errors. Implementing real constraints will cost more effort and could be done later if it proves to be necessary.

## Summary by Sourcery

Introduce support for specifying build constraints for dependencies in pyproject.toml, allowing users to control build-time dependency versions for specific packages.

New Features:
- Add support for [tool.poetry.build-constraints] section in pyproject.toml to specify build-time dependency constraints for individual packages.

Enhancements:
- Propagate build constraints through the installation and build process, including installer, executor, and isolated build environments.

Documentation:
- Document the new build-constraints feature and its usage in the user guide.

Tests:
- Add tests to verify correct parsing, propagation, and enforcement of build constraints during installation and isolated builds.