### PR TITLE
fix(docs): use eval for poetry env activate example

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -184,7 +184,7 @@ For example, these commands should output the same python path:
 conda activate your_env_name
 which python
 poetry run which python
-eval $(poetry env activate)
+eval "$(poetry env activate)"
 which python
 ```
 


### PR DESCRIPTION
## Description
The documentation in the "Using poetry run when managing your own virtual environment externally" section implicitly suggests that running `poetry env activate` changes the active Python path, stating: *"For example, these commands should output the same python path."*

However, `poetry env activate` only outputs the shell commands; it does not execute them in the current shell. So, the subsequent `which python` command in the example currently outputs the system Python (or whatever is active) rather than the Poetry environment path, which may cause confusion.

## Solution
I have updated the command to:
`eval "$(poetry env activate)"`

This ensures the activation script is actually evaluated by the shell, making the example functionally correct.

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/python-poetry/poetry/blob/main/CONTRIBUTING.md).
- [x] This is a documentation change only.

## Summary by Sourcery

Documentation:
- Update the virtual environment usage example to use `eval $(poetry env activate)` so the documented commands actually activate the Poetry environment before checking the Python path.