### PR TITLE
dulwich: remove redundant encode

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -254,7 +254,7 @@ class Git:
 
         with local:
             result: FetchPackResult = client.fetch(
-                path.encode(),
+                path,
                 local,
                 determine_wants=local.object_store.determine_wants_all,
             )

--- a/tests/integration/test_utils_vcs_git.py
+++ b/tests/integration/test_utils_vcs_git.py
@@ -110,9 +110,7 @@ def _remote_refs(source_url: str, local_repo: Repo) -> FetchPackResult:
     path: str
     client, path = get_transport_and_path(source_url)
     return client.fetch(
-        path.encode(),
-        local_repo,
-        determine_wants=local_repo.object_store.determine_wants_all,
+        path, local_repo, determine_wants=local_repo.object_store.determine_wants_all
     )
 
 


### PR DESCRIPTION
minor addition regarding #10674

The `encode()` was necessary with dulwich 0.24.10, but is not anymore with dulwich 0.25.0. See https://github.com/jelmer/dulwich/pull/2036

## Summary by Sourcery

Enhancements:
- Simplify Git remote reference fetching by passing the transport path string directly to dulwich instead of encoding it to bytes.