### PR TITLE
fix: warn when group name is normalized in --with/--without/--only options

### DIFF
--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -103,6 +103,16 @@ class GroupCommand(Command):
             key: {canonicalize_name(group) for group in key_groups}
             for key, key_groups in groups.items()
         }
+        # Warn if any group name was normalized
+        for key_groups in groups.values():
+            for group in key_groups:
+                normalized = canonicalize_name(group)
+                if normalized != group:
+                    self.line_error(
+                        f"<warning>Group '{group}' was normalized to '{normalized}'."
+                        " Consider updating your command to use the normalized name.</warning>"
+                    )
+
         norm_default_groups = {canonicalize_name(name) for name in self.default_groups}
 
         return norm_groups["only"] or norm_default_groups.union(
@@ -121,7 +131,9 @@ class GroupCommand(Command):
         invalid_options = defaultdict(set)
         for opt, groups in group_options.items():
             for group in groups:
-                if not self.poetry.package.has_dependency_group(group):
+                if not self.poetry.package.has_dependency_group(
+                    canonicalize_name(group)
+                ):
                     invalid_options[group].add(opt)
         if invalid_options:
             message_parts = []

--- a/src/poetry/console/commands/group_command.py
+++ b/src/poetry/console/commands/group_command.py
@@ -103,11 +103,13 @@ class GroupCommand(Command):
             key: {canonicalize_name(group) for group in key_groups}
             for key, key_groups in groups.items()
         }
-        # Warn if any group name was normalized
+        # Warn if any group name was normalized (deduplicate warnings)
+        warned: set[str] = set()
         for key_groups in groups.values():
             for group in key_groups:
                 normalized = canonicalize_name(group)
-                if normalized != group:
+                if normalized != group and group not in warned:
+                    warned.add(group)
                     self.line_error(
                         f"<warning>Group '{group}' was normalized to '{normalized}'."
                         " Consider updating your command to use the normalized name.</warning>"

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -396,6 +396,47 @@ def test_invalid_groups_with_without_only(
                 )
 
 
+@pytest.mark.parametrize(
+    "option",
+    ["--with", "--without", "--only"],
+)
+def test_non_normalized_group_name_emits_warning(
+    tester: CommandTester,
+    mocker: MockerFixture,
+    option: str,
+) -> None:
+    """
+    A warning is emitted when a group name passed via --with/--without/--only
+    differs from its normalized form (e.g. 'Foo' instead of 'foo').
+    """
+    assert isinstance(tester.command, InstallerCommand)
+    mocker.patch.object(tester.command.installer, "run", return_value=0)
+
+    # 'Foo' normalizes to 'foo', which exists in the fixture pyproject
+    tester.execute(f"{option} Foo")
+
+    error_output = tester.io.fetch_error()
+    assert "was normalized to" in error_output
+    assert "'Foo'" in error_output
+    assert "'foo'" in error_output
+
+
+def test_normalized_group_name_does_not_raise(
+    tester: CommandTester,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Passing a non-normalized but valid group name (e.g. 'Foo' for group 'foo')
+    should not raise a GroupNotFoundError.
+    """
+    assert isinstance(tester.command, InstallerCommand)
+    mocker.patch.object(tester.command.installer, "run", return_value=0)
+
+    # Should not raise even though 'Foo' != 'foo', because they normalize to the same name
+    tester.execute("--with Foo")
+    assert tester.status_code != 1 or "not found" not in tester.io.fetch_error()
+
+
 def test_dry_run_populates_installer(
     tester: CommandTester, mocker: MockerFixture
 ) -> None:

--- a/tests/console/commands/test_install.py
+++ b/tests/console/commands/test_install.py
@@ -397,13 +397,21 @@ def test_invalid_groups_with_without_only(
 
 
 @pytest.mark.parametrize(
-    "option",
-    ["--with", "--without", "--only"],
+    ("option", "group_input", "normalized"),
+    [
+        ("--with", "Foo", "foo"),
+        ("--without", "Foo", "foo"),
+        ("--only", "Foo", "foo"),
+        ("--with", "FOO", "foo"),
+        ("--with", "bim", "bim"),
+    ],
 )
 def test_non_normalized_group_name_emits_warning(
     tester: CommandTester,
     mocker: MockerFixture,
     option: str,
+    group_input: str,
+    normalized: str,
 ) -> None:
     """
     A warning is emitted when a group name passed via --with/--without/--only
@@ -412,13 +420,15 @@ def test_non_normalized_group_name_emits_warning(
     assert isinstance(tester.command, InstallerCommand)
     mocker.patch.object(tester.command.installer, "run", return_value=0)
 
-    # 'Foo' normalizes to 'foo', which exists in the fixture pyproject
-    tester.execute(f"{option} Foo")
-
+    tester.execute(f"{option} {group_input}")
     error_output = tester.io.fetch_error()
-    assert "was normalized to" in error_output
-    assert "'Foo'" in error_output
-    assert "'foo'" in error_output
+
+    if group_input != normalized:
+        assert "was normalized to" in error_output
+        assert f"'{group_input}'" in error_output
+        assert f"'{normalized}'" in error_output
+    else:
+        assert "was normalized to" not in error_output
 
 
 def test_normalized_group_name_does_not_raise(
@@ -433,8 +443,14 @@ def test_normalized_group_name_does_not_raise(
     mocker.patch.object(tester.command.installer, "run", return_value=0)
 
     # Should not raise even though 'Foo' != 'foo', because they normalize to the same name
-    tester.execute("--with Foo")
-    assert tester.status_code != 1 or "not found" not in tester.io.fetch_error()
+    # Use --no-root to avoid editable build failure in the test project fixture
+    tester.execute("--with Foo --no-root")
+    error_output = tester.io.fetch_error()
+    assert tester.status_code == 0
+    assert "GroupNotFoundError" not in error_output
+    assert "not found" not in error_output
+    assert "was normalized to" in error_output
+    assert "'Foo'" in error_output
 
 
 def test_dry_run_populates_installer(


### PR DESCRIPTION
Resolves: #10580

- [x] Added **tests** for changed code.

Since Poetry 2.2.0, dependency group names are silently normalized in the
lock file (e.g. `Dev-Tools` → `dev-tools`). This could cause CI pipelines
to silently skip installing a group when using `--with Dev-Tools`.

This PR adds two guardrails:
1. **Normalization warning**: When `--with`/`--without`/`--only` is passed
   a group name that differs from its normalized form, Poetry now emits a warning suggesting t
he user update their command to use the normalized name.

2. **Validation fix**: [_validate_group_options()] now normalizes group names
   before checking `has_dependency_group()`, so `Dev-Tools`, `dev_tools`, and `dev-tools` all correctly resolve to the same group.

## Tests added
- [test_non_normalized_group_name_emits_warning] - verifies a warning is
  emitted for `--with`, `--without`, and `--only` when a non-normalized name is passed. 
- [test_normalized_group_name_does_not_raise] - verifies no `GroupNotFoundError`
  is raised when a valid group name is passed in a non-normalized form.

## Summary by Sourcery

Warn when dependency group CLI options use names that normalize differently and ensure normalized names are used for validation.

Bug Fixes:
- Normalize group names before validating dependency groups so differently formatted names resolve to existing groups.

Enhancements:
- Emit a warning when dependency group names passed to --with/--without/--only are normalized to a different name, guiding users toward the canonical form.

Tests:
- Add tests to verify a warning is emitted for non-normalized group names across --with/--without/--only options.
- Add a test ensuring non-normalized but valid group names do not raise GroupNotFoundError.