### PR TITLE
feat: adds an option to generate a project with pacakge mode = false

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -58,6 +58,7 @@ class InitCommand(Command):
             flag=False,
             multiple=True,
         ),
+        option("disable-package-mode", "-N", "Disables package mode.", flag=True),
         option("license", "l", "License of the package.", flag=False),
     ]
 
@@ -141,9 +142,12 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         if is_interactive:
             question = self.create_question(
-                f"Version [<comment>{version}</comment>]: ", default=version
+                f"Version [<comment>{version}</comment>]: ",
+                default=version if not self.option("disable-package-mode") else "",
             )
             version = self.ask(question)
+        else:
+            version = version if not self.option("disable-package-mode") else ""
 
         description = self.option("description") or ""
         if not description and is_interactive:
@@ -244,6 +248,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             python=python,
             dependencies=requirements,
             dev_dependencies=dev_requirements,
+            package_mode=not self.option("disable-package-mode"),
         )
 
         create_layout = not project_path.exists() or (

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1207,3 +1207,108 @@ def test_init_does_not_create_project_structure_in_non_empty_directory(
     # Existing files should remain
     assert (source_dir / "existing_file.txt").exists()
     assert (source_dir / "existing_dir").exists()
+
+
+def test_init_with_no_package_mode_flag_active(
+    tester: CommandTester, source_dir: Path
+) -> None:
+    """Test that poetry init add package-mode = false to pyproject.toml"""
+    inputs = [
+        "my-package",  # Package name
+        "",  # Version
+        "",  # Description
+        "n",  # Author
+        "",  # License
+        "",  # Python
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    expected = """\
+[tool.poetry]
+package-mode = false
+"""
+    tester.execute("--disable-package-mode", inputs="\n".join(inputs))
+
+    assert (source_dir / "pyproject.toml").exists()
+    assert expected in (source_dir / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_init_with_no_package_mode_flag_active_short_flag(
+    tester: CommandTester, source_dir: Path
+) -> None:
+    """Test that poetry init add package-mode = false to pyproject.toml"""
+    inputs = [
+        "my-package",  # Package name
+        "",  # Version
+        "",  # Description
+        "n",  # Author
+        "",  # License
+        "",  # Python
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    expected = """\
+[tool.poetry]
+package-mode = false
+"""
+    tester.execute("-N", inputs="\n".join(inputs))
+
+    assert (source_dir / "pyproject.toml").exists()
+    assert expected in (source_dir / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_init_with_no_package_mode_flag_active_remove_optional_fields(
+    tester: CommandTester, source_dir: Path
+) -> None:
+    """Test that poetry init add package-mode = false to pyproject.toml"""
+    inputs = [
+        "my-package",  # Package name
+        "",  # Version
+        "",  # Description
+        "n",  # Author
+        "",  # License
+        "",  # Python
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    tester.execute("-N", inputs="\n".join(inputs))
+
+    assert (source_dir / "pyproject.toml").exists()
+    toml_content = (source_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert "version = " not in toml_content
+    assert "description =" not in toml_content
+    assert "authors =" not in toml_content
+
+
+def test_init_with_no_package_mode_flag_active_remove_optional_fields_with_email(
+    tester: CommandTester, source_dir: Path
+) -> None:
+    """Test that poetry init add package-mode = false to pyproject.toml"""
+    inputs = [
+        "my-package",  # Package name
+        "",  # Version
+        "",  # Description
+        "poetry <poetry@poetry.com>",  # Author
+        "",  # License
+        "",  # Python
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    tester.execute("-N", inputs="\n".join(inputs))
+    expected = """
+authors = [
+    {name = "poetry",email = "poetry@poetry.com"}
+]
+"""
+
+    assert (source_dir / "pyproject.toml").exists()
+    toml_content = (source_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert expected in toml_content


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9447 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This small pull request adds an option to disable package mode: `-N` and `----disable-package-mode`.
When this options are enabled optional field in the `pyproject.toml` are skipped if the user leaves the default value