### PR TITLE
Fix cache clear example to use PyPI instead of pypi

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -263,7 +263,7 @@ poetry cache clear PyPI --all
 To only remove a specific package from a cache, you have to specify the cache entry in the following form `cache:package:version`:
 
 ```bash
-poetry cache clear pypi:requests:2.24.0
+poetry cache clear PyPI:requests:2.24.0
 ```
 
 ### cache list


### PR DESCRIPTION
Fixes #10743

## Problem
The package-specific cache clear example uses lowercase `pypi` while the --all example above it uses `PyPI`. Since cache names are case-sensitive, this inconsistency can cause issues when users copy/paste the example.

## Solution
Updated the example from `poetry cache clear pypi:requests:2.24.0` to `poetry cache clear PyPI:requests:2.24.0` to be consistent with the --all example.

## References
- Original issue: #9516
- Previous fix PR: #9736 (which updated the --all example but not this one)

## Summary by Sourcery

Documentation:
- Correct the package-specific cache clear example to use the proper case-sensitive `PyPI` cache name.