### PR TITLE
fix: `ensure_project_plugins` is not called when `--no-plugins` flag is true

### DIFF
--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -111,7 +111,8 @@ you can set the "package-mode" to false in your pyproject.toml file.
 
         from poetry.masonry.builders.editable import EditableBuilder
 
-        PluginManager.ensure_project_plugins(self.poetry, self.io)
+        if not self.option("no-plugins"):
+            PluginManager.ensure_project_plugins(self.poetry, self.io)
 
         if self.option("extras") and self.option("all-extras"):
             self.line_error(

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -259,8 +259,15 @@ def test_extras_are_parsed_and_populate_installer(
     assert tester.command.installer._extras == ["first", "second", "third"]
 
 
+@pytest.mark.parametrize(
+    ("options", "call_count"),
+    [
+        ("--no-plugins", 0),
+        ("", 1),
+    ],
+)
 def test_install_ensures_project_plugins(
-    tester: CommandTester, mocker: MockerFixture
+    tester: CommandTester, mocker: MockerFixture, options: str, call_count: int
 ) -> None:
     assert isinstance(tester.command, InstallerCommand)
     mocker.patch.object(tester.command.installer, "run", return_value=1)
@@ -268,9 +275,9 @@ def test_install_ensures_project_plugins(
         "poetry.plugins.plugin_manager.PluginManager.ensure_project_plugins"
     )
 
-    tester.execute("")
+    tester.execute(options)
 
-    ensure_project_plugins.assert_called_once()
+    assert ensure_project_plugins.call_count == call_count
 
 
 def test_extras_conflicts_all_extras(


### PR DESCRIPTION
# Pull Request Check List

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR fixes when the user wants to run `poetry install` but does not want to install the plugins.

Many poetry plugins ([shell](https://github.com/python-poetry/poetry-plugin-shell), [export](https://github.com/python-poetry/poetry-plugin-export), ...) are usually intended for development environments only. Ensuring plugin installation whenever `poetry install` is run means that all environments need to be compatible, not only with project dependencies, but also with plugins (which might not always be the case).

For instance, I'm trying to install a project in Databricks, but I can't because the plugin is incompatible.
![image](https://github.com/user-attachments/assets/e2f926c1-fe00-48cc-b7a3-81d7e66b26a6)

However, if I manually edit the `pyproject.toml` and remove the plugins, I can install it.
![image](https://github.com/user-attachments/assets/af9d0314-58cf-451f-a0dd-f1cc875c36ba)



Currently, the `--no-plugins` [documentation](https://python-poetry.org/docs/cli/#global-options) is minimal; however, in IMHO, `--no-plugins` should prevent the installation.

## Summary by Sourcery

Modify the installer command to skip plugin setup when the --no-plugins flag is used

Bug Fixes:
- Respect the --no-plugins flag by not calling PluginManager.ensure_project_plugins during install

Tests:
- Add parameterized test to verify ensure_project_plugins is called only when plugins are enabled