### PR TITLE
Show Python path for Poetry in `debug info`

### DIFF
--- a/src/poetry/console/commands/debug/info.py
+++ b/src/poetry/console/commands/debug/info.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import sys
 
+from pathlib import Path
+
 from poetry.console.commands.command import Command
 
 
@@ -19,8 +21,8 @@ class DebugInfoCommand(Command):
                 [
                     f"<info>Version</info>:    <comment>{self.poetry.VERSION}</>",
                     f"<info>Python</info>:     <comment>{poetry_python_version}</>",
-                    f"<info>Path</info>:       <comment>{sys.prefix}</>",
-                    f"<info>Executable</info>: <comment>{sys.executable or 'Unknown'}</>",
+                    f"<info>Path</info>:       <comment>{Path(sys.prefix)}</>",
+                    f"<info>Executable</info>: <comment>{Path(sys.executable) if sys.executable else 'Unknown'}</>",
                 ]
             )
         )

--- a/tests/console/commands/debug/test_info.py
+++ b/tests/console/commands/debug/test_info.py
@@ -48,14 +48,14 @@ def test_debug_info_displays_complete_info(tester: CommandTester) -> None:
 Poetry
 Version:    {__version__}
 Python:     {".".join(str(v) for v in sys.version_info[:3])}
-Path:       /poetry/prefix
-Executable: /poetry/prefix/bin/python
+Path:       {Path("/poetry/prefix")}
+Executable: {Path("/poetry/prefix/bin/python")}
 
 Virtualenv
 Python:         3.7.0
 Implementation: CPython
 Path:           {Path("/prefix")}
-Executable:     {sys.executable}
+Executable:     {Path(sys.executable)}
 Valid:          True
 
 Base


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10559

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

# Summary

Adds the executable and environment path for the Python executable running Poetry to `poetry self debug`.

I believe the `sys` calls are correct, but happy to adjust as needed. Also, I did not see any docs that required updating.

## Summary by Sourcery

Include the Python environment path and executable in the output of `poetry self debug`.

Enhancements:
- Add 'Path' and 'Executable' fields under the Poetry section in debug info
- Adjust label alignment for Version and Python fields

Tests:
- Add tests to verify the display of Poetry's path and executable in debug info