### PR TITLE
cli: suggest poetry self lock for self subcommands (#10536)

### DIFF
--- a/src/poetry/console/commands/check.py
+++ b/src/poetry/console/commands/check.py
@@ -7,6 +7,7 @@ from typing import ClassVar
 from cleo.helpers import option
 
 from poetry.console.commands.command import Command
+from poetry.utils.helpers import lock_command_hint_for
 
 
 if TYPE_CHECKING:
@@ -161,9 +162,10 @@ class CheckCommand(Command):
         if self.option("lock") and not self.poetry.locker.is_locked():
             check_result["errors"] += ["poetry.lock was not found."]
         if self.poetry.locker.is_locked() and not self.poetry.locker.is_fresh():
+            hint = lock_command_hint_for(self.poetry.locker.lock)
             check_result["errors"] += [
                 "pyproject.toml changed significantly since poetry.lock was last generated. "
-                "Run `poetry lock` to fix the lock file."
+                f"Run {hint} to fix the lock file."
             ]
 
         return_code = 0

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -13,6 +13,7 @@ from packaging.utils import canonicalize_name
 
 from poetry.console.commands.env_command import EnvCommand
 from poetry.console.commands.group_command import GroupCommand
+from poetry.utils.helpers import lock_command_hint_for
 
 
 if TYPE_CHECKING:
@@ -146,9 +147,9 @@ lists all packages available."""
             self.io.input.set_option("latest", True)
 
         if not self.poetry.locker.is_locked():
+            hint = lock_command_hint_for(self.poetry.locker.lock)
             self.line_error(
-                "<error>Error: poetry.lock not found. Run `poetry lock` to create"
-                " it.</error>"
+                f"<error>Error: poetry.lock not found. Run {hint} to create it.</error>"
             )
             return 1
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -12,6 +12,7 @@ from poetry.repositories import Repository
 from poetry.repositories import RepositoryPool
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.repositories.lockfile_repository import LockfileRepository
+from poetry.utils.helpers import lock_command_hint_for
 
 
 if TYPE_CHECKING:
@@ -255,9 +256,10 @@ class Installer:
             self._io.write_line("<info>Installing dependencies from lock file</>")
 
             if not self._locker.is_fresh():
+                hint = lock_command_hint_for(self._locker.lock)
                 raise ValueError(
                     "pyproject.toml changed significantly since poetry.lock was last"
-                    " generated. Run `poetry lock` to fix the lock file."
+                    f" generated. Run {hint} to fix the lock file."
                 )
             if not (reresolve or self._locker.is_locked_groups_and_markers()):
                 if self._io.is_verbose():

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -64,6 +64,25 @@ non_prioritised_available_hash_types: frozenset[str] = frozenset(
 )
 
 
+def lock_command_hint_for(lock_path: Path) -> str:
+    """Return the appropriate lock command hint for a given lock file path.
+
+    If the lock file resides in Poetry's configuration directory, this suggests
+    using the self-locking command. Otherwise, it suggests the regular project
+    lock command.
+    """
+    try:
+        from poetry.locations import CONFIG_DIR
+    except Exception:
+        return "`poetry lock`"
+
+    return (
+        "`poetry self lock`"
+        if lock_path.parent == Path(CONFIG_DIR)
+        else "`poetry lock`"
+    )
+
+
 @contextmanager
 def directory(path: Path) -> Iterator[Path]:
     cwd = Path.cwd()

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -228,6 +228,25 @@ def test_not_fresh_lock(installer: Installer, locker: Locker) -> None:
         installer.run()
 
 
+def test_not_fresh_lock_in_self_context_suggests_self_lock(
+    installer: Installer, locker: Locker
+) -> None:
+    from pathlib import Path
+
+    from poetry.locations import CONFIG_DIR
+
+    locker.locked().fresh(False).set_lock_path(Path(CONFIG_DIR))
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "pyproject.toml changed significantly since poetry.lock was last generated. "
+            "Run `poetry self lock` to fix the lock file."
+        ),
+    ):
+        installer.run()
+
+
 def test_run_with_dependencies(
     installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
 ) -> None:


### PR DESCRIPTION
- Add lock_command_hint_for() to choose hint by lockfile location (CONFIG_DIR → poetry self lock, else
poetry lock).
- Use in installer (stale lock), show (missing lock), and check (stale lock).

Motivation

- Avoids suggesting poetry lock for poetry self … commands (fixes confusion in #10536).

Tests

- tests/installation/test_installer.py::test_not_fresh_lock_in_self_context_suggests_self_lock
- tests/console/commands/self/test_show.py::test_self_show_errors_without_lock_file

Compatibility

- Project commands still suggest poetry lock.

Resolves: #10536

# Pull Request Check List

- [x] Added tests for changed code.
- [ ] Updated documentation for changed code. (N/A)

## Summary by Sourcery

Improve lock-related error messages by detecting when commands are running in Poetry’s own configuration directory and suggesting `poetry self lock` instead of `poetry lock` where applicable

New Features:
- Introduce lock_command_hint_for helper to choose between `poetry lock` and `poetry self lock` based on lockfile location
- Integrate lock_command_hint_for into show, check, and installer commands to suggest the appropriate lock command

Tests:
- Add test verifying `poetry self lock` suggestion when lock is stale in self context installer
- Add test verifying missing lock file error suggests `poetry self lock` in show command