### PR TITLE
installer: improve support of Python pre-releases

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -202,9 +202,12 @@ class Provider:
         original_python_constraint = self._package_python_constraint
 
         self._env = env
+        # We use the stable version here to improve support of environments of Python pre-release
+        # versions, e.g. Python 3.14rc2. Without using the stable version here, a dependency with
+        # a marker like `python_version >= "3.14"` would not be installed.
         self._package_python_constraint = Version.parse(
             env.marker_env["python_full_version"]
-        )
+        ).stable
 
         try:
             yield self


### PR DESCRIPTION
Closes: python-poetry/poetry-core#879
Closes: python-poetry/poetry#10515

This is a less pervasive solution for the issue described in python-poetry/poetry-core#879:

> https://github.com/python-poetry/poetry/actions/runs/17171517004/job/48721759731?pr=10514 (failure in `tests/utils/test_isolated_build.py::test_isolated_env_install_discards_requirements_not_needed_by_env` with Python 3.14rc2) shows that our installer does not handle environments of Python pre-release versions well. A dependency with the marker `python_version == "3.14"` is not installed because it is translated into a Python constraint `>=3.14,<3.15`, which does not allow Python 3.14rc2.

This PR just considers the stable part of the Python version of the environment to decide if dependencies should be installed. While the solution in python-poetry/poetry-core#879 seems (at least partially) more correct, it results in inconsistencies shown in the poetry-plugin-export tests in #10515.

Of course, this solution will break the evaluation of certain `python_full_version` markers, which explicitly reference a pre-release. However, I suppose such markers are not commonly used so that this might be acceptable.

## Summary by Sourcery

Bug Fixes:
- Compute the environment's python constraint from the stable part of python_full_version to allow dependencies with python_version markers to install on pre-release interpreters.