### PR TITLE
release: bump version to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [2.3.1] - 2026-01-20
+
+### Fixed
+
+- Fix an issue where cached information about each package was always considered outdated ([#10699](https://github.com/python-poetry/poetry/pull/10699)).
+
+### Docs
+
+- Document SHELL_VERBOSITY environment variable ([#10678](https://github.com/python-poetry/poetry/pull/10678)).
+
+
 ## [2.3.0] - 2026-01-18
 
 ### Added
@@ -2636,7 +2647,8 @@ Initial release
 
 
 
-[Unreleased]: https://github.com/python-poetry/poetry/compare/2.3.0...main
+[Unreleased]: https://github.com/python-poetry/poetry/compare/2.3.1...main
+[2.3.1]: https://github.com/python-poetry/poetry/releases/tag/2.3.1
 [2.3.0]: https://github.com/python-poetry/poetry/releases/tag/2.3.0
 [2.2.1]: https://github.com/python-poetry/poetry/releases/tag/2.2.1
 [2.2.0]: https://github.com/python-poetry/poetry/releases/tag/2.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry"
-version = "2.3.0"
+version = "2.3.1"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.10,<4.0"
 dependencies = [


### PR DESCRIPTION
### Fixed

- Fix an issue where cached information about each package was always considered outdated ([#10699](https://github.com/python-poetry/poetry/pull/10699)).

### Docs

- Document SHELL_VERBOSITY environment variable ([#10678](https://github.com/python-poetry/poetry/pull/10678)).
