### PR TITLE
fix: make relative working directory absolute

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -190,6 +190,10 @@ class Application(BaseApplication):
         return self._project_directory or self._working_directory
 
     @property
+    def working_directory(self) -> Path:
+        return self._working_directory
+
+    @property
     def poetry(self) -> Poetry:
         from poetry.factory import Factory
 
@@ -339,7 +343,7 @@ class Application(BaseApplication):
         # this will raise an exception if the path is invalid
         self._working_directory = ensure_path(
             io.input.option("directory") or Path.cwd(), is_directory=True
-        )
+        ).resolve()
 
         self._project_directory = io.input.option("project")
         if self._project_directory is not None:


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/python-poetry/poetry/issues/10541
Resolves: https://github.com/python-poetry/poetry/issues/10287

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Resolve the application's working directory to an absolute path when a relative --directory option is provided and expose it via a new property, with corresponding test updates.

New Features:
- Add a working_directory property to expose the internal working directory Path

Enhancements:
- Call resolve() on the directory path in _configure_global_options to convert relative paths to absolute

Tests:
- Add a test to verify that passing a relative directory parameter yields an absolute WorkingDirectory
- Update the existing version command test to assert usage of the application.working_directory property