### PR TITLE
feat: allow publishing artifacts if version is determined dynamically

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -711,8 +711,14 @@ poetry publish
 It can also build the package if you pass it the `--build` option.
 
 {{% note %}}
-See [Publishable Repositories]({{< relref "repositories/#publishable-repositories" >}}) for more information on how to configure and use publishable repositories.
+See [Publishable Repositories]({{< relref "repositories/#publishable-repositories" >}}) for more information
+on how to configure and use publishable repositories.
 {{% /note %}}
+
+{{% warning %}}
+Only artifacts of the latest version of your package in the dist directory will be uploaded.
+Older versions from previous builds as well as artifacts of other packages are ignored.
+{{% /warning %}}
 
 #### Options
 

--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -82,8 +82,9 @@ the config command.
 
             self.call("build", args=f"--output {dist_dir}")
 
-        files = publisher.files
-        if not files:
+            publisher = Publisher(self.poetry, self.io, Path(dist_dir))
+
+        if not publisher.files:
             self.line_error(
                 "<error>No files to publish. "
                 "Run poetry build first or use the --build option.</error>"

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -79,7 +79,7 @@ class Publisher:
             repository_name = "PyPI"
         self._io.write_line(
             f"Publishing <c1>{self._package.pretty_name}</c1>"
-            f" (<c2>{self._package.pretty_version}</c2>) to"
+            f" (<c2>{self._uploader.version}</c2>) to"
             f" <info>{repository_name}</info>"
         )
 

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -50,6 +50,8 @@ def test_publish_can_publish_to_given_repository(
     config: Config,
     fixture_name: str,
 ) -> None:
+    uploader_version = "1.2.3+test"
+    mocker.patch("poetry.publishing.uploader.Uploader.version", uploader_version)
     uploader_auth = mocker.patch("poetry.publishing.uploader.Uploader.auth")
     uploader_upload = mocker.patch("poetry.publishing.uploader.Uploader.upload")
 
@@ -62,6 +64,9 @@ def test_publish_can_publish_to_given_repository(
 
     mocker.patch("poetry.config.config.Config.create", return_value=config)
     poetry = Factory().create_poetry(fixture_dir(fixture_name))
+    # Normally both versions are equal, but we want to check that the correct version
+    # is displayed in the output if they are different.
+    assert poetry.package.version != uploader_version
 
     io = BufferedIO()
     publisher = Publisher(poetry, io)
@@ -74,7 +79,7 @@ def test_publish_can_publish_to_given_repository(
         {"cert": True, "client_cert": None, "dry_run": False, "skip_existing": False},
     ]
     project_name = canonicalize_name(fixture_name)
-    assert f"Publishing {project_name} (1.2.3) to foo" in io.fetch_output()
+    assert f"Publishing {project_name} ({uploader_version}) to foo" in io.fetch_output()
 
 
 def test_publish_raises_error_for_undefined_repository(


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Until now, `poetry publish` did only upload artifacts that matched the name and the version in the pyproject.toml. This PR changes this constraint so that artifacts of the latest version in the dist directory are uploaded. (The name is still matched.) This is useful if some kind of dynamic versioning is used, e.g.:
- `poetry build --local-version`
- poetry plugins for dynamic versioning
- an alternative build backend, which supports dynamic versioning (cf [Support for alternative build backends in Poetry ](https://python-poetry.org/blog/announcing-poetry-2.1.0/#support-for-alternative-build-backends-in-poetry))

## Summary by Sourcery

Allow publishing the latest built distribution artifacts regardless of the static version in pyproject, improving support for dynamic versioning scenarios.

New Features:
- Select distribution files to publish based on the latest available version in the dist directory rather than the version declared in pyproject.toml.
- Expose the resolved artifact version from the uploader so the publisher can display the actual published version.

Enhancements:
- Update uploader registration to reuse the selected distribution artifacts instead of requiring a version-matched sdist.
- Clarify CLI docs for `poetry publish` to describe how artifacts are selected from the dist directory.

Tests:
- Add tests verifying that the uploader only considers artifacts for the current project name and only uploads files for the latest version, including local version identifiers.
- Adjust publisher and uploader tests to reflect the new artifact selection and registration behavior.