### PR TITLE
chore: update freebsd image in cirrus.ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 tests_task:
   # We only use Cirrus CI for FreeBSD at present; the rest of the task will assume FreeBSD.
   freebsd_instance:
-    image_family: freebsd-14-2
+    image_family: freebsd-14-3
     # Cirrus has a concurrency limit of 8 vCPUs for FreeBSD. Allow executing 4 tasks in parallel.
     cpu: 2
     memory: 2G


### PR DESCRIPTION
```
{
"error": {
"code": 404,
"message": "The resource 'projects/freebsd-org-cloud-dev/global/images/family/freebsd-14-2' was not found",
"errors": [
{
"message": "The resource 'projects/freebsd-org-cloud-dev/global/images/family/freebsd-14-2' was not found",
"domain": "global",
"reason": "notFound"
}
]
}
}
```

https://github.com/python-poetry/poetry/pull/10634/checks?check_run_id=57332122301

## Summary by Sourcery

CI:
- Switch Cirrus CI FreeBSD instance image family from freebsd-14-2 to freebsd-14-3 for test runs.