### PR TITLE
feature: poetry show json output format

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1061,6 +1061,7 @@ required by
 * `--all (-a)`: Show all packages (even those not compatible with current system).
 * `--top-level (-T)`: Only show explicitly defined packages.
 * `--no-truncate`: Do not truncate the output based on the terminal width.
+* `--output`: Specify the output format. JSON cannot be combined with the `--tree` option. Default is text. Supported formats: text, json.
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1061,7 +1061,7 @@ required by
 * `--all (-a)`: Show all packages (even those not compatible with current system).
 * `--top-level (-T)`: Only show explicitly defined packages.
 * `--no-truncate`: Do not truncate the output based on the terminal width.
-* `--output`: Specify the output format. JSON cannot be combined with the `--tree` option. Default is text. Supported formats: text, json.
+* `--output`: Specify the output format (`text` or `json`). Default is `text`. `json` cannot be combined with the `--tree` option.
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1061,7 +1061,7 @@ required by
 * `--all (-a)`: Show all packages (even those not compatible with current system).
 * `--top-level (-T)`: Only show explicitly defined packages.
 * `--no-truncate`: Do not truncate the output based on the terminal width.
-* `--output`: Specify the output format (`text` or `json`). Default is `text`. `json` cannot be combined with the `--tree` option.
+* `--output`: Specify the output format (`json` or `text`). Default is `text`. `json` cannot be combined with the `--tree` option.
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1061,7 +1061,7 @@ required by
 * `--all (-a)`: Show all packages (even those not compatible with current system).
 * `--top-level (-T)`: Only show explicitly defined packages.
 * `--no-truncate`: Do not truncate the output based on the terminal width.
-* `--output`: Specify the output format (`json` or `text`). Default is `text`. `json` cannot be combined with the `--tree` option.
+* `--format (-f)`: Specify the output format (`json` or `text`). Default is `text`. `json` cannot be combined with the `--tree` option.
 
 {{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -132,9 +132,9 @@ lists all packages available."""
 
             return 1
 
-        if self.option("output") == "json" and self.option("tree"):
+        if self.option("output") != "text" and self.option("tree"):
             self.line_error(
-                "<error>Error: JSON output format cannot be used with --tree option.</error>"
+                "<error>Error: --tree option can only be used the the text output.</error>"
             )
             return 1
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -134,7 +134,7 @@ lists all packages available."""
 
         if self.option("output") != "text" and self.option("tree"):
             self.line_error(
-                "<error>Error: --tree option can only be used the the text output.</error>"
+                "<error>Error: --tree option can only be used with the text output option.</error>"
             )
             return 1
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -127,7 +127,7 @@ lists all packages available."""
 
         if self.option("output") not in OUTPUT_FORMATS:
             self.line_error(
-                "<error>Error: Invalid output format. Supported formats are: text, json.</error>"
+                f"<error>Error: Invalid output format. Supported formats are: {', '.join(sorted(OUTPUT_FORMATS))}.</error>"
             )
 
             return 1

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -378,24 +378,18 @@ lists all packages available."""
 
                 package = {}
                 package["name"] = locked.pretty_name
-
-                installed_status = self.get_installed_status(
+                package["installed_status"] = self.get_installed_status(
                     locked, installed_repo.packages
                 )
-                package["installed_status"] = installed_status
-
-                version = get_package_version_display_string(
+                package["version"] = get_package_version_display_string(
                     locked, root=self.poetry.file.path.parent
                 )
-                package["version"] = version
 
                 if show_latest:
                     latest = latest_packages[locked.pretty_name]
-                    update_status = latest_statuses[locked.pretty_name]
-                    version = get_package_version_display_string(
+                    package["latest_version"] = get_package_version_display_string(
                         latest, root=self.poetry.file.path.parent
                     )
-                    package["latest_version"] = version
 
                 if show_why:
                     required_by = reverse_deps(locked, locked_repository)

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -376,7 +376,7 @@ lists all packages available."""
                 if show_top_level and not any(locked.satisfies(r) for r in requires):
                     continue
 
-                package = {}
+                package: dict[str, str | list[str]] = {}
                 package["name"] = locked.pretty_name
                 package["installed_status"] = self.get_installed_status(
                     locked, installed_repo.packages
@@ -394,8 +394,7 @@ lists all packages available."""
                 if show_why:
                     required_by = reverse_deps(locked, locked_repository)
                     if required_by:
-                        content = ",".join(required_by.keys())
-                        package["required_by"] = content
+                        package["required_by"] = list(required_by.keys())
 
                 package["description"] = locked.description
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -129,7 +129,7 @@ lists all packages available."""
 
                 return 1
 
-        if self.option("format") not in OutputFormats:
+        if self.option("format") not in set(OutputFormats):
             self.line_error(
                 f"<error>Error: Invalid output format. Supported formats are: {', '.join(OutputFormats)}.</error>"
             )

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -37,7 +37,7 @@ def reverse_deps(pkg: Package, repo: Repository) -> dict[str, str]:
     return required_by
 
 
-OUTPUT_FORMATS = ["text", "json"]
+OUTPUT_FORMATS = {"text", "json"}
 
 
 class ShowCommand(GroupCommand, EnvCommand):
@@ -220,7 +220,6 @@ lists all packages available."""
             if required_by:
                 package_info["required by"] = dict(required_by)
 
-            # need to get the anscii output option here
             self.line(json.dumps(package_info))
             return 0
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -218,7 +218,7 @@ lists all packages available."""
                     for dependency in pkg.requires
                 }
             if required_by:
-                package_info["required by"] = dict(required_by)
+                package_info["required_by"] = dict(required_by)
 
             self.line(json.dumps(package_info))
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 
+from enum import Enum
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
@@ -38,7 +39,9 @@ def reverse_deps(pkg: Package, repo: Repository) -> dict[str, str]:
     return required_by
 
 
-OUTPUT_FORMATS = {"text", "json"}
+class OutputFormats(str, Enum):
+    JSON = "json"
+    TEXT = "text"
 
 
 class ShowCommand(GroupCommand, EnvCommand):
@@ -76,9 +79,9 @@ class ShowCommand(GroupCommand, EnvCommand):
             "Do not truncate the output based on the terminal width.",
         ),
         option(
-            "output",
-            None,
-            "Specify the output format. JSON cannot be combined with the <info>--tree</info> option. Default is text. Supported formats: text, json.",
+            "format",
+            "f",
+            "Specify the output format (`json` or `text`). Default is `text`. `json` cannot be combined with the <info>--tree</info> option.",
             flag=False,
             default="text",
         ),
@@ -126,14 +129,14 @@ lists all packages available."""
 
                 return 1
 
-        if self.option("output") not in OUTPUT_FORMATS:
+        if self.option("format") not in OutputFormats:
             self.line_error(
-                f"<error>Error: Invalid output format. Supported formats are: {', '.join(sorted(OUTPUT_FORMATS))}.</error>"
+                f"<error>Error: Invalid output format. Supported formats are: {', '.join(OutputFormats)}.</error>"
             )
 
             return 1
 
-        if self.option("output") != "text" and self.option("tree"):
+        if self.option("format") != OutputFormats.TEXT and self.option("tree"):
             self.line_error(
                 "<error>Error: --tree option can only be used with the text output option.</error>"
             )
@@ -205,7 +208,7 @@ lists all packages available."""
 
             return 0
 
-        if self.option("output") == "json":
+        if self.option("format") == OutputFormats.JSON:
             package_info: dict[str, str | dict[str, str]] = {
                 "name": pkg.pretty_name,
                 "version": pkg.pretty_version,
@@ -356,7 +359,7 @@ lists all packages available."""
                         required_by_length, len(" from " + ",".join(required_by.keys()))
                     )
 
-        if self.option("output") == "json":
+        if self.option("format") == OutputFormats.JSON:
             packages = []
 
             for locked in locked_packages:

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -363,14 +363,14 @@ lists all packages available."""
             packages = []
 
             for locked in locked_packages:
+                if locked not in required_locked_packages and not show_all:
+                    continue
+
                 if (
                     show_latest
                     and self.option("outdated")
                     and latest_statuses[locked.pretty_name] == "up-to-date"
                 ):
-                    continue
-
-                if locked not in required_locked_packages and not show_all:
                     continue
 
                 if show_top_level and not any(locked.satisfies(r) for r in requires):

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -207,7 +207,7 @@ lists all packages available."""
         if self.option("output") == "json":
             import json
 
-            package_info = {
+            package_info: dict[str, str | dict[str, str]] = {
                 "name": pkg.pretty_name,
                 "version": pkg.pretty_version,
                 "description": pkg.description,
@@ -218,7 +218,7 @@ lists all packages available."""
                     for dependency in pkg.requires
                 }
             if required_by:
-                package_info["required_by"] = dict(required_by)
+                package_info["required_by"] = required_by
 
             self.line(json.dumps(package_info))
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 
 from typing import TYPE_CHECKING
@@ -205,8 +206,6 @@ lists all packages available."""
             return 0
 
         if self.option("output") == "json":
-            import json
-
             package_info: dict[str, str | dict[str, str]] = {
                 "name": pkg.pretty_name,
                 "version": pkg.pretty_version,
@@ -358,8 +357,6 @@ lists all packages available."""
                     )
 
         if self.option("output") == "json":
-            import json
-
             packages = []
 
             for locked in locked_packages:

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -905,7 +905,32 @@ def test_show_latest_decorated(
     assert tester.io.fetch_output() == expected
 
 
+@pytest.mark.parametrize(
+    ("expected", "output_format"),
+    [
+        (
+            """\
+cachy 0.1.0 0.2.0 Cachy package
+""",
+            "",
+        ),
+        (
+            [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "latest_version": "0.2.0",
+                    "description": "Cachy package",
+                    "installed_status": "installed",
+                },
+            ],
+            "--output json",
+        ),
+    ],
+)
 def test_show_outdated(
+    expected: str,
+    output_format: str,
     tester: CommandTester,
     poetry: Poetry,
     installed: Repository,
@@ -961,16 +986,30 @@ def test_show_outdated(
         }
     )
 
-    tester.execute("--outdated")
+    tester.execute("--outdated" if not output_format else "--outdated " + output_format)
 
-    expected = """\
-cachy 0.1.0 0.2.0 Cachy package
-"""
+    if output_format:
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        assert tester.io.fetch_output() == expected
 
-    assert tester.io.fetch_output() == expected
 
-
+@pytest.mark.parametrize(
+    ("expected", "output_format"),
+    [
+        (
+            "",
+            "",
+        ),
+        (
+            [],
+            "--output json",
+        ),
+    ],
+)
 def test_show_outdated_with_only_up_to_date_packages(
+    expected: str,
+    output_format: str,
     tester: CommandTester,
     poetry: Poetry,
     installed: Repository,
@@ -1005,14 +1044,40 @@ def test_show_outdated_with_only_up_to_date_packages(
         }
     )
 
-    tester.execute("--outdated")
+    tester.execute("--outdated" if not output_format else "--outdated " + output_format)
 
-    expected = ""
+    if output_format:
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        assert tester.io.fetch_output() == expected
 
-    assert tester.io.fetch_output() == expected
 
-
+@pytest.mark.parametrize(
+    ("expected", "output_format"),
+    [
+        (
+            """\
+cachy 0.1.0 0.2.0 Cachy package
+""",
+            "",
+        ),
+        (
+            [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "latest_version": "0.2.0",
+                    "description": "Cachy package",
+                    "installed_status": "installed",
+                },
+            ],
+            "--output json",
+        ),
+    ],
+)
 def test_show_outdated_has_prerelease_but_not_allowed(
+    expected: str,
+    output_format: str,
     tester: CommandTester,
     poetry: Poetry,
     installed: Repository,
@@ -1073,16 +1138,40 @@ def test_show_outdated_has_prerelease_but_not_allowed(
         }
     )
 
-    tester.execute("--outdated")
+    tester.execute("--outdated" if not output_format else "--outdated " + output_format)
 
-    expected = """\
-cachy 0.1.0 0.2.0 Cachy package
-"""
+    if output_format:
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        assert tester.io.fetch_output() == expected
 
-    assert tester.io.fetch_output() == expected
 
-
+@pytest.mark.parametrize(
+    ("expected", "output_format"),
+    [
+        (
+            """\
+cachy 0.1.0.dev1 0.3.0.dev123 Cachy package
+""",
+            "",
+        ),
+        (
+            [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0.dev1",
+                    "latest_version": "0.3.0.dev123",
+                    "description": "Cachy package",
+                    "installed_status": "installed",
+                },
+            ],
+            "--output json",
+        ),
+    ],
+)
 def test_show_outdated_has_prerelease_and_allowed(
+    expected: str,
+    output_format: str,
     tester: CommandTester,
     poetry: Poetry,
     installed: Repository,
@@ -1147,16 +1236,48 @@ def test_show_outdated_has_prerelease_and_allowed(
         }
     )
 
-    tester.execute("--outdated")
+    tester.execute("--outdated" if not output_format else "--outdated " + output_format)
 
-    expected = """\
-cachy 0.1.0.dev1 0.3.0.dev123 Cachy package
-"""
+    if output_format:
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        assert tester.io.fetch_output() == expected
 
-    assert tester.io.fetch_output() == expected
 
-
+@pytest.mark.parametrize(
+    ("expected", "output_format"),
+    [
+        (
+            """\
+cachy    0.1.0 0.2.0 Cachy package
+pendulum 2.0.0 2.0.1 Pendulum package
+""",
+            "",
+        ),
+        (
+            [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "latest_version": "0.2.0",
+                    "description": "Cachy package",
+                    "installed_status": "installed",
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "latest_version": "2.0.1",
+                    "description": "Pendulum package",
+                    "installed_status": "installed",
+                },
+            ],
+            "--output json",
+        ),
+    ],
+)
 def test_show_outdated_formatting(
+    expected: str,
+    output_format: str,
     tester: CommandTester,
     poetry: Poetry,
     installed: Repository,
@@ -1215,14 +1336,12 @@ def test_show_outdated_formatting(
         }
     )
 
-    tester.execute("--outdated")
+    tester.execute("--outdated" if not output_format else "--outdated " + output_format)
 
-    expected = """\
-cachy    0.1.0 0.2.0 Cachy package
-pendulum 2.0.0 2.0.1 Pendulum package
-"""
-
-    assert tester.io.fetch_output() == expected
+    if output_format:
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        assert tester.io.fetch_output() == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -38,7 +38,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def output_format_parametrize(func: F) -> F:
-    formats = ["", "--output json"]
+    formats = ["", "--format json"]
     return cast("F", pytest.mark.parametrize("output_format", formats)(func))
 
 
@@ -221,7 +221,7 @@ pytest 3.7.3 Pytest package
 """,
         ),
         (
-            "--output json",
+            "--format json",
             [
                 {
                     "name": "cachy",
@@ -246,7 +246,7 @@ pytest   3.7.3 Pytest package
 """,
         ),
         (
-            "--with time --output json",
+            "--with time --format json",
             [
                 {
                     "name": "cachy",
@@ -275,7 +275,7 @@ cachy 0.1.0 Cachy package
 """,
         ),
         (
-            "--without test --output json",
+            "--without test --format json",
             [
                 {
                     "name": "cachy",
@@ -292,7 +292,7 @@ pytest 3.7.3 Pytest package
 """,
         ),
         (
-            f"--without {MAIN_GROUP} --output json",
+            f"--without {MAIN_GROUP} --format json",
             [
                 {
                     "name": "pytest",
@@ -309,7 +309,7 @@ cachy 0.1.0 Cachy package
 """,
         ),
         (
-            f"--only {MAIN_GROUP} --output json",
+            f"--only {MAIN_GROUP} --format json",
             [
                 {
                     "name": "cachy",
@@ -327,7 +327,7 @@ pendulum 2.0.0 Pendulum package
 """,
         ),
         (
-            "--with time --without test --output json",
+            "--with time --without test --format json",
             [
                 {
                     "name": "cachy",
@@ -350,7 +350,7 @@ pendulum 2.0.0 Pendulum package
 """,
         ),
         (
-            f"--with time --without {MAIN_GROUP},test --output json",
+            f"--with time --without {MAIN_GROUP},test --format json",
             [
                 {
                     "name": "pendulum",
@@ -367,7 +367,7 @@ pendulum 2.0.0 Pendulum package
 """,
         ),
         (
-            "--only time --output json",
+            "--only time --format json",
             [
                 {
                     "name": "pendulum",
@@ -384,7 +384,7 @@ pendulum 2.0.0 Pendulum package
 """,
         ),
         (
-            "--only time --with test --output json",
+            "--only time --with test --format json",
             [
                 {
                     "name": "pendulum",
@@ -403,7 +403,7 @@ pytest   3.7.3 Pytest package
 """,
         ),
         (
-            "--with time --output json",
+            "--with time --format json",
             [
                 {
                     "name": "cachy",
@@ -2930,7 +2930,7 @@ def test_show_error_invalid_output_format(
     tester: CommandTester,
 ) -> None:
     expected = "Error: Invalid output format. Supported formats are: json, text.\n"
-    tester.execute("--output invalid")
+    tester.execute("--format invalid")
     assert tester.io.fetch_error() == expected
     assert tester.status_code == 1
 
@@ -2939,6 +2939,6 @@ def test_show_error_invalid_output_format_with_tree_option(
     tester: CommandTester,
 ) -> None:
     expected = "Error: --tree option can only be used with the text output option.\n"
-    tester.execute("--output json --tree")
+    tester.execute("--format json --tree")
     assert tester.io.fetch_error() == expected
     assert tester.status_code == 1

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -481,7 +481,7 @@ def test_show_basic_with_group_options(
     ],
 )
 def test_show_basic_with_installed_packages_single(
-    expected: str,
+    expected: list[str] | dict[str, str],
     output_format: str,
     tester: CommandTester,
     poetry: Poetry,
@@ -545,7 +545,7 @@ def test_show_basic_with_installed_packages_single(
     ],
 )
 def test_show_basic_with_installed_packages_single_canonicalized(
-    expected: str,
+    expected: list[str] | dict[str, str],
     output_format: str,
     tester: CommandTester,
     poetry: Poetry,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10451

Adds a `--output` option to the `poetry show` command for `text` and `json` outputs.

`poetry self show` is not updated and there is some test duplication in `test_show.py` but this PR doesn't update them as I wanted to keep changes as contained as possible.

Duplicated test coverage:
- `test_show_non_dev_with_basic_installed_packages` captured in `test_show_basic_with_group_options --without test`
- `test_show_with_group_only` captured in `test_show_basic_with_group_options --only {MAIN_GROUP}`
- `test_show_with_optional_group` captured in `test_show_basic_with_group_options --with time`

I will open another PR for the duplicated tests.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Implement an --output flag for poetry show that enables JSON output alongside the existing text format, add validation for invalid or conflicting options, serialize package data to JSON in appropriate code paths, update tests accordingly, and document the new flag.

New Features:
- Add an --output option to the poetry show command to select between text and JSON output
- Support JSON formatting for both single-package and multi-package show invocations

Enhancements:
- Validate the output format and disallow combining JSON output with the --tree option
- Serialize package information to JSON in both single and list display modes

Documentation:
- Document the --output option in the CLI reference and note supported formats and constraints

Tests:
- Extend existing show command tests to verify JSON output across all options and edge cases
- Add tests for invalid output formats and tree/JSON incompatibility errors

## Summary by Sourcery

Add an `--output` flag to the `poetry show` command to support JSON output alongside text, with validation for invalid formats and conflicting `--tree` usage

New Features:
- Add `--output` option for the `poetry show` command to choose between text and JSON formats
- Enable JSON output for both single-package and multi-package displays, including group filters, top-level, outdated, latest, and reverse-dependency views

Enhancements:
- Validate the `--output` argument and emit errors for unsupported formats or invalid `--tree` combinations
- Refactor the show command to handle JSON serialization early and streamline display logic

Documentation:
- Document the new `--output` option in the CLI reference with supported formats and constraints

Tests:
- Parameterize existing show tests to cover both text and JSON output across all modes
- Add tests for invalid `--output` values and JSON/`--tree` incompatibility errors