### PR TITLE
Fix: indicate location of toml file in question when raising a TOMLDecodeError

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -205,7 +205,9 @@ class Application(BaseApplication):
                 disable_cache=self._disable_cache,
             )
         except TOMLError as e:
-            raise PoetryRuntimeError(f"Problem processing TOML configuration: {e}") from e
+            raise PoetryRuntimeError(
+                f"Problem processing TOML configuration in {self.project_directory}: {e}"
+            ) from e
 
         return self._poetry
 


### PR DESCRIPTION
Fixes #10270

## Summary by Sourcery

Bug Fixes:
- Include the path to the problematic TOML configuration file in the runtime error raised when local configuration parsing fails.