### PR TITLE
tests: make test independent of git setting of default branch

### DIFF
--- a/tests/vcs/git/conftest.py
+++ b/tests/vcs/git/conftest.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 @pytest.fixture()
 def temp_repo(tmp_path: Path) -> TempRepoFixture:
     """Temporary repository with 2 commits"""
-    repo = dulwich.repo.Repo.init(str(tmp_path))
+    repo = dulwich.repo.Repo.init(str(tmp_path), default_branch=b'main')
     worktree = repo.get_worktree()
 
     # init commit

--- a/tests/vcs/git/conftest.py
+++ b/tests/vcs/git/conftest.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 @pytest.fixture()
 def temp_repo(tmp_path: Path) -> TempRepoFixture:
     """Temporary repository with 2 commits"""
-    repo = dulwich.repo.Repo.init(str(tmp_path), default_branch=b'main')
+    repo = dulwich.repo.Repo.init(str(tmp_path), default_branch=b"main")
     worktree = repo.get_worktree()
 
     # init commit

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -276,7 +276,7 @@ def test_clone_existing_locked_tag(tmp_path: Path, temp_repo: TempRepoFixture) -
         Git.clone(url=source_url, source_root=source_root_dir, name="clone-test")
 
     expected_short = (
-        f"Failed to clone {source_url} at 'refs/heads/master',"
+        f"Failed to clone {source_url} at 'refs/heads/main',"
         f" unable to acquire file lock for {tag_ref}."
     )
     assert str(exc_info.value) == expected_short


### PR DESCRIPTION
## Summary by Sourcery

Ensure git backend tests use a repository with a fixed 'main' default branch and update related expectations to be independent of external git default-branch settings.

Tests:
- Initialize temporary git test repositories with 'main' as the default branch to decouple tests from environment-specific git settings.
- Adjust clone error expectation to reference 'refs/heads/main' instead of 'refs/heads/master' in git backend tests.