### PR TITLE
cache clear: make cache name optional to clear all caches

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -231,9 +231,15 @@ The `cache` command groups subcommands to interact with Poetry's cache.
 
 ### cache clear
 
-The `cache clear` command removes packages from a cached repository.
+The `cache clear` command removes packages from cached repositories.
 
-For example, to clear the whole cache of packages from the `PyPI` repository, run:
+For example, to clear the whole cache of packages from all repositories, run:
+
+```bash
+poetry cache clear --all
+```
+
+To only clear all packages from the `PyPI` repository, run:
 
 ```bash
 poetry cache clear PyPI --all

--- a/src/poetry/console/commands/cache/clear.py
+++ b/src/poetry/console/commands/cache/clear.py
@@ -21,10 +21,10 @@ if TYPE_CHECKING:
 
 class CacheClearCommand(Command):
     name = "cache clear"
-    description = "Clears a Poetry cache by name."
+    description = "Clear Poetry's caches."
 
     arguments: ClassVar[list[Argument]] = [
-        argument("cache", description="The name of the cache to clear.")
+        argument("cache", description="The name of the cache to clear.", optional=True)
     ]
     options: ClassVar[list[Option]] = [
         option("all", description="Clear all entries in the cache.")
@@ -33,8 +33,12 @@ class CacheClearCommand(Command):
     def handle(self) -> int:
         cache = self.argument("cache")
 
-        parts = cache.split(":")
-        root = parts[0]
+        if cache:
+            parts = cache.split(":")
+            root = parts[0]
+        else:
+            parts = []
+            root = ""
 
         config = Config.create()
         cache_dir = config.repository_cache_directory / root
@@ -46,14 +50,16 @@ class CacheClearCommand(Command):
 
         cache = FileCache(cache_dir)
 
-        if len(parts) == 1:
+        if len(parts) < 2:
             if not self.option("all"):
                 raise RuntimeError(
-                    f"Add the --all option if you want to clear all {parts[0]} caches"
+                    "Add the --all option if you want to clear all cache entries"
                 )
 
             if not cache_dir.exists():
-                self.line(f"No cache entries for {parts[0]}")
+                self.line(
+                    f"No cache entries for {root}" if root else "No cache entries"
+                )
                 return 0
 
             # Calculate number of entries

--- a/tests/console/commands/cache/test_clear.py
+++ b/tests/console/commands/cache/test_clear.py
@@ -35,6 +35,36 @@ def test_cache_clear_all(
     caches: list[FileCache[dict[str, str]]],
     inputs: str,
 ) -> None:
+    exit_code = tester.execute("cache clear --all", inputs=inputs)
+
+    assert exit_code == 0
+    assert tester.io.fetch_output() == ""
+
+    if inputs == "yes":
+        assert not repository_dirs[0].exists() or not any(repository_dirs[0].iterdir())
+        assert not repository_dirs[1].exists() or not any(repository_dirs[1].iterdir())
+        assert not caches[0].has("cachy:0.1")
+        assert not caches[0].has("cleo:0.2")
+        assert not caches[1].has("cachy:0.1")
+        assert not caches[1].has("cashy:0.2")
+    else:
+        assert any((repository_cache_dir / repositories[0]).iterdir())
+        assert any((repository_cache_dir / repositories[1]).iterdir())
+        assert caches[0].has("cachy:0.1")
+        assert caches[0].has("cleo:0.2")
+        assert caches[1].has("cachy:0.1")
+        assert caches[1].has("cashy:0.2")
+
+
+@pytest.mark.parametrize("inputs", ["yes", "no"])
+def test_cache_clear_all_one_cache(
+    tester: ApplicationTester,
+    repository_cache_dir: Path,
+    repositories: list[str],
+    repository_dirs: list[Path],
+    caches: list[FileCache[dict[str, str]]],
+    inputs: str,
+) -> None:
     exit_code = tester.execute(f"cache clear {repositories[0]} --all", inputs=inputs)
 
     assert exit_code == 0
@@ -52,6 +82,39 @@ def test_cache_clear_all(
     assert any((repository_cache_dir / repositories[1]).iterdir())
     assert caches[1].has("cachy:0.1")
     assert caches[1].has("cashy:0.2")
+
+
+def test_cache_clear_all_no_entries(tester: ApplicationTester) -> None:
+    exit_code = tester.execute("cache clear --all")
+
+    assert exit_code == 0
+    assert tester.io.fetch_output().strip() == "No cache entries"
+
+
+def test_cache_clear_all_one_cache_no_entries(
+    tester: ApplicationTester,
+    repository_cache_dir: Path,
+    repositories: list[str],
+) -> None:
+    exit_code = tester.execute(f"cache clear {repositories[0]} --all")
+
+    assert exit_code == 0
+
+    assert tester.io.fetch_output().strip() == f"No cache entries for {repositories[0]}"
+
+
+@pytest.mark.parametrize("with_repo", [False, True])
+def test_cache_clear_missing_option(
+    tester: ApplicationTester, repositories: list[str], with_repo: bool
+) -> None:
+    command = f"cache clear {repositories[0]}" if with_repo else "cache clear"
+    exit_code = tester.execute(command)
+
+    assert exit_code == 1
+    assert (
+        "Add the --all option if you want to clear all cache entries"
+        in tester.io.fetch_error()
+    )
 
 
 @pytest.mark.parametrize("inputs", ["yes", "no"])


### PR DESCRIPTION
People have already used the workaround `poetry cache clear --all .` or `poetry cache clear --all ""`
See https://github.com/python-poetry/poetry/pull/10585#issuecomment-3567005876.

Let's have an official (and more obvious option): `poetry cache clear --all`

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Allow clearing Poetry caches without specifying a cache name and align messaging with the broader behavior.

New Features:
- Support clearing all caches with `poetry cache clear --all` without requiring a cache name.

Enhancements:
- Make the cache name argument optional and generalize user-facing messages when clearing caches.

Documentation:
- Document the ability to clear all caches at once and clarify examples for clearing specific repositories.

Tests:
- Add coverage for clearing all caches without a cache name and retain tests for clearing a single repository cache.