### PR TITLE
fix deprecated parts in pyproject example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dependencies = [
     # dependency with extras
     "requests[security] (>=2.28,<3.0)",
     # version-specific dependency with prereleases allowed (see below)
-    "tomli (>=2.0.1,<3.0.0) ; python_version < \"3.11\"",
+    "tomli (>=2.0.1,<3.0.0) ; python_version < '3.11'",
     # git dependency with branch specified
     "cleo @ git+https://github.com/python-poetry/cleo.git@main",
 ]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ my-extra = ["pendulum (>=3.1.0,<4.0.0)"]
 # Python upper bound for locking
 python = ">=3.9,<4.0"
 # Version-specific dependencies with prereleases allowed
-tomli = {allow-prereleases = true, python = "<3.11"}
+tomli = { allow-prereleases = true }
 
 # Dependency groups are supported for organizing your dependencies
 [tool.poetry.group.dev.dependencies]

--- a/README.md
+++ b/README.md
@@ -16,29 +16,37 @@ Poetry replaces `setup.py`, `requirements.txt`, `setup.cfg`, `MANIFEST.in` and `
 based project format.
 
 ```toml
-[tool.poetry]
+[project]
 name = "my-package"
 version = "0.1.0"
 description = "The description of the package"
 
-license = "MIT"
+license = { text = "MIT" }
+readme = "README.md"
+
+# No python upper bound for package metadata
+requires-python = ">=3.8"
 
 authors = [
-    "Sébastien Eustace <sebastien@eustace.io>"
+    { name = "Sébastien Eustace", email = "sebastien@eustace.io" },
 ]
-
-repository = "https://github.com/python-poetry/poetry"
-homepage = "https://python-poetry.org"
-
-# README file(s) are used as the package description
-readme = ["README.md", "LICENSE"]
 
 # Keywords (translated to tags on the package index)
 keywords = ["packaging", "poetry"]
 
+dynamic = [ "dependencies" ]
+
+[project.urls]
+repository = "https://github.com/python-poetry/poetry"
+homepage = "https://python-poetry.org"
+
+# Scripts are easily expressed
+[project.scripts]
+my_package_cli = 'my_package.console:run'
+
 [tool.poetry.dependencies]
-# Compatible Python versions
-python = ">=3.8"
+# Python upper bound for locking
+python = ">=3.8,<4.0"
 # Standard dependency with semver constraints
 aiohttp = "^3.8.1"
 # Dependency with extras
@@ -60,10 +68,6 @@ pytest-cov = "^3.0"
 optional = true
 [tool.poetry.group.docs.dependencies]
 Sphinx = "^5.1.1"
-
-# Python-style entrypoints and scripts are easily expressed
-[tool.poetry.scripts]
-my-script = "my_package:main"
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ license = { text = "MIT" }
 readme = "README.md"
 
 # No python upper bound for package metadata
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 authors = [
     { name = "Sébastien Eustace", email = "sebastien@eustace.io" },
@@ -34,7 +34,16 @@ authors = [
 # Keywords (translated to tags on the package index)
 keywords = ["packaging", "poetry"]
 
-dynamic = [ "dependencies" ]
+dependencies = [
+    # equivalent to ^3.8.1 with semver constraints
+    "aiohttp (>=3.8.1,<4.0.0)",
+    # dependency with extras
+    "requests[security] (>=2.28,<3.0)",
+    # version-specific dependency with prereleases allowed (see below)
+    "tomli (>=2.0.1,<3.0.0) ; python_version < \"3.11\"",
+    # git dependency with branch specified
+    "cleo @ git+https://github.com/python-poetry/cleo.git@main",
+]
 
 [project.urls]
 repository = "https://github.com/python-poetry/poetry"
@@ -44,19 +53,15 @@ homepage = "https://python-poetry.org"
 [project.scripts]
 my_package_cli = 'my_package.console:run'
 
+[project.optional-dependencies]
+# optional dependency to be installed via 'poetry install -E my-extra'
+my-extra = ["pendulum (>=3.1.0,<4.0.0)"]
+
 [tool.poetry.dependencies]
 # Python upper bound for locking
-python = ">=3.8,<4.0"
-# Standard dependency with semver constraints
-aiohttp = "^3.8.1"
-# Dependency with extras
-requests = { version = "^2.28", extras = ["security"] }
+python = ">=3.9,<4.0"
 # Version-specific dependencies with prereleases allowed
-tomli = { version = "^2.0.1", python = "<3.11", allow-prereleases = true }
-# Git dependencies
-cleo = { git = "https://github.com/python-poetry/cleo.git", branch = "main" }
-# Optional dependencies (installed by extras)
-pendulum = { version = "^2.1.2", optional = true }
+tomli = {allow-prereleases = true, python = "<3.11"}
 
 # Dependency groups are supported for organizing your dependencies
 [tool.poetry.group.dev.dependencies]
@@ -64,6 +69,7 @@ pytest = "^7.1.2"
 pytest-cov = "^3.0"
 
 # ...and can be installed only when explicitly requested
+# via 'poetry install --with docs'
 [tool.poetry.group.docs]
 optional = true
 [tool.poetry.group.docs.dependencies]


### PR DESCRIPTION
This pull request updates the `pyproject.toml` example in the README as it was largely deprecated according to [this section](https://python-poetry.org/docs/pyproject/#the-toolpoetry-section) of the documentation.
A more detailed list of affected fields can be found in issue #10477 
The new example should basically be equivalent to the old example, but sticks closer to the documentation's recommendations.

# Pull Request Check List

Resolves: #10477 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code. (no code changed)
- [x] Updated **documentation** for changed code. (no code changed)
- [x] Checked pyproject changes with `poetry check`

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Revise the pyproject.toml example in the README to remove deprecated tool.poetry sections and adopt the PEP 621–compliant [project] table with updated metadata and dependency syntax.

Documentation:
- Replace the legacy [tool.poetry] example with a PEP 621–style [project] section
- Update metadata fields (license, readme, python requirements, authors, keywords) to align with documentation
- Refactor dependencies and optional dependencies to inline semver constraints under [project.dependencies] and [project.optional-dependencies]
- Add [project.urls] and [project.scripts] sections and remove deprecated tool.poetry.group and tool.poetry.scripts entries