### PR TITLE
Use authenticated_url when accessing HTTP BASIC repository

### DIFF
--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -401,7 +401,7 @@ class HTTPRepository(CachedRepository):
         return None
 
     def _get_response(self, endpoint: str) -> requests.Response | None:
-        url = self._url + endpoint
+        url = self.authenticated_url + endpoint
         try:
             response: requests.Response = self.session.get(
                 url, raise_for_status=False, timeout=REQUESTS_TIMEOUT


### PR DESCRIPTION
# Pull Request Check List

Resolves: Authorization error accessing <url> when using http-basic repository and credentials configuration 

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Summary by Sourcery

Bug Fixes:
- Fix authorization failures by constructing request URLs with credentials when using HTTP BASIC repositories.