### PR TITLE
fix(config): support repository names containing dots

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -29,7 +29,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
 
-    from poetry.config.config_source import ConfigSource
+from poetry.config.config_source import ConfigSource
+from poetry.config.config_source import split_config_key
 
 
 def boolean_validator(val: str) -> bool:
@@ -313,7 +314,7 @@ class Config:
         """
         Retrieve a setting value.
         """
-        keys = setting_name.split(".")
+        keys = split_config_key(setting_name)
         build_config_settings: Mapping[
             NormalizedName, Mapping[str, str | Sequence[str]]
         ] = {}

--- a/src/poetry/config/config_source.py
+++ b/src/poetry/config/config_source.py
@@ -33,6 +33,34 @@ class ConfigSource(ABC):
     def remove_property(self, key: str) -> None: ...
 
 
+def split_config_key(key: str) -> list[str]:
+    parts: list[str] = []
+    current: list[str] = []
+    escaped = False
+
+    for char in key:
+        if escaped:
+            current.append(char)
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == ".":
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+
+    if escaped:
+        current.append("\\")
+
+    parts.append("".join(current))
+    return parts
+
+
+def escape_config_key(key: str) -> str:
+    return key.replace("\\", "\\\\").replace(".", "\\.")
+
+
 @dataclasses.dataclass
 class ConfigSourceMigration:
     old_key: str

--- a/src/poetry/config/dict_config_source.py
+++ b/src/poetry/config/dict_config_source.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from poetry.config.config_source import ConfigSource
 from poetry.config.config_source import PropertyNotFoundError
+from poetry.config.config_source import split_config_key
 
 
 class DictConfigSource(ConfigSource):
@@ -15,7 +16,7 @@ class DictConfigSource(ConfigSource):
         return self._config
 
     def get_property(self, key: str) -> Any:
-        keys = key.split(".")
+        keys = split_config_key(key)
         config = self._config
 
         for i, key in enumerate(keys):
@@ -28,7 +29,7 @@ class DictConfigSource(ConfigSource):
             config = config[key]
 
     def add_property(self, key: str, value: Any) -> None:
-        keys = key.split(".")
+        keys = split_config_key(key)
         config = self._config
 
         for i, key in enumerate(keys):
@@ -42,7 +43,7 @@ class DictConfigSource(ConfigSource):
             config = config[key]
 
     def remove_property(self, key: str) -> None:
-        keys = key.split(".")
+        keys = split_config_key(key)
 
         config = self._config
         for i, key in enumerate(keys):

--- a/src/poetry/config/file_config_source.py
+++ b/src/poetry/config/file_config_source.py
@@ -10,6 +10,7 @@ from tomlkit import table
 from poetry.config.config_source import ConfigSource
 from poetry.config.config_source import PropertyNotFoundError
 from poetry.config.config_source import drop_empty_config_category
+from poetry.config.config_source import split_config_key
 
 
 if TYPE_CHECKING:
@@ -33,7 +34,7 @@ class FileConfigSource(ConfigSource):
         return self._file
 
     def get_property(self, key: str) -> Any:
-        keys = key.split(".")
+        keys = split_config_key(key)
 
         config = self.file.read() if self.file.exists() else {}
 
@@ -49,7 +50,7 @@ class FileConfigSource(ConfigSource):
     def add_property(self, key: str, value: Any) -> None:
         with self.secure() as toml:
             config: dict[str, Any] = toml
-            keys = key.split(".")
+            keys = split_config_key(key)
 
             for i, key in enumerate(keys):
                 if key not in config and i < len(keys) - 1:
@@ -64,7 +65,7 @@ class FileConfigSource(ConfigSource):
     def remove_property(self, key: str) -> None:
         with self.secure() as toml:
             config: dict[str, Any] = toml
-            keys = key.split(".")
+            keys = split_config_key(key)
 
             current_config = config
             for i, key in enumerate(keys):

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -113,7 +113,8 @@ To remove a repository (repo is a short alias for repositories):
 
         from poetry.core.pyproject.exceptions import PyProjectError
 
-        from poetry.config.config import Config
+from poetry.config.config import Config
+from poetry.config.config_source import escape_config_key
         from poetry.config.file_config_source import FileConfigSource
         from poetry.locations import CONFIG_DIR
         from poetry.toml.file import TOMLFile
@@ -182,7 +183,8 @@ To remove a repository (repo is a short alias for repositories):
                     if config.get("repositories") is not None:
                         value = config.get("repositories")
                 else:
-                    repo = config.get(f"repositories.{m.group(1)}")
+                    repository = escape_config_key(m.group(1))
+                    repo = config.get(f"repositories.{repository}")
                     if repo is None:
                         raise ValueError(f"There is no {m.group(1)} repository defined")
 
@@ -221,20 +223,23 @@ To remove a repository (repo is a short alias for repositories):
         if m:
             if not m.group(1):
                 raise ValueError("You cannot remove the [repositories] section")
+            repository = escape_config_key(m.group(1))
 
             if self.option("unset"):
-                repo = config.get(f"repositories.{m.group(1)}")
+                repo = config.get(f"repositories.{repository}")
                 if repo is None:
                     raise ValueError(f"There is no {m.group(1)} repository defined")
 
-                config.config_source.remove_property(f"repositories.{m.group(1)}")
+                config.config_source.remove_property(f"repositories.{repository}")
 
                 return 0
 
             if len(values) == 1:
                 url = values[0]
 
-                config.config_source.add_property(f"repositories.{m.group(1)}.url", url)
+                config.config_source.add_property(
+                    f"repositories.{repository}.url", url
+                )
 
                 return 0
 
@@ -286,9 +291,9 @@ To remove a repository (repo is a short alias for repositories):
             return 0
 
         # handle certs
-        m = re.match(r"certificates\.([^.]+)\.(cert|client-cert)", self.argument("key"))
+        m = re.match(r"certificates\.(.+)\.(cert|client-cert)", self.argument("key"))
         if m:
-            repository = m.group(1)
+            repository = escape_config_key(m.group(1))
             key = m.group(2)
 
             if self.option("unset"):

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -113,8 +113,8 @@ To remove a repository (repo is a short alias for repositories):
 
         from poetry.core.pyproject.exceptions import PyProjectError
 
-from poetry.config.config import Config
-from poetry.config.config_source import escape_config_key
+        from poetry.config.config import Config
+        from poetry.config.config_source import escape_config_key
         from poetry.config.file_config_source import FileConfigSource
         from poetry.locations import CONFIG_DIR
         from poetry.toml.file import TOMLFile
@@ -237,9 +237,7 @@ from poetry.config.config_source import escape_config_key
             if len(values) == 1:
                 url = values[0]
 
-                config.config_source.add_property(
-                    f"repositories.{repository}.url", url
-                )
+                config.config_source.add_property(f"repositories.{repository}.url", url)
 
                 return 0
 

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -226,8 +226,9 @@ To remove a repository (repo is a short alias for repositories):
             repository = escape_config_key(m.group(1))
 
             if self.option("unset"):
-                repo = config.get(f"repositories.{repository}")
-                if repo is None:
+                try:
+                    config.config_source.get_property(f"repositories.{repository}")
+                except PropertyNotFoundError:
                     raise ValueError(f"There is no {m.group(1)} repository defined")
 
                 config.config_source.remove_property(f"repositories.{repository}")

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from poetry.publishing.uploader import Uploader
+from poetry.config.config_source import escape_config_key
 from poetry.utils.authenticator import Authenticator
 
 
@@ -49,7 +50,8 @@ class Publisher:
             repository_name = "pypi"
         else:
             # Retrieving config information
-            url = self._poetry.config.get(f"repositories.{repository_name}.url")
+            repository = escape_config_key(repository_name)
+            url = self._poetry.config.get(f"repositories.{repository}.url")
             if url is None:
                 raise RuntimeError(f"Repository {repository_name} is not defined")
 

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -4,8 +4,8 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from poetry.publishing.uploader import Uploader
 from poetry.config.config_source import escape_config_key
+from poetry.publishing.uploader import Uploader
 from poetry.utils.authenticator import Authenticator
 
 

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -22,6 +22,7 @@ from requests_toolbelt import user_agent
 
 from poetry.__version__ import __version__
 from poetry.config.config import Config
+from poetry.config.config_source import escape_config_key
 from poetry.console.exceptions import ConsoleMessage
 from poetry.console.exceptions import PoetryRuntimeError
 from poetry.exceptions import PoetryError
@@ -50,12 +51,13 @@ class RepositoryCertificateConfig:
         cls, repository: str, config: Config | None
     ) -> RepositoryCertificateConfig:
         config = config if config else Config.create()
+        repository_key = escape_config_key(repository)
 
         verify: str | bool = config.get(
-            f"certificates.{repository}.verify",
-            config.get(f"certificates.{repository}.cert", True),
+            f"certificates.{repository_key}.verify",
+            config.get(f"certificates.{repository_key}.cert", True),
         )
-        client_cert: str = config.get(f"certificates.{repository}.client-cert")
+        client_cert: str = config.get(f"certificates.{repository_key}.client-cert")
 
         return cls(
             cert=Path(verify) if isinstance(verify, str) else None,
@@ -389,7 +391,8 @@ class Authenticator:
         if self._configured_repositories is None:
             self._configured_repositories = {}
             for repository_name in self._config.get("repositories", []):
-                url = self._config.get(f"repositories.{repository_name}.url")
+                repository = escape_config_key(repository_name)
+                url = self._config.get(f"repositories.{repository}.url")
                 self._configured_repositories[repository_name] = (
                     AuthenticatorRepositoryConfig(repository_name, url)
                 )

--- a/tests/config/test_dict_config_source.py
+++ b/tests/config/test_dict_config_source.py
@@ -66,3 +66,20 @@ def test_dict_config_source_get_property_should_raise_if_not_found() -> None:
         PropertyNotFoundError, match=r"Key virtualenvs\.use-poetry-python not in config"
     ):
         _ = config_source.get_property("virtualenvs.use-poetry-python")
+
+
+def test_dict_config_source_escaped_dot_key() -> None:
+    config_source = DictConfigSource()
+
+    config_source.add_property("repositories.foo\\.bar.url", "https://example.com/simple")
+    assert config_source._config == {
+        "repositories": {"foo.bar": {"url": "https://example.com/simple"}}
+    }
+
+    assert (
+        config_source.get_property("repositories.foo\\.bar.url")
+        == "https://example.com/simple"
+    )
+
+    config_source.remove_property("repositories.foo\\.bar.url")
+    assert config_source._config == {"repositories": {"foo.bar": {}}}

--- a/tests/config/test_dict_config_source.py
+++ b/tests/config/test_dict_config_source.py
@@ -71,7 +71,9 @@ def test_dict_config_source_get_property_should_raise_if_not_found() -> None:
 def test_dict_config_source_escaped_dot_key() -> None:
     config_source = DictConfigSource()
 
-    config_source.add_property("repositories.foo\\.bar.url", "https://example.com/simple")
+    config_source.add_property(
+        "repositories.foo\\.bar.url", "https://example.com/simple"
+    )
     assert config_source._config == {
         "repositories": {"foo.bar": {"url": "https://example.com/simple"}}
     }

--- a/tests/config/test_file_config_source.py
+++ b/tests/config/test_file_config_source.py
@@ -89,3 +89,19 @@ def test_file_config_source_get_property_should_raise_if_not_found(
         PropertyNotFoundError, match=r"Key virtualenvs\.use-poetry-python not in config"
     ):
         _ = config_source.get_property("virtualenvs.use-poetry-python")
+
+
+def test_file_config_source_escaped_dot_key(tmp_path: Path) -> None:
+    config = tmp_path.joinpath("config.toml")
+    config.touch()
+
+    config_source = FileConfigSource(TOMLFile(config))
+    config_source.add_property("repositories.foo\\.bar.url", "https://example.com/simple")
+
+    assert config_source._file.read() == {
+        "repositories": {"foo.bar": {"url": "https://example.com/simple"}}
+    }
+    assert (
+        config_source.get_property("repositories.foo\\.bar.url")
+        == "https://example.com/simple"
+    )

--- a/tests/config/test_file_config_source.py
+++ b/tests/config/test_file_config_source.py
@@ -96,7 +96,9 @@ def test_file_config_source_escaped_dot_key(tmp_path: Path) -> None:
     config.touch()
 
     config_source = FileConfigSource(TOMLFile(config))
-    config_source.add_property("repositories.foo\\.bar.url", "https://example.com/simple")
+    config_source.add_property(
+        "repositories.foo\\.bar.url", "https://example.com/simple"
+    )
 
     assert config_source._file.read() == {
         "repositories": {"foo.bar": {"url": "https://example.com/simple"}}

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -237,6 +237,13 @@ def test_display_single_setting(
     assert tester.io.fetch_output() == expected
 
 
+def test_repositories_setting_with_dot_in_name(tester: CommandTester) -> None:
+    tester.execute("repositories.foo.bar.url https://bar.com/simple/")
+    tester.execute("repositories.foo.bar")
+
+    assert tester.io.fetch_output() == "{'url': 'https://bar.com/simple/'}\n"
+
+
 def test_display_single_local_setting(
     command_tester_factory: CommandTesterFactory, fixture_dir: FixtureDirGetter
 ) -> None:

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -238,7 +238,7 @@ def test_display_single_setting(
 
 
 def test_repositories_setting_with_dot_in_name(tester: CommandTester) -> None:
-    tester.execute("repositories.foo.bar.url https://bar.com/simple/")
+    tester.execute("repositories.foo.bar https://bar.com/simple/")
     tester.execute("repositories.foo.bar")
 
     assert tester.io.fetch_output() == "{'url': 'https://bar.com/simple/'}\n"

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -143,6 +143,55 @@ def test_set_http_password_with_dot_in_repo_name(
     assert auth["password"] == "qux"
 
 
+def test_get_http_auth_with_dot_in_repo_name(
+    config: Config, with_fail_keyring: None
+) -> None:
+    config.auth_config_source.add_property(
+        "http-basic.foo\\.bar", {"username": "baz", "password": "qux"}
+    )
+    manager = PasswordManager(config)
+
+    auth = manager.get_http_auth("foo.bar")
+    assert auth.username == "baz"
+    assert auth.password == "qux"
+
+
+def test_delete_http_password_with_dot_in_repo_name(
+    config: Config, with_fail_keyring: None
+) -> None:
+    config.auth_config_source.add_property(
+        "http-basic.foo\\.bar", {"username": "baz", "password": "qux"}
+    )
+    manager = PasswordManager(config)
+
+    manager.delete_http_password("foo.bar")
+    assert config.get("http-basic.foo\\.bar") is None
+
+
+def test_get_http_auth_with_dot_in_repo_name_keyring(
+    config: Config, with_simple_keyring: None, dummy_keyring: DummyBackend
+) -> None:
+    manager = PasswordManager(config)
+    manager.set_http_password("foo.bar", "baz", "qux")
+
+    auth = manager.get_http_auth("foo.bar")
+    assert auth.username == "baz"
+    assert auth.password == "qux"
+    assert dummy_keyring.get_password("poetry-repository-foo.bar", "baz") == "qux"
+
+
+def test_delete_http_password_with_dot_in_repo_name_keyring(
+    config: Config, with_simple_keyring: None, dummy_keyring: DummyBackend
+) -> None:
+    manager = PasswordManager(config)
+    manager.set_http_password("foo.bar", "baz", "qux")
+
+    manager.delete_http_password("foo.bar")
+
+    assert dummy_keyring.get_password("poetry-repository-foo.bar", "baz") is None
+    assert config.get("http-basic.foo\\.bar") is None
+
+
 @pytest.mark.parametrize(
     ("username", "password", "is_valid"),
     [
@@ -207,6 +256,47 @@ def test_set_pypi_token_with_dot_in_repo_name(
     manager.set_pypi_token("foo.bar", "baz")
 
     assert config.get("pypi-token.foo\\.bar") == "baz"
+
+
+def test_get_pypi_token_with_dot_in_repo_name(
+    config: Config, with_fail_keyring: None
+) -> None:
+    config.auth_config_source.add_property("pypi-token.foo\\.bar", "baz")
+    manager = PasswordManager(config)
+
+    assert manager.get_pypi_token("foo.bar") == "baz"
+
+
+def test_delete_pypi_token_with_dot_in_repo_name(
+    config: Config, with_fail_keyring: None
+) -> None:
+    config.auth_config_source.add_property("pypi-token.foo\\.bar", "baz")
+    manager = PasswordManager(config)
+
+    manager.delete_pypi_token("foo.bar")
+    assert config.get("pypi-token.foo\\.bar") is None
+
+
+def test_get_pypi_token_with_dot_in_repo_name_keyring(
+    config: Config, with_simple_keyring: None, dummy_keyring: DummyBackend
+) -> None:
+    manager = PasswordManager(config)
+    manager.set_pypi_token("foo.bar", "baz")
+
+    assert manager.get_pypi_token("foo.bar") == "baz"
+    assert (
+        dummy_keyring.get_password("poetry-repository-foo.bar", "__token__") == "baz"
+    )
+
+
+def test_delete_pypi_token_with_dot_in_repo_name_keyring(
+    config: Config, with_simple_keyring: None, dummy_keyring: DummyBackend
+) -> None:
+    manager = PasswordManager(config)
+    manager.set_pypi_token("foo.bar", "baz")
+
+    manager.delete_pypi_token("foo.bar")
+    assert dummy_keyring.get_password("poetry-repository-foo.bar", "__token__") is None
 
 
 def test_get_pypi_token_with_unavailable_backend(

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -132,6 +132,17 @@ def test_set_http_password_with_unavailable_backend(
     assert auth["password"] == "baz"
 
 
+def test_set_http_password_with_dot_in_repo_name(
+    config: Config, with_fail_keyring: None
+) -> None:
+    manager = PasswordManager(config)
+    manager.set_http_password("foo.bar", "baz", "qux")
+
+    auth = config.get("http-basic.foo\\.bar")
+    assert auth["username"] == "baz"
+    assert auth["password"] == "qux"
+
+
 @pytest.mark.parametrize(
     ("username", "password", "is_valid"),
     [
@@ -187,6 +198,15 @@ def test_set_pypi_token_with_unavailable_backend(
     manager.set_pypi_token("foo", "baz")
 
     assert config.get("pypi-token.foo") == "baz"
+
+
+def test_set_pypi_token_with_dot_in_repo_name(
+    config: Config, with_fail_keyring: None
+) -> None:
+    manager = PasswordManager(config)
+    manager.set_pypi_token("foo.bar", "baz")
+
+    assert config.get("pypi-token.foo\\.bar") == "baz"
 
 
 def test_get_pypi_token_with_unavailable_backend(

--- a/tests/utils/test_password_manager.py
+++ b/tests/utils/test_password_manager.py
@@ -284,9 +284,7 @@ def test_get_pypi_token_with_dot_in_repo_name_keyring(
     manager.set_pypi_token("foo.bar", "baz")
 
     assert manager.get_pypi_token("foo.bar") == "baz"
-    assert (
-        dummy_keyring.get_password("poetry-repository-foo.bar", "__token__") == "baz"
-    )
+    assert dummy_keyring.get_password("poetry-repository-foo.bar", "__token__") == "baz"
 
 
 def test_delete_pypi_token_with_dot_in_repo_name_keyring(


### PR DESCRIPTION
## Summary
- support escaped-dot key segments in config path parsing (`foo\.bar` stays one segment)
- escape dynamic repository names when reading/writing settings for:
  - `repositories.<name>.url`
  - `http-basic.<name>` / `pypi-token.<name>`
  - `certificates.<name>.*`
- update repository/certificate related command handling in `poetry config`
- add coverage for escaped-dot behavior in config sources and password manager

Fixes #1328.

## Testing
- `pytest -q -o addopts='' tests/config/test_dict_config_source.py tests/config/test_file_config_source.py tests/utils/test_password_manager.py`

## Notes
- `tests/console/commands/test_config.py` includes a new dotted-repository test, but this file could not be run locally in this environment because `deepdiff` is missing.

## Summary by Sourcery

Support configuration keys and repository names containing dots by introducing escaped-dot handling in config key parsing and applying it across repository, certificate, and credential configuration.

Bug Fixes:
- Ensure config access for repositories, certificates, and credentials works when repository names contain dots by escaping those names in config keys.

Enhancements:
- Introduce shared helpers to split and escape config keys with support for escaped dots and use them in config, dict/file config sources, publishing, authentication, and password management code paths.

Tests:
- Add tests covering escaped-dot behavior for dict and file config sources, password manager HTTP auth and PyPI token handling, and CLI config commands with dotted repository names.