### PR TITLE
docs: add usage guide for contributors on existing Poetry projects (#8131)

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -340,4 +340,3 @@ and update the lock file with the new versions.
 Poetry will display a **Warning** when executing an install command if `poetry.lock` and `pyproject.toml`
 are not synchronized.
 {{% /note %}}
-


### PR DESCRIPTION
Hey everyone! 👋

I added a new section to the documentation for people who want to **contribute to a project that already uses Poetry**.  

Right now, the basic usage guide mostly covers creating new projects, which can be a bit confusing if you just want to get started contributing to an existing project.

### What’s included:

- How to install all project dependencies (`poetry install`)
- How to activate the virtual environment (`poetry shell`)
- How to run commands within the environment (`poetry run <command>`)
- How to add new dependencies if needed (`poetry add <package-name>` or dev dependencies)
- A pointer to the existing “Basic Usage” guide for creating new projects

This change is purely **documentation**, so it won’t affect how Poetry works—just makes it easier for newcomers to contribute.

Fixes / relates to issue: [#8131](https://github.com/python-poetry/poetry/issues/8131)

## Summary by Sourcery

Documentation:
- Add a contributor-focused section explaining how to install dependencies, use the virtual environment, run commands, and manage dependencies in existing Poetry-managed projects.