### PR TITLE
tests: tidy up cache command tests

### DIFF
--- a/tests/console/commands/cache/test_list.py
+++ b/tests/console/commands/cache/test_list.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
     from cleo.testers.command_tester import CommandTester
 
+    from poetry.utils.cache import FileCache
     from tests.types import CommandTesterFactory
 
 
@@ -19,13 +20,15 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
 
 
 def test_cache_list(
-    tester: CommandTester, mock_caches: None, repository_one: str, repository_two: str
+    tester: CommandTester,
+    caches: list[FileCache[dict[str, str]]],
+    repositories: list[str],
 ) -> None:
     tester.execute()
 
     expected = f"""\
-{repository_one}
-{repository_two}
+{repositories[0]}
+{repositories[1]}
 """
 
     assert tester.io.fetch_output() == expected


### PR DESCRIPTION
## Summary by Sourcery

Refactor cache command tests to use shared multi-repository fixtures and cover both confirmation responses in a more compact way.

Enhancements:
- Introduce shared fixtures providing multiple repositories, their cache directories, and corresponding FileCache instances for cache command tests.
- Expand cache clear tests to validate behavior for both affirmative and negative user confirmations in a single parametrized test suite.
- Ensure cache list tests use the new shared fixtures to assert output for multiple repositories.

Tests:
- Restructure cache clear and cache list tests around new list-based fixtures to reduce duplication and improve coverage of multi-repository scenarios.