### PR TITLE
solver: fix dependency resolution for self-referential extras with duplicate dependencies

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -614,7 +614,7 @@ class Provider:
 
             if len(duplicates_by_extras) == 1:
                 active_extras = (
-                    self._active_root_extras if package.is_root() else dependency.extras
+                    self._active_root_extras if package.is_root() else found_extras
                 )
                 deps = self._resolve_overlapping_markers(package, deps, active_extras)
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -543,6 +543,7 @@ def create_package(repo: Repository) -> PackageFactory:
         version: str | None = None,
         dependencies: list[Dependency] | None = None,
         extras: dict[str, list[str]] | None = None,
+        merge_extras: bool = False,
     ) -> Package:
         version = version or "1.0"
         package = get_package(name, version)
@@ -574,16 +575,20 @@ def create_package(repo: Repository) -> PackageFactory:
 
                     extra_dependency.constraint = parse_constraint(f"^{pkg.version}")
 
-                    # if requirement already exists in the package, update the marker
-                    for requirement in package.requires:
-                        if (
-                            requirement.name == extra_dependency.name
-                            and requirement.is_optional()
-                        ):
-                            requirement.marker = requirement.marker.union(
-                                extra_dependency.marker
-                            )
-                            break
+                    if merge_extras:
+                        # if requirement already exists in the package,
+                        # update the marker
+                        for requirement in package.requires:
+                            if (
+                                requirement.name == extra_dependency.name
+                                and requirement.is_optional()
+                            ):
+                                requirement.marker = requirement.marker.union(
+                                    extra_dependency.marker
+                                )
+                                break
+                        else:
+                            package.add_dependency(extra_dependency)
                     else:
                         package.add_dependency(extra_dependency)
 

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -571,6 +571,7 @@ def test_solver_returns_extras_if_requested_in_multiple_groups(
         (["py"], ["py310-package", "a"]),
     ],
 )
+@pytest.mark.parametrize("merge_extras", [True, False])
 @pytest.mark.parametrize("top_level_dependency", [True, False])
 def test_solver_resolves_self_referential_extras(
     enabled_extras: list[str],
@@ -580,6 +581,7 @@ def test_solver_resolves_self_referential_extras(
     repo: Repository,
     package: ProjectPackage,
     create_package: PackageFactory,
+    merge_extras: bool,
 ) -> None:
     dependency = (
         create_package(
@@ -587,13 +589,15 @@ def test_solver_resolves_self_referential_extras(
             str(package.version),
             extras={
                 "download": ["download-package"],
+                "download2": ["download-package"],  # same package as download
                 "install": ["install-package"],
                 "py38": ["py38-package ; python_version == '3.8'"],
                 "py310": ["py310-package ; python_version > '3.8'"],
-                "all": ["a[download,install]"],
+                "all": ["a[download,download2,install]"],
                 "py": ["a[py38,py310]"],
                 "nested": ["a[all]"],
             },
+            merge_extras=merge_extras,
         )
         .to_dependency()
         .with_features(enabled_extras)

--- a/tests/types.py
+++ b/tests/types.py
@@ -78,6 +78,7 @@ class PackageFactory(Protocol):
         version: str | None = None,
         dependencies: list[Dependency] | None = None,
         extras: dict[str, list[str]] | None = None,
+        merge_extras: bool = False,
     ) -> Package: ...
 
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10434

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Fix solver dependency resolution for self-referential extras containing duplicate dependencies and extend test fixtures to cover merged extra markers

Enhancements:
- Use found_extras instead of dependency.extras when resolving overlapping markers for non-root packages to handle duplicate extra dependencies correctly

Tests:
- Add merge_extras parameter to the test package factory to support merging markers of duplicate optional dependencies
- Parametrize test_solver_resolves_self_referential_extras on merge_extras and include duplicate dependent extras in the test data