### PR TITLE
fix: suggest `poetry self lock` for self commands (#10536)

### DIFF
--- a/src/poetry/console/commands/self/self_command.py
+++ b/src/poetry/console/commands/self/self_command.py
@@ -143,6 +143,7 @@ class SelfCommand(InstallerCommand):
         # unexpected consequences.
 
         self.reset()
+        self.installer.set_lock_command_hint("poetry self lock")
 
         with directory(self.system_pyproject.parent):
             return self._system_project_handle()

--- a/src/poetry/console/commands/self/show/__init__.py
+++ b/src/poetry/console/commands/self/show/__init__.py
@@ -38,6 +38,10 @@ file.
 """
 
     @property
+    def _lock_command_hint(self) -> str:
+        return "poetry self lock"
+
+    @property
     def activated_groups(self) -> set[NormalizedName]:
         if self.option("addons", False):
             return {SelfCommand.ADDITIONAL_PACKAGE_GROUP}

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -48,6 +48,10 @@ class ShowCommand(GroupCommand, EnvCommand):
     name = "show"
     description = "Shows information about packages."
 
+    @property
+    def _lock_command_hint(self) -> str:
+        return "poetry lock"
+
     arguments: ClassVar[list[Argument]] = [
         argument("package", "The package to inspect", optional=True)
     ]
@@ -147,8 +151,8 @@ lists all packages available."""
 
         if not self.poetry.locker.is_locked():
             self.line_error(
-                "<error>Error: poetry.lock not found. Run `poetry lock` to create"
-                " it.</error>"
+                "<error>Error: poetry.lock not found."
+                f" Run `{self._lock_command_hint}` to create it.</error>"
             )
             return 1
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -61,6 +61,7 @@ class Installer:
         self._groups: Iterable[NormalizedName] | None = None
         self._skip_directory = False
         self._lock = False
+        self._lock_command_hint = "poetry lock"
 
         self._whitelist: list[NormalizedName] = []
 
@@ -94,6 +95,11 @@ class Installer:
 
     def set_locker(self, locker: Locker) -> Installer:
         self._locker = locker
+
+        return self
+
+    def set_lock_command_hint(self, hint: str) -> Installer:
+        self._lock_command_hint = hint
 
         return self
 
@@ -266,7 +272,7 @@ class Installer:
             if not self._locker.is_fresh():
                 raise ValueError(
                     "pyproject.toml changed significantly since poetry.lock was last"
-                    " generated. Run `poetry lock` to fix the lock file."
+                    f" generated. Run `{self._lock_command_hint}` to fix the lock file."
                 )
             if not (reresolve or self._locker.is_locked_groups_and_markers()):
                 if self._io.is_verbose():

--- a/tests/console/commands/self/test_show.py
+++ b/tests/console/commands/self/test_show.py
@@ -70,3 +70,22 @@ def test_show_format(tester: CommandTester, options: str) -> None:
     )
     assert tester.execute(options) == 0
     assert tester.io.fetch_output().strip() == expected
+
+
+def test_show_errors_without_lock_file_suggests_self_lock(
+    tester: CommandTester,
+) -> None:
+    command = tester.command
+    assert isinstance(command, SelfCommand)
+    # Ensure the system pyproject exists but the lock file doesn't
+    system_pyproject_file = command.system_pyproject
+    system_pyproject_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = system_pyproject_file.parent.joinpath("poetry.lock")
+    if lock_path.exists():
+        lock_path.unlink()
+
+    tester.execute()
+
+    expected = "Error: poetry.lock not found. Run `poetry self lock` to create it.\n"
+    assert tester.io.fetch_error() == expected
+    assert tester.status_code == 1

--- a/tests/installation/test_installer.py
+++ b/tests/installation/test_installer.py
@@ -228,6 +228,19 @@ def test_not_fresh_lock(installer: Installer, locker: Locker) -> None:
         installer.run()
 
 
+def test_not_fresh_lock_custom_hint(installer: Installer, locker: Locker) -> None:
+    locker.locked().fresh(False)
+    installer.set_lock_command_hint("poetry self lock")
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "pyproject.toml changed significantly since poetry.lock was last generated. "
+            "Run `poetry self lock` to fix the lock file."
+        ),
+    ):
+        installer.run()
+
+
 def test_run_with_dependencies(
     installer: Installer, locker: Locker, repo: Repository, package: ProjectPackage
 ) -> None:


### PR DESCRIPTION
## Summary
- When `poetry self` subcommands (e.g. `self install`, `self sync`, `self show`) encounter an outdated or missing lock file, the error message now correctly suggests `poetry self lock` instead of `poetry lock`
- Added `set_lock_command_hint()` method to `Installer` to allow customizing the lock command suggestion in error messages
- Added `_lock_command_hint` property to `ShowCommand` (overridden in `SelfShowCommand`) for the "lock not found" error message

Fixes #10536

## Test plan
- [x] Existing `test_not_fresh_lock` test continues to verify the default `poetry lock` suggestion
- [x] New `test_not_fresh_lock_custom_hint` test verifies the `poetry self lock` suggestion when the hint is set
- [x] New `test_show_errors_without_lock_file_suggests_self_lock` test verifies `poetry self show` suggests `poetry self lock`
- [x] All existing self command tests pass (31 passed, 1 skipped)
- [x] All existing show and check command lock-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update lock-file related error hints so self subcommands correctly reference `poetry self lock` and make the installer’s lock hint configurable.

Bug Fixes:
- Correct self command error messages to suggest `poetry self lock` when the self lock file is missing or outdated.

Enhancements:
- Add configurable lock command hint to the installer and show command so different command contexts can customize lock-related guidance.

Tests:
- Extend installer and self show tests to cover custom lock command hints and the new `poetry self lock` suggestion for self commands.