### PR TITLE
feat: check requires-poetry before any validation

### DIFF
--- a/tests/fixtures/self_version_not_ok_invalid_config/pyproject.toml
+++ b/tests/fixtures/self_version_not_ok_invalid_config/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.poetry]
+package-mode = false
+requires-poetry = "<1.2"
+invalid_option = 42
+
+[tool.poetry.dependencies]
+python = "^3.8"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -256,6 +256,17 @@ def test_create_poetry_version_not_ok(fixture_dir: FixtureDirGetter) -> None:
     )
 
 
+def test_create_poetry_check_version_before_validation(
+    fixture_dir: FixtureDirGetter,
+) -> None:
+    with pytest.raises(PoetryError) as e:
+        Factory().create_poetry(fixture_dir("self_version_not_ok_invalid_config"))
+    assert (
+        str(e.value)
+        == f"This project requires Poetry <1.2, but you are using Poetry {__version__}"
+    )
+
+
 @pytest.mark.parametrize(
     "project",
     ("with_primary_source_implicit", "with_primary_source_explicit"),


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/10582

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Ensure that the project’s requires-poetry constraint is validated immediately when creating a Poetry instance, raising an error early if the running Poetry version does not satisfy the requirement.

Enhancements:
- Extract the version constraint check into a shared _ensure_valid_poetry_version helper and invoke it before any other validation.
- Remove duplicated version-check logic from Factory.create_poetry.

Tests:
- Add a test and fixture to verify that an invalid requires-poetry setting triggers an error before other validations.