### PR TITLE
fix wording

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1186,7 +1186,7 @@ develop = false
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "HEAD"
-resolved_reference = "a2c068227358984d835c9684de723b046bdcd67a"
+resolved_reference = "41702651de85c3d100607c7c53579d0164b2969d"
 
 [[package]]
 name = "pre-commit"

--- a/tests/console/commands/test_check.py
+++ b/tests/console/commands/test_check.py
@@ -173,7 +173,7 @@ Error: Declared README file does not exist: never/exists.md
 Error: Invalid source "not-exists" referenced in dependencies.
 Error: Invalid source "not-exists2" referenced in dependencies.
 Error: poetry.lock was not found.
-Warning: [project.license] is not a valid SPDX identifier.\
+Warning: [project.license] is not a valid SPDX expression.\
  This is deprecated and will raise an error in the future.
 Warning: A wildcard Python dependency is ambiguous.\
  Consider specifying a more explicit one.


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change warning message from "SPDX identifier" to "SPDX expression" in project license error output