### PR TITLE
refactor: make sure that `marker_env` is complete for each type of `Env`

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -1017,7 +1017,7 @@ class Provider:
 
         :param extras: the values to add to the 'extra' marker value
         """
-        result = self._env.marker_env.copy() if self._env is not None else {}
+        result = dict(self._env.marker_env) if self._env is not None else {}
         if extras is not None:
             assert "extra" not in result, (
                 "'extra' marker key is already present in environment"

--- a/src/poetry/puzzle/transaction.py
+++ b/src/poetry/puzzle/transaction.py
@@ -8,6 +8,8 @@ from poetry.utils.extras import get_extra_package_names
 
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from packaging.utils import NormalizedName
     from poetry.core.packages.package import Package
 
@@ -22,7 +24,7 @@ class Transaction:
         result_packages: list[Package] | dict[Package, TransitivePackageInfo],
         installed_packages: list[Package] | None = None,
         root_package: Package | None = None,
-        marker_env: dict[str, Any] | None = None,
+        marker_env: Mapping[str, Any] | None = None,
         groups: set[NormalizedName] | None = None,
     ) -> None:
         self._current_packages = current_packages
@@ -60,7 +62,7 @@ class Transaction:
 
         extra_packages: set[NormalizedName] = set()
         if self._marker_env:
-            marker_env_with_extras = self._marker_env.copy()
+            marker_env_with_extras = dict(self._marker_env)
             if extras is not None:
                 marker_env_with_extras["extra"] = extras
         elif extras is not None:

--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import TypedDict
 
 from installer.utils import SCHEME_NAMES
 from virtualenv.seed.wheels.embed import get_embed_wheel
@@ -32,6 +33,24 @@ if TYPE_CHECKING:
     from poetry.utils.env.generic_env import GenericEnv
 
     PythonVersion = tuple[int, int, int, str, int]
+
+
+class MarkerEnv(TypedDict):
+    implementation_name: str
+    implementation_version: str
+    os_name: str
+    platform_machine: str
+    platform_release: str
+    platform_system: str
+    platform_version: str
+    python_full_version: str
+    platform_python_implementation: str
+    python_version: str
+    sys_platform: str
+    version_info: PythonVersion
+    interpreter_name: str
+    interpreter_version: str
+    sysconfig_platform: str
 
 
 class Env(ABC):
@@ -97,7 +116,7 @@ class Env(ABC):
         return Path(self._bin(self._executable))
 
     @cached_property
-    def marker_env(self) -> dict[str, Any]:
+    def marker_env(self) -> MarkerEnv:
         return self.get_marker_env()
 
     @property
@@ -352,7 +371,7 @@ class Env(ABC):
         return Path(sys.prefix)
 
     @abstractmethod
-    def get_marker_env(self) -> dict[str, Any]: ...
+    def get_marker_env(self) -> MarkerEnv: ...
 
     def get_pip_command(self, embedded: bool = False) -> list[str]:
         if embedded or not Path(self._bin(self._pip_executable)).exists():

--- a/src/poetry/utils/env/system_env.py
+++ b/src/poetry/utils/env/system_env.py
@@ -7,7 +7,6 @@ import sys
 import sysconfig
 
 from pathlib import Path
-from typing import Any
 
 from packaging.tags import Tag
 from packaging.tags import interpreter_name
@@ -15,6 +14,7 @@ from packaging.tags import interpreter_version
 from packaging.tags import sys_tags
 
 from poetry.utils.env.base_env import Env
+from poetry.utils.env.base_env import MarkerEnv
 
 
 class SystemEnv(Env):
@@ -44,7 +44,7 @@ class SystemEnv(Env):
     def get_supported_tags(self) -> list[Tag]:
         return list(sys_tags())
 
-    def get_marker_env(self) -> dict[str, Any]:
+    def get_marker_env(self) -> MarkerEnv:
         if hasattr(sys, "implementation"):
             info = sys.implementation.version
             iver = f"{info.major}.{info.minor}.{info.micro}"
@@ -73,6 +73,7 @@ class SystemEnv(Env):
             "version_info": sys.version_info,
             "interpreter_name": interpreter_name(),
             "interpreter_version": interpreter_version(),
+            "sysconfig_platform": sysconfig.get_platform(),
         }
 
     def is_venv(self) -> bool:

--- a/src/poetry/utils/env/virtual_env.py
+++ b/src/poetry/utils/env/virtual_env.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from poetry.utils.env.base_env import Env
+from poetry.utils.env.base_env import MarkerEnv
 from poetry.utils.env.script_strings import GET_BASE_PREFIX
 from poetry.utils.env.script_strings import GET_ENVIRONMENT_INFO
 from poetry.utils.env.script_strings import GET_PATHS
@@ -89,10 +90,12 @@ class VirtualEnv(Env):
             *compatible_tags(python, interpreter=interpreter, platforms=platforms),
         ]
 
-    def get_marker_env(self) -> dict[str, Any]:
+    def get_marker_env(self) -> MarkerEnv:
         output = self.run_python_script(GET_ENVIRONMENT_INFO)
 
-        env: dict[str, Any] = json.loads(output)
+        env: MarkerEnv = json.loads(output)
+        # Lists and tuples are the same in JSON and loaded as list.
+        env["version_info"] = tuple(env["version_info"])  # type: ignore[typeddict-item]
         return env
 
     def get_paths(self) -> dict[str, str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from poetry.poetry import Poetry
+    from poetry.utils.env.base_env import PythonVersion
     from tests.types import CommandFactory
     from tests.types import FixtureCopier
     from tests.types import FixtureDirGetter
@@ -428,12 +429,12 @@ def current_env() -> SystemEnv:
 
 
 @pytest.fixture(scope="session")
-def current_python(current_env: SystemEnv) -> tuple[int, int, int]:
-    return current_env.version_info[:3]
+def current_python(current_env: SystemEnv) -> PythonVersion:
+    return current_env.version_info
 
 
 @pytest.fixture(scope="session")
-def default_python(current_python: tuple[int, int, int]) -> str:
+def default_python(current_python: PythonVersion) -> str:
     return "^" + ".".join(str(v) for v in current_python[:2])
 
 

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from cleo.testers.command_tester import CommandTester
     from pytest_mock import MockerFixture
 
+    from poetry.utils.env.base_env import PythonVersion
     from tests.types import CommandTesterFactory
     from tests.types import MockedPythonRegister
 
@@ -35,11 +36,11 @@ def setup(mocker: MockerFixture) -> None:
 
 @pytest.fixture(autouse=True)
 def mock_subprocess_calls(
-    setup: None, current_python: tuple[int, int, int], mocker: MockerFixture
+    setup: None, current_python: PythonVersion, mocker: MockerFixture
 ) -> None:
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(Version.from_parts(*current_python)),
+        side_effect=check_output_wrapper(Version.from_parts(*current_python[:3])),
     )
     mocker.patch(
         "subprocess.Popen.communicate",
@@ -95,7 +96,7 @@ def test_activate_activates_non_existing_virtualenv_no_envs_file(
 
 def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     tester: CommandTester,
-    current_python: tuple[int, int, int],
+    current_python: PythonVersion,
     venv_cache: Path,
     venv_name: str,
     venvs_in_cache_config: None,
@@ -127,7 +128,7 @@ Using virtualenv: {venv_dir}
 def test_get_prefers_explicitly_activated_non_existing_virtualenvs_over_env_var(
     mocker: MockerFixture,
     tester: CommandTester,
-    current_python: tuple[int, int, int],
+    current_python: PythonVersion,
     venv_cache: Path,
     venv_name: str,
     venvs_in_cache_config: None,

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from pytest_mock.plugin import MockerFixture
 
     from poetry.poetry import Poetry
+    from poetry.utils.env.base_env import PythonVersion
     from tests.types import FixtureDirGetter
     from tests.types import ProjectFactory
 
@@ -205,7 +206,7 @@ def test_load_successful_with_invalid_distribution(
 
 
 def test_loads_in_correct_sys_path_order(
-    tmp_path: Path, current_python: tuple[int, int, int], fixture_dir: FixtureDirGetter
+    tmp_path: Path, current_python: PythonVersion, fixture_dir: FixtureDirGetter
 ) -> None:
     path1 = tmp_path / "path1"
     path1.mkdir()

--- a/tests/utils/env/test_env.py
+++ b/tests/utils/env/test_env.py
@@ -560,3 +560,18 @@ def test_env_scheme_dict_returns_modified_when_read_only(
         and scheme_dict[scheme].startswith(paths["userbase"])
         for scheme in SCHEME_NAMES
     )
+
+
+def test_marker_env_is_equal_for_all_envs(tmp_path: Path, manager: EnvManager) -> None:
+    venv_path = tmp_path / "Virtual Env"
+    manager.build_venv(venv_path)
+    venv = VirtualEnv(venv_path)
+    generic_env = GenericEnv(venv.path)
+    system_env = SystemEnv(Path(sys.prefix))
+
+    venv_marker_env = venv.marker_env
+    generic_marker_env = generic_env.marker_env
+    system_marker_env = system_env.marker_env
+
+    assert venv_marker_env == generic_marker_env
+    assert venv_marker_env == system_marker_env


### PR DESCRIPTION
* add a test that checks that `marker_env` is equal for all types of envs
* make `marker_env` a `TypedDict`
* add `sysconfig_platform` to `SystemEnv.marker_env` (is not used so that it is not a relevant bug that it was missing)

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
