### PR TITLE
feat(check): validate [project.readme] field as per PEP 621

### DIFF
--- a/src/poetry/console/commands/check.py
+++ b/src/poetry/console/commands/check.py
@@ -88,12 +88,13 @@ class CheckCommand(Command):
 
     def _validate_readme(self, readme: str | list[str], poetry_file: Path) -> list[str]:
         """Check existence of referenced readme files"""
-
         readmes = [readme] if isinstance(readme, str) else readme
 
         errors = []
         for name in readmes:
-            if not (poetry_file.parent / name).exists():
+            if not name:
+                errors.append("Declared README file is an empty string.")
+            elif not (poetry_file.parent / name).exists():
                 errors.append(f"Declared README file does not exist: {name}")
         return errors
 
@@ -156,14 +157,15 @@ class CheckCommand(Command):
             readme_errors += self._validate_readme(poetry_config["readme"], poetry_file)
 
         project_readme = project.get("readme")
-        if project_readme:
+        if project_readme is not None:
             if isinstance(project_readme, dict):
                 readme_path = project_readme.get("file")
-                if readme_path:
+                if readme_path is not None:
                     readme_errors += self._validate_readme(readme_path, poetry_file)
             elif isinstance(project_readme, str):
                 readme_errors += self._validate_readme(project_readme, poetry_file)
             else:
+                # should not happen due to prior schema validation, but just in case
                 readme_errors.append(
                     f"Invalid format for [project.readme]: {project_readme!r}"
                 )


### PR DESCRIPTION
This adds validation for [project.readme] defined according to PEP 621. Previously, Poetry only validated [tool.poetry.readme]. The new logic ensures referenced files in [project.readme] exist and are accessible.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Extend the check command to validate the existence and format of files referenced in the PEP 621 [project.readme] field in addition to the existing [tool.poetry.readme] validation.

New Features:
- Validate PEP 621 [project.readme] field alongside [tool.poetry.readme]
- Support both string and table formats for the project.readme field

Enhancements:
- Accumulate readme validation errors centrally and report invalid format entries