### PR TITLE
git: be more robust against dangling lock files

### DIFF
--- a/tests/vcs/git/conftest.py
+++ b/tests/vcs/git/conftest.py
@@ -50,6 +50,8 @@ def temp_repo(tmp_path: Path) -> TempRepoFixture:
         no_verify=True,
     )
 
+    repo[b"refs/tags/v1"] = head_commit
+
     return TempRepoFixture(
         path=tmp_path,
         repo=repo,

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -93,6 +95,27 @@ def test_clone_success(tmp_path: Path, temp_repo: TempRepoFixture) -> None:
 
     target_dir = source_root_dir / "clone-test"
     assert (target_dir / ".git").is_dir()
+
+
+@pytest.mark.skip_git_mock
+def test_clone_existing_locked_tag(tmp_path: Path, temp_repo: TempRepoFixture) -> None:
+    source_root_dir = tmp_path / "test-repo"
+    Git.clone(
+        url=temp_repo.path.as_uri(), source_root=source_root_dir, name="clone-test"
+    )
+
+    tag_ref = source_root_dir / "clone-test" / ".git" / "refs" / "tags" / "v1"
+    assert tag_ref.is_file()
+
+    tag_ref_lock = tag_ref.with_name("v1.lock")
+    shutil.copy(tag_ref, tag_ref_lock)
+
+    Git.clone(
+        url=temp_repo.path.as_uri(), source_root=source_root_dir, name="clone-test"
+    )
+
+    assert tag_ref.is_file()
+    assert not tag_ref_lock.is_file()
 
 
 @pytest.mark.skip_git_mock


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7832

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Make Git clone more robust against stale lock files by retrying ref imports and deleting dangling locks

Bug Fixes:
- Prevent clone failures due to existing lock files in refs directory

Enhancements:
- Retry importing refs up to twice when encountering a FileLocked error
- Remove stale lock files automatically before retrying ref imports

Tests:
- Add test to verify that cloning removes existing lock files and succeeds
- Include a tag in the temporary Git repository fixture for testing locked tags