### PR TITLE
deps: allow importlib-metadata 8.7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -739,14 +739,14 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "importlib-metadata"
-version = "8.6.1"
+version = "8.7.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e"},
-    {file = "importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580"},
+    {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
+    {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
 ]
 markers = {main = "python_version < \"3.12\"", test = "python_version == \"3.9\""}
 
@@ -2027,4 +2027,4 @@ cffi = ["cffi (>=1.17) ; python_version >= \"3.13\" and platform_python_implemen
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "daa6cd9277450d0b1210491a925245171e778f91c01acefedf994830e6ba2285"
+content-hash = "cf1eefff3c1d6ea8bf1beaea7b3ea695766783a7069f4504e5ee7e1deaeea175"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,7 @@ dependencies = [
     "cleo (>=2.1.0,<3.0.0)",
     "dulwich (>=0.24.0,<0.25.0)",
     "fastjsonschema (>=2.18.0,<3.0.0)",
-    # <8.7 because .metadata() (and Distribution.metadata) can now return None,
-    # which requires some adaptions to our code.
-    "importlib-metadata (>=4.4,<8.7) ; python_version < '3.10'",
+    "importlib-metadata (>=4.4) ; python_version < '3.10'",
     "installer (>=0.7.0,<0.8.0)",
     "keyring (>=25.1.0,<26.0.0)",
     # packaging uses calver, so version is unclamped

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -692,6 +692,7 @@ def verify_installed_distribution(
 
     distribution = distributions[0]
     metadata = distribution.metadata
+    assert metadata
     assert metadata["Name"] == package.name
     assert metadata["Version"] == package.version.text
 


### PR DESCRIPTION
We did not allow importlib-metadata 8.7 because 

> `.metadata()` (and `Distribution.metadata`) can now return `None` if the metadata directory exists but not metadata file is present

~I added a test and it turns out that no changes are required because such distributions are not returned when calling `metadata.distributions()`. Further, our code that does not expect `None`, does not expect empty `PackageMetadata` either. (It will raise an exception in both cases.)~

I tested it with Python 3.10. However, importlib-metadata is only used for Python 3.9 - and it fails if the metadata is `None` instead of empty metadata. Further, there is already a test so that we do not need a new one: `test_load_successful_with_invalid_distribution`

For whomever is wondering why we should care about Python 3.9 even though its EOL is near: Newer importlib-metadata versions will be included in newer Python versions. Thus, we will probably have the same issue with Python ~3.14~ 3.15.

## Summary by Sourcery

Loosen importlib-metadata version constraint and add validation for distributions without metadata

Build:
- Allow importlib-metadata 8.7 for Python <3.10 by removing the upper bound on the dependency

Tests:
- Add test to ensure distributions missing metadata files are ignored by the repository loader