### PR TITLE
Fix _remove to catch EnvCommandError instead of CalledProcessError

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait
 from pathlib import Path
-from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -624,7 +623,7 @@ class Executor:
 
         try:
             return self.run_pip("uninstall", package.name, "-y")
-        except CalledProcessError as e:
+        except EnvCommandError as e:
             if "not installed" in str(e):
                 return 0
 


### PR DESCRIPTION
## Problem

`Executor._remove()` catches `CalledProcessError`, but `run_pip()` never raises that — it wraps it inside `EnvCommandError`:

```python
def run_pip(self, *args, **kwargs) -> int:
    try:
        self._env.run_pip(*args, **kwargs)
    except EnvCommandError as e:
        ...
        raise  # re-raises EnvCommandError, not CalledProcessError
    return 0
```

So the handler in `_remove()`:

```python
except CalledProcessError as e:
    if "not installed" in str(e):
        return 0
```

is dead code. When pip reports "not installed", the `EnvCommandError` propagates to `_execute_operation`, which treats it as a fatal error and sets `self._shutdown = True`, aborting the entire installation.

This can happen during `poetry update` if a package was already removed externally (e.g. `pip uninstall` by hand).

## Fix

Catch `EnvCommandError` instead of `CalledProcessError`, and remove the now-unused import.

## Summary by Sourcery

Bug Fixes:
- Prevent poetry installations from aborting when attempting to uninstall packages that are already not installed by catching EnvCommandError instead of CalledProcessError in the removal logic.