### PR TITLE
fix: allow to set `data-dir` and `python-installation-dir`

### DIFF
--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -103,6 +103,7 @@ To remove a repository (repo is a short alias for repositories):
             ),
             "solver.lazy-wheel": (boolean_validator, boolean_normalizer),
             "keyring.enabled": (boolean_validator, boolean_normalizer),
+            "python.installation-dir": (str, lambda val: str(Path(val))),
         }
 
         return unique_config_values


### PR DESCRIPTION
Without this fix, Poetry will report `Setting data-dir does not exist` or `Setting python.installation-dir does not exist`.