### PR TITLE
feat: deferred updates

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -405,11 +405,10 @@ class Config:
             return int_normalizer
 
         if name == "installer.minimum-release-age-exclude":
-            return lambda val: (
-                [v.strip() for v in val.split(",")]
-                if isinstance(val, str)
-                else list(val)
-            )
+            return lambda val: [
+                str(v).strip()
+                for v in (val.split(",") if isinstance(val, str) else val)
+            ]
 
         if name in ["installer.no-binary", "installer.only-binary"]:
             return PackageFilterPolicy.normalize

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -170,6 +170,8 @@ class Config:
             "no-binary": None,
             "only-binary": None,
             "build-config-settings": {},
+            "minimum-release-age": None,
+            "minimum-release-age-exclude": [],
         },
         "python": {"installation-dir": os.path.join("{data-dir}", "python")},
         "solver": {
@@ -398,8 +400,16 @@ class Config:
         if name in {
             "installer.max-workers",
             "requests.max-retries",
+            "installer.minimum-release-age",
         }:
             return int_normalizer
+
+        if name == "installer.minimum-release-age-exclude":
+            return lambda val: (
+                [v.strip() for v in val.split(",")]
+                if isinstance(val, str)
+                else list(val)
+            )
 
         if name in ["installer.no-binary", "installer.only-binary"]:
             return PackageFilterPolicy.normalize

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -171,7 +171,7 @@ class Config:
             "only-binary": None,
             "build-config-settings": {},
             "minimum-release-age": None,
-            "minimum-release-age-exclude": [],
+            "minimum-release-age-exclude": None,
         },
         "python": {"installation-dir": os.path.join("{data-dir}", "python")},
         "solver": {

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -101,6 +101,17 @@ To remove a repository (repo is a short alias for repositories):
                 PackageFilterPolicy.validator,
                 PackageFilterPolicy.normalize,
             ),
+            "installer.minimum-release-age": (
+                lambda val: int(val) >= 0,
+                int_normalizer,
+            ),
+            "installer.minimum-release-age-exclude": (
+                lambda val: True,
+                lambda val: [
+                    str(v).strip()
+                    for v in (val.split(",") if isinstance(val, str) else val)
+                ],
+            ),
             "solver.lazy-wheel": (boolean_validator, boolean_normalizer),
             "keyring.enabled": (boolean_validator, boolean_normalizer),
             "python.installation-dir": (str, lambda val: str(Path(val))),

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -5,6 +5,9 @@ import hashlib
 
 from contextlib import contextmanager
 from contextlib import suppress
+from datetime import datetime
+from datetime import timezone
+from fnmatch import fnmatch
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
@@ -71,6 +74,12 @@ class HTTPRepository(CachedRepository):
 
         self._lazy_wheel = config.get("solver.lazy-wheel", True)
         self._max_retries = config.get("requests.max-retries", 0)
+        self._minimum_release_age: int | None = config.get(
+            "installer.minimum-release-age"
+        )
+        self._minimum_release_age_exclude: list[str] = config.get(
+            "installer.minimum-release-age-exclude", []
+        )
         # We are tracking if a domain supports range requests or not to avoid
         # unnecessary requests.
         # ATTENTION: A domain might support range requests only for some files, so the
@@ -477,3 +486,49 @@ class HTTPRepository(CachedRepository):
         if self._is_json_response(response):
             return SimpleJsonPage(response.url, response.json())
         return HTMLPage(response.url, response.text)
+
+    def _release_age_days(
+        self, page: LinkSource, name: NormalizedName, version: Any
+    ) -> int | None:
+        """
+        Return the age in days of the oldest distribution file for the given version,
+        or None if no upload_time data is available (e.g. HTML-only index pages).
+        """
+        upload_times = [
+            datetime.fromisoformat(link.upload_time_isoformat)
+            for link in page.links_for_version(name, version)
+            if link.upload_time_isoformat is not None
+        ]
+        if not upload_times:
+            return None
+        return (datetime.now(timezone.utc) - min(upload_times)).days
+
+    def _is_release_age_excluded(self, name: NormalizedName) -> bool:
+        return any(
+            fnmatch(str(name), pattern)
+            for pattern in self._minimum_release_age_exclude
+        )
+
+    def _version_meets_minimum_age(
+        self, page: LinkSource, name: NormalizedName, version: Any
+    ) -> bool:
+        """
+        Return True if the version is old enough to satisfy minimum-release-age,
+        or if the feature is disabled / the package is excluded / age data is absent.
+        """
+        if self._minimum_release_age is None:
+            return True
+        if self._is_release_age_excluded(name):
+            return True
+        age = self._release_age_days(page, name, version)
+        if age is None:
+            # No upload_time data available (HTML index) — fail open.
+            return True
+        if age < self._minimum_release_age:
+            self._log(
+                f"Skipping {name} {version}: released {age} day(s) ago"
+                f" (minimum-release-age={self._minimum_release_age})",
+                level="debug",
+            )
+            return False
+        return True

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -528,8 +528,7 @@ class HTTPRepository(CachedRepository):
 
     def _is_release_age_excluded(self, name: NormalizedName) -> bool:
         return any(
-            fnmatch(str(name), pattern)
-            for pattern in self._minimum_release_age_exclude
+            fnmatch(str(name), pattern) for pattern in self._minimum_release_age_exclude
         )
 
     def _version_meets_minimum_age(

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -487,6 +487,27 @@ class HTTPRepository(CachedRepository):
             return SimpleJsonPage(response.url, response.json())
         return HTMLPage(response.url, response.text)
 
+    @staticmethod
+    def _parse_upload_time(value: str) -> datetime | None:
+        """
+        Parse an ISO 8601 upload timestamp into a timezone-aware UTC datetime.
+
+        Handles the trailing ``Z`` suffix that PyPI uses, which is only accepted
+        by ``datetime.fromisoformat`` on Python 3.11+.  Returns ``None`` for any
+        value that cannot be parsed so a single bad timestamp does not abort
+        dependency resolution.
+        """
+        try:
+            # Replace trailing Z with +00:00 for cross-version compatibility.
+            normalized = value.rstrip("Z") + "+00:00" if value.endswith("Z") else value
+            dt = datetime.fromisoformat(normalized)
+            # Make naive datetimes explicitly UTC.
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except (ValueError, AttributeError):
+            return None
+
     def _release_age_days(
         self, page: LinkSource, name: NormalizedName, version: Any
     ) -> int | None:
@@ -495,9 +516,11 @@ class HTTPRepository(CachedRepository):
         or None if no upload_time data is available (e.g. HTML-only index pages).
         """
         upload_times = [
-            datetime.fromisoformat(link.upload_time_isoformat)
+            parsed
             for link in page.links_for_version(name, version)
             if link.upload_time_isoformat is not None
+            if (parsed := self._parse_upload_time(link.upload_time_isoformat))
+            is not None
         ]
         if not upload_times:
             return None

--- a/src/poetry/repositories/legacy_repository.py
+++ b/src/poetry/repositories/legacy_repository.py
@@ -95,6 +95,7 @@ class LegacyRepository(HTTPRepository):
             (version, page.yanked(name, version))
             for version in page.versions(name)
             if constraint.allows(version)
+            and self._version_meets_minimum_age(page, name, version)
         ]
 
         return [

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -118,6 +118,7 @@ class PyPiRepository(HTTPRepository):
             (version, json_page.yanked(name, version))
             for version in json_page.versions(name)
             if constraint.allows(version)
+            and self._version_meets_minimum_age(json_page, name, version)
         ]
 
         return [Package(name, version, yanked=yanked) for version, yanked in versions]

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -67,6 +67,8 @@ def test_list_displays_default_value_if_not_set(
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
 installer.max-workers = null
+installer.minimum-release-age = null
+installer.minimum-release-age-exclude = null
 installer.no-binary = null
 installer.only-binary = null
 installer.parallel = true
@@ -102,6 +104,8 @@ def test_list_displays_set_get_setting(
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
 installer.max-workers = null
+installer.minimum-release-age = null
+installer.minimum-release-age-exclude = null
 installer.no-binary = null
 installer.only-binary = null
 installer.parallel = true
@@ -158,6 +162,8 @@ def test_unset_setting(
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
 installer.max-workers = null
+installer.minimum-release-age = null
+installer.minimum-release-age-exclude = null
 installer.no-binary = null
 installer.only-binary = null
 installer.parallel = true
@@ -192,6 +198,8 @@ def test_unset_repo_setting(
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
 installer.max-workers = null
+installer.minimum-release-age = null
+installer.minimum-release-age-exclude = null
 installer.no-binary = null
 installer.only-binary = null
 installer.parallel = true
@@ -327,6 +335,8 @@ def test_list_displays_set_get_local_setting(
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
 installer.max-workers = null
+installer.minimum-release-age = null
+installer.minimum-release-age-exclude = null
 installer.no-binary = null
 installer.only-binary = null
 installer.parallel = true
@@ -370,6 +380,8 @@ def test_list_must_not_display_sources_from_pyproject_toml(
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
 installer.max-workers = null
+installer.minimum-release-age = null
+installer.minimum-release-age-exclude = null
 installer.no-binary = null
 installer.only-binary = null
 installer.parallel = true

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime
-from datetime import timezone
 from io import BytesIO
 from typing import TYPE_CHECKING
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -16,6 +13,7 @@ from requests.exceptions import TooManyRedirects
 from requests.models import Response
 
 from poetry.factory import Factory
+from poetry.repositories.link_sources.json import SimpleJsonPage
 from poetry.repositories.pypi_repository import PyPiRepository
 
 
@@ -33,38 +31,34 @@ def _use_simple_keyring(with_simple_keyring: None) -> None:
 
 
 def test_release_age_days_with_upload_time(
-    pypi_repository: PyPiRepository, mocker: MockerFixture
+    pypi_repository: PyPiRepository,
 ) -> None:
-    """_release_age_days should compute age relative to now."""
-    link = MagicMock()
-    link.upload_time_isoformat = "2020-01-01T00:00:00+00:00"
-
-    page = MagicMock()
-    page.links_for_version.return_value = [link]
-
-    fixed_now = datetime(2020, 1, 11, tzinfo=timezone.utc)
-    mocker.patch(
-        "poetry.repositories.http_repository.datetime",
-        now=MagicMock(return_value=fixed_now),
-        fromisoformat=datetime.fromisoformat,
-    )
-
+    # requests fixture has upload-time from 2017, so always well over 1000 days old
+    page = pypi_repository.get_page(canonicalize_name("requests"))
     age = pypi_repository._release_age_days(
         page, canonicalize_name("requests"), Version.parse("2.18.0")
     )
-    assert age == 10
+    assert age is not None
+    assert age > 1000
 
 
 def test_release_age_days_without_upload_time(
     pypi_repository: PyPiRepository,
 ) -> None:
-    """_release_age_days should return None when no upload_time is present."""
-    link = MagicMock()
-    link.upload_time_isoformat = None
-
-    page = MagicMock()
-    page.links_for_version.return_value = [link]
-
+    page = SimpleJsonPage(
+        "https://pypi.org/simple/requests/",
+        {
+            "meta": {"api-version": "1.0"},
+            "name": "requests",
+            "files": [
+                {
+                    "filename": "requests-2.18.0-py2.py3-none-any.whl",
+                    "url": "https://files.pythonhosted.org/packages/requests-2.18.0.whl",
+                    "hashes": {"sha256": "abc123"},
+                }
+            ],
+        },
+    )
     age = pypi_repository._release_age_days(
         page, canonicalize_name("requests"), Version.parse("2.18.0")
     )
@@ -126,84 +120,76 @@ def test_find_packages_yanked(
     assert [str(p.version) for p in packages] == expected
 
 
-def test_find_packages_minimum_release_age_filters_new_versions(
-    pypi_repository: PyPiRepository, mocker: MockerFixture
-) -> None:
-    """Versions whose age is below the threshold should be excluded."""
-    # requests fixture has multiple versions; make them all appear brand-new.
-    mocker.patch.object(pypi_repository, "_release_age_days", return_value=0)
-    pypi_repository._minimum_release_age = 7
-
-    packages = pypi_repository.find_packages(
-        Factory.create_dependency("requests", "~2.18.0")
-    )
-    assert packages == []
-
-
-def test_find_packages_minimum_release_age_allows_old_versions(
-    pypi_repository: PyPiRepository, mocker: MockerFixture
-) -> None:
-    """Versions old enough should still be returned."""
-    mocker.patch.object(pypi_repository, "_release_age_days", return_value=30)
-    pypi_repository._minimum_release_age = 7
-
-    packages = pypi_repository.find_packages(
-        Factory.create_dependency("requests", "~2.18.0")
-    )
-    assert len(packages) == 5
-
-
-def test_find_packages_minimum_release_age_exclude_skips_filter(
-    pypi_repository: PyPiRepository, mocker: MockerFixture
-) -> None:
-    """Packages in the exclude list should bypass the age filter."""
-    mocker.patch.object(pypi_repository, "_release_age_days", return_value=0)
-    pypi_repository._minimum_release_age = 7
-    pypi_repository._minimum_release_age_exclude = ["requests"]
-
-    packages = pypi_repository.find_packages(
-        Factory.create_dependency("requests", "~2.18.0")
-    )
-    assert len(packages) == 5
-
-
-def test_find_packages_minimum_release_age_exclude_glob(
-    pypi_repository: PyPiRepository, mocker: MockerFixture
-) -> None:
-    """Glob patterns in the exclude list should work."""
-    mocker.patch.object(pypi_repository, "_release_age_days", return_value=0)
-    pypi_repository._minimum_release_age = 7
-    pypi_repository._minimum_release_age_exclude = ["req*"]
-
-    packages = pypi_repository.find_packages(
-        Factory.create_dependency("requests", "~2.18.0")
-    )
-    assert len(packages) == 5
-
-
-def test_find_packages_minimum_release_age_none_data_fails_open(
-    pypi_repository: PyPiRepository, mocker: MockerFixture
-) -> None:
-    """When upload_time data is absent (returns None), the version is allowed."""
-    mocker.patch.object(pypi_repository, "_release_age_days", return_value=None)
-    pypi_repository._minimum_release_age = 7
-
-    packages = pypi_repository.find_packages(
-        Factory.create_dependency("requests", "~2.18.0")
-    )
-    assert len(packages) == 5
-
-
-def test_find_packages_minimum_release_age_disabled_by_default(
+@pytest.mark.parametrize(
+    ["minimum_age", "expected_count"],
+    [
+        # disabled (default): all versions returned
+        (None, 5),
+        # threshold well below fixture age (~3100+ days): all versions pass
+        (365, 5),
+        # threshold far exceeding fixture age: all versions filtered
+        (99999, 0),
+    ],
+)
+def test_find_packages_minimum_release_age(
+    minimum_age: int | None,
+    expected_count: int,
     pypi_repository: PyPiRepository,
 ) -> None:
-    """With no minimum-release-age configured, all versions are returned normally."""
-    assert pypi_repository._minimum_release_age is None
-
+    pypi_repository._minimum_release_age = minimum_age
     packages = pypi_repository.find_packages(
         Factory.create_dependency("requests", "~2.18.0")
     )
-    assert len(packages) == 5
+    assert len(packages) == expected_count
+
+
+@pytest.mark.parametrize(
+    ["exclude_patterns", "expected_count"],
+    [
+        # no exclusions: all filtered by the high threshold
+        ([], 0),
+        # exact name bypasses filter
+        (["requests"], 5),
+        # glob pattern bypasses filter
+        (["req*"], 5),
+    ],
+)
+def test_find_packages_minimum_release_age_exclude(
+    exclude_patterns: list[str],
+    expected_count: int,
+    pypi_repository: PyPiRepository,
+) -> None:
+    pypi_repository._minimum_release_age = 99999
+    pypi_repository._minimum_release_age_exclude = exclude_patterns
+    packages = pypi_repository.find_packages(
+        Factory.create_dependency("requests", "~2.18.0")
+    )
+    assert len(packages) == expected_count
+
+
+def test_version_meets_minimum_age_fails_open_without_upload_time(
+    pypi_repository: PyPiRepository,
+) -> None:
+    # A page with no upload-time should allow the version through (fail open)
+    page = SimpleJsonPage(
+        "https://pypi.org/simple/requests/",
+        {
+            "meta": {"api-version": "1.0"},
+            "name": "requests",
+            "files": [
+                {
+                    "filename": "requests-2.18.0-py2.py3-none-any.whl",
+                    "url": "https://files.pythonhosted.org/packages/requests-2.18.0.whl",
+                    "hashes": {"sha256": "abc123"},
+                }
+            ],
+        },
+    )
+    pypi_repository._minimum_release_age = 99999
+    result = pypi_repository._version_meets_minimum_age(
+        page, canonicalize_name("requests"), Version.parse("2.18.0")
+    )
+    assert result is True
 
 
 def test_package(

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -30,6 +30,31 @@ def _use_simple_keyring(with_simple_keyring: None) -> None:
     pass
 
 
+@pytest.mark.parametrize(
+    ["value", "expected_is_none"],
+    [
+        # Z suffix (PyPI's format) — must not raise on Python <3.11
+        ("2017-06-14T15:44:35.080617Z", False),
+        # Explicit UTC offset
+        ("2017-06-14T15:44:35+00:00", False),
+        # Naive datetime — treated as UTC
+        ("2017-06-14T15:44:35", False),
+        # Malformed — must return None, not raise
+        ("not-a-date", True),
+        ("", True),
+    ],
+)
+def test_parse_upload_time(
+    value: str, expected_is_none: bool, pypi_repository: PyPiRepository
+) -> None:
+    result = pypi_repository._parse_upload_time(value)
+    if expected_is_none:
+        assert result is None
+    else:
+        assert result is not None
+        assert result.tzinfo is not None
+
+
 def test_release_age_days_with_upload_time(
     pypi_repository: PyPiRepository,
 ) -> None:

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from datetime import datetime
+from datetime import timezone
 from io import BytesIO
 from typing import TYPE_CHECKING
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -27,6 +30,45 @@ if TYPE_CHECKING:
 @pytest.fixture(autouse=True)
 def _use_simple_keyring(with_simple_keyring: None) -> None:
     pass
+
+
+def test_release_age_days_with_upload_time(
+    pypi_repository: PyPiRepository, mocker: MockerFixture
+) -> None:
+    """_release_age_days should compute age relative to now."""
+    link = MagicMock()
+    link.upload_time_isoformat = "2020-01-01T00:00:00+00:00"
+
+    page = MagicMock()
+    page.links_for_version.return_value = [link]
+
+    fixed_now = datetime(2020, 1, 11, tzinfo=timezone.utc)
+    mocker.patch(
+        "poetry.repositories.http_repository.datetime",
+        now=MagicMock(return_value=fixed_now),
+        fromisoformat=datetime.fromisoformat,
+    )
+
+    age = pypi_repository._release_age_days(
+        page, canonicalize_name("requests"), Version.parse("2.18.0")
+    )
+    assert age == 10
+
+
+def test_release_age_days_without_upload_time(
+    pypi_repository: PyPiRepository,
+) -> None:
+    """_release_age_days should return None when no upload_time is present."""
+    link = MagicMock()
+    link.upload_time_isoformat = None
+
+    page = MagicMock()
+    page.links_for_version.return_value = [link]
+
+    age = pypi_repository._release_age_days(
+        page, canonicalize_name("requests"), Version.parse("2.18.0")
+    )
+    assert age is None
 
 
 def test_find_packages(pypi_repository: PyPiRepository) -> None:
@@ -82,6 +124,86 @@ def test_find_packages_yanked(
     packages = repo.find_packages(Factory.create_dependency("black", constraint))
 
     assert [str(p.version) for p in packages] == expected
+
+
+def test_find_packages_minimum_release_age_filters_new_versions(
+    pypi_repository: PyPiRepository, mocker: MockerFixture
+) -> None:
+    """Versions whose age is below the threshold should be excluded."""
+    # requests fixture has multiple versions; make them all appear brand-new.
+    mocker.patch.object(pypi_repository, "_release_age_days", return_value=0)
+    pypi_repository._minimum_release_age = 7
+
+    packages = pypi_repository.find_packages(
+        Factory.create_dependency("requests", "~2.18.0")
+    )
+    assert packages == []
+
+
+def test_find_packages_minimum_release_age_allows_old_versions(
+    pypi_repository: PyPiRepository, mocker: MockerFixture
+) -> None:
+    """Versions old enough should still be returned."""
+    mocker.patch.object(pypi_repository, "_release_age_days", return_value=30)
+    pypi_repository._minimum_release_age = 7
+
+    packages = pypi_repository.find_packages(
+        Factory.create_dependency("requests", "~2.18.0")
+    )
+    assert len(packages) == 5
+
+
+def test_find_packages_minimum_release_age_exclude_skips_filter(
+    pypi_repository: PyPiRepository, mocker: MockerFixture
+) -> None:
+    """Packages in the exclude list should bypass the age filter."""
+    mocker.patch.object(pypi_repository, "_release_age_days", return_value=0)
+    pypi_repository._minimum_release_age = 7
+    pypi_repository._minimum_release_age_exclude = ["requests"]
+
+    packages = pypi_repository.find_packages(
+        Factory.create_dependency("requests", "~2.18.0")
+    )
+    assert len(packages) == 5
+
+
+def test_find_packages_minimum_release_age_exclude_glob(
+    pypi_repository: PyPiRepository, mocker: MockerFixture
+) -> None:
+    """Glob patterns in the exclude list should work."""
+    mocker.patch.object(pypi_repository, "_release_age_days", return_value=0)
+    pypi_repository._minimum_release_age = 7
+    pypi_repository._minimum_release_age_exclude = ["req*"]
+
+    packages = pypi_repository.find_packages(
+        Factory.create_dependency("requests", "~2.18.0")
+    )
+    assert len(packages) == 5
+
+
+def test_find_packages_minimum_release_age_none_data_fails_open(
+    pypi_repository: PyPiRepository, mocker: MockerFixture
+) -> None:
+    """When upload_time data is absent (returns None), the version is allowed."""
+    mocker.patch.object(pypi_repository, "_release_age_days", return_value=None)
+    pypi_repository._minimum_release_age = 7
+
+    packages = pypi_repository.find_packages(
+        Factory.create_dependency("requests", "~2.18.0")
+    )
+    assert len(packages) == 5
+
+
+def test_find_packages_minimum_release_age_disabled_by_default(
+    pypi_repository: PyPiRepository,
+) -> None:
+    """With no minimum-release-age configured, all versions are returned normally."""
+    assert pypi_repository._minimum_release_age is None
+
+    packages = pypi_repository.find_packages(
+        Factory.create_dependency("requests", "~2.18.0")
+    )
+    assert len(packages) == 5
 
 
 def test_package(


### PR DESCRIPTION
Adds installer.minimum-release-age and installer.minimum-release-age-exclude config options. Versions released more recently than the configured threshold are filtered out during dependency resolution, guarding against supply chain attacks on freshly published packages (inline with pnpm's minimumReleaseAge).

Upload time is sourced from the PEP 691 Simple API page already fetched for version listing, so no extra HTTP requests are made. HTML-only index pages fail open (no upload_time available). Glob patterns are supported in the exclude list.

# Pull Request Check List

Resolves: #10646
Also discussed here: https://github.com/orgs/python-poetry/discussions/10555

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Introduce configurable minimum release age filtering for dependency resolution to avoid using very recently published package versions.

New Features:
- Add installer.minimum-release-age config option to restrict dependency resolution to package versions older than a configured age.
- Add installer.minimum-release-age-exclude config option supporting glob patterns to bypass minimum-age checks for selected packages.
- Apply minimum release age checks in HTTP-based repositories when selecting candidate versions, failing open when upload time data is unavailable.

Tests:
- Add unit tests covering release age calculation, minimum-release-age filtering behavior, exclusion patterns, and fail-open semantics when upload time metadata is missing.