### PR TITLE
docs: update unspecified version docs for `add`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,8 +44,7 @@ poetry about
 
 The `add` command adds required packages to your `pyproject.toml` and installs them.
 
-If you do not specify a version constraint,
-poetry will choose a suitable one based on the available package versions.
+If you do not specify a version constraint, poetry will attempt to use the latest version.
 
 ```bash
 poetry add requests pendulum


### PR DESCRIPTION
Updates the documentation for when `poetry add` is called without specifying a version constraints.

It was highlighted in https://github.com/python-poetry/poetry/issues/10444 by [dimbleby](https://github.com/dimbleby) that when a version constraint is not specified for `poetry add` it will attempt to use the latest version.

I think the current documentation does not clearlycommunicate this as `poetry will choose a suitable one based on the available package versions.` can mislead readers into thinking poetry itself will attempt to resolve versions to find a suitable version, when it instead will try the latest and if this fails will fail and then someone may need to manually select a version that works for them.



# Pull Request Check List

Resolves: #10444

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Clarify the documentation for `poetry add` when no version constraint is provided to indicate that Poetry will attempt to use the latest package version and add corresponding tests to cover this behavior.

Enhancements:
- Clarify the behavior of `poetry add` without a version constraint in the CLI documentation.

Documentation:
- Update the `add` command description to state that Poetry will attempt to use the latest version when no constraint is specified.

Tests:
- Add tests to verify the default version resolution behavior of `poetry add`.