### PR TITLE
Add tests for pbs_installer_supported_arch

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,6 +4,7 @@ import os
 
 from tests.helpers import flatten_dict
 from tests.helpers import isolated_environment
+from tests.helpers import pbs_installer_supported_arch
 
 
 def test_flatten_dict() -> None:
@@ -44,3 +45,15 @@ def test_isolated_environment_updates_environ() -> None:
     with isolated_environment(environ={"NEW_VAR": "new_value"}):
         assert os.environ["NEW_VAR"] == "new_value"
     assert "NEW_VAR" not in os.environ
+
+#---------------------2 new tests-----------------------
+
+def test_pbs_installer_supported_arch_accepts_supported_archs() -> None:
+    assert pbs_installer_supported_arch("x86_64") is True
+    assert pbs_installer_supported_arch("amd64") is True
+    assert pbs_installer_supported_arch("arm64") is True
+
+
+def test_pbs_installer_supported_arch_rejects_unsupported_archs() -> None:
+    assert pbs_installer_supported_arch("sparc") is False
+    assert pbs_installer_supported_arch("mips") is False


### PR DESCRIPTION
Adds unit tests for `pbs_installer_supported_arch` to improve coverage of `tests/helpers.py`.

Resolves: #9161

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Summary by Sourcery

Tests:
- Add tests ensuring pbs_installer_supported_arch returns True for supported architectures and False for unsupported architectures.