### PR TITLE
poetry init --author doesn't seem to allow multiple authors on Windows #8864

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -163,13 +163,13 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             )
             question.set_validator(lambda v: self._validate_author(v, authors))
             author = self.ask(question)
-            if author == author_str:
+            if author == author_str: # user entered nothing, dont change authors
                 author = ""
-            if author is None:
-                authors = author
+            if author is None: # none is returned if user enters "n",
+                authors = author # author gets overwritted by default settings defined in question.set
 
 
-        authors = [author] if author else authors
+        authors = [author] if author else authors # checks if author = None or ""
         authors = authors if authors else []
 
         license_name = self.option("license")

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -236,7 +236,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
             self.line("")
 
-
         layout_ = layout(layout_name)(
             name,
             version,

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -149,14 +149,12 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             description = self.ask(self.create_question("Description []: ", default=""))
 
         authors = self.option("author")
-        author = ""
         if not authors and vcs_config.get("user.name"):
             author = vcs_config["user.name"]
             author_email = vcs_config.get("user.email")
             if author_email:
                 author += f" <{author_email}>"
             authors = [author]
-        print(f"AUTHORS VARIABLE:     {authors}")
 
         if is_interactive:
             author_str = ", ".join(authors)

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -157,14 +157,13 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             authors = [author]
 
         if is_interactive:
-            default_author_str = ", ".join(authors) if authors else ""
             author_str = ", ".join(authors)
             question = self.create_question(
                 f"Author [<comment>{author_str}</comment>, n to skip]: ", default=author_str
             )
             question.set_validator(lambda v: self._validate_author(v, authors[0]))
             author = self.ask(question)
-            if author in [default_author_str, "n"]:
+            if author in [author_str, "n"]:
                 author = ""
 
         authors = [author] if author else authors

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -149,22 +149,27 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             description = self.ask(self.create_question("Description []: ", default=""))
 
         authors = self.option("author")
+        author = ""
         if not authors and vcs_config.get("user.name"):
             author = vcs_config["user.name"]
             author_email = vcs_config.get("user.email")
             if author_email:
                 author += f" <{author_email}>"
             authors = [author]
+        print(f"AUTHORS VARIABLE:     {authors}")
 
         if is_interactive:
             author_str = ", ".join(authors)
             question = self.create_question(
                 f"Author [<comment>{author_str}</comment>, n to skip]: ", default=author_str
             )
-            question.set_validator(lambda v: self._validate_author(v, authors[0]))
+            question.set_validator(lambda v: self._validate_author(v, authors))
             author = self.ask(question)
-            if author in [author_str, "n"]:
+            if author == author_str:
                 author = ""
+            if author is None:
+                authors = author
+
 
         authors = [author] if author else authors
         authors = authors if authors else []

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -148,21 +148,24 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if not description and is_interactive:
             description = self.ask(self.create_question("Description []: ", default=""))
 
-        author = self.option("author")
-        if not author and vcs_config.get("user.name"):
+        authors = self.option("author")
+        if not authors and vcs_config.get("user.name"):
             author = vcs_config["user.name"]
             author_email = vcs_config.get("user.email")
             if author_email:
                 author += f" <{author_email}>"
+            authors = [author]
 
         if is_interactive:
+            author_str = ", ".join(authors)
             question = self.create_question(
-                f"Author [<comment>{author}</comment>, n to skip]: ", default=author
+                f"Author [<comment>{author_str}</comment>, n to skip]: ", default=author_str
             )
-            question.set_validator(lambda v: self._validate_author(v, author))
+            question.set_validator(lambda v: self._validate_author(v, authors[0]))
             author = self.ask(question)
 
-        authors = [author] if author else []
+        authors = [author] if author else authors
+        authors = authors if authors else []
 
         license_name = self.option("license")
         if not license_name and is_interactive:
@@ -233,11 +236,12 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
             self.line("")
 
+
         layout_ = layout(layout_name)(
             name,
             version,
             description=description,
-            author=authors[0] if authors else None,
+            author=authors if authors else None,
             readme_format=readme_format,
             license=license_name,
             python=python,

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -157,12 +157,15 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             authors = [author]
 
         if is_interactive:
+            default_author_str = ", ".join(authors) if authors else ""
             author_str = ", ".join(authors)
             question = self.create_question(
                 f"Author [<comment>{author_str}</comment>, n to skip]: ", default=author_str
             )
             question.set_validator(lambda v: self._validate_author(v, authors[0]))
             author = self.ask(question)
+            if author in [default_author_str, "n"]:
+                author = ""
 
         authors = [author] if author else authors
         authors = authors if authors else []

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -40,7 +40,7 @@ class InitCommand(Command):
     options: ClassVar[list[Option]] = [
         option("name", None, "Name of the package.", flag=False),
         option("description", None, "Description of the package.", flag=False),
-        option("author", None, "Author name of the package.", flag=False),
+        option("author", None, "Author name of the package.", flag=False, multiple=True),
         option("python", None, "Compatible Python versions.", flag=False),
         option(
             "dependency",

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -40,7 +40,9 @@ class InitCommand(Command):
     options: ClassVar[list[Option]] = [
         option("name", None, "Name of the package.", flag=False),
         option("description", None, "Description of the package.", flag=False),
-        option("author", None, "Author name of the package.", flag=False, multiple=True),
+        option(
+            "author", None, "Author name of the package.", flag=False, multiple=True
+        ),
         option("python", None, "Compatible Python versions.", flag=False),
         option(
             "dependency",
@@ -159,17 +161,17 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if is_interactive:
             author_str = ", ".join(authors)
             question = self.create_question(
-                f"Author [<comment>{author_str}</comment>, n to skip]: ", default=author_str
+                f"Author [<comment>{author_str}</comment>, n to skip]: ",
+                default=author_str,
             )
             question.set_validator(lambda v: self._validate_author(v, authors))
             author = self.ask(question)
-            if author == author_str: # user entered nothing, dont change authors
+            if author == author_str:  # user entered nothing, dont change authors
                 author = ""
-            if author is None: # none is returned if user enters "n",
-                authors = author # author gets overwritted by default settings defined in question.set
+            if author is None:  # none is returned if user enters "n",
+                authors = author  # author gets overwritted by default settings defined in question.set
 
-
-        authors = [author] if author else authors # checks if author = None or ""
+        authors = [author] if author else authors  # checks if author = None or ""
         authors = authors if authors else []
 
         license_name = self.option("license")

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -86,7 +86,7 @@ class Layout:
 
         if not author:
             self._authors = ["Your Name <you@example.com>"]
-        elif isinstance(author, str): # check if only 1 author was added
+        elif isinstance(author, str):  # check if only 1 author was added
             self._authors = [author]
         else:
             self._authors = author

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -85,7 +85,7 @@ class Layout:
         self._dev_dependencies = dev_dependencies or {}
 
         if not author:
-            self._authors = "Your Name <you@example.com>"
+            self._authors = ["Your Name <you@example.com>"]
         elif isinstance(author, str): # check if only 1 author was added
             self._authors = [author]
         else:
@@ -156,8 +156,8 @@ class Layout:
                     author["email"] = email
                 project_content["authors"].append(author)
 
-            if self._license:
-                project_content["license"]["text"] = self._license
+        if self._license:
+            project_content["license"]["text"] = self._license
         else:
             project_content.remove("license")
 

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -63,7 +63,7 @@ class Layout:
         version: str = "0.1.0",
         description: str = "",
         readme_format: str = "md",
-        author: str | None = None,
+        author: str | list[str] | None = None,
         license: str | None = None,
         python: str | None = None,
         dependencies: Mapping[str, str | Mapping[str, Any]] | None = None,
@@ -85,9 +85,11 @@ class Layout:
         self._dev_dependencies = dev_dependencies or {}
 
         if not author:
-            author = "Your Name <you@example.com>"
-
-        self._author = author
+            self._authors = "Your Name <you@example.com>"
+        elif isinstance(author, str): # check if only 1 author was added
+            self._authors = [author]
+        else:
+            self._authors = author
 
     @property
     def basedir(self) -> Path:
@@ -143,18 +145,19 @@ class Layout:
         project_content["name"] = self._project
         project_content["version"] = self._version
         project_content["description"] = self._description
-        m = AUTHOR_REGEX.match(self._author)
-        if m is None:
-            # This should not happen because author has been validated before.
-            raise ValueError(f"Invalid author: {self._author}")
-        else:
-            author = {"name": m.group("name")}
-            if email := m.group("email"):
-                author["email"] = email
-            project_content["authors"].append(author)
+        for author_string in self._authors:  # Iterate through the list of authors
+            m = AUTHOR_REGEX.match(author_string)
+            if m is None:
+                # This should not happen because author has been validated before.
+                raise ValueError(f"Invalid author: {author_string}")
+            else:
+                author = {"name": m.group("name")}
+                if email := m.group("email"):
+                    author["email"] = email
+                project_content["authors"].append(author)
 
-        if self._license:
-            project_content["license"]["text"] = self._license
+            if self._license:
+                project_content["license"]["text"] = self._license
         else:
             project_content.remove("license")
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -891,6 +891,21 @@ pytest = "^3.6.0"
 """
 
     output = tester.io.fetch_output()
+    # 1. Print the raw output to the console.
+    print("--- Raw Output ---")
+    print(output)
+    print("--- End Raw Output ---")
+
+    # 2.  Extract TOML and print it for comparison.
+    start_index = output.find("[project]")
+    if start_index != -1:
+        toml_output = output[start_index:].strip()
+        print("\n--- Extracted TOML Output ---")
+        print(toml_output)
+        print("--- End Extracted TOML Output ---")
+        assert toml_output == expected
+    else:
+        assert False, "Could not find [project] in output"
     assert expected in output
 def test_predefined_2_authors(tester: CommandTester, repo: TestRepository) -> None:
     repo.add_package(get_package("pendulum", "2.0.0"))
@@ -905,14 +920,24 @@ def test_predefined_2_authors(tester: CommandTester, repo: TestRepository) -> No
     ]
 
     tester.execute(
-        "--name my-package "
-        "--description 'This is a description' "
-        "--author 'Foo Bar <foo@example.com>' "
-        "--author 'Author 2 <bar@example.com>' "
-        "--python '>=3.8' "
-        "--license MIT "
-        "--dependency pendulum "
-        "--dev-dependency pytest",
+        [
+            "--name",
+            "my-package",
+            "--description",
+            "This is a description",
+            "--author",
+            "Foo Bar <foo@example.com>",
+            "--author",
+            "Author 2 <bar@example.com>",
+            "--python",
+            ">=3.8",
+            "--license",
+            "MIT",
+            "--dependency",
+            "pendulum",
+            "--dev-dependency",
+            "pytest",
+        ],
         inputs="\n".join(inputs),
     )
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -907,7 +907,8 @@ def test_predefined_2_authors(tester: CommandTester, repo: TestRepository) -> No
     tester.execute(
         "--name my-package "
         "--description 'This is a description' "
-        "--author 'Authorname1 <foo@example.com>' --author 'Authorname2 <foo@example.com>'",
+        "--author 'Foo Bar <foo@example.com>' "
+        "--author 'Author 2 <bar@example.com>' "
         "--python '>=3.8' "
         "--license MIT "
         "--dependency pendulum "
@@ -916,29 +917,44 @@ def test_predefined_2_authors(tester: CommandTester, repo: TestRepository) -> No
     )
 
     expected = """\
-    [project]
-    name = "my-package"
-    version = "1.2.3"
-    description = "This is a description"
-    authors = [
-        {name = "Foo Bar",email = "foo@example.com"}
-    ]
-    license = {text = "MIT"}
-    readme = "README.md"
-    requires-python = ">=3.8"
-    dependencies = [
-        "pendulum (>=2.0.0,<3.0.0)"
-    ]
+[project]
+name = "my-package"
+version = "1.2.3"
+description = "This is a description"
+authors = [
+    {name = "Foo Bar",email = "foo@example.com"}
+    {name = "Author 2",email = "bar@example.com"}
+]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "pendulum (>=2.0.0,<3.0.0)"
+]
 
-    [tool.poetry]
+[tool.poetry]
 
-    [tool.poetry.group.dev.dependencies]
-    pytest = "^3.6.0"
-    """
+[tool.poetry.group.dev.dependencies]
+pytest = "^3.6.0"
+"""
 
     output = tester.io.fetch_output()
-    assert expected in output
+    # 1. Print the raw output to the console.
+    print("--- Raw Output ---")
+    print(output)
+    print("--- End Raw Output ---")
 
+    # 2.  Extract TOML and print it for comparison.
+    start_index = output.find("[project]")
+    if start_index != -1:
+        toml_output = output[start_index:].strip()
+        print("\n--- Extracted TOML Output ---")
+        print(toml_output)
+        print("--- End Extracted TOML Output ---")
+        assert toml_output == expected
+    else:
+        assert False, "Could not find [project] in output"
+    assert expected in output
 def test_add_package_with_extras_and_whitespace(tester: CommandTester) -> None:
     command = tester.command
     assert isinstance(command, InitCommand)

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -943,22 +943,8 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 """
 
-    output = tester.io.fetch_output()
-    # 1. Print the raw output to the console.
-    print("--- Raw Output ---")
-    print(output)
-    print("--- End Raw Output ---")
 
-    # 2.  Extract TOML and print it for comparison.
-    start_index = output.find("[project]")
-    if start_index != -1:
-        toml_output = output[start_index:].strip()
-        print("\n--- Extracted TOML Output ---")
-        print(toml_output)
-        print("--- End Extracted TOML Output ---")
-        assert toml_output == expected
-    else:
-        assert False, "Could not find [project] in output"
+    output = tester.io.fetch_output()
     assert expected in output
 def test_add_package_with_extras_and_whitespace(tester: CommandTester) -> None:
     command = tester.command

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -840,11 +840,11 @@ pytest = "^3.6.0"
 pytest-requests = "^0.2.0"
 """
 
+
     output = tester.io.fetch_output()
     assert expected in output
     assert 'pytest-requests = "^0.2.0"' in output
     assert 'pytest = "^3.6.0"' in output
-
 
 
 def test_predefined_all_options(tester: CommandTester, repo: TestRepository) -> None:
@@ -940,6 +940,10 @@ pytest = "^3.6.0"
 """
 
     output = tester.io.fetch_output()
+    # 1. Print the raw output to the console.
+    print("--- Raw Output ---")
+    print(output)
+    print("--- End Raw Output ---")
     assert expected in output
 
 def test_add_package_with_extras_and_whitespace(tester: CommandTester) -> None:

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -923,7 +923,7 @@ name = "my-package"
 version = "1.2.3"
 description = "This is a description"
 authors = [
-    {name = "Foo Bar",email = "foo@example.com"}
+    {name = "Foo Bar",email = "foo@example.com"},
     {name = "Author 2",email = "bar@example.com"}
 ]
 license = {text = "MIT"}
@@ -937,14 +937,11 @@ dependencies = [
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^3.6.0"
-
-[build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.core.masonry.api"
 """
 
     output = tester.io.fetch_output()
     assert expected in output
+
 def test_add_package_with_extras_and_whitespace(tester: CommandTester) -> None:
     command = tester.command
     assert isinstance(command, InitCommand)

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -937,6 +937,10 @@ dependencies = [
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^3.6.0"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
 """
 
     output = tester.io.fetch_output()

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -939,10 +939,6 @@ pytest = "^3.6.0"
 """
 
     output = tester.io.fetch_output()
-    # 1. Print the raw output to the console.
-    print("--- Raw Output ---")
-    print(output)
-    print("--- End Raw Output ---")
     assert expected in output
 
 def test_add_package_with_extras_and_whitespace(tester: CommandTester) -> None:

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -892,6 +892,8 @@ pytest = "^3.6.0"
 
     output = tester.io.fetch_output()
     assert expected in output
+
+
 def test_predefined_2_authors(tester: CommandTester, repo: TestRepository) -> None:
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
@@ -940,6 +942,7 @@ pytest = "^3.6.0"
 
     output = tester.io.fetch_output()
     assert expected in output
+
 
 def test_add_package_with_extras_and_whitespace(tester: CommandTester) -> None:
     command = tester.command

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -846,6 +846,7 @@ pytest-requests = "^0.2.0"
     assert 'pytest = "^3.6.0"' in output
 
 
+
 def test_predefined_all_options(tester: CommandTester, repo: TestRepository) -> None:
     repo.add_package(get_package("pendulum", "2.0.0"))
     repo.add_package(get_package("pytest", "3.6.0"))
@@ -891,21 +892,6 @@ pytest = "^3.6.0"
 """
 
     output = tester.io.fetch_output()
-    # 1. Print the raw output to the console.
-    print("--- Raw Output ---")
-    print(output)
-    print("--- End Raw Output ---")
-
-    # 2.  Extract TOML and print it for comparison.
-    start_index = output.find("[project]")
-    if start_index != -1:
-        toml_output = output[start_index:].strip()
-        print("\n--- Extracted TOML Output ---")
-        print(toml_output)
-        print("--- End Extracted TOML Output ---")
-        assert toml_output == expected
-    else:
-        assert False, "Could not find [project] in output"
     assert expected in output
 def test_predefined_2_authors(tester: CommandTester, repo: TestRepository) -> None:
     repo.add_package(get_package("pendulum", "2.0.0"))
@@ -920,24 +906,14 @@ def test_predefined_2_authors(tester: CommandTester, repo: TestRepository) -> No
     ]
 
     tester.execute(
-        [
-            "--name",
-            "my-package",
-            "--description",
-            "This is a description",
-            "--author",
-            "Foo Bar <foo@example.com>",
-            "--author",
-            "Author 2 <bar@example.com>",
-            "--python",
-            ">=3.8",
-            "--license",
-            "MIT",
-            "--dependency",
-            "pendulum",
-            "--dev-dependency",
-            "pytest",
-        ],
+        "--name my-package "
+        "--description 'This is a description' "
+        "--author 'Foo Bar <foo@example.com>' "
+        "--author 'Author 2 <bar@example.com>' "
+        "--python '>=3.8' "
+        "--license MIT "
+        "--dependency pendulum "
+        "--dev-dependency pytest",
         inputs="\n".join(inputs),
     )
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -840,7 +840,6 @@ pytest = "^3.6.0"
 pytest-requests = "^0.2.0"
 """
 
-
     output = tester.io.fetch_output()
     assert expected in output
     assert 'pytest-requests = "^0.2.0"' in output

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -943,7 +943,6 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 """
 
-
     output = tester.io.fetch_output()
     assert expected in output
 def test_add_package_with_extras_and_whitespace(tester: CommandTester) -> None:

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -892,7 +892,52 @@ pytest = "^3.6.0"
 
     output = tester.io.fetch_output()
     assert expected in output
+def test_predefined_2_authors(tester: CommandTester, repo: TestRepository) -> None:
+    repo.add_package(get_package("pendulum", "2.0.0"))
+    repo.add_package(get_package("pytest", "3.6.0"))
 
+    inputs = [
+        "1.2.3",  # Version
+        "",  # Author
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    tester.execute(
+        "--name my-package "
+        "--description 'This is a description' "
+        "--author 'Authorname1 <foo@example.com>' --author 'Authorname2 <foo@example.com>'",
+        "--python '>=3.8' "
+        "--license MIT "
+        "--dependency pendulum "
+        "--dev-dependency pytest",
+        inputs="\n".join(inputs),
+    )
+
+    expected = """\
+    [project]
+    name = "my-package"
+    version = "1.2.3"
+    description = "This is a description"
+    authors = [
+        {name = "Foo Bar",email = "foo@example.com"}
+    ]
+    license = {text = "MIT"}
+    readme = "README.md"
+    requires-python = ">=3.8"
+    dependencies = [
+        "pendulum (>=2.0.0,<3.0.0)"
+    ]
+
+    [tool.poetry]
+
+    [tool.poetry.group.dev.dependencies]
+    pytest = "^3.6.0"
+    """
+
+    output = tester.io.fetch_output()
+    assert expected in output
 
 def test_add_package_with_extras_and_whitespace(tester: CommandTester) -> None:
     command = tester.command


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8864

Changed Authors option in init.py to multiple=True. This allows the user to input –author name1 –author name2, to the nth author name. This does change the output of this option from a string to a list, which impacts downstream code.

For init.py changed line 151, author, Is now authors as this variable corresponds to a potential list of authors instead of a string. Since we are now handling a list, line 157 has to change the vcs.config author created into a list, so downstream code will work with it. 

Updated the is_interactive string, so multiple authors can be displayed (lines 164 to 168). Lines 166 to 169 handle user inputs to the is_interactive. If the user inputs nothing, then displayed authors should stay the same. If user enters “n” then author reverts to defaults. This is defined in the tests, removing this will cause errors where authors in the final file won't be set to defaults. Lines 172 and 173 handle the original line 165. This may be a different issue, not sure if user entering "n" should mean no to current input or no to entering a different author.

The layout function  (248 init.py) now takes an entire list of authors, before it only took index 0. This required changes to layout, as it wasn’t coded to handle multiple author inputs. 

Updated layout.py to take list inputs, line64, previously it only took str inputs. Added a handle for if user enters multiple or just 1 author as an --author input (lines 88 to 92 layout.py).

Now when creating the layout, a for loop is needed to iterate over the list of multiple authors the only change is wrapping the existing code handling authors in a for loop iterating over each author in the list (lines 148 to 157 layout.py)

In test_init.py added a new test to check for multiple author inputs. Simply copied test_predefined to create a 2 author input. The only change is line 911 and 912, and then changes to the expected output for the check (lines 926 and 927). The remaining code is copied from test_predefined.

Poetry run pytest successfully completes with only a threading error which I think is due to issues with my local environment setup ->   tests/utils/test_threading.py::test_threading_atomic_cached_property_different_instances[value_functools_cache-24] - AssertionError: assert 11 == 24



- [x] Added **tests** for changed code.
------ Only Added 1 new test, that adds 2 authors, existing test check for 1 author, did not test 3 or more authors
- [No] Updated **documentation** for changed code. 
------Code doesn't require a documentation change. Currently --author command is documented, and it seems the method of adding multiple commands (e.g --author name1 --author name2... --author nameX, is standard for these types of commands) Documentation could be added for extra clarification but doesn't seem required currently.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
