### PR TITLE
tests: fix deprecation warning

### DIFF
--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1177,7 +1177,7 @@ def test_init_does_not_create_project_structure_in_non_empty_directory(
 ) -> None:
     """Test that poetry init does not create project structure in non-empty directory."""
     # Create some existing files
-    (source_dir / "existing_file.txt").write_text("existing content")
+    (source_dir / "existing_file.txt").write_text("existing content", encoding="utf-8")
     (source_dir / "existing_dir").mkdir()
 
     inputs = [


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Specify UTF-8 encoding in write_text calls to satisfy new API requirements and avoid deprecation warnings