### PR TITLE
Add test for Git LFS repository cloning

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -616,7 +616,7 @@ version = "1.2.1"
 description = "Python Git Library"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "dulwich-1.2.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e45a68da922a4abe8fd015ed020ec0123ee58176a6984a34d2a2c74c959e45d3"},
     {file = "dulwich-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e88fd960a9327d87556a3bad76ad84b6346d3a07409fe8f081877a775977c86b"},
@@ -2025,7 +2025,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "python_version < \"3.13\"", dev = "python_version == \"3.10\"", github-actions = "python_version == \"3.10\"", test = "python_version == \"3.10\""}
+markers = {main = "python_version < \"3.13\"", dev = "python_version == \"3.10\"", github-actions = "python_version == \"3.10\"", test = "python_version < \"3.12\""}
 
 [[package]]
 name = "urllib3"
@@ -2267,4 +2267,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "5cfdc2e870f25504fe57aa00e30688d352a4b6f9ad42d49ce20fcdb4f2c29a77"
+content-hash = "744c205ce298c167a6965c34382a9efc5309c6e4051cc9c5215adecf217244da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ pytest-cov = ">=4.0"
 pytest-mock = ">=3.9"
 pytest-randomly = ">=3.12"
 pytest-xdist = { version = ">=3.1", extras = ["psutil"] }
+dulwich = ">=1.2.1"
 
 [tool.poetry.group.typing.dependencies]
 mypy = ">=1.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ pre-commit = ">=2.10"
 [tool.poetry.group.test.dependencies]
 coverage = ">=7.2.0"
 deepdiff = ">=6.3"
+# test_clone_with_lfs_files relies on being able to use being able to
+# use locally cloned LFS stores, which requires dulwich>=1.2.1
+dulwich = ">=1.2.1"
 responses = ">=0.25.8"
 jaraco-classes = ">=3.3.1"
 pytest = ">=9.0"
@@ -79,7 +82,6 @@ pytest-cov = ">=4.0"
 pytest-mock = ">=3.9"
 pytest-randomly = ">=3.12"
 pytest-xdist = { version = ">=3.1", extras = ["psutil"] }
-dulwich = ">=1.2.1"
 
 [tool.poetry.group.typing.dependencies]
 mypy = ">=1.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,8 @@ pre-commit = ">=2.10"
 [tool.poetry.group.test.dependencies]
 coverage = ">=7.2.0"
 deepdiff = ">=6.3"
-# test_clone_with_lfs_files relies on being able to use being able to
-# use locally cloned LFS stores, which requires dulwich>=1.2.1
+# test_clone_with_lfs_files relies on being able to use
+# locally cloned LFS stores, which requires dulwich>=1.2.1
 dulwich = ">=1.2.1"
 responses = ">=0.25.8"
 jaraco-classes = ">=3.3.1"

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -455,3 +455,79 @@ def test_clone_legacy_strips_ref_prefixes(
 
     mock_clone.assert_called_once()
     mock_checkout.assert_called_once_with(expected_checkout, target)
+
+
+@pytest.mark.skip_git_mock
+def test_clone_with_lfs_files(tmp_path: Path) -> None:
+    """Test cloning a repository with Git LFS files (issue #8723)."""
+    from dulwich import porcelain
+    from dulwich.lfs import LFSStore
+
+    # Create a source repository with LFS support
+    source_path = tmp_path / "source-repo"
+    source_path.mkdir()
+    repo = Repo.init(str(source_path))
+
+    # Set up LFS in the repository
+    lfs_dir = source_path / ".git" / "lfs"
+    lfs_dir.mkdir(parents=True)
+    lfs_store = LFSStore.create(str(lfs_dir))
+
+    # Configure .gitattributes to track large files with LFS
+    gitattributes = source_path / ".gitattributes"
+    gitattributes.write_text("*.bin filter=lfs diff=lfs merge=lfs -text\n")
+    porcelain.add(repo, str(gitattributes))
+
+    # Create a regular file
+    regular_file = source_path / "regular.txt"
+    regular_file.write_text("This is a regular file")
+    porcelain.add(repo, str(regular_file))
+
+    # Create an LFS file with a pointer
+    lfs_content = b"This is a large binary file content for LFS storage"
+    lfs_file = source_path / "large.bin"
+
+    # Store the actual content in LFS store and create pointer
+    lfs_object_id = lfs_store.write_object([lfs_content])
+    lfs_pointer = (
+        f"version https://git-lfs.github.com/spec/v1\n"
+        f"oid sha256:{lfs_object_id}\n"
+        f"size {len(lfs_content)}\n"
+    )
+    lfs_file.write_text(lfs_pointer)
+    porcelain.add(repo, str(lfs_file))
+
+    # Commit the files
+    porcelain.commit(
+        repo,
+        message=b"Add files with LFS support",
+        author=b"Test <test@example.com>",
+        committer=b"Test <test@example.com>",
+    )
+
+    # Clone the repository
+    source_root_dir = tmp_path / "clone-root"
+    source_root_dir.mkdir()
+    Git.clone(
+        url=source_path.as_uri(),
+        source_root=source_root_dir,
+        name="clone-test",
+    )
+
+    # Verify the clone succeeded
+    clone_dir = source_root_dir / "clone-test"
+    assert (clone_dir / ".git").is_dir()
+
+    # Verify regular file is present
+    assert (clone_dir / "regular.txt").exists()
+    assert (clone_dir / "regular.txt").read_text() == "This is a regular file"
+
+    # Verify .gitattributes is present
+    assert (clone_dir / ".gitattributes").exists()
+    assert "filter=lfs" in (clone_dir / ".gitattributes").read_text()
+
+    # Verify LFS file is present with actual content (not just pointer)
+    # The LFS system should automatically retrieve the actual content
+    assert (clone_dir / "large.bin").exists()
+    lfs_file_content = (clone_dir / "large.bin").read_bytes()
+    assert lfs_file_content == lfs_content

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -503,6 +503,7 @@ def test_clone_with_lfs_files(tmp_path: Path) -> None:
         message=b"Add files with LFS support",
         author=b"Test <test@example.com>",
         committer=b"Test <test@example.com>",
+        sign=False,
     )
 
     # Clone the repository


### PR DESCRIPTION
Verifies that Poetry can successfully clone Git repositories that use Git Large File Storage (LFS) and that LFS files are properly retrieved with their actual content rather than just pointer files.

Note that while LFS support works in Dulwich >=1, the tests specifically
rely on it being able to use locally cloned LFS stores,
which requires dulwich 1.2.1 (hence the requirement of dulwich 1.2.1 in dev dependencies).

Resolves: #8723

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

## Summary by Sourcery

Tests:
- Add an integration-style test that initializes a Git repo with Git LFS configuration and verifies Poetry can clone it with LFS files materialized to their real content.