### PR TITLE
env activate: fallback to POSIX compatible builtin

### DIFF
--- a/src/poetry/console/commands/env/activate.py
+++ b/src/poetry/console/commands/env/activate.py
@@ -51,8 +51,10 @@ class EnvActivateCommand(EnvCommand):
             command, filename = ".", "activate.ps1"
         elif shell == "cmd":
             command, filename = ".", "activate.bat"
-        else:
+        elif shell in ["bash", "mksh", "zsh"]:
             command, filename = "source", "activate"
+        else:
+            command, filename = ".", "activate"
 
         if (activation_script := env.bin_dir / filename).exists():
             if WINDOWS:

--- a/tests/console/commands/env/test_activate.py
+++ b/tests/console/commands/env/test_activate.py
@@ -24,6 +24,7 @@ def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
 @pytest.mark.parametrize(
     "shell, command, ext",
     (
+        ("dash", ".", ""),
         ("bash", "source", ""),
         ("zsh", "source", ""),
         ("fish", "source", ".fish"),


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

# Rationale

POSIX.1-2024 and earlier standards define the [_dot_][1] special built-in utility. Its command name consists of a single character `.`. Execution of the _source_ command is explicitly unspecified by the standard. Most shells provide this convenient alias, some do not. Notable exception is dash, Debian Almquist shell, which mainly conforms to the POSIX standard and intentionally stays away from bashisms. BusyBox incorporates another ash variant in which the _source_ command may be disabled at configuration time.

In this pull request, `poetry env activate` prints the _source_ command only in shells that guarantied to support it, that is Bash, fish, mksh (MirBSD Korn shell), and Zsh. But fish already has an _if_ branch.

I tested the changes manually in Alpine Docker with above mentioned shells. And dash no longer throws the following error and actually activates environment if any.

```
# eval $(poetry env activate)
dash: 1: eval: source: not found
```

 [1]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#dot

## Summary by Sourcery

Adjust virtual environment activation command selection to be POSIX-compatible across different shells.

Bug Fixes:
- Use the POSIX-compliant '.' builtin instead of 'source' for shells that do not guarantee support for the 'source' command, preventing activation failures in such environments.

Tests:
- Extend env activation tests to cover dash and validate the correct activation command per shell.