### PR TITLE
tests: adapt expectations to poetry-core#879

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1184,9 +1184,9 @@ develop = false
 
 [package.source]
 type = "git"
-url = "https://github.com/python-poetry/poetry-core.git"
-reference = "HEAD"
-resolved_reference = "e0bd00670fd883238838d0ced7d6bfe24c733dfd"
+url = "https://github.com/radoering/poetry-core.git"
+reference = "fix-python-constraint-prereleases"
+resolved_reference = "c155ade8dd353e5c5793f37aa9a4966dd7568779"
 
 [[package]]
 name = "pre-commit"
@@ -2027,4 +2027,4 @@ cffi = ["cffi (>=1.17) ; python_version >= \"3.13\" and platform_python_implemen
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "daa6cd9277450d0b1210491a925245171e778f91c01acefedf994830e6ba2285"
+content-hash = "3e9f36b3a1948151b71eef1d5cb9138941589b48b28a50b92251aea724eb3cd7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.2.0.dev0"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.9,<4.0"
 dependencies = [
-    "poetry-core @ git+https://github.com/python-poetry/poetry-core.git",
+    "poetry-core @ git+https://github.com/radoering/poetry-core.git@fix-python-constraint-prereleases",
     "build (>=1.2.1,<2.0.0)",
     "cachecontrol[filecache] (>=0.14.0,<0.15.0)",
     "cleo (>=2.1.0,<3.0.0)",

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -1408,7 +1408,7 @@ content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8
     assert str(httpx_deps[0].python_constraint) == "<3.7"
 
     assert httpx_deps[1].constraint == Version.parse("2.0.0")
-    assert str(httpx_deps[1].python_constraint) == ">=3.7"
+    assert str(httpx_deps[1].python_constraint) == ">=3.7.dev0"
     assert httpx_deps[1].extras == {"brotli"}
 
 

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -290,7 +290,7 @@ def test_get_package_information_chooses_correct_distribution(
 
     assert package.requires == [Dependency("futures", "*")]
     futures_dep = package.requires[0]
-    assert futures_dep.python_versions == "~2.7"
+    assert futures_dep.python_versions == "2.7.*"
 
 
 def test_get_package_information_includes_python_requires(

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -106,7 +106,7 @@ def test_package(
     ]
     win_inet = package.extras[canonicalize_name("socks")][1]
     assert win_inet.name == "win-inet-pton"
-    assert win_inet.python_versions in {"~2.7 || ~2.6", ">=2.6 <2.8"}
+    assert win_inet.python_versions == ">=2.6.dev0 <2.8"
 
     # Different versions of poetry-core simplify the following marker differently,
     # either is fine.
@@ -231,7 +231,7 @@ def test_fallback_inspects_sdist_first_if_no_matching_wheels_can_be_found(
 
     dep = package.requires[0]
     assert dep.name == "futures"
-    assert dep.python_versions == "~2.7"
+    assert dep.python_versions == "2.7.*"
 
 
 def test_fallback_pep_658_metadata(
@@ -255,7 +255,7 @@ def test_fallback_pep_658_metadata(
 
         dep = package.requires[0]
         assert dep.name == "futures"
-        assert dep.python_versions == "~2.7"
+        assert dep.python_versions == "2.7.*"
 
 
 def test_pypi_repository_supports_reading_bz2_files(

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -91,7 +91,7 @@ def test_create_poetry(fixture_dir: FixtureDirGetter) -> None:
 
     pathlib2 = dependencies[canonicalize_name("pathlib2")]
     assert pathlib2.pretty_constraint == "^2.2"
-    assert parse_constraint(pathlib2.python_versions) == parse_constraint("~2.7")
+    assert parse_constraint(pathlib2.python_versions) == parse_constraint("2.7.*")
     assert not pathlib2.is_optional()
 
     demo = dependencies[canonicalize_name("demo")]


### PR DESCRIPTION
## Summary by Sourcery

Adapt test suites and project dependency to accommodate updated Python version constraint formatting introduced by python-poetry/poetry-core#879

Enhancements:
- Point poetry-core dependency to a patched branch handling prerelease constraints

Tests:
- Update expected python_versions in PyPI repository tests to new simplified formats
- Adjust expected python_versions in legacy repository and locker tests to '2.7.*' and '>=3.7.dev0' where applicable
- Modify factory tests to parse '2.7.*' instead of '~2.7'