### PR TITLE
Add warning about `~/.netrc` for Poetry credential configuration

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -42,7 +42,6 @@ Then, assuming the repository requires authentication, configure credentials for
 poetry config http-basic.foo <username> <password>
 ```
 {{% warning %}}
-🐉 HERE LIE DRAGONS 🐉
 If you have completed configuring credentials and are receiving authorization failures, check for the presence of `~/.netrc`, which has been known to conflict with Poetry's configured authentication.
 {{% /warning %}}
 


### PR DESCRIPTION
Added warning about potential authorization issues with Poetry and .netrc file.

I didn't even have this issue, but I sat next to someone who did, for many hours, and it was painful to say the least. Finding that there is an outstanding issue with people suggesting a change to the documentation but then not proposing that change, I figured I'd go ahead and.... do the thing.

# Pull Request Check List

Doesn't resolve but until it is, may as well let folks know:
https://github.com/python-poetry/poetry/issues/8443


- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

## Summary by Sourcery

Documentation:
- Add a warning about ~/.netrc potentially conflicting with Poetry's configured repository authentication and causing authorization failures.