### PR TITLE
fill url, size and upload-time in Package.files, bump cache version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1347,7 +1347,7 @@ develop = false
 type = "git"
 url = "https://github.com/python-poetry/poetry-core.git"
 reference = "HEAD"
-resolved_reference = "2548a4c47e172d298c2c34d0e511e5c589397de5"
+resolved_reference = "c162294efca69eaf5d74b02b1a3fee750988c2e4"
 
 [[package]]
 name = "pre-commit"

--- a/src/poetry/packages/direct_origin.py
+++ b/src/poetry/packages/direct_origin.py
@@ -73,6 +73,14 @@ class DirectOrigin:
                 f"Unable to determine package info from path: {file_path}"
             )
 
+        package.files = [
+            {
+                "file": file_path.name,
+                "hash": "sha256:" + get_file_hash(file_path),
+                "size": file_path.stat().st_size,
+            }
+        ]
+
         return package
 
     @classmethod
@@ -91,9 +99,6 @@ class DirectOrigin:
         )
 
         package = self.get_package_from_file(artifact)
-        package.files = [
-            {"file": link.filename, "hash": "sha256:" + get_file_hash(artifact)}
-        ]
 
         package._source_type = "url"
         package._source_url = url

--- a/src/poetry/packages/locker.py
+++ b/src/poetry/packages/locker.py
@@ -601,7 +601,13 @@ class Locker:
                 ):
                     if not marker.is_any():
                         data["markers"][group] = str(marker)
-        data["files"] = sorted(package.files, key=lambda x: x["file"])
+        data["files"] = sorted(
+            [
+                {k: v for k, v in f.items() if k in {"file", "hash"}}
+                for f in package.files
+            ],
+            key=lambda x: x["file"],
+        )
 
         if dependencies:
             data["dependencies"] = table()

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -31,7 +31,6 @@ from poetry.packages.direct_origin import DirectOrigin
 from poetry.packages.package_collection import PackageCollection
 from poetry.puzzle.exceptions import OverrideNeededError
 from poetry.repositories.repository_pool import Priority
-from poetry.utils.helpers import get_file_hash
 
 
 if TYPE_CHECKING:
@@ -343,13 +342,6 @@ class Provider:
 
         if dependency.base is not None:
             package.root_dir = dependency.base
-
-        package.files = [
-            {
-                "file": dependency.path.name,
-                "hash": "sha256:" + get_file_hash(dependency.full_path),
-            }
-        ]
 
         return package
 

--- a/src/poetry/repositories/cached_repository.py
+++ b/src/poetry/repositories/cached_repository.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 
 class CachedRepository(Repository, ABC):
-    CACHE_VERSION = parse_constraint("2.0.0")
+    CACHE_VERSION = parse_constraint("2.1.0")
 
     def __init__(
         self, name: str, *, disable_cache: bool = False, config: Config | None = None

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -378,6 +378,10 @@ class HTTPRepository(CachedRepository):
                         "url": link.url_without_fragment,
                     }
                 )
+                if link.size is not None:
+                    files[-1]["size"] = link.size
+                if link.upload_time_isoformat is not None:
+                    files[-1]["upload_time"] = link.upload_time_isoformat
 
         if not files:
             raise PackageNotFoundError(

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -371,7 +371,13 @@ class HTTPRepository(CachedRepository):
                     level="warning",
                 )
             else:
-                files.append({"file": link.filename, "hash": file_hash})
+                files.append(
+                    {
+                        "file": link.filename,
+                        "hash": file_hash,
+                        "url": link.url_without_fragment,
+                    }
+                )
 
         if not files:
             raise PackageNotFoundError(

--- a/src/poetry/repositories/link_sources/json.py
+++ b/src/poetry/repositories/link_sources/json.py
@@ -32,6 +32,8 @@ class SimpleJsonPage(LinkSource):
             requires_python = file.get("requires-python")
             hashes = file.get("hashes", {})
             yanked = file.get("yanked", False)
+            size = file.get("size")
+            upload_time = file.get("upload-time")
 
             # see https://peps.python.org/pep-0714/#clients
             # and https://peps.python.org/pep-0691/#project-detail
@@ -51,6 +53,8 @@ class SimpleJsonPage(LinkSource):
                 hashes=hashes,
                 yanked=yanked,
                 metadata=metadata,
+                size=size,
+                upload_time=upload_time,
             )
 
             if link.ext not in self.SUPPORTED_FORMATS:

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -181,6 +181,10 @@ class PyPiRepository(HTTPRepository):
                         "url": file_info["url"],
                     }
                 )
+                if (size := file_info.get("size")) is not None:
+                    files[-1]["size"] = size
+                if upload_time := file_info.get("upload_time_iso_8601"):
+                    files[-1]["upload_time"] = upload_time
         data.files = files
 
         if self._fallback and data.requires_dist is None:

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -178,6 +178,7 @@ class PyPiRepository(HTTPRepository):
                     {
                         "file": file_info["filename"],
                         "hash": "sha256:" + file_info["digests"]["sha256"],
+                        "url": file_info["url"],
                     }
                 )
         data.files = files

--- a/tests/installation/test_chooser.py
+++ b/tests/installation/test_chooser.py
@@ -216,7 +216,7 @@ def test_chooser_chooses_distributions_that_match_the_package_hashes(
     files: list[PackageFile] = [
         {
             "file": filename,
-            "hash": (f"sha256:{dist_hash_getter(filename).sha256}"),
+            "hash": f"sha256:{dist_hash_getter(filename).sha256}",
         }
         for filename in [
             f"{package.name}-{package.version}.tar.gz",
@@ -291,7 +291,7 @@ def test_chooser_does_not_choose_yanked_if_others(
     files: list[PackageFile] = [
         {
             "file": filename,
-            "hash": (f"sha256:{dist_hash_getter(filename).sha256}"),
+            "hash": f"sha256:{dist_hash_getter(filename).sha256}",
         }
         for filename in [
             f"{package.name}-{package.version}-py2-none-any.whl",

--- a/tests/packages/test_direct_origin.py
+++ b/tests/packages/test_direct_origin.py
@@ -21,6 +21,13 @@ def test_direct_origin_get_package_from_file(fixture_dir: FixtureDirGetter) -> N
     wheel_path = fixture_dir("distributions") / "demo-0.1.2-py2.py3-none-any.whl"
     package = DirectOrigin.get_package_from_file(wheel_path)
     assert package.name == "demo"
+    assert package.files == [
+        {
+            "file": "demo-0.1.2-py2.py3-none-any.whl",
+            "hash": "sha256:55dde4e6828081de7a1e429f33180459c333d9da593db62a3d75a8f5e505dde1",
+            "size": 1552,
+        }
+    ]
 
 
 def test_direct_origin_caches_url_dependency(tmp_path: Path) -> None:
@@ -31,6 +38,13 @@ def test_direct_origin_caches_url_dependency(tmp_path: Path) -> None:
     package = direct_origin.get_package_from_url(url)
 
     assert package.name == "demo"
+    assert package.files == [
+        {
+            "file": "demo-0.1.0-py2.py3-none-any.whl",
+            "hash": "sha256:70e704135718fffbcbf61ed1fc45933cfd86951a744b681000eaaa75da31f17a",
+            "size": 1116,
+        }
+    ]
     assert artifact_cache.get_cached_archive_for_link(Link(url), strict=True)
 
 
@@ -51,6 +65,13 @@ def test_direct_origin_does_not_download_url_dependency_when_cached(
     package = direct_origin.get_package_from_url(url)
 
     assert package.name == "demo"
+    assert package.files == [
+        {
+            "file": "demo-0.1.2-py2.py3-none-any.whl",
+            "hash": "sha256:55dde4e6828081de7a1e429f33180459c333d9da593db62a3d75a8f5e505dde1",
+            "size": 1552,
+        }
+    ]
     artifact_cache.get_cached_archive_for_link.assert_called_once_with(
         Link(url), strict=True, download_func=download_file
     )

--- a/tests/packages/test_locker.py
+++ b/tests/packages/test_locker.py
@@ -701,7 +701,7 @@ demo = [
             package.files = []
 
 
-def test_lock_packages_with_null_description(
+def test_locker_dumps_packages_with_null_description(
     locker: Locker, root: ProjectPackage, transitive_info: TransitivePackageInfo
 ) -> None:
     package_a = get_package("A", "1.0.0")
@@ -723,6 +723,46 @@ optional = false
 python-versions = "*"
 groups = ["main"]
 files = []
+
+[metadata]
+lock-version = "2.1"
+python-versions = "*"
+content-hash = "115cf985d932e9bf5f540555bbdd75decbb62cac81e399375fc19f6277f8c1d8"
+"""
+
+    assert content == expected
+
+
+def test_locker_does_not_dump_file_urls(
+    locker: Locker, root: ProjectPackage, transitive_info: TransitivePackageInfo
+) -> None:
+    package_a = get_package("A", "1.0")
+    package_a.files = [
+        {
+            "file": "a-1.0.whl",
+            "hash": "sha256:abcdef1234567890",
+            "url": "https://example.org/a-1.0.whl",
+        },
+    ]
+
+    locker.set_lock_data(root, {package_a: transitive_info})
+
+    with locker.lock.open(encoding="utf-8") as f:
+        content = f.read()
+
+    expected = f"""\
+# {GENERATED_COMMENT}
+
+[[package]]
+name = "A"
+version = "1.0"
+description = ""
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {{file = "a-1.0.whl", hash = "sha256:abcdef1234567890"}},
+]
 
 [metadata]
 lock-version = "2.1"

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -544,6 +544,13 @@ def test_search_for_file_sdist(
 
     assert package.name == "demo"
     assert package.version.text == "0.1.0"
+    assert package.files == [
+        {
+            "file": "demo-0.1.0.tar.gz",
+            "hash": "sha256:9fa123ad707a5c6c944743bf3e11a0e80d86cb518d3cf25320866ca3ef43e2ad",
+            "size": 1003,
+        }
+    ]
 
     required = {
         r for r in sorted(package.requires, key=lambda r: r.name) if not r.is_optional()
@@ -575,6 +582,13 @@ def test_search_for_file_sdist_with_extras(
 
     assert package.name == "demo"
     assert package.version.text == "0.1.0"
+    assert package.files == [
+        {
+            "file": "demo-0.1.0.tar.gz",
+            "hash": "sha256:9fa123ad707a5c6c944743bf3e11a0e80d86cb518d3cf25320866ca3ef43e2ad",
+            "size": 1003,
+        }
+    ]
 
     required = {
         r for r in sorted(package.requires, key=lambda r: r.name) if not r.is_optional()
@@ -605,6 +619,13 @@ def test_search_for_file_wheel(
 
     assert package.name == "demo"
     assert package.version.text == "0.1.0"
+    assert package.files == [
+        {
+            "file": "demo-0.1.0-py2.py3-none-any.whl",
+            "hash": "sha256:70e704135718fffbcbf61ed1fc45933cfd86951a744b681000eaaa75da31f17a",
+            "size": 1116,
+        }
+    ]
 
     required = {
         r for r in sorted(package.requires, key=lambda r: r.name) if not r.is_optional()
@@ -636,6 +657,13 @@ def test_search_for_file_wheel_with_extras(
 
     assert package.name == "demo"
     assert package.version.text == "0.1.0"
+    assert package.files == [
+        {
+            "file": "demo-0.1.0-py2.py3-none-any.whl",
+            "hash": "sha256:70e704135718fffbcbf61ed1fc45933cfd86951a744b681000eaaa75da31f17a",
+            "size": 1116,
+        }
+    ]
 
     required = {
         r for r in sorted(package.requires, key=lambda r: r.name) if not r.is_optional()

--- a/tests/repositories/fixtures/pypi.py
+++ b/tests/repositories/fixtures/pypi.py
@@ -4,6 +4,7 @@ import json
 import re
 
 from typing import TYPE_CHECKING
+from typing import Any
 from urllib.parse import urlparse
 
 import pytest
@@ -165,8 +166,10 @@ def pypi_repository(
 
 
 @pytest.fixture
-def get_pypi_dist_url(package_json_locations: list[Path]) -> Callable[[str], str]:
-    def get_url(name: str) -> str:
+def get_pypi_file_info(
+    package_json_locations: list[Path],
+) -> Callable[[str], dict[str, Any]]:
+    def get_file_info(name: str) -> dict[str, Any]:
         if name.endswith(".whl"):
             package_name, version, _build, _tags = parse_wheel_filename(name)
         else:
@@ -185,9 +188,7 @@ def get_pypi_dist_url(package_json_locations: list[Path]) -> Callable[[str], str
             content = json.load(f)
         for url in content["urls"]:
             if url["filename"] == name:
-                url = url["url"]
-                assert isinstance(url, str)
-                return url
+                return url  # type: ignore[no-any-return]
         raise RuntimeError(f"No URL in pypi.org json fixture of {name} {version}")
 
-    return get_url
+    return get_file_info

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 
@@ -86,7 +87,7 @@ def test_find_packages_yanked(
 def test_package(
     pypi_repository: PyPiRepository,
     dist_hash_getter: DistributionHashGetter,
-    get_pypi_dist_url: Callable[[str], str],
+    get_pypi_file_info: Callable[[str], dict[str, Any]],
 ) -> None:
     repo = pypi_repository
 
@@ -102,7 +103,9 @@ def test_package(
         {
             "file": filename,
             "hash": f"sha256:{dist_hash_getter(filename).sha256}",
-            "url": get_pypi_dist_url(filename),
+            "url": (file_info := get_pypi_file_info(filename))["url"],
+            "size": file_info["size"],
+            "upload_time": file_info["upload_time_iso_8601"],
         }
         for filename in [
             f"{package.name}-{package.version}-py2.py3-none-any.whl",

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -16,6 +16,8 @@ from poetry.repositories.pypi_repository import PyPiRepository
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
     from tests.types import DistributionHashGetter
@@ -82,7 +84,9 @@ def test_find_packages_yanked(
 
 
 def test_package(
-    pypi_repository: PyPiRepository, dist_hash_getter: DistributionHashGetter
+    pypi_repository: PyPiRepository,
+    dist_hash_getter: DistributionHashGetter,
+    get_pypi_dist_url: Callable[[str], str],
 ) -> None:
     repo = pypi_repository
 
@@ -97,7 +101,8 @@ def test_package(
     assert package.files == [
         {
             "file": filename,
-            "hash": (f"sha256:{dist_hash_getter(filename).sha256}"),
+            "hash": f"sha256:{dist_hash_getter(filename).sha256}",
+            "url": get_pypi_dist_url(filename),
         }
         for filename in [
             f"{package.name}-{package.version}-py2.py3-none-any.whl",


### PR DESCRIPTION
# Pull Request Check List

Actually, this is just an internal change that makes it easier to get the url, size and upload-time of a wheel/sdist. However, the change requires a bump of the cache version.

Requires: https://github.com/python-poetry/poetry-core/pull/905
Related-to: https://github.com/python-poetry/poetry-plugin-export/issues/336
Related-to: https://github.com/python-poetry/poetry/issues/10356
Related-to: https://github.com/python-poetry/poetry/issues/10646

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Populate package file metadata with URLs, sizes, and upload times and ensure this additional information is not persisted into lock files, updating cache expectations accordingly.

New Features:
- Include file URLs, sizes, and upload times in package file metadata when resolving from HTTP, PyPI JSON, and legacy repositories, as well as for direct file and URL origins.

Enhancements:
- Adjust link and repository handling to propagate size and upload-time data into package links and file entries.
- Ensure the locker strips non-essential file metadata (such as URLs) when writing lock files, preserving only file names and hashes.
- Expand and update tests and fixtures across repositories, providers, and direct origins to validate the new file metadata behaviour and cache version bump.

Tests:
- Add and update tests for legacy and PyPI repositories, provider search, direct origins, and locker behaviour to cover the enriched package file metadata and lockfile output.

Chores:
- Bump the cached repository cache version to reflect the new package file shape and temporarily depend on a feature branch of poetry-core exposing file metadata.