### PR TITLE
Update pre-commit ruff legacy alias

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,9 @@ repos:
       - id: validate_manifest
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.12.7
     hooks:
-      - id: ruff
+      - id: ruff-check
       - id: ruff-format
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit

--- a/src/poetry/inspection/lazy_wheel.py
+++ b/src/poetry/inspection/lazy_wheel.py
@@ -138,8 +138,8 @@ class MergeIntervals:
             right: Index after last overlapping downloaded data
         """
         lslice, rslice = self._left[left:right], self._right[left:right]
-        i = start = min([start] + lslice[:1])
-        end = max([end] + rslice[-1:])
+        i = start = min([start, *lslice[:1]])
+        end = max([end, *rslice[-1:]])
         for j, k in zip(lslice, rslice):
             if j > i:
                 yield i, j - 1

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -203,7 +203,7 @@ def test_run_script_exit_code(
 ) -> None:
     mocker.patch(
         "os.execvpe",
-        lambda file, args, env: subprocess.call([file] + args[1:], env=env),
+        lambda file, args, env: subprocess.call([file, *args[1:]], env=env),
     )
     install_tester = command_tester_factory(
         "install",
@@ -235,7 +235,7 @@ def test_run_script_sys_argv0(
     mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
     mocker.patch(
         "os.execvpe",
-        lambda file, args, env: subprocess.call([file] + args[1:], env=env),
+        lambda file, args, env: subprocess.call([file, *args[1:]], env=env),
     )
 
     install_tester = command_tester_factory(


### PR DESCRIPTION
# Pull Request Check List

Changes:
```
ruff (legacy alias)......................................................Passed
```
into:
```
ruff check...............................................................Passed
```

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Update the ruff pre-commit hook configuration to use the new "ruff-check" alias

Build:
- Change hook id from "ruff" to "ruff-check"

## Summary by Sourcery

Update pre-commit ruff alias and refactor list concatenations for clarity

Enhancements:
- Bump ruff-pre-commit hook to v0.12.7 and switch hook id from ruff to ruff-check
- Simplify slice merging logic in lazy_wheel using iterable unpacking
- Refactor test lambdas to use argument unpacking instead of list concatenation