### PR TITLE
fix support of free-threaded Python if Poetry itself is not installed with a free-threaded Python

### DIFF
--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -51,6 +51,7 @@ class MarkerEnv(TypedDict):
     interpreter_name: str
     interpreter_version: str
     sysconfig_platform: str
+    free_threading: bool
 
 
 class Env(ABC):

--- a/src/poetry/utils/env/script_strings.py
+++ b/src/poetry/utils/env/script_strings.py
@@ -86,6 +86,7 @@ env = {
     ),
     "interpreter_version": interpreter_version(),
     "sysconfig_platform": sysconfig.get_platform(),
+    "free_threading": bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
 }
 
 print(json.dumps(env))

--- a/src/poetry/utils/env/system_env.py
+++ b/src/poetry/utils/env/system_env.py
@@ -74,6 +74,7 @@ class SystemEnv(Env):
             "interpreter_name": interpreter_name(),
             "interpreter_version": interpreter_version(),
             "sysconfig_platform": sysconfig.get_platform(),
+            "free_threading": bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
         }
 
     def is_venv(self) -> bool:

--- a/src/poetry/utils/env/virtual_env.py
+++ b/src/poetry/utils/env/virtual_env.py
@@ -58,11 +58,15 @@ class VirtualEnv(Env):
         interpreter_name = self.marker_env["interpreter_name"]
         interpreter_version = self.marker_env["interpreter_version"]
         sysconfig_platform = self.marker_env["sysconfig_platform"]
+        free_threading = self.marker_env["free_threading"]
 
+        abis: list[str] | None = None
         if interpreter_name == "pp":
             interpreter = "pp3"
         elif interpreter_name == "cp":
             interpreter = f"{interpreter_name}{interpreter_version}"
+            if free_threading:
+                abis = [f"{interpreter}t"]
         else:
             interpreter = None
 
@@ -83,7 +87,7 @@ class VirtualEnv(Env):
 
         return [
             *(
-                cpython_tags(python, platforms=platforms)
+                cpython_tags(python, abis=abis, platforms=platforms)
                 if interpreter_name == "cp"
                 else generic_tags(platforms=platforms)
             ),


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/orgs/python-poetry/discussions/10601

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Add support for free-threaded Python interpreters by introducing a free_threading marker and updating tag generation to include or exclude the 't' ABI suffix accordingly.

Bug Fixes:
- Ensure get_supported_tags omits the 't' ABI when free_threading is false and includes it when true

Enhancements:
- Add free_threading field to MarkerEnv and populate it in system_env and script_strings

Tests:
- Add test_env_get_supported_tags_free_threading to verify tag lists for both free-threaded and standard interpreters