### PR TITLE
legacy repository: prefer JSON API to HTML API

### DIFF
--- a/src/poetry/repositories/link_sources/base.py
+++ b/src/poetry/repositories/link_sources/base.py
@@ -124,3 +124,24 @@ class LinkSource:
     @cached_property
     def _link_cache(self) -> LinkCache:
         raise NotImplementedError()
+
+
+class SimpleRepositoryRootPage:
+    """
+    This class represents the parsed content of a "simple" repository's root page.
+    """
+
+    def search(self, query: str | list[str]) -> list[str]:
+        results: list[str] = []
+        tokens = query if isinstance(query, list) else [query]
+
+        for name in self.package_names:
+            if any(token in name for token in tokens):
+                results.append(name)
+
+        return results
+
+    @cached_property
+    def package_names(self) -> list[str]:
+        # should be overridden in subclasses
+        return []

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from poetry.core.packages.utils.link import Link
 
 from poetry.repositories.link_sources.base import LinkSource
+from poetry.repositories.link_sources.base import SimpleRepositoryRootPage
 from poetry.repositories.parsers.html_page_parser import HTMLPageParser
 
 
@@ -68,10 +69,11 @@ class HTMLPage(LinkSource):
         return links
 
 
-class SimpleRepositoryRootPage:
+class SimpleRepositoryHTMLRootPage(SimpleRepositoryRootPage):
     """
-    This class represents the parsed content of a "simple" repository's root page. This follows the
-    specification laid out in PEP 503.
+    This class represents the parsed content of the HTML version
+    of a "simple" repository's root page.
+    This follows the specification laid out in PEP 503.
 
     See: https://peps.python.org/pep-0503/
     """
@@ -80,17 +82,6 @@ class SimpleRepositoryRootPage:
         parser = HTMLPageParser()
         parser.feed(content or "")
         self._parsed = parser.anchors
-
-    def search(self, query: str | list[str]) -> list[str]:
-        results: list[str] = []
-        tokens = query if isinstance(query, list) else [query]
-
-        for anchor in self._parsed:
-            href = anchor.get("href")
-            if href and any(token in href for token in tokens):
-                results.append(href.rstrip("/"))
-
-        return results
 
     @cached_property
     def package_names(self) -> list[str]:

--- a/tests/console/commands/test_search.py
+++ b/tests/console/commands/test_search.py
@@ -113,9 +113,10 @@ def test_search_only_legacy_repository(
     tester.execute("ipython")
 
     expected = """\
- Package Version Source Description
- ipython 5.7.0   legacy
- ipython 7.5.0   legacy
+ Package Version  Source Description
+ ipython 4.1.0rc1 legacy
+ ipython 5.7.0    legacy
+ ipython 7.5.0    legacy
 """
 
     output = clean_output(tester.io.fetch_output())
@@ -133,11 +134,12 @@ def test_search_multiple_queries(
     tester.execute("ipython isort")
 
     expected = """\
- Package        Version Source Description
- ipython        5.7.0   legacy
- ipython        7.5.0   legacy
- isort          4.3.4   legacy
- isort-metadata 4.3.4   legacy
+ Package        Version  Source Description
+ ipython        4.1.0rc1 legacy
+ ipython        5.7.0    legacy
+ ipython        7.5.0    legacy
+ isort          4.3.4    legacy
+ isort-metadata 4.3.4    legacy
 """
 
     output = clean_output(tester.io.fetch_output())

--- a/tests/installation/conftest.py
+++ b/tests/installation/conftest.py
@@ -21,7 +21,7 @@ def env() -> MockEnv:
 
 
 @pytest.fixture()
-def pool(legacy_repository: LegacyRepository) -> RepositoryPool:
+def pool(legacy_repository_html: LegacyRepository) -> RepositoryPool:
     pool = RepositoryPool()
 
     pool.add_repository(PyPiRepository(disable_cache=True))

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -56,6 +56,16 @@ DEFAULT_SOURCE_REF = (
 )
 
 
+@pytest.fixture
+def legacy_repository(legacy_repository_html: LegacyRepository) -> LegacyRepository:
+    """
+    Override fixture to only test with the html version of the legacy repository
+    because the json version has the same packages as the PyPI repository and thus
+    cause different results in the tests that rely on differences.
+    """
+    return legacy_repository_html
+
+
 def set_package_python_versions(provider: Provider, python_versions: str) -> None:
     provider._package.python_versions = python_versions
     provider._package_python_constraint = provider._package.python_constraint

--- a/tests/repositories/fixtures/legacy/black.html
+++ b/tests/repositories/fixtures/legacy/black.html
@@ -5,7 +5,9 @@
 <body>
     <h1>Links for black</h1>
     <a href="https://files.pythonhosted.org/packages/fd/bb/ad34bbc93d1bea3de086d7c59e528d4a503ac8fe318bd1fa48605584c3d2/black-19.10b0-py36-none-any.whl#sha256=13001c5b7dbc81137164b43137320a1785e95ce84e4db849279786877ac6d7f6" data-requires-python=">=3.6">black-19.10b0-py36-none-any.whl</a>
+    <a href="https://files.pythonhosted.org/packages/b0/dc/ecd83b973fb7b82c34d828aad621a6e5865764d52375b8ac1d7a45e23c8d/black-19.10b0.tar.gz#sha256=c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539" data-requires-python="&gt;=3.6" >black-19.10b0.tar.gz</a>
     <a href="https://files.pythonhosted.org/packages/3d/ad/1cf514e7f9ee4c3d8df7c839d7977f7605ad76557f3fca741ec67f76dba6/black-21.11b0-py3-none-any.whl#sha256=38f6ad54069912caf2fa2d4f25d0c5dedef4b2338a0cb545dbe2fdf54a6a8891" data-requires-python=">=3.6.2" data-yanked="Broken regex dependency. Use 21.11b1 instead.">black-21.11b0-py3-none-any.whl</a>
+    <a href="https://files.pythonhosted.org/packages/2f/db/03e8cef689ab0ff857576ee2ee288d1ff2110ef7f3a77cac62e61f18acaf/black-21.11b0.tar.gz#sha256=83f3852301c8dcb229e9c444dd79f573c8d31c7c2dad9bbaaa94c808630e32aa" data-requires-python="&gt;=3.6.2" data-yanked="Broken regex dependency. Use 21.11b1 instead." >black-21.11b0.tar.gz</a>
     </body>
 </html>
 <!--SERIAL 6044498-->

--- a/tests/repositories/fixtures/legacy/ipython.html
+++ b/tests/repositories/fixtures/legacy/ipython.html
@@ -5,6 +5,8 @@
   </head>
   <body>
     <h1>Links for ipython</h1>
+    <a href="https://files.pythonhosted.org/packages/ac/02/04a5d372b4e64f9c97b2846646aec1ce4532885005aa4ba51eb20b80e17f/ipython-4.1.0rc1-py2.py3-none-any.whl#md5=2aff56d8e78341f64663bcbc81366376" data-requires-python="&gt;=3.5">ipython-4.1.0rc1-py2.py3-none-any.whl</a><br/>
+    <a href="https://files.pythonhosted.org/packages/a0/de/f71f0c8b8a26ef28cc968fbf1859729ad3e68146cd2eb4a759e9c88da218/ipython-4.1.0rc1.tar.gz#sha256=efa3a5a676648cb18e2a2d3cd6353f3c83f0f704df8eb0eb6ae7d0dcbf187ea1" data-requires-python="&gt;=3.5">ipython-4.1.0rc1.tar.gz</a><br/>
     <a href="https://files.pythonhosted.org/packages/52/19/aadde98d6bde1667d0bf431fb2d22451f880aaa373e0a241c7e7cb5815a0/ipython-5.7.0-py2-none-any.whl#md5=20da5e0b1f79dccb37f033a885d798d7">ipython-5.7.0-py2-none-any.whl</a><br/>
     <a href="https://files.pythonhosted.org/packages/c7/b6/03e0b5b0972e6161d16c4cec8d41a20372bd0634f8cb4cc0c984b8a91db6/ipython-5.7.0-py3-none-any.whl#sha256=4292c026552a77b2edc0543941516eddd6fe1a4b681a76ac40b3f585d2fca76f">ipython-5.7.0-py3-none-any.whl</a><br/>
     <a href="https://files.pythonhosted.org/packages/3c/fd/559fead731a29eaa55cc235c8029807b2520976a937c30e9ee603f3bb566/ipython-5.7.0.tar.gz#sha256=4e7fb265e0264498bd0d62c6261936a658bf3d38beb8a7b10cd2c6327c62ac2a">ipython-5.7.0.tar.gz</a><br/>

--- a/tests/repositories/fixtures/legacy/json/_readme
+++ b/tests/repositories/fixtures/legacy/json/_readme
@@ -1,0 +1,1 @@
+Files from tests/repositories/fixtures/pypi.org/json are used as fallback!

--- a/tests/repositories/fixtures/legacy/json/absolute.json
+++ b/tests/repositories/fixtures/legacy/json/absolute.json
@@ -1,0 +1,36 @@
+{
+  "alternate-locations": [],
+  "files": [
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry-0.1.0-py3-none-any.whl",
+      "hashes": {
+        "sha256": "1d85132efab8ead3c6f69202843da40a03823992091c29f8d65a31af68940163"
+      },
+      "requires-python": ">=3.6.0",
+      "url": "https://files.pythonhosted.org/packages/e9/df/0ab4afa9c5d9e6b690c5c27c9f50330b98a7ecfe1185ce2dc1b19188b064/poetry-0.1.0-py3-none-any.whl"
+    },
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry-0.1.0.tar.gz",
+      "hashes": {
+        "sha256": "db33179244321b0b86c6c3645225ff2062ed3495ca16d0d64b3a5df804a82273"
+      },
+      "requires-python": ">=3.6.0",
+      "url": "https://files.pythonhosted.org/packages/d5/c5/4efe096ce56505435ccbe8aeefcd5c8c3bb0da211ef8fe58934d087daef2/poetry-0.1.0.tar.gz"
+    }
+  ],
+  "meta": {
+    "_last-serial": 0,
+    "api-version": "1.0"
+  },
+  "name": "poetry",
+  "project-status": {
+    "status": "active"
+  },
+  "versions": [
+    "0.1.0"
+  ]
+}

--- a/tests/repositories/fixtures/legacy/json/demo.json
+++ b/tests/repositories/fixtures/legacy/json/demo.json
@@ -1,0 +1,22 @@
+{
+  "alternate-locations": [],
+  "files": [
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "demo-0.1.0.tar.gz",
+      "url": "https://files.pythonhosted.org/distributions/demo-0.1.0.tar.gz"
+    }
+  ],
+  "meta": {
+    "_last-serial": 0,
+    "api-version": "1.0"
+  },
+  "name": "demo",
+  "project-status": {
+    "status": "active"
+  },
+  "versions": [
+    "0.1.0"
+  ]
+}

--- a/tests/repositories/fixtures/legacy/json/invalid-version.json
+++ b/tests/repositories/fixtures/legacy/json/invalid-version.json
@@ -1,0 +1,37 @@
+{
+  "alternate-locations": [],
+  "files": [
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry-21.07.28.5ffb65e2ff8067c732e2b178d03b707c7fb27855-py3-none-any.whl",
+      "hashes": {
+        "sha256": "1d85132efab8ead3c6f69202843da40a03823992091c29f8d65a31af68940163"
+      },
+      "requires-python": ">=3.6.0",
+      "url": "poetry-21.07.28.5ffb65e2ff8067c732e2b178d03b707c7fb27855-py3-none-any.whl"
+    },
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry-0.1.0-py3-none-any.whl",
+      "hashes": {
+        "sha256": "1d85132efab8ead3c6f69202843da40a03823992091c29f8d65a31af68940163"
+      },
+      "requires-python": ">=3.6.0",
+      "url": "poetry-0.1.0-py3-none-any.whl"
+    }
+  ],
+  "meta": {
+    "_last-serial": 0,
+    "api-version": "1.0"
+  },
+  "name": "poetry",
+  "project-status": {
+    "status": "active"
+  },
+  "versions": [
+    "0.1.0",
+    "21.07.28.5ffb65e2ff8067c732e2b178d03b707c7fb27855"
+  ]
+}

--- a/tests/repositories/fixtures/legacy/json/isort-metadata.json
+++ b/tests/repositories/fixtures/legacy/json/isort-metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "isort-metadata",
+  "files": [
+    {
+      "filename": "isort-metadata-4.3.4-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/1f/2c/non-existent/isort-metadata-4.3.4-py3-none-any.whl",
+      "dist-info-metadata": {
+        "sha256": "e360bf0ed8a06390513d50dd5b7e9d635c789853a93b84163f9de4ae0647580c"
+      },
+      "hashes": {
+        "sha256": "1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af"
+      }
+    }
+  ],
+  "meta": {
+    "api-version": "1.0",
+    "_last-serial": 3575149
+  }
+}

--- a/tests/repositories/fixtures/legacy/json/jupyter.json
+++ b/tests/repositories/fixtures/legacy/json/jupyter.json
@@ -1,0 +1,22 @@
+{
+  "alternate-locations": [],
+  "files": [
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "jupyter-1.0.0.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/c9/a9/371d0b8fe37dd231cf4b2cff0a9f0f25e98f3a73c3771742444be27f2944/jupyter-1.0.0.tar.gz"
+    }
+  ],
+  "meta": {
+    "_last-serial": 0,
+    "api-version": "1.0"
+  },
+  "name": "jupyter",
+  "project-status": {
+    "status": "active"
+  },
+  "versions": [
+    "1.0.0"
+  ]
+}

--- a/tests/repositories/fixtures/legacy/json/poetry-test-py2-py3-metadata-merge.json
+++ b/tests/repositories/fixtures/legacy/json/poetry-test-py2-py3-metadata-merge.json
@@ -1,0 +1,28 @@
+{
+  "alternate-locations": [],
+  "files": [
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry_test_py2_py3_metadata_merge-0.1.0-py2-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/52/19/poetry_test_py2_py3_metadata_merge-0.1.0-py2-none-any.whl"
+    },
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry_test_py2_py3_metadata_merge-0.1.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/c7/b6/poetry_test_py2_py3_metadata_merge-0.1.0-py3-none-any.whl"
+    }
+  ],
+  "meta": {
+    "_last-serial": 0,
+    "api-version": "1.0"
+  },
+  "name": "poetry-test-py2-py3-metadata-merge",
+  "project-status": {
+    "status": "active"
+  },
+  "versions": [
+    "0.1.0"
+  ]
+}

--- a/tests/repositories/fixtures/legacy/json/relative.json
+++ b/tests/repositories/fixtures/legacy/json/relative.json
@@ -1,0 +1,47 @@
+{
+  "alternate-locations": [],
+  "files": [
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry-0.1.0-py3-none-any.whl",
+      "hashes": {
+        "sha256": "1d85132efab8ead3c6f69202843da40a03823992091c29f8d65a31af68940163"
+      },
+      "requires-python": ">=3.6.0",
+      "url": "poetry-0.1.0-py3-none-any.whl"
+    },
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry-0.1.0.tar.gz",
+      "hashes": {
+        "sha256": "db33179244321b0b86c6c3645225ff2062ed3495ca16d0d64b3a5df804a82273"
+      },
+      "requires-python": ">=3.6.0",
+      "url": "poetry-0.1.0.tar.gz"
+    },
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "poetry-0.1.1.tar.bz2",
+      "hashes": {
+        "sha256": "db33179244321b0b86c6c3645225ff2062ed3495ca16d0d64b3a5df804a82273"
+      },
+      "requires-python": ">=3.6.0",
+      "url": "poetry-0.1.1.tar.bz2"
+    }
+  ],
+  "meta": {
+    "_last-serial": 0,
+    "api-version": "1.0"
+  },
+  "name": "poetry",
+  "project-status": {
+    "status": "active"
+  },
+  "versions": [
+    "0.1.0",
+    "0.1.1"
+  ]
+}

--- a/tests/repositories/fixtures/legacy/json/sqlalchemy-legacy.json
+++ b/tests/repositories/fixtures/legacy/json/sqlalchemy-legacy.json
@@ -1,0 +1,22 @@
+{
+  "alternate-locations": [],
+  "files": [
+    {
+      "core-metadata": false,
+      "data-dist-info-metadata": false,
+      "filename": "sqlalchemy-legacy-4.3.4-py2-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/41/d8/a945da414f2adc1d9e2f7d6e7445b27f2be42766879062a2e63616ad4199/sqlalchemy-legacy-4.3.4-py2-none-any.whl"
+    }
+  ],
+  "meta": {
+    "_last-serial": 0,
+    "api-version": "1.0"
+  },
+  "name": "sqlalchemy-legacy",
+  "project-status": {
+    "status": "active"
+  },
+  "versions": [
+    "4.3.4"
+  ]
+}

--- a/tests/repositories/link_sources/test_json.py
+++ b/tests/repositories/link_sources/test_json.py
@@ -2,7 +2,94 @@ from __future__ import annotations
 
 import pytest
 
+from packaging.utils import canonicalize_name
+from poetry.core.constraints.version.version import Version
+
 from poetry.repositories.link_sources.json import SimpleJsonPage
+from poetry.repositories.link_sources.json import SimpleRepositoryJsonRootPage
+
+
+@pytest.fixture
+def root_page() -> SimpleRepositoryJsonRootPage:
+    names = ["poetry", "poetry-core", "requests"]
+
+    return SimpleRepositoryJsonRootPage(
+        {
+            "meta": {"api-version": "1.4"},
+            "projects": [{"name": name} for name in names],
+        }
+    )
+
+
+def test_root_page_package_names(root_page: SimpleRepositoryJsonRootPage) -> None:
+    assert root_page.package_names == ["poetry", "poetry-core", "requests"]
+
+
+def test_attributes() -> None:
+    content = {
+        "files": [
+            # minimal
+            {"url": "https://example.org/demo-0.1.whl"},
+            # all (with non-default values)
+            {
+                "url": "https://example.org/demo-0.1.tar.gz",
+                "requires-python": ">=3.6",
+                "yanked": True,
+                "hashes": {"sha256": "abcd1234"},
+                "core-metadata": True,
+            },
+        ]
+    }
+    page = SimpleJsonPage("https://example.org", content)
+
+    assert page.url == "https://example.org"
+    links = list(page.links)
+    assert len(links) == 2
+
+    assert links[0].url == "https://example.org/demo-0.1.whl"
+    assert links[0].requires_python is None
+    assert links[0].yanked is False
+    assert links[0].hashes == {}
+    assert links[0].has_metadata is False
+
+    assert links[1].url == "https://example.org/demo-0.1.tar.gz"
+    assert links[1].requires_python == ">=3.6"
+    assert links[1].yanked is True
+    assert links[1].hashes == {"sha256": "abcd1234"}
+    assert links[1].has_metadata is True
+
+
+@pytest.mark.parametrize(
+    ("yanked", "expected"),
+    [
+        ((None, None), False),
+        ((False, False), False),
+        ((True, False), False),
+        ((False, True), False),
+        ((True, True), True),
+        (("reason", True), "reason"),
+        ((True, "reason"), "reason"),
+        (("reason", "reason"), "reason"),
+        (("reason 1", "reason 2"), "reason 1\nreason 2"),
+    ],
+)
+def test_yanked(
+    yanked: tuple[str | None, str | None],
+    expected: bool | str,
+) -> None:
+    content = {
+        "files": [
+            {"url": "https://example.org/demo-0.1.tar.gz", "yanked": yanked[0]},
+            {"url": "https://example.org/demo-0.1.whl", "yanked": yanked[1]},
+        ]
+    }
+    if yanked[0] is None:
+        del content["files"][0]["yanked"]
+    if yanked[1] is None:
+        del content["files"][1]["yanked"]
+    page = SimpleJsonPage("https://example.org", content)
+
+    assert page.yanked(canonicalize_name("demo"), Version.parse("0.1")) == expected
 
 
 @pytest.mark.parametrize(
@@ -77,3 +164,24 @@ def test_metadata(
     link = next(page.links)
     assert link.has_metadata is expected_has_metadata
     assert link.metadata_hashes == expected_metadata_hashes
+
+
+@pytest.mark.parametrize(
+    ("url", "repo_url", "expected"),
+    (
+        (
+            "https://example.org/files/demo-0.1.whl",
+            "https://example.org/simple/",
+            "https://example.org/files/demo-0.1.whl",
+        ),
+        (
+            "demo-0.1.whl",
+            "https://example.org/simple/",
+            "https://example.org/simple/demo-0.1.whl",
+        ),
+    ),
+)
+def test_base_url(url: str, repo_url: str, expected: str) -> None:
+    page = SimpleJsonPage(repo_url, {"files": [{"url": url}]})
+    link = next(iter(page.links))
+    assert link.url == expected


### PR DESCRIPTION
## Motivation

Some information (e.g. `size` and `upload-time`) is only available via JSON. `size` and `upload-time` are optional in `pylock.toml`, but `size` is at least a "should". `upload-time` is also useful for features like https://github.com/python-poetry/poetry/issues/10646 / https://github.com/orgs/python-poetry/discussions/10555

## Changes

* prefer JSON in legacy repositories and fallback to HTML if JSON is not supported
* add support for JSON root pages
* add support for relative URLs in JSON pages
* add support for hashes in JSON pages
* extend legacy tests so that they are run with the HTML variant and the JSON variant
* harmonize HTML and JSON fixtures so that we get the same results in the tests

# Pull Request Check List

Related-to: https://github.com/python-poetry/poetry-plugin-export/issues/336
Related-to: #10356
Related-to: #10646

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Prefer JSON Simple API for legacy repositories while keeping HTML as a fallback, and introduce a shared root-page abstraction used by both HTML and JSON link sources.

New Features:
- Support parsing and use of PEP 691 JSON Simple API pages for legacy repositories, including root project listings, hashes, and yanked metadata.
- Allow JSON and HTML legacy repositories to be exercised interchangeably via parametrized test fixtures.

Enhancements:
- Introduce a common SimpleRepositoryRootPage base class with unified search semantics shared by HTML and JSON root pages.
- Normalize URL resolution for links in HTML and JSON pages, including handling of repository base URLs and hash fragments.
- Extend legacy fixtures to better align HTML and JSON repositories and to expose additional distributions for search and yanking scenarios.

Tests:
- Add unit tests for JSON link source behavior, including root page parsing, yanked handling, hashes, and relative URLs.
- Update HTML link source tests for root page parsing, hash extraction from URLs, and base URL handling.
- Parametrize legacy repository tests to run against both HTML and JSON variants where appropriate and adjust expectations accordingly.
- Adapt solver, search command, and installation tests to work with the new legacy repository behavior and fixtures.