### PR TITLE
consider dependency-groups in lockfile hash

### DIFF
--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -98,7 +98,7 @@ class Locker(BaseLocker):
     def is_fresh(self) -> bool:
         return self._fresh
 
-    def _get_content_hash(self) -> str:
+    def _get_content_hash(self, *, with_dependency_groups: bool = True) -> str:
         return "123456789"
 
     def _write_lock_data(self, data: dict[str, Any]) -> None:

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -10,6 +10,7 @@ import uuid
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 
@@ -1460,10 +1461,12 @@ content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8
 
 
 @pytest.mark.parametrize(
-    ("local_config", "fresh"),
+    ("local_config", "legacy"),
     [
         ({}, True),
         ({"dependencies": [uuid.uuid4().hex]}, True),
+        ({"dependencies": [uuid.uuid4().hex], "source": [uuid.uuid4().hex]}, True),
+        ({"dependencies": [uuid.uuid4().hex], "extras": [uuid.uuid4().hex]}, True),
         (
             {
                 "dependencies": [uuid.uuid4().hex],
@@ -1478,28 +1481,179 @@ content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8
             },
             True,
         ),
-        ({"dependencies": [uuid.uuid4().hex], "groups": [uuid.uuid4().hex]}, False),
+        ({"dependencies": [uuid.uuid4().hex], "group": [uuid.uuid4().hex]}, False),
     ],
 )
 def test_content_hash_with_legacy_is_compatible(
-    local_config: dict[str, list[str]], fresh: bool, locker: Locker
+    local_config: dict[str, list[str]], legacy: bool, locker: Locker
 ) -> None:
-    # old hash generation
-    relevant_content = {}
-    for key in locker._legacy_keys:
-        relevant_content[key] = local_config.get(key)
+    """Legacy generation if there is no group."""
+
+    def _get_legacy_content_hash() -> str:
+        relevant_content = {}
+        for key in locker._legacy_keys:
+            relevant_content[key] = local_config.get(key)
+
+        content_hash = sha256(
+            json.dumps(relevant_content, sort_keys=True).encode()
+        ).hexdigest()
+
+        return content_hash
 
     locker = locker.__class__(
         lock=locker.lock,
         pyproject_data={"tool": {"poetry": local_config}},
     )
 
-    old_content_hash = sha256(
-        json.dumps(relevant_content, sort_keys=True).encode()
-    ).hexdigest()
+    old_content_hash = _get_legacy_content_hash()
     content_hash = locker._get_content_hash()
 
-    assert (content_hash == old_content_hash) or fresh
+    if legacy:
+        assert content_hash == old_content_hash
+    else:
+        assert content_hash != old_content_hash
+
+
+@pytest.mark.parametrize(
+    ("project", "legacy"),
+    [
+        ({"name": "foo"}, True),  # irrelevant key
+        ({"requires-python": ">=3.9"}, False),
+        ({"dependencies": ["bar"]}, False),
+        ({"dependencies": []}, False),  # relevant even if empty
+        ({"optional-dependencies": "..."}, False),
+    ],
+)
+@pytest.mark.parametrize(
+    "local_config",
+    [
+        {},  # empty
+        {"dependencies": [uuid.uuid4().hex]},  # only legacy
+        {
+            "dependencies": [uuid.uuid4().hex],
+            "group": [uuid.uuid4().hex],
+        },  # legacy and new
+    ],
+)
+def test_content_hash_with_project_section(
+    project: dict[str, Any],
+    local_config: dict[str, list[str]],
+    legacy: bool,
+    locker: Locker,
+) -> None:
+    """Legacy generation if there is no project section."""
+
+    def _get_legacy_content_hash() -> str:
+        relevant_content = {}
+        for key in locker._relevant_keys:
+            data = local_config.get(key)
+
+            if data is None and key not in locker._legacy_keys:
+                continue
+
+            relevant_content[key] = data
+
+        return sha256(json.dumps(relevant_content, sort_keys=True).encode()).hexdigest()
+
+    locker = locker.__class__(
+        lock=locker.lock,
+        pyproject_data={"project": project, "tool": {"poetry": local_config}},
+    )
+
+    old_content_hash = _get_legacy_content_hash()
+    content_hash = locker._get_content_hash()
+
+    if legacy:
+        assert content_hash == old_content_hash
+    else:
+        assert content_hash != old_content_hash
+
+
+@pytest.mark.parametrize(
+    ("groups", "legacy"),
+    [
+        ({}, True),
+        ({"foo": []}, False),
+    ],
+)
+@pytest.mark.parametrize(
+    "project",
+    [
+        {"name": "foo"},  # irrelevant key
+        {"requires-python": ">=3.9"},  # relevant key
+    ],
+)
+@pytest.mark.parametrize(
+    "local_config",
+    [
+        {},  # empty
+        {"dependencies": [uuid.uuid4().hex]},  # only legacy
+        {
+            "dependencies": [uuid.uuid4().hex],
+            "group": [uuid.uuid4().hex],
+        },  # legacy and new
+    ],
+)
+def test_content_hash_with_dependency_groups_section(
+    groups: dict[str, Any],
+    project: dict[str, Any],
+    local_config: dict[str, Any],
+    legacy: bool,
+    locker: Locker,
+) -> None:
+    """Legacy generation if there is no dependency-groups section."""
+
+    def _get_legacy_content_hash() -> str:
+        project_content = project
+        tool_poetry_content = local_config
+
+        relevant_project_content = {}
+        for key in locker._relevant_project_keys:
+            data = project_content.get(key)
+            if data is not None:
+                relevant_project_content[key] = data
+
+        relevant_poetry_content: dict[str, Any] = {}
+        for key in locker._relevant_keys:
+            data = tool_poetry_content.get(key)
+
+            if data is None and (
+                # Special handling for legacy keys is just for backwards compatibility,
+                # and thereby not required if there is relevant content in [project].
+                key not in locker._legacy_keys or relevant_project_content
+            ):
+                continue
+
+            relevant_poetry_content[key] = data
+
+        if relevant_project_content:
+            relevant_content = {
+                "project": relevant_project_content,
+                "tool": {"poetry": relevant_poetry_content},
+            }
+        else:
+            # For backwards compatibility, we have to put the relevant content
+            # of the [tool.poetry] section at top level!
+            relevant_content = relevant_poetry_content
+
+        return sha256(json.dumps(relevant_content, sort_keys=True).encode()).hexdigest()
+
+    locker = locker.__class__(
+        lock=locker.lock,
+        pyproject_data={
+            "project": project,
+            "dependency-groups": groups,
+            "tool": {"poetry": local_config},
+        },
+    )
+
+    old_content_hash = _get_legacy_content_hash()
+    content_hash = locker._get_content_hash()
+
+    if legacy:
+        assert content_hash == old_content_hash
+    else:
+        assert content_hash != old_content_hash
 
 
 def test_lock_file_resolves_file_url_symlinks(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10598

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Unfortunately, just considering dependency-groups has the following effects:

1. The new Poetry version will consider a lock file generated with an old version outdated if dependency-groups are defined in the pyproject.toml file.
2. An old Poetry version will consider a lock file generated with the new Poetry version outdated if dependency-groups are defined in the pyproject.toml file.

I handled the first issue in the second commit. I assume it is controversial if this should be addressed at all. I decided to do it to make the update process smoother and avoid failing pipelines.

I think we have to accept the second issue. (I think we just should not include this fix in a micro release but in a minor release.)

By the way, I extended the tests for changes to the hash function significantly because it is critical for backwards compatibility that the hash does not change if a new field is not used.

## Summary by Sourcery

Include dependency-groups in the lockfile content hash while preserving backward compatibility with pre-2.3.0 Poetry by allowing recomputation of the hash without dependency-groups and updating tests accordingly

New Features:
- Update lockfile hash computation to include dependency-groups by default
- Detect and accept lockfiles generated by Poetry <2.3.0 by recomputing hash without dependency-groups

Enhancements:
- Add with_dependency_groups flag to Locker._get_content_hash and adjust relevant content selection to incorporate dependency-groups
- Update is_fresh to conditionally fallback to legacy hash for older lockfile versions

Tests:
- Extend tests for lockfile freshness and content hash generation to cover dependency-groups and legacy compatibility
- Adjust installer stub in tests to support with_dependency_groups parameter