### PR TITLE
docs: add note about Microsoft Store Python PATH on Windows

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -195,7 +195,8 @@ If you have installed Python through the Microsoft Store, the `poetry` binary
 will be installed to a different location, for example:
 
 ```
-%LOCALAPPDATA%\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\Roaming\Python\Scripts
+%LOCALAPPDATA%\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0
+\LocalCache\Roaming\Python\Scripts
 ```
 
 Replace `3.12` with your installed Python version and `qbz5n2kfra8p0` with your suffix.


### PR DESCRIPTION
Resolves: #10364

The installation docs state that on Windows, the `poetry` binary is installed to `%APPDATA%\Python\Scripts`. However, when Python is installed  via the Microsoft Store, the binary is instead placed at:

`%LOCALAPPDATA%\Packages\PythonSoftwareFoundation.Python<Version>_qbz5n2kfra8p0\LocalCache\Roaming\Python\Scripts`

This has caused confusion for multiple users (see also #8566 - which is now closed). This PR adds  a note to the "Add Poetry to your PATH" step in the official installer section, consistent in style with the existing Microsoft Store note in step 1 of the same section.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->
- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Documentation:
- Add a note to the installation guide describing the Microsoft Store-specific path where the Poetry binary is installed on Windows.