### PR TITLE
adapt to improved type hints and fix edge case issues with `Package-files`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -42,7 +42,7 @@ name = "build"
 version = "1.3.0"
 description = "A simple, correct Python build frontend"
 optional = false
-python-versions = ">= 3.9"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
     {file = "build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4"},
@@ -481,7 +481,7 @@ name = "cryptography"
 version = "46.0.3"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
-python-versions = ">=3.8, !=3.9.0, !=3.9.1"
+python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main"]
 markers = "sys_platform == \"linux\""
 files = [
@@ -1214,7 +1214,7 @@ name = "nodeenv"
 version = "1.9.1"
 description = "Node.js virtual environment builder"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
 files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
@@ -1338,12 +1338,16 @@ name = "poetry-core"
 version = "2.2.1"
 description = "Poetry PEP 517 Build Backend"
 optional = false
-python-versions = ">=3.9, <4.0"
+python-versions = ">=3.10, <4.0"
 groups = ["main"]
-files = [
-    {file = "poetry_core-2.2.1-py3-none-any.whl", hash = "sha256:bdfce710edc10bfcf9ab35041605c480829be4ab23f5bc01202cfe5db8f125ab"},
-    {file = "poetry_core-2.2.1.tar.gz", hash = "sha256:97e50d8593c8729d3f49364b428583e044087ee3def1e010c6496db76bd65ac5"},
-]
+files = []
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/python-poetry/poetry-core.git"
+reference = "HEAD"
+resolved_reference = "2548a4c47e172d298c2c34d0e511e5c589397de5"
 
 [[package]]
 name = "pre-commit"
@@ -2177,4 +2181,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "48113a39a874cca468450846747299f3ad6193b4a5849258b35a6baf7b2e14b4"
+content-hash = "22571b7e3ea21cc6b16624f5a218075ea74b3bd819fffcf1e56bc6629f0b0180"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.2.1"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "poetry-core (==2.2.1)",
+    "poetry-core @ git+https://github.com/python-poetry/poetry-core.git",
     "build (>=1.2.1,<2.0.0)",
     "cachecontrol[filecache] (>=0.14.0,<0.15.0)",
     "cleo (>=2.1.0,<3.0.0)",

--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -29,11 +29,11 @@ from poetry.utils.isolated_build import isolated_builder
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from collections.abc import Mapping
     from collections.abc import Sequence
 
     from packaging.metadata import RawMetadata
     from packaging.utils import NormalizedName
+    from poetry.core.packages.package import PackageFile
     from poetry.core.packages.project_package import ProjectPackage
 
 
@@ -57,7 +57,7 @@ class PackageInfo:
         summary: str | None = None,
         requires_dist: list[str] | None = None,
         requires_python: str | None = None,
-        files: Sequence[Mapping[str, str]] | None = None,
+        files: Sequence[PackageFile] | None = None,
         yanked: str | bool = False,
         cache_version: str | None = None,
     ) -> None:

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -420,7 +420,10 @@ class Locker:
             package.files = package_files
         elif "hashes" in metadata:
             hashes = cast("dict[str, Any]", metadata["hashes"])
-            package.files = [{"name": h, "hash": h} for h in hashes[name]]
+            # Strictly speaking, this is not correct,
+            # but we do not know the file names here,
+            # so we just set both file and hash.
+            package.files = [{"file": h, "hash": h} for h in hashes[name]]
         elif source_type in {"git", "directory", "url"}:
             package.files = []
         else:

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -15,6 +15,8 @@ from poetry.utils.env import MockEnv
 
 
 if TYPE_CHECKING:
+    from poetry.core.packages.package import PackageFile
+
     from poetry.repositories.repository_pool import RepositoryPool
     from tests.conftest import Config
     from tests.types import DistributionHashGetter
@@ -211,7 +213,7 @@ def test_chooser_chooses_distributions_that_match_the_package_hashes(
     chooser = Chooser(pool, env)
 
     package = Package("isort", "4.3.4")
-    files = [
+    files: list[PackageFile] = [
         {
             "file": filename,
             "hash": (f"sha256:{dist_hash_getter(filename).sha256}"),
@@ -246,9 +248,9 @@ def test_chooser_chooses_yanked_if_no_others(
     chooser = Chooser(pool, env)
 
     package = Package("black", "21.11b0")
-    files = [
+    files: list[PackageFile] = [
         {
-            "filename": filename,
+            "file": filename,
             "hash": (f"sha256:{dist_hash_getter(filename).sha256}"),
         }
         for filename in [f"{package.name}-{package.version}-py3-none-any.whl"]
@@ -286,9 +288,9 @@ def test_chooser_does_not_choose_yanked_if_others(
     )
 
     package = Package("futures", "3.2.0")
-    files = [
+    files: list[PackageFile] = [
         {
-            "filename": filename,
+            "file": filename,
             "hash": (f"sha256:{dist_hash_getter(filename).sha256}"),
         }
         for filename in [
@@ -330,12 +332,12 @@ def test_chooser_throws_an_error_if_package_hashes_do_not_match(
     chooser = Chooser(pool, env)
 
     package = Package("isort", "4.3.4")
-    files = [
+    files: list[PackageFile] = [
         {
             "hash": (
                 "sha256:0000000000000000000000000000000000000000000000000000000000000000"
             ),
-            "filename": "isort-4.3.4.tar.gz",
+            "file": "isort-4.3.4.tar.gz",
         }
     ]
     if source_type == "legacy":
@@ -373,7 +375,7 @@ def test_chooser_md5_remote_fallback_to_sha256_inline_calculation(
     )
     package.files = [
         {
-            "filename": filename,
+            "file": filename,
             "hash": (f"sha256:{dist_hash_getter(filename).sha256}"),
         }
         for filename in [f"{package.name}-{package.version}.tar.gz"]

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
 
+    from poetry.core.packages.package import PackageFile
     from pytest_mock import MockerFixture
 
     from poetry.config.config import Config
@@ -1819,7 +1820,7 @@ Package operations: 1 install, 0 updates, 0 removals
     ],
 )
 def test_executor_known_hashes(
-    package_files: list[dict[str, str]],
+    package_files: list[PackageFile],
     expected_url_reference: dict[str, Any],
     tmp_venv: VirtualEnv,
     pool: RepositoryPool,


### PR DESCRIPTION
# Pull Request Check List

Requires: python-poetry/poetry-core#904

Fix edge case issues (and corrupt tests) uncovered by python-poetry/poetry-core#904.

## Summary by Sourcery

Align package file handling with updated typing and fix edge cases around missing or invalid file hashes.

Bug Fixes:
- Correct package file key usage in chooser, executor, and locker logic to prevent mismatches and corrupted tests.
- Skip files without resolvable hashes in HTTP repository link conversion to avoid writing invalid lockfile entries.

Enhancements:
- Adopt the shared PackageFile type in repositories, inspection, executor tests, and chooser tests for stricter type safety and consistency.

Build:
- Update poetry-core dependency to a specific Git revision that introduces improved package file typing.

Tests:
- Adjust installation chooser and executor tests to use the new PackageFile structure and align with updated hash handling.