### PR TITLE
git: improve error message in case a file lock could not be acquired while cloning a repo

### DIFF
--- a/tests/vcs/git/conftest.py
+++ b/tests/vcs/git/conftest.py
@@ -50,6 +50,8 @@ def temp_repo(tmp_path: Path) -> TempRepoFixture:
         no_verify=True,
     )
 
+    repo[b"refs/tags/v1"] = head_commit
+
     return TempRepoFixture(
         path=tmp_path,
         repo=repo,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #7832

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Short error message: `Failed to clone <repo_url> at <ref>, unable to acquire file lock for <path>.`

Verbose error message:

```
Failed to clone <repo_url> at <ref>, unable to acquire file lock for <path>.

Note: This error arises from interacting with the specified vcs source and is likely not a Poetry issue.
This issue could be caused by any of the following;

- another process is holding the file lock
- another process crashed while holding the file lock

Try again later or remove the <lock file path> manually if you are sure no other process is holding it.
```
