### PR TITLE
Explain in which cases `packages` are automatically detected

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -577,19 +577,17 @@ A list of packages and modules to include in the final distribution.
 If packages are not automatically detected, you can specify the packages you want
 to include in the final distribution.
 
-#### Automatic package detection
-
-Poetry automatically detects packages if there is either a **module** or a
-**package** whose name matches the project name (canonicalized, with `-`
-replaced by `_`).
+{{% note %}}
+Poetry automatically detects a single **module** or **package** whose name matches the
+[normalized](https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization)
+project name with `-` replaced with `_`.
 
 The detected module or package must be located either:
 
 - at the same level as the `pyproject.toml` file (flat layout), or
 - inside a `src/` directory (src layout).
 
-If packages are not automatically detected, they must be explicitly specified
-using `packages`.
+{{% /note %}}
 
 ```toml
 [tool.poetry]


### PR DESCRIPTION
Resolves: #8713

#### Standard Project Structure

Poetry considers a "standard project structure" to be:

```bash
project_name/
├── pyproject.toml
├── README.md
├── project_name/
│   └── __init__.py
└── tests/
    └── __init__.py
The top-level directory contains pyproject.toml and README.md.
The main package directory matches the name field in pyproject.toml (or a snake_case variant).
Tests go in a separate tests/ directory.
{{% note %}} If your project matches this layout, Poetry will auto-detect your main package, and you do not need to list it in [tool.poetry.packages]. {{% /note %}}
{{% warning %}} If your project differs from this standard layout — for example, packages inside a lib/ directory, or the top-level package name doesn’t match name in pyproject.toml — you must explicitly list them in [tool.poetry.packages] to include them in your distribution. {{% /warning %}}

## Summary by Sourcery

Documentation:
- Document automatic package detection rules based on normalized project name and supported flat/src layouts in pyproject.md.