### PR TITLE
keep deprecation a little longer since it does not really hurt

### DIFF
--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -100,8 +100,7 @@ you can set the "package-mode" to false in your pyproject.toml file.
         if with_synchronization:
             self.line_error(
                 "<warning>The `<fg=yellow;options=bold>--sync</>` option is"
-                " deprecated and slated for removal in the next minor release"
-                " after June 2025, use the"
+                " deprecated and slated for removal, use the"
                 f" `<fg=yellow;options=bold>{self._alternative_sync_command}</>`"
                 " command instead.</warning>"
             )


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplify the --sync deprecation message by removing the specified removal timeline.