### PR TITLE
fix `poetry self show`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -974,6 +974,7 @@ poetry self show
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.
+* `--format (-f)`: Specify the output format (`json` or `text`). Default is `text`. `json` cannot be combined with the `--tree` option.
 
 ### self show plugins
 

--- a/src/poetry/console/commands/self/show/__init__.py
+++ b/src/poetry/console/commands/self/show/__init__.py
@@ -18,7 +18,11 @@ class SelfShowCommand(SelfCommand, ShowCommand):
     name = "self show"
     options: ClassVar[list[Option]] = [
         option("addons", None, "List only add-on packages installed."),
-        *[o for o in ShowCommand.options if o.name in {"tree", "latest", "outdated"}],
+        *[
+            o
+            for o in ShowCommand.options
+            if o.name in {"tree", "latest", "outdated", "format"}
+        ],
     ]
     description = "Show packages from Poetry's runtime environment."
     help = f"""\

--- a/tests/console/commands/self/test_show.py
+++ b/tests/console/commands/self/test_show.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+
+from typing import TYPE_CHECKING
+
+import pytest
+import tomlkit
+
+from poetry.__version__ import __version__
+from poetry.console.commands.self.self_command import SelfCommand
+
+
+if TYPE_CHECKING:
+    from cleo.testers.command_tester import CommandTester
+
+    from tests.types import CommandTesterFactory
+
+
+@pytest.fixture()
+def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
+    return command_tester_factory("self show")
+
+
+@pytest.mark.parametrize("options", ["", "--format json", "--format text"])
+def test_show_format(tester: CommandTester, options: str) -> None:
+    pyproject_content = {
+        "tool": {
+            "poetry": {
+                "name": "poetry-instance",
+                "version": __version__,
+                "dependencies": {"python": "^3.9", "poetry": __version__},
+            }
+        }
+    }
+    lock_content = {
+        "package": [
+            {
+                "name": "poetry",
+                "version": __version__,
+                "optional": False,
+                "platform": "*",
+                "python-versions": "*",
+                "files": [],
+            },
+        ],
+        "metadata": {
+            "lock-version": "2.0",
+            "python-versions": "^3.9",
+            "content-hash": "123456789",
+        },
+    }
+    if "json" in options:
+        expected = json.dumps(
+            [
+                {
+                    "name": "poetry",
+                    "installed_status": "installed",
+                    "version": __version__,
+                    "description": "",
+                }
+            ]
+        )
+    else:
+        expected = f"poetry {__version__}"
+    system_pyproject_file = SelfCommand.get_default_system_pyproject_file()
+    system_pyproject_file.write_text(tomlkit.dumps(pyproject_content), encoding="utf-8")
+    system_pyproject_file.parent.joinpath("poetry.lock").write_text(
+        tomlkit.dumps(lock_content), encoding="utf-8"
+    )
+    assert tester.execute(options) == 0
+    assert tester.io.fetch_output().strip() == expected


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10553

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Add format support to the `poetry self show` command by introducing a `--format` flag, updating documentation, and adding corresponding tests

New Features:
- Add `--format` option to `poetry self show` command to specify JSON or text output

Documentation:
- Document the new `--format` flag in the self show CLI reference

Tests:
- Add tests for `poetry self show` covering default, JSON, and text formats