### PR TITLE
Propose `init` when trying to `new` an existing directory

### DIFF
--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -75,7 +75,7 @@ class NewCommand(InitCommand):
         if path.exists() and list(path.glob("*")):
             # Directory is not empty. Aborting.
             raise RuntimeError(
-                f"Destination <fg=yellow>{path}</> exists and is not empty"
+                f"Destination <fg=yellow>{path}</> exists and is not empty. Did you mean `poetry init`?"
             )
 
         if self.option("src"):


### PR DESCRIPTION
I'm new to poetry and tried to do `poetry new .` when I was following https://python-poetry.org/docs/basic-usage/#project-setup in a folder that has some code in it. I got confused as to how to proceed.

# Pull Request Check List

Resolves: N/A

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Summary by Sourcery

Enhancements:
- Suggest using `poetry init` when running `poetry new` in a non-empty directory