### PR TITLE
Fix poetry-install pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,7 +18,8 @@
   name: poetry-install
   description: run poetry install to install dependencies from the lock file
   entry: poetry install
-  language: python
+  language: system
+  args: ["--sync"]
   pass_filenames: false
   stages: [post-checkout, post-merge]
   always_run: true

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -93,10 +93,19 @@ The `poetry-install` hook calls the `poetry install` command to make sure all lo
 In order to install this hook, you either need to specify `default_install_hook_types`, or you have
 to install it via `pre-commit install --install-hooks -t post-checkout -t post-merge`.
 
+{{% warning %}}
+Versions up to and including 2.2.1 incorrectly configured the `poetry-install` hook with `language: python`.
+Starting from 2.2.2, the hook uses `language: system` and includes `args: ["--sync"]` by default.
+If you are upgrading from an earlier version, you may need to update your `.pre-commit-config.yaml` accordingly.
+{{% /warning %}}
+
 ### Arguments
 
 The hook takes the same arguments as the poetry command.
 For more information, see the [install command]({{< relref "cli#install" >}}).
+
+The default arguments are `args: ["--sync"]`, which ensures that the environment is synchronized
+with the lock file by removing any packages not in the lock file.
 
 ## Usage
 


### PR DESCRIPTION
- Change language from python to system for poetry-install hook
- Add default args: ["--sync"] to poetry-install hook
- Update documentation with warning about versions up to 2.2.1

Resolves: #9393