### PR TITLE
Documentation: Clarified negating VCS excluded files

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -645,12 +645,6 @@ You can explicitly specify to Poetry that a set of globs should be ignored or in
 The globs specified in the exclude field identify a set of files that are not included when a package is built.
 `include` has priority over `exclude`.
 
-If a VCS is being used for a package, the exclude field will be seeded with the VCS’ ignore settings (`.gitignore` for git, for example).
-
-{{% note %}}
-Explicitly declaring entries in `include` will negate VCS' ignore settings.
-{{% /note %}}
-
 You can also specify the formats for which these patterns have to be included, as shown here:
 
 ```toml
@@ -672,6 +666,11 @@ Pay attention to include top level files and directories with common names like
 `CHANGELOG.md`, `LICENSE`, `tests` or `docs` only in sdists and **not** in wheels.
 {{% /warning %}}
 
+If a VCS is being used for a package, the exclude field will be seeded with the VCS’ ignore settings (`.gitignore` for git, for example).
+
+{{% note %}}
+VCS ignore settings can be negated by adding entries in `include`; be sure to explicitly set the `format` as above.
+{{% /note %}}
 
 ### dependencies and dependency groups
 


### PR DESCRIPTION
My earlier issue (#10418) was caused a misleading statement in the documentation which conflicts with a later statement:

> Explicitly declaring entries in `include` will negate VCS' ignore settings.

As written, this is untrue because of the asymmetry between `include` and `exclude`:

> If no format is specified, `include` defaults to only `sdist`.
> 
> In contrast, `exclude` defaults to both `sdist` and `wheel`.

So _only_ declaring `include` entries with explicit formats can properly negate VCS.

To try to help future readers, I've moved the discussion of VCS down below the part on explicit formats so the closest code examples show explicit format, and clarified the note to inform readers the format must also be given.

# Pull Request Check List

Resolves: #10418

- [ ] Added **tests** for changed code. (NA.)
- [ ] Updated **documentation** for changed code.



## Summary by Sourcery

Documentation:
- Move the VCS ignore note below the explicit formats section and update its wording to specify that `format` must be provided when using `include` to override VCS ignore settings.