### PR TITLE
docs: remove outdated statements

### DIFF
--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -62,11 +62,10 @@ the dependencies logically.
 {{% /note %}}
 
 {{% note %}}
-Dependency groups, other than the implicit `main` group, must only contain dependencies you need in your development
-process. Installing them is only possible by using Poetry.
-
-To declare a set of dependencies, which add additional functionality to the project during runtime,
-use [extras]({{< relref "pyproject#extras" >}}) instead. Extras can be installed by the end user using `pip`.
+Dependency groups, other than the implicit `main` group,
+must only contain dependencies you need in your development process.
+To declare a set of dependencies, which add additional functionality to the project
+during runtime, use [extras]({{< relref "pyproject#extras" >}}) instead.
 {{% /note %}}
 
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10549

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Clean up the managing-dependencies documentation by removing outdated statements about installing dependency groups and extras.

Documentation:
- Remove statement that dependency groups can only be installed via Poetry
- Remove note that extras can be installed by end users using pip