### PR TITLE
fix indeterministic markers

### DIFF
--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -29,6 +29,7 @@ from tomlkit import table
 
 from poetry.__version__ import __version__
 from poetry.packages.transitive_package_info import TransitivePackageInfo
+from poetry.packages.transitive_package_info import group_sort_key
 from poetry.toml.file import TOMLFile
 from poetry.utils._compat import tomllib
 
@@ -583,7 +584,7 @@ class Locker:
             "description": package.description or "",
             "optional": package.optional,
             "python-versions": package.python_versions,
-            "groups": sorted(transitive_info.groups, key=lambda x: (x != "main", x)),
+            "groups": sorted(transitive_info.groups, key=group_sort_key),
         }
         if transitive_info.markers:
             if len(markers := set(transitive_info.markers.values())) == 1:
@@ -593,7 +594,7 @@ class Locker:
                 data["markers"] = inline_table()
                 for group, marker in sorted(
                     transitive_info.markers.items(),
-                    key=lambda x: (x[0] != "main", x[0]),
+                    key=lambda x: group_sort_key(x[0]),
                 ):
                     if not marker.is_any():
                         data["markers"][group] = str(marker)

--- a/src/poetry/packages/transitive_package_info.py
+++ b/src/poetry/packages/transitive_package_info.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.version.markers import BaseMarker
 from poetry.core.version.markers import EmptyMarker
 
@@ -13,6 +14,10 @@ if TYPE_CHECKING:
     from packaging.utils import NormalizedName
 
 
+def group_sort_key(group: NormalizedName) -> tuple[bool, NormalizedName]:
+    return group != MAIN_GROUP, group
+
+
 @dataclass
 class TransitivePackageInfo:
     depth: int  # max depth in the dependency tree
@@ -21,7 +26,7 @@ class TransitivePackageInfo:
 
     def get_marker(self, groups: Iterable[NormalizedName]) -> BaseMarker:
         marker: BaseMarker = EmptyMarker()
-        for group in groups:
+        for group in sorted(groups, key=group_sort_key):
             if group_marker := self.markers.get(group):
                 marker = marker.union(group_marker)
         return marker

--- a/tests/packages/test_transitive_package_info.py
+++ b/tests/packages/test_transitive_package_info.py
@@ -15,15 +15,15 @@ DEV_GROUP = canonicalize_name("dev")
 @pytest.mark.parametrize(
     "groups, expected",
     [
-        ([], "<empty>"),
-        (["main"], 'sys_platform == "linux"'),
-        (["dev"], 'python_version < "3.9"'),
-        (["main", "dev"], 'sys_platform == "linux" or python_version < "3.9"'),
-        (["foo"], "<empty>"),
-        (["main", "foo", "dev"], 'sys_platform == "linux" or python_version < "3.9"'),
+        (set(), "<empty>"),
+        ({"main"}, 'sys_platform == "linux"'),
+        ({"dev"}, 'python_version < "3.9"'),
+        ({"main", "dev"}, 'sys_platform == "linux" or python_version < "3.9"'),
+        ({"foo"}, "<empty>"),
+        ({"main", "foo", "dev"}, 'sys_platform == "linux" or python_version < "3.9"'),
     ],
 )
-def test_get_marker(groups: list[str], expected: str) -> None:
+def test_get_marker(groups: set[str], expected: str) -> None:
     info = TransitivePackageInfo(
         depth=0,
         groups={MAIN_GROUP, DEV_GROUP},


### PR DESCRIPTION
Currently, this is only relevant for poetry-plugin-export because in poetry itself, we only evaluate the marker.

See https://github.com/python-poetry/poetry-plugin-export/issues/334#issuecomment-2821402691 ff.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Ensure deterministic ordering of dependency groups and their markers when generating transitive package metadata.

Bug Fixes:
- Fix non-deterministic marker generation by sorting dependency groups before combining group markers.

Enhancements:
- Introduce and reuse a shared group sorting helper that prioritizes the main group for consistent output ordering.

Tests:
- Update transitive package marker tests to use sets for groups and validate deterministic marker combinations regardless of input order.