### PR TITLE
fix: clean up dangling references when removing empty dependency groups

### DIFF
--- a/tests/console/commands/test_remove.py
+++ b/tests/console/commands/test_remove.py
@@ -7,6 +7,7 @@ from typing import cast
 import pytest
 import tomlkit
 
+from poetry.core.packages.dependency_group import DependencyGroup
 from poetry.core.packages.package import Package
 
 from poetry.factory import Factory
@@ -776,8 +777,10 @@ include-groups = [
 
 
 @pytest.mark.parametrize("pep_735", [True, False])
+@pytest.mark.parametrize("args", ["", " --group bar"])
 def test_remove_group_cleans_up_include_group_references(
     pep_735: bool,
+    args: str,
     tester: CommandTester,
     app: PoetryTestApplication,
     repo: TestRepository,
@@ -793,7 +796,6 @@ def test_remove_group_cleans_up_include_group_references(
     repo.add_package(Package("baz", "1.0.0"))
 
     pyproject: dict[str, Any] = app.poetry.file.read()
-    pyproject["tool"]["poetry"]["dependencies"]["baz"] = "^1.0.0"
 
     if pep_735:
         groups_content: dict[str, Any] = tomlkit.parse(
@@ -804,6 +806,15 @@ bar = [
 ]
 foobar = [
     { include-group = "bar" },
+]
+foobar2 = [
+    "baz (>=1.0)",
+    { include-group = "bar" },
+    "baz (<=3.0)",
+]
+foobar3 = [
+    { include-group = "bar" },
+    { include-group = "foobar2" },
 ]
 """
         )
@@ -818,6 +829,20 @@ foo = "^2.0.0"
 include-groups = [
     "bar",
 ]
+
+[tool.poetry.group.foobar2]
+include-groups = [
+    "bar",
+]
+
+[tool.poetry.group.foobar2.dependencies]
+baz = "(>=1.0,<=3.0)"
+
+[tool.poetry.group.foobar3]
+include-groups = [
+    "bar",
+    "foobar2",
+]
 """
         )
         groups_content = cast("dict[str, Any]", groups_content)
@@ -826,14 +851,26 @@ include-groups = [
     pyproject = cast("TOMLDocument", pyproject)
     app.poetry.file.write(pyproject)
 
-    app.poetry.package.add_dependency(Factory.create_dependency("baz", "^1.0.0"))
     app.poetry.package.add_dependency(
         Factory.create_dependency("foo", "^2.0.0", groups=["bar"])
     )
+    app.poetry.package.add_dependency(
+        Factory.create_dependency("baz", "^1.0.0", groups=["foobar2"])
+    )
+    foobar = DependencyGroup("foobar")
+    foobar.include_dependency_group(app.poetry.package.dependency_group("bar"))
+    app.poetry.package.add_dependency_group(foobar)
+    foobar2 = DependencyGroup("foobar2")
+    foobar2.include_dependency_group(app.poetry.package.dependency_group("bar"))
+    app.poetry.package.add_dependency_group(foobar2)
+    foobar3 = DependencyGroup("foobar3")
+    foobar3.include_dependency_group(app.poetry.package.dependency_group("bar"))
+    foobar3.include_dependency_group(app.poetry.package.dependency_group("foobar2"))
+    app.poetry.package.add_dependency_group(foobar3)
 
     # Remove all packages from the "bar" group, which should delete the group
     # and also clean up references to it in "foobar"
-    tester.execute("foo --group bar")
+    tester.execute(f"foo{args}")
 
     pyproject = app.poetry.file.read()
     pyproject = cast("dict[str, Any]", pyproject)
@@ -844,9 +881,28 @@ include-groups = [
         assert "bar" not in pyproject.get("dependency-groups", {})
         # "foobar" group should also be removed since it only had include-group
         assert "foobar" not in pyproject.get("dependency-groups", {})
+        # "foobar2" should have its include-group cleaned up
+        assert "foobar2" in pyproject.get("dependency-groups", {})
+        assert pyproject["dependency-groups"]["foobar2"] == [
+            "baz (>=1.0)",
+            "baz (<=3.0)",
+        ]
+        # "foobar3" should have its include-groups cleaned up
+        assert "foobar3" in pyproject.get("dependency-groups", {})
+        assert pyproject["dependency-groups"]["foobar3"] == [
+            {"include-group": "foobar2"}
+        ]
     else:
         # "bar" group should be removed
         assert "bar" not in content.get("group", {})
-        # "foobar" should have its include-groups cleaned up
-        if "foobar" in content.get("group", {}):
-            assert "include-groups" not in content["group"]["foobar"]
+        # "foobar" group should also be removed since it only had include-group
+        assert "foobar" not in content.get("group", {})
+        # "foobar2" should have its include-groups cleaned up
+        assert "foobar2" in content.get("group", {})
+        assert "include-groups" not in content["group"]["foobar2"]
+        assert "dependencies" in content["group"]["foobar2"]
+        assert content["group"]["foobar2"]["dependencies"] == {"baz": "(>=1.0,<=3.0)"}
+        # "foobar3" should have its include-groups cleaned up
+        assert "foobar3" in content.get("group", {})
+        assert "include-groups" in content["group"]["foobar3"]
+        assert content["group"]["foobar3"]["include-groups"] == ["foobar2"]


### PR DESCRIPTION
Fixes #10590.

When a dependency group becomes empty after removing packages, it is removed from the configuration. However, references to this group in other groups' `include-groups` (Legacy) or `include-group` (PEP 735) were left dangling, causing errors.

This PR adds logic to clean up these references when a group is removed.

## Summary by Sourcery

Clean up dependency group references when groups become empty after package removal to prevent dangling references in the configuration.

Bug Fixes:
- Remove include-group entries in PEP 735 dependency-groups that point to groups removed due to becoming empty.
- Remove include-groups entries in legacy [tool.poetry.group] sections that reference groups removed due to becoming empty.
- Ensure empty dependencies sections are removed before deleting groups, avoiding stray empty tables in the configuration.

Tests:
- Adjust remove command tests to cover cleanup of dangling group references and existence checks for remaining groups.