### PR TITLE
fix: improve lock suggestion for poetry self commands

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -605,6 +605,7 @@ class Application(BaseApplication):
 
     @staticmethod
     def configure_installer_for_command(command: InstallerCommand, io: IO) -> None:
+        from poetry.console.commands.self.self_command import SelfCommand
         from poetry.installation.installer import Installer
 
         poetry = command.poetry
@@ -617,6 +618,7 @@ class Application(BaseApplication):
             poetry.config,
             disable_cache=poetry.disable_cache,
             build_constraints=poetry.build_constraints,
+            is_self_command=isinstance(command, SelfCommand),
         )
         command.set_installer(installer)
 

--- a/src/poetry/installation/installer.py
+++ b/src/poetry/installation/installer.py
@@ -46,6 +46,7 @@ class Installer:
         disable_cache: bool = False,
         *,
         build_constraints: Mapping[NormalizedName, list[Dependency]] | None = None,
+        is_self_command: bool = False,
     ) -> None:
         self._io = io
         self._env = env
@@ -53,6 +54,7 @@ class Installer:
         self._locker = locker
         self._pool = pool
         self._config = config
+        self._is_self_command = is_self_command
 
         self._dry_run = False
         self._requires_synchronization = False
@@ -264,9 +266,13 @@ class Installer:
             self._io.write_line("<info>Installing dependencies from lock file</>")
 
             if not self._locker.is_fresh():
+                if self._is_self_command:
+                    lock_cmd = "poetry self lock"
+                else:
+                    lock_cmd = "poetry lock"
                 raise ValueError(
                     "pyproject.toml changed significantly since poetry.lock was last"
-                    " generated. Run `poetry lock` to fix the lock file."
+                    f" generated. Run `{lock_cmd}` to fix the lock file."
                 )
             if not (reresolve or self._locker.is_locked_groups_and_markers()):
                 if self._io.is_verbose():


### PR DESCRIPTION
When the lock file is outdated and a poetry self command is run, the error message now also suggests 'poetry self lock' as an alternative.

Closes #10536

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Enhancements:
- Improve guidance in the lock-file-out-of-date error message by suggesting `poetry self lock` when using `poetry self` commands.