### PR TITLE
tests: add test for cyclic self-referential dependencies

### DIFF
--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -564,6 +564,7 @@ def test_solver_returns_extras_if_requested_in_multiple_groups(
         ([], ["a"]),
         (["all"], ["download-package", "install-package", "a"]),
         (["nested"], ["download-package", "install-package", "a"]),
+        (["cyclic"], ["download-package", "install-package", "a"]),
         (["install", "download"], ["download-package", "install-package", "a"]),
         (["install"], ["install-package", "a"]),
         (["download"], ["download-package", "a"]),
@@ -596,6 +597,8 @@ def test_solver_resolves_self_referential_extras(
                 "all": ["a[download,download2,install]"],
                 "py": ["a[py38,py310]"],
                 "nested": ["a[all]"],
+                "cyclic": ["a[cyclic2]", "download-package"],
+                "cyclic2": ["a[cyclic]", "install-package"],
             },
             merge_extras=merge_extras,
         )


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Add tests to ensure the dependency solver handles cyclic self-referential extras correctly

Tests:
- Add a "cyclic" extras group to test_solver_returns_extras_if_requested_in_multiple_groups
- Add reciprocal "cyclic" and "cyclic2" entries to test_solver_resolves_self_referential_extras to simulate self-referential dependency cycles