### PR TITLE
fix detection of python and pip executables on Windows and simplify tests

### DIFF
--- a/src/poetry/utils/env/generic_env.py
+++ b/src/poetry/utils/env/generic_env.py
@@ -8,6 +8,7 @@ import subprocess
 from typing import TYPE_CHECKING
 from typing import Any
 
+from poetry.utils._compat import WINDOWS
 from poetry.utils.env.script_strings import GET_PATHS
 from poetry.utils.env.virtual_env import VirtualEnv
 
@@ -38,6 +39,9 @@ class GenericEnv(VirtualEnv):
                 (f"python{minor_version}", f"pip{minor_version}"),
                 (f"python{major_version}", f"pip{major_version}"),
             ]
+
+        if WINDOWS:
+            patterns = [(f"{p[0]}.exe", f"{p[1]}.exe") for p in patterns]
 
         python_executable = None
         pip_executable = None


### PR DESCRIPTION
The glob did not find anything on Windows in case of `self._child_env` being set because the executables end with `.exe`. The fallback test did not test the fallback on Windows because specific pip executables were not deleted because there is no `python{major}.{minor}.exe` on Windows.

The bug is not very relevant because by default executables without version information in their names are used. It was just uncovered due to failing tests when trying to update virtualenv to 20.35 (because this version starts creating `python3.exe` on Windows).

## Summary by Sourcery

Fix detection of Python and pip executables in generic virtual environments, including proper handling of Windows-specific .exe names and corresponding test coverage.

Bug Fixes:
- Ensure GenericEnv correctly locates python and pip executables with .exe suffix on Windows when using child environments.
- Correct fallback resolution logic for selecting python and pip executables so it behaves consistently across platforms, including Windows.

Tests:
- Adjust generic environment tests to assert Windows executables as python.exe and pip.exe and to properly exercise fallback paths for executable discovery.

## Summary by Sourcery

Fix detection and fallback selection of python and pip executables in generic virtual environments, particularly on Windows.

Bug Fixes:
- Ensure GenericEnv searches for Windows-specific .exe-suffixed python and pip executables when resolving binaries in generic environments.
- Correct fallback resolution of python and pip executables by reliably selecting default, major, or minor versioned binaries when some candidates are missing.

Tests:
- Adjust generic environment tests to assert Windows .exe names for detected executables.
- Simplify and harden fallback executable tests by explicitly removing higher-priority candidates and asserting selection of default executables.