### PR TITLE
Fix sdist directory name extraction — rstrip misused as suffix removal

### DIFF
--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -108,7 +108,14 @@ class Chef:
             if len(elements) == 1 and elements[0].is_dir():
                 sdist_dir = elements[0]
             else:
-                sdist_dir = archive_dir / archive.name.rstrip(suffix)
+                # Remove known archive suffixes properly — rstrip treats
+                # its argument as a character set, not a suffix string.
+                stem = archive.name
+                for ext in (".tar.gz", ".tar.bz2", ".tar.xz", ".tar", ".zip"):
+                    if stem.endswith(ext):
+                        stem = stem[: -len(ext)]
+                        break
+                sdist_dir = archive_dir / stem
                 if not sdist_dir.is_dir():
                     sdist_dir = archive_dir
 


### PR DESCRIPTION
## Problem

`_prepare_sdist` uses `archive.name.rstrip(suffix)` to strip the file extension and derive the expected directory name inside the extracted sdist. However, `str.rstrip()` treats its argument as a **set of characters to strip**, not as a suffix string.

For `.tar.gz` archives:
- `archive.suffix` → `".gz"`
- `"package-1.0.tar.gz".rstrip(".gz")` strips `{'.', 'g', 'z'}` → `"package-1.0.tar"` (leaves `.tar`)

For `.zip` archives with names ending in strip-set characters:
- `"zipp-24.0.0.zip".rstrip(".zip")` strips `{'.', 'z', 'i', 'p'}` → could over-strip the package name itself

This means the fallback directory lookup (when the sdist extracts to multiple entries) always looks for the wrong name, fails the `is_dir()` check, and falls through to using `archive_dir` directly.

## Fix

Replace `rstrip(suffix)` with explicit suffix matching against known archive extensions (`.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar`, `.zip`).

## Summary by Sourcery

Bug Fixes:
- Correct sdist directory name extraction by removing known archive suffixes explicitly for .tar.* and .zip files instead of using rstrip(), preventing fallback to the wrong directory.