### PR TITLE
publish: use the artifact metadata instead of the project metadata

### DIFF
--- a/tests/publishing/test_uploader.py
+++ b/tests/publishing/test_uploader.py
@@ -155,3 +155,78 @@ def test_uploader_properly_handles_file_not_existing(
         uploader.upload("https://foo.com")
 
     assert f"Archive ({uploader.files[0]}) does not exist" == str(e.value)
+
+
+def test_uploader_post_data_wheel(fixture_dir: FixtureDirGetter) -> None:
+    file = (
+        fixture_dir("simple_project")
+        / "dist"
+        / "simple_project-1.2.3-py2.py3-none-any.whl"
+    )
+    assert Uploader.post_data(file) == {
+        "md5_digest": "fb4a5266406b9cf34ceaa88d1c8b7a01",
+        "sha256_digest": "fc365a242d4de8b8661babc088f44b3df25e9e0017ef5dd7140dfe50f9323e16",
+        "blake2_256_digest": "2e006d1fbfef0ed38fbded1ec1614dc4fd66f81061fe290528e2744dbc25ce31",
+        "filetype": "bdist_wheel",
+        "pyversion": "py2.py3",
+        "metadata_version": "2.1",
+        "name": "simple-project",
+        "version": "1.2.3",
+        "summary": "Some description.",
+        "author": "Sébastien Eustace",
+        "author_email": "sebastien@eustace.io",
+        "license": "MIT",
+        "classifiers": [
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Topic :: Software Development :: Build Tools",
+            "Topic :: Software Development :: Libraries :: Python Modules",
+        ],
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
+        "description": "My Package\n==========\n\n",
+        "description_content_type": "text/x-rst",
+        "keywords": "packaging, dependency, poetry",
+        "home_page": "https://poetry.eustace.io",
+        "project_urls": [
+            "Documentation, https://poetry.eustace.io/docs",
+            "Repository, https://github.com/sdispater/poetry",
+        ],
+    }
+
+
+def test_uploader_post_data_sdist(fixture_dir: FixtureDirGetter) -> None:
+    file = fixture_dir("simple_project") / "dist" / "simple_project-1.2.3.tar.gz"
+    assert Uploader.post_data(file) == {
+        "md5_digest": "e611cbb8f31258243d90f7681dfda68a",
+        "sha256_digest": "c4a72becabca29ec2a64bf8c820bbe204d2268f53e102501ea5605bc1c1675d1",
+        "blake2_256_digest": "d3df22f4944f6acd02105e7e2df61ef63c7b0f4337a12df549ebc2805a13c2be",
+        "filetype": "sdist",
+        "pyversion": "source",
+        "metadata_version": "2.1",
+        "name": "simple-project",
+        "version": "1.2.3",
+        "summary": "Some description.",
+        "author": "Sébastien Eustace",
+        "author_email": "sebastien@eustace.io",
+        "classifiers": [
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Topic :: Software Development :: Build Tools",
+            "Topic :: Software Development :: Libraries :: Python Modules",
+        ],
+        "requires_python": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
+        "keywords": "packaging, dependency, poetry",
+        "home_page": "https://poetry.eustace.io",
+        "project_urls": [
+            "Documentation, https://poetry.eustace.io/docs",
+            "Repository, https://github.com/sdispater/poetry",
+        ],
+    }


### PR DESCRIPTION
Especially, since we do support other build backends than poetry-core this is more correct.

# Pull Request Check List

This resolves an issue noticed in https://github.com/python-poetry/poetry-core/pull/894#issuecomment-3551941105

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Revise the package upload logic to derive metadata from distribution files (wheel and sdist) instead of the project, improving compatibility with alternative build backends.

New Features:
- Parse metadata directly from wheel and sdist artifacts for uploads

Bug Fixes:
- Use artifact metadata instead of project metadata to support non-poetry-core build backends

Enhancements:
- Refactor post_data into a classmethod and streamline upload payload construction by iterating over artifact metadata
- Introduce a _get_metadata helper to extract and normalize metadata from .whl and .tar.gz files
- Convert _get_type to a staticmethod with explicit return type annotations

Tests:
- Add tests for Uploader.post_data with both wheel and sdist distributions