### PR TITLE
docs: clarify local vs global config precedence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,8 +41,8 @@ the local/project configuration takes precedence over the global configuration.
 {{% /note %}}
 
 {{% warning %}}
-Be mindful about checking in this file into your repository since it may contain user-specific or sensitive information.
-{{% /note %}}
+Be mindful when checking in this file into your repository since it may contain user-specific or sensitive information.
+{{% /warning %}}
 
 ## Listing the current configuration
 


### PR DESCRIPTION
Resolves: #10329

This PR clarifies how Poetry handles conflicting configuration settings when the same setting is defined both locally (in poetry.toml) and globally (in config.toml).
A new note has been added to the Configuration documentation:
**Note**: If a setting is defined in both poetry.toml (local/project) and config.toml (global), the local/project configuration takes precedence over the global configuration.
This change helps **contributors and users** understand which configuration will apply without needing to test it themselves.
No code changes were made—only the documentation has been updated.

## Summary by Sourcery

Documentation:
- Document that local/project configuration in poetry.toml overrides global configuration in config.toml when the same setting is defined in both.