### PR TITLE
Fix file scripts not copied to bin on poetry install

### DIFF
--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -217,7 +217,13 @@ class EditableBuilder(Builder):
             "scripts", {}
         ).items():
             if isinstance(specification, dict) and specification.get("type") == "file":
-                source = specification["reference"]
+                source = specification.get("reference")
+                if not source:
+                    self._io.write_error_line(
+                        f"  - File script <c2>{name}</c2> is missing"
+                        " a \"reference\" field"
+                    )
+                    continue
                 source_path = self._path / source
 
                 if not source_path.exists():

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -213,15 +213,13 @@ class EditableBuilder(Builder):
                 added.append(cmd_script)
 
         # Handle file scripts (type = "file" in [tool.poetry.scripts])
-        for name, specification in self._poetry.local_config.get(
-            "scripts", {}
-        ).items():
+        for name, specification in self._poetry.local_config.get("scripts", {}).items():
             if isinstance(specification, dict) and specification.get("type") == "file":
                 source = specification.get("reference")
                 if not source:
                     self._io.write_error_line(
                         f"  - File script <c2>{name}</c2> is missing"
-                        " a \"reference\" field"
+                        ' a "reference" field'
                     )
                     continue
                 source_path = self._path / source

--- a/tests/fixtures/file_scripts_dir_ref_project/bin/some-directory/.gitkeep
+++ b/tests/fixtures/file_scripts_dir_ref_project/bin/some-directory/.gitkeep
@@ -1,0 +1,1 @@
+# Marker so git tracks the directory needed by test_builder_skips_directory_file_script

--- a/tests/fixtures/file_scripts_dir_ref_project/file_scripts_dir_ref_project/__init__.py
+++ b/tests/fixtures/file_scripts_dir_ref_project/file_scripts_dir_ref_project/__init__.py
@@ -1,0 +1,2 @@
+def main():
+    print("Hello from console entry point")

--- a/tests/fixtures/file_scripts_dir_ref_project/file_scripts_dir_ref_project/__init__.py
+++ b/tests/fixtures/file_scripts_dir_ref_project/file_scripts_dir_ref_project/__init__.py
@@ -1,2 +1,5 @@
-def main():
-    print("Hello from console entry point")
+from __future__ import annotations
+
+
+def main() -> None:
+    return None

--- a/tests/fixtures/file_scripts_dir_ref_project/pyproject.toml
+++ b/tests/fixtures/file_scripts_dir_ref_project/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "file-scripts-dir-ref-project"
+version = "1.0.0"
+description = "A project with a file script referencing a directory."
+authors = ["Test Author <test@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+[tool.poetry.scripts]
+dir-script = { reference = "bin/some-directory", type = "file" }
+console-entry = "file_scripts_dir_ref_project:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/fixtures/file_scripts_missing_ref_project/file_scripts_missing_ref_project/__init__.py
+++ b/tests/fixtures/file_scripts_missing_ref_project/file_scripts_missing_ref_project/__init__.py
@@ -1,0 +1,2 @@
+def main():
+    print("Hello from console entry point")

--- a/tests/fixtures/file_scripts_missing_ref_project/file_scripts_missing_ref_project/__init__.py
+++ b/tests/fixtures/file_scripts_missing_ref_project/file_scripts_missing_ref_project/__init__.py
@@ -1,2 +1,5 @@
-def main():
-    print("Hello from console entry point")
+from __future__ import annotations
+
+
+def main() -> None:
+    return None

--- a/tests/fixtures/file_scripts_missing_ref_project/pyproject.toml
+++ b/tests/fixtures/file_scripts_missing_ref_project/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "file-scripts-missing-ref-project"
+version = "1.0.0"
+description = "A project with a file script referencing a non-existent file."
+authors = ["Test Author <test@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+[tool.poetry.scripts]
+missing-script = { reference = "bin/does-not-exist.sh", type = "file" }
+console-entry = "file_scripts_missing_ref_project:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/fixtures/file_scripts_no_ref_field_project/file_scripts_no_ref_field_project/__init__.py
+++ b/tests/fixtures/file_scripts_no_ref_field_project/file_scripts_no_ref_field_project/__init__.py
@@ -1,0 +1,2 @@
+def main():
+    print("Hello from console entry point")

--- a/tests/fixtures/file_scripts_no_ref_field_project/file_scripts_no_ref_field_project/__init__.py
+++ b/tests/fixtures/file_scripts_no_ref_field_project/file_scripts_no_ref_field_project/__init__.py
@@ -1,2 +1,5 @@
-def main():
-    print("Hello from console entry point")
+from __future__ import annotations
+
+
+def main() -> None:
+    return None

--- a/tests/fixtures/file_scripts_no_ref_field_project/pyproject.toml
+++ b/tests/fixtures/file_scripts_no_ref_field_project/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "file-scripts-no-ref-field-project"
+version = "1.0.0"
+description = "A project with a file script missing the reference field."
+authors = ["Test Author <test@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+[tool.poetry.scripts]
+no-ref-script = { type = "file" }
+console-entry = "file_scripts_no_ref_field_project:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/fixtures/file_scripts_project/bin/my-script.sh
+++ b/tests/fixtures/file_scripts_project/bin/my-script.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Hello from file script"

--- a/tests/fixtures/file_scripts_project/file_scripts_project/__init__.py
+++ b/tests/fixtures/file_scripts_project/file_scripts_project/__init__.py
@@ -1,0 +1,2 @@
+def main():
+    print("Hello from console entry point")

--- a/tests/fixtures/file_scripts_project/file_scripts_project/__init__.py
+++ b/tests/fixtures/file_scripts_project/file_scripts_project/__init__.py
@@ -1,2 +1,5 @@
-def main():
-    print("Hello from console entry point")
+from __future__ import annotations
+
+
+def main() -> None:
+    return None

--- a/tests/fixtures/file_scripts_project/pyproject.toml
+++ b/tests/fixtures/file_scripts_project/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "file-scripts-project"
+version = "1.0.0"
+description = "A project with file scripts."
+authors = ["Test Author <test@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+[tool.poetry.scripts]
+my-script = { reference = "bin/my-script.sh", type = "file" }
+console-entry = "file_scripts_project:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -422,3 +422,43 @@ def test_builder_catches_bad_scripts_too_many_colon(
     assert "foo::bar" in msg
     # and some hint about what is wrong
     assert "Too many" in msg
+
+
+@pytest.fixture()
+def file_scripts_poetry(fixture_dir: FixtureDirGetter) -> Poetry:
+    poetry = Factory().create_poetry(fixture_dir("file_scripts_project"))
+    return poetry
+
+
+def test_builder_installs_file_scripts(
+    file_scripts_poetry: Poetry,
+    tmp_path: Path,
+) -> None:
+    env_manager = EnvManager(file_scripts_poetry)
+    venv_path = tmp_path / "venv"
+    env_manager.build_venv(venv_path)
+    tmp_venv = VirtualEnv(venv_path)
+
+    builder = EditableBuilder(file_scripts_poetry, tmp_venv, NullIO())
+    builder.build()
+
+    # The file script should be copied to the venv bin directory
+    script_path = tmp_venv._bin_dir.joinpath("my-script")
+    assert script_path.exists(), (
+        f"File script 'my-script' was not copied to {tmp_venv._bin_dir}"
+    )
+
+    # Check script content matches the source
+    source_content = (
+        file_scripts_poetry.file.path.parent / "bin" / "my-script.sh"
+    ).read_text(encoding="utf-8")
+    assert script_path.read_text(encoding="utf-8") == source_content
+
+    # Check the file is executable
+    assert os.access(script_path, os.X_OK)
+
+    # The console entry point should also be installed
+    console_script = tmp_venv._bin_dir.joinpath("console-entry")
+    assert console_script.exists(), (
+        f"Console script 'console-entry' was not installed to {tmp_venv._bin_dir}"
+    )

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -518,27 +518,13 @@ def test_builder_skips_directory_file_script(
 
 def test_builder_skips_file_script_missing_reference_field(
     fixture_dir: FixtureDirGetter,
-    tmp_path: Path,
 ) -> None:
-    from cleo.io.buffered_io import BufferedIO
-
-    poetry = Factory().create_poetry(
-        fixture_dir("file_scripts_no_ref_field_project")
-    )
-    env_manager = EnvManager(poetry)
-    venv_path = tmp_path / "venv"
-    env_manager.build_venv(venv_path)
-    tmp_venv = VirtualEnv(venv_path)
-
-    io = BufferedIO()
-    builder = EditableBuilder(poetry, tmp_venv, io)
-    builder.build()
-
-    # The file script with missing reference field must not be created
-    script_path = tmp_venv._bin_dir.joinpath("no-ref-script")
-    assert not script_path.exists()
-
-    # The error message should be logged
-    error_output = io.fetch_error()
-    assert "no-ref-script" in error_output
-    assert "reference" in error_output
+    """A file script with no reference field is rejected at config validation
+    time (poetry-core's extra-scripts schema requires `reference`), so this
+    case is never reached by EditableBuilder. This test documents the
+    schema-level enforcement.
+    """
+    with pytest.raises(RuntimeError, match="The Poetry configuration is invalid"):
+        Factory().create_poetry(
+            fixture_dir("file_scripts_no_ref_field_project")
+        )

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -525,6 +525,4 @@ def test_builder_skips_file_script_missing_reference_field(
     schema-level enforcement.
     """
     with pytest.raises(RuntimeError, match="The Poetry configuration is invalid"):
-        Factory().create_poetry(
-            fixture_dir("file_scripts_no_ref_field_project")
-        )
+        Factory().create_poetry(fixture_dir("file_scripts_no_ref_field_project"))


### PR DESCRIPTION
## Summary

Fixes #10664

When `pyproject.toml` defines scripts with `type = "file"`:

```toml
[tool.poetry.scripts]
my-command = { reference = "my-script.sh", type = "file" }
```

`poetry install` does not copy the referenced file into the virtualenv's `bin/` directory. Only `poetry build` handles these correctly (via `WheelBuilder._copy_file_scripts`). Running `poetry run my-command` after install produces a warning about the script not being installed.

### Changes

- **`src/poetry/masonry/builders/editable.py`**: After processing console script entry points in `_add_scripts()`, added a second pass that iterates over `[tool.poetry.scripts]` entries, identifies those with `type = "file"`, validates that the referenced file exists, and copies it to the virtualenv's script directory with executable permissions. This mirrors what `WheelBuilder._copy_file_scripts` already does for built wheels.

- **Test fixture + test**: Added `tests/fixtures/file_scripts_project/` with a project that has both a file script and a console entry point, and a test that verifies both are installed correctly during an editable build.

## Test plan

- [ ] New test `test_builder_installs_file_scripts` verifies file scripts are copied to the venv bin directory with correct content and permissions
- [ ] Existing tests continue to pass (console scripts, bad scripts, etc.)
- [ ] Manual verification: create a project with `type = "file"` script, run `poetry install`, confirm the script appears in the venv's `bin/`

## Summary by Sourcery

Ensure editable installs copy file-based scripts into the virtualenv alongside console entry points.

Bug Fixes:
- Fix editable installations not copying file-based scripts defined in [tool.poetry.scripts] into the virtualenv bin directory.

Tests:
- Add fixture project and test verifying file-based scripts and console entry points are installed with correct content and executability during editable builds.