### PR TITLE
Improve example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ based project format.
 
 ```toml
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [project]


### PR DESCRIPTION
This PR improves the example in the main README.md page:

- Add `build-system` to the top. This was missing before, but is increasingly important to specify with modern Python ecosystems.
- Update `license` and add `license-files`, as documented [here](https://python-poetry.org/docs/pyproject/#license)

## Summary by Sourcery

Update the README’s pyproject.toml example to reflect current recommended Poetry configuration.

Documentation:
- Document the required Poetry build-system section in the example pyproject.toml.
- Clarify license configuration in the example by switching to the string form and adding license-files.