### PR TITLE
env use: fail if python version is not supported by the project

### DIFF
--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -395,7 +395,6 @@ class EnvManager:
 
         create_venv = self._poetry.config.get("virtualenvs.create")
         in_project_venv = self.use_in_project_venv()
-        use_poetry_python = self._poetry.config.get("virtualenvs.use-poetry-python")
         venv_prompt = self._poetry.config.get("virtualenvs.prompt")
 
         specific_python_requested = python is not None
@@ -420,7 +419,7 @@ class EnvManager:
             # If an executable has been specified, we stop there
             # and notify the user of the incompatibility.
             # Otherwise, we try to find a compatible Python version.
-            if specific_python_requested and use_poetry_python:
+            if specific_python_requested:
                 raise NoCompatiblePythonVersionFoundError(
                     self._poetry.package.python_versions,
                     python.patch_version.to_string(),

--- a/tests/console/commands/env/conftest.py
+++ b/tests/console/commands/env/conftest.py
@@ -26,7 +26,9 @@ def venv_name(app: PoetryTestApplication) -> str:
 
 @pytest.fixture
 def venv_cache(tmp_path: Path) -> Path:
-    return tmp_path
+    path = tmp_path / "venv_cache"
+    path.mkdir()
+    return path
 
 
 @pytest.fixture(scope="module")

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -991,14 +991,16 @@ def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
     assert m.call_count == 0
 
 
+@pytest.mark.parametrize("use_poetry_python", [True, False])
 def test_create_venv_does_not_try_to_find_compatible_versions_with_executable(
     manager: EnvManager,
     poetry: Poetry,
     config: Config,
     mocker: MockerFixture,
     mocked_python_register: MockedPythonRegister,
+    use_poetry_python: bool,
 ) -> None:
-    config.config["virtualenvs"]["use-poetry-python"] = True
+    config.config["virtualenvs"]["use-poetry-python"] = use_poetry_python
     if "VIRTUAL_ENV" in os.environ:
         del os.environ["VIRTUAL_ENV"]
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: https://github.com/orgs/python-poetry/discussions/10523

`use-poetry-python` should only be relevant if no specific python version has been requested.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

This bug originates from #4852 when the condition was not as clear as it is now:

```
if not executable and prefer_active_python:
    executable = self._detect_active_python(io)

...

if executable and not prefer_active_python:
    raise NoCompatiblePythonVersionFound(
        self._poetry.package.python_versions, python_patch
    )
```

## Summary by Sourcery

Ensure `env use` and virtualenv creation fail cleanly when a specifically requested Python version is not compatible with the project, regardless of the `use-poetry-python` setting.

Bug Fixes:
- Prevent creation or activation of virtualenvs when a user explicitly requests an unsupported Python version, independent of the `virtualenvs.use-poetry-python` configuration.

Tests:
- Add tests verifying that `env use` does not create or activate environments for unsupported Python versions and that executable-based venv creation skips compatibility lookups for both values of `use-poetry-python`.

Chores:
- Adjust test fixtures to use a dedicated virtualenv cache directory and assert its initial emptiness before environment creation.