### PR TITLE
fix `poetry add` with PEP 735 `dependency-groups` with `include-group`

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -5,6 +5,7 @@ import contextlib
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
+from typing import Literal
 
 from cleo.helpers import argument
 from cleo.helpers import option
@@ -161,7 +162,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
 
         use_project_section = False
         use_groups_section = False
-        project_dependency_names = []
+        project_dependency_names: list[NormalizedName | Literal["<include-group>"]] = []
 
         # Run-Time Deps incl. extras
         if group == MAIN_GROUP:
@@ -195,6 +196,11 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
 
                 project_dependency_names = [
                     Dependency.create_from_pep_508(dep).name
+                    if isinstance(dep, str)
+                    # We have to add an entry for "include-group" items because
+                    # later the index of the dependency is used to replace it.
+                    # We just choose a name that cannot be a package's name.
+                    else "<include-group>"
                     for dep in groups_content[group]
                 ]
 
@@ -416,7 +422,7 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
         self,
         packages: list[str],
         section: dict[str, Any],
-        project_dependencies: Collection[NormalizedName],
+        project_dependencies: Collection[NormalizedName | Literal["<include-group>"]],
     ) -> list[str]:
         existing_packages = []
 

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -643,7 +643,9 @@ def test_add_to_existing_group(
 [dependency-groups]
 example = [
     "cachy (>=0.2.0,<0.3.0)",
+    {include-group = "included"},
 ]
+included = []
 """
     )
     pyproject["dependency-groups"] = groups_content["dependency-groups"]
@@ -675,6 +677,7 @@ Using version ^1.4.4 for pendulum
     assert "example" in pyproject["dependency-groups"]
     assert pyproject["dependency-groups"]["example"] == [
         "cachy (>=0.2.0,<0.3.0)",
+        {"include-group": "included"},
         "pendulum (>=1.4.4,<2.0.0)",
     ]
     if additional_poetry_group:
@@ -694,9 +697,11 @@ def test_add_to_group_with_latest_overwrite_existing(
         """\
 [dependency-groups]
 example = [
+    {include-group = "included"},
     "cachy (>=0.1.0,<0.2.0)",
     "pendulum (>=1.4.4,<2.0.0)",
 ]
+included = []
 """
     )
     pyproject["dependency-groups"] = groups_content["dependency-groups"]
@@ -718,6 +723,7 @@ Using version ^0.2.0 for cachy
     pyproject = cast("dict[str, Any]", pyproject)
     assert "example" in pyproject["dependency-groups"]
     assert pyproject["dependency-groups"]["example"] == [
+        {"include-group": "included"},
         "cachy (>=0.2.0,<0.3.0)",
         "pendulum (>=1.4.4,<2.0.0)",
     ]


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10632

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Fix handling of PEP 735 dependency groups in `poetry add` when groups contain `include-group` entries, ensuring dependencies are correctly updated without errors.

Bug Fixes:
- Ensure `poetry add` correctly processes dependency groups that include `include-group` items by tracking them alongside normal dependencies.

Tests:
- Extend `poetry add` command tests to cover dependency groups containing `include-group` entries and verify correct group contents after additions.