### PR TITLE
docs: update README to use PEP 735 dependency-groups syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,12 @@ python = ">=3.9,<4.0"
 tomli = { allow-prereleases = true }
 
 # Dependency groups are supported for organizing your dependencies
-[tool.poetry.group.dev.dependencies]
-pytest = "^7.1.2"
-pytest-cov = "^3.0"
+[dependency-groups]
+dev = ["pytest>=7.1.2", "pytest-cov>=3.0"]
+docs = ["sphinx>=5.1.1"]
 
 # ...and can be installed only when explicitly requested
 # via 'poetry install --with docs'
-[tool.poetry.group.docs]
-optional = true
-[tool.poetry.group.docs.dependencies]
-Sphinx = "^5.1.1"
 ```
 
 ## Installation


### PR DESCRIPTION
Update example in README to use the new [dependency-groups] table syntax instead of Poetry-specific [tool.poetry.group.*] format, as Poetry 2.2.0 now supports PEP 735.

Closes #10548

## Summary by Sourcery

Documentation:
- Revise README dependency group example to use the standard [dependency-groups] table instead of Poetry-specific [tool.poetry.group.*] configuration.