### PR TITLE
docs: clarify install vs update command differences

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -475,9 +475,19 @@ poetry init
 The `install` command reads the `pyproject.toml` file from the current project,
 resolves the dependencies, and installs them.
 
+```bash
+poetry install
+```
+
+If there is a `poetry.lock` file in the current directory,
+it will use the exact versions from there instead of resolving them.
+This ensures that everyone using the library will get the same versions of the dependencies.
+
+If there is no `poetry.lock` file, Poetry will create one after dependency resolution.
+
 {{% note %}}
 **When to use `install` vs `update`:**
-- Use `poetry install` to install dependencies as specified in `poetry.lock` (or resolve dependencies and create the lock file if it's missing).
+- Use `poetry install` to install dependencies as specified in `poetry.lock` (or resolve dependencies and create the lock file if it is missing).
   This is what you run after cloning a project. For reproducible installs, prefer `poetry sync`,
   which also removes packages that are not in the lock file.
 - Use `poetry update` when you want to update dependencies to their latest versions (within the constraints from the `pyproject.toml`)
@@ -491,16 +501,6 @@ which is discouraged, or `virtualenvs.options.system-site-packages = true` to ma
 system site-packages available in your virtual environment, you should use `poetry install`
 because `poetry sync` will normally not work well in these cases.
 {{% /note %}}
-
-```bash
-poetry install
-```
-
-If there is a `poetry.lock` file in the current directory,
-it will use the exact versions from there instead of resolving them.
-This ensures that everyone using the library will get the same versions of the dependencies.
-
-If there is no `poetry.lock` file, Poetry will create one after dependency resolution.
 
 If you want to exclude one or more dependency groups for the installation, you can use
 the `--without` option.


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4117

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary
Improves documentation for `install` and `update` commands to address common user confusion.

## Changes
- Added note in `install` section explaining when to use `install` vs `update`
- Clarified that `update` also installs packages after updating the lock file
- Added note that `update` does **not** modify `pyproject.toml`

## Questions Addressed (from issue)
- When doing `update`, are new packages installed?-> Yes
- Is `pyproject.toml` updated? -> No, only `poetry.lock`
- When should one do `install`? → After cloning or for reproducible installs

## Summary by Sourcery

Clarify the behavioral differences between the `poetry install` and `poetry update` commands in the CLI documentation.

Documentation:
- Document when to use `poetry install` versus `poetry update`, emphasizing reproducible installs and lockfile creation.
- Clarify that `poetry update` both updates and installs dependencies while only modifying `poetry.lock` and not `pyproject.toml`, and direct users to `add` for changing version constraints.