### PR TITLE
Fix #8797: validate version constraint in interactive init flow

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -11,6 +11,8 @@ from typing import ClassVar
 
 from cleo.helpers import option
 from packaging.utils import canonicalize_name
+from poetry.core.constraints.version import parse_constraint
+from poetry.core.constraints.version.exceptions import ParseConstraintError
 from tomlkit import inline_table
 
 from poetry.console.commands.command import Command
@@ -395,6 +397,14 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                             f"Using version <b>{package_constraint}</b> for"
                             f" <c1>{package}</c1>"
                         )
+                    else:
+                        try:
+                            parse_constraint(package_constraint)
+                        except ParseConstraintError:
+                            self.line_error(
+                                "<error>Invalid version constraint. Please enter a valid version specifier.</error>"
+                            )
+                            continue
 
                     constraint["version"] = package_constraint
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1215,3 +1215,38 @@ def test_init_does_not_add_readme_key_when_readme_missing(
     # Assert
     pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
     assert "readme =" not in pyproject
+
+
+def test_interactive_rejects_invalid_version_constraint(
+    tester: CommandTester, repo: TestRepository
+) -> None:
+    repo.add_package(get_package("pendulum", "2.0.0"))
+
+    inputs = [
+        "my-package",  # Package name
+        "1.0.0",  # Version
+        "Desc",  # Description
+        "n",  # Author
+        "MIT",  # License
+        ">=3.8",  # Python
+        "",  # Interactive packages
+        "pendulum",  # Search package
+        "0",  # Select first result
+        "isort",  # INVALID version constraint
+        ">=2.0.0",  # VALID version constraint
+        "",  # Stop searching for packages
+        "",  # Interactive dev packages
+        "",
+        "\n",  # Generate
+    ]
+
+    tester.execute(inputs="\n".join(inputs))
+
+    output = tester.io.fetch_output()
+    error = tester.io.fetch_error()
+
+    # Must show validation error
+    assert "Invalid version constraint" in error
+
+    # Must use valid constraint
+    assert "pendulum (>=2.0.0" in output


### PR DESCRIPTION
Closes #8797

Adds validation of version constraint in interactive init flow using parse_constraint.

If the user enters an invalid version constraint, an error is shown and the prompt is repeated.

Includes regression test.

## Summary by Sourcery

Validate dependency version constraints entered in the interactive init flow and ensure invalid inputs are rejected with a clear error message.

Bug Fixes:
- Prevent acceptance of invalid dependency version constraints during the interactive init workflow by validating user input before applying it.

Tests:
- Add a regression test covering rejection of invalid version constraints and acceptance of a subsequent valid constraint in the interactive init flow.