### PR TITLE
fix(publish): normalize legacy repository URL trailing slash

### DIFF
--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import urllib.parse
 
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,16 @@ if TYPE_CHECKING:
     from poetry.poetry import Poetry
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_legacy_repository_url(url: str) -> str:
+    parsed = urllib.parse.urlsplit(url)
+
+    if parsed.path.endswith("/legacy") and not parsed.path.endswith("/legacy/"):
+        parsed = parsed._replace(path=f"{parsed.path}/")
+        return urllib.parse.urlunsplit(parsed)
+
+    return url
 
 
 class Publisher:
@@ -52,6 +63,7 @@ class Publisher:
             url = self._poetry.config.get(f"repositories.{repository_name}.url")
             if url is None:
                 raise RuntimeError(f"Repository {repository_name} is not defined")
+            url = _normalize_legacy_repository_url(url)
 
         if not (username and password):
             # Check if we have a token first


### PR DESCRIPTION
Fixes #6687.

When a repository upload URL ends with /legacy (no trailing slash), some servers respond with a redirect that can cause uploads to silently fail. Poetry now normalizes legacy upload URLs to ensure they end with /legacy/.

Test:
- python -m pytest -o addopts='' tests/publishing/test_publisher.py

## Summary by Sourcery

Normalize legacy repository upload URLs used during publishing to avoid issues caused by missing trailing slashes.

Bug Fixes:
- Ensure legacy repository URLs ending with /legacy are normalized to include a trailing slash before publishing to prevent redirect-related upload failures.

Tests:
- Add a publishing test verifying that legacy repository URLs without a trailing slash are normalized before invoking the uploader.