### PR TITLE
docs: document SHELL_VERBOSITY environment variable

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,20 +26,16 @@ then `--help` combined with any of those can give you more information.
 You can also set the verbosity level using the `SHELL_VERBOSITY` environment variable.
 This is useful in CI/CD pipelines or scripts where you cannot easily modify command-line arguments.
 
-| Value | Equivalent | Description |
-|-------|------------|-------------|
-| `-1` | `-q` | Quiet mode |
-| `0` | (default) | Normal output |
-| `1` | `-v` | Verbose output |
-| `2` | `-vv` | More verbose output |
-| `3` | `-vvv` | Debug output |
+| Value  | Equivalent | Description         |
+|--------|------------|---------------------|
+| `-1`   | `-q`       | Quiet mode          |
+| `0`    | (default)  | Normal output       |
+| `1`    | `-v`       | Verbose output      |
+| `2`    | `-vv`      | More verbose output |
+| `3`    | `-vvv`     | Debug output        |
 
-For example, to enable debug output:
-```bash
-export SHELL_VERBOSITY=3
-poetry install
-```
 {{% /note %}}
+
 * `--help (-h)` : Display help information.
 * `--quiet (-q)` : Do not output any message.
 * `--ansi`: Force ANSI output.


### PR DESCRIPTION
## Summary

This PR adds documentation for the `SHELL_VERBOSITY` environment variable as requested in #7601.

### Changes

Added a note to the Global Options section in `docs/cli.md` that:
- Explains `SHELL_VERBOSITY` as an alternative to `-v/-vv/-vvv` flags
- Provides a table showing verbosity levels and their command-line equivalents
- Includes an example usage for CI/CD pipelines

### Context

From the issue discussion, @Secrus (maintainer) confirmed:
> There is `SHELL_VERBOSITY` flag that sets up the verbosity level. It should probably be added to docs somewhere.

This feature is inherited from the Cleo library and is particularly useful in environments like dh-poetry where command-line invocation is outside user control.

Closes #7601

---
Ahmed Adel Bakr Alderai

## Summary by Sourcery

Documentation:
- Add CLI documentation explaining the SHELL_VERBOSITY environment variable, its mapping to verbosity flags, and example usage for scripts and CI/CD pipelines.