### PR TITLE
improve pyproject.toml validation error messages by replacing `data` with `tool.poetry`

### DIFF
--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -332,7 +332,9 @@ class Factory(BaseFactory):
         results = super().validate(toml_data, strict)
         poetry_config = toml_data["tool"]["poetry"]
 
-        results["errors"].extend(validate_object(poetry_config))
+        results["errors"].extend(
+            [e.replace("data.", "tool.poetry.") for e in validate_object(poetry_config)]
+        )
 
         # A project should not depend on itself.
         # TODO: consider [project.dependencies] and [project.optional-dependencies]

--- a/tests/json/test_schema.py
+++ b/tests/json/test_schema.py
@@ -26,7 +26,7 @@ def test_pyproject_toml_invalid_priority() -> None:
     ).read()
     assert Factory.validate(toml) == {
         "errors": [
-            "data.source[0].priority must be one of ['primary',"
+            "tool.poetry.source[0].priority must be one of ['primary',"
             " 'supplemental', 'explicit']"
         ],
         "warnings": [],
@@ -41,7 +41,7 @@ def test_self_valid() -> None:
 def test_self_invalid_version() -> None:
     toml: dict[str, Any] = TOMLFile(FIXTURE_DIR / "self_invalid_version.toml").read()
     assert Factory.validate(toml) == {
-        "errors": ["data.requires-poetry must be string"],
+        "errors": ["tool.poetry.requires-poetry must be string"],
         "warnings": [],
     }
 
@@ -50,7 +50,7 @@ def test_self_invalid_plugin() -> None:
     toml: dict[str, Any] = TOMLFile(FIXTURE_DIR / "self_invalid_plugin.toml").read()
     assert Factory.validate(toml) == {
         "errors": [
-            "data.requires-plugins.foo must be valid exactly by one definition"
+            "tool.poetry.requires-plugins.foo must be valid exactly by one definition"
             " (0 matches found)"
         ],
         "warnings": [],

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -392,13 +392,17 @@ def test_validate_fails(fixture_dir: FixtureDirGetter) -> None:
     complete = TOMLFile(fixture_dir("complete.toml"))
     pyproject: dict[str, Any] = complete.read()
     pyproject["tool"]["poetry"]["this key is not in the schema"] = ""
+    pyproject["tool"]["poetry"]["source"] = {}
 
-    expected = (
-        "Additional properties are not allowed "
-        "('this key is not in the schema' was unexpected)"
-    )
+    expected = [
+        "tool.poetry.source must be array",
+        (
+            "Additional properties are not allowed "
+            "('this key is not in the schema' was unexpected)"
+        ),
+    ]
 
-    assert Factory.validate(pyproject) == {"errors": [expected], "warnings": []}
+    assert Factory.validate(pyproject) == {"errors": expected, "warnings": []}
 
 
 def test_create_poetry_fails_on_invalid_configuration(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9900

Replaces the `data` prefix in the validation error messages with `tool.poetry` to better report toml structure errors

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Replace 'data.' prefix in pyproject.toml validation error messages with 'tool.poetry.' and adjust tests accordingly

Enhancements:
- Prefix validation error paths with 'tool.poetry.' instead of 'data.' in pyproject.toml errors

Tests:
- Update test_validate_fails to expect the new 'tool.poetry.' error messages and flattened error list

## Summary by Sourcery

Replace the "data." prefix in pyproject.toml validation error messages with "tool.poetry." and adjust tests accordingly

Enhancements:
- Prefix TOML validation error paths with "tool.poetry." instead of "data."

Tests:
- Update tests to expect the new "tool.poetry." error messages and flatter error list structure