### PR TITLE
cache: automatic refresh if files of locked package differ from files in cache

### DIFF
--- a/src/poetry/repositories/cached_repository.py
+++ b/src/poetry/repositories/cached_repository.py
@@ -70,3 +70,6 @@ class CachedRepository(Repository, ABC):
         return self.get_release_info(canonicalize_name(name), version).to_package(
             name=name
         )
+
+    def forget(self, name: str, version: Version) -> None:
+        self._release_cache.forget(f"{canonicalize_name(name)}:{version}")

--- a/src/poetry/repositories/repository_pool.py
+++ b/src/poetry/repositories/repository_pool.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from poetry.config.config import Config
 from poetry.repositories.abstract_repository import AbstractRepository
+from poetry.repositories.cached_repository import CachedRepository
 from poetry.repositories.exceptions import PackageNotFoundError
 from poetry.repositories.repository import Repository
 from poetry.utils.cache import ArtifactCache
@@ -181,3 +182,10 @@ class RepositoryPool(AbstractRepository):
         for repo in self.repositories:
             results += repo.search(query)
         return results
+
+    def refresh(self, package: Package) -> Package:
+        repository_name = package.source_reference or "PyPI"
+        repo = self.repository(repository_name)
+        if isinstance(repo, CachedRepository):
+            repo.forget(package.name, package.version)
+        return repo.package(package.name, package.version)

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -1854,6 +1854,14 @@ def test_add_does_not_update_locked_dependencies(
     for package in docker_locked, docker_new, foo:
         repo.add_package(package)
 
+    # set correct files to avoid cache refresh
+    if locked:
+        docker_locked.files = (
+            poetry_with_up_to_date_lockfile.locker.locked_repository()
+            .package("docker", Version.parse("4.3.1"))
+            .files
+        )
+
     tester.execute(command)
 
     lock_data = poetry_with_up_to_date_lockfile.locker.lock_data

--- a/tests/console/commands/test_lock.py
+++ b/tests/console/commands/test_lock.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poetry.core.constraints.version import Version
+
 from poetry.packages import Locker
 from tests.helpers import get_package
 
@@ -92,7 +94,8 @@ def test_lock_does_not_update_if_not_necessary(
     poetry_with_old_lockfile: Poetry,
     repo: TestRepository,
 ) -> None:
-    repo.add_package(get_package("sampleproject", "1.3.1"))
+    package = get_package("sampleproject", "1.3.1")
+    repo.add_package(package)
     repo.add_package(get_package("sampleproject", "2.0.0"))
 
     locker = Locker(
@@ -105,6 +108,13 @@ def test_lock_does_not_update_if_not_necessary(
     assert (
         poetry_with_old_lockfile.locker.lock_data["metadata"].get("lock-version")
         == "1.0"
+    )
+
+    # set correct files to avoid cache refresh
+    package.files = (
+        locker.locked_repository()
+        .package("sampleproject", Version.parse("1.3.1"))
+        .files
     )
 
     tester = command_tester_factory("lock", poetry=poetry_with_old_lockfile)

--- a/tests/repositories/test_cached_repository.py
+++ b/tests/repositories/test_cached_repository.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from packaging.utils import NormalizedName
+from packaging.utils import canonicalize_name
+from poetry.core.constraints.version import Version
+
+from poetry.inspection.info import PackageInfo
+from poetry.repositories.cached_repository import CachedRepository
+
+
+class MockCachedRepository(CachedRepository):
+    def _get_release_info(
+        self, name: NormalizedName, version: Version
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def release_info() -> PackageInfo:
+    return PackageInfo(
+        name="mylib",
+        version="1.0",
+        summary="",
+        requires_dist=[],
+        requires_python=">=3.9",
+        files=[
+            {
+                "file": "mylib-1.0-py3-none-any.whl",
+                "hash": "sha256:dummyhashvalue1234567890abcdef",
+            },
+            {
+                "file": "mylib-1.0.tar.gz",
+                "hash": "sha256:anotherdummyhashvalueabcdef1234567890",
+            },
+        ],
+        cache_version=str(CachedRepository.CACHE_VERSION),
+    )
+
+
+@pytest.fixture
+def outdated_release_info() -> PackageInfo:
+    return PackageInfo(
+        name="mylib",
+        version="1.0",
+        summary="",
+        requires_dist=[],
+        requires_python=">=3.9",
+        files=[
+            {
+                "file": "mylib-1.0-py3-none-any.whl",
+                "hash": "sha256:dummyhashvalue1234567890abcdef",
+            }
+        ],
+        cache_version=str(CachedRepository.CACHE_VERSION),
+    )
+
+
+@pytest.mark.parametrize("disable_cache", [False, True])
+def test_get_release_info_cache(
+    release_info: PackageInfo, outdated_release_info: PackageInfo, disable_cache: bool
+) -> None:
+    repo = MockCachedRepository("mock", disable_cache=disable_cache)
+    repo._get_release_info = lambda name, version: outdated_release_info.asdict()  # type: ignore[method-assign]
+
+    name = canonicalize_name("mylib")
+    version = Version.parse("1.0")
+    assert len(repo.get_release_info(name, version).files) == 1
+
+    # without disable_cache: cached value is returned even if the underlying data has changed
+    # with disable_cache: cached value is ignored and updated data is returned
+    repo._get_release_info = lambda name, version: release_info.asdict()  # type: ignore[method-assign]
+    assert len(repo.get_release_info(name, version).files) == (
+        2 if disable_cache else 1
+    )
+
+    # after clearing the cache entry, updated data is returned
+    repo.forget(name, version)
+    assert len(repo.get_release_info(name, version).files) == 2


### PR DESCRIPTION
When working on a project with many developers, unnecessary diffs in the lockfile due to outdated caches of some developers are an annoying issue. Outdated caches are normally the result of postponed artifact uploads. This change detects such diffs and refreshes the cache automatically.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Automatically refresh cached package metadata when lockfile files differ from repository cache to avoid unnecessary lockfile diffs.

New Features:
- Add repository pool refresh mechanism that invalidates cached package metadata and reloads it from the underlying repository when needed.

Bug Fixes:
- Ensure packages completed from the pool are refreshed when their cached file list is outdated compared to the locked package, preventing spurious lockfile changes.

Enhancements:
- Track refreshed packages in the provider to avoid repeated cache refreshes for the same package version and source.
- Expose a forget operation on cached repositories to clear cached release info entries by name and version.

Tests:
- Add provider tests covering cache refresh behavior when package files in the lock differ from cached repository data.
- Extend lock and add command tests to account for cache refresh logic and ensure no unnecessary updates occur.
- Add cached repository tests verifying release info caching, cache disabling, and behavior after clearing cached entries.