### PR TITLE
Update docs with 3.10+ requirement

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -18,7 +18,7 @@ Poetry offers a lockfile to ensure repeatable installs, and can build your proje
 
 ## System requirements
 
-Poetry requires **Python 3.9+**. It is multi-platform and the goal is to make it work equally well
+Poetry requires **Python 3.10+**. It is multi-platform and the goal is to make it work equally well
 on Linux, macOS and Windows.
 
 ## Installation


### PR DESCRIPTION
I found this issue while investigating why a Python 3.9 CI environment lost the ability to run Poetry.

# Pull Request Check List

Related-to: https://github.com/python-poetry/poetry/pull/10634
Related-to: https://github.com/DataBiosphere/calhoun/pull/83

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Documentation:
- Document Python 3.10+ as the minimum required version for Poetry instead of Python 3.9+.