### PR TITLE
Add tests for `switch_working_directory` helper

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import os
 
+import pytest
+
 from tests.helpers import flatten_dict
 from tests.helpers import isolated_environment
+from tests.helpers import switch_working_directory
 
 
 def test_flatten_dict() -> None:
@@ -44,3 +47,25 @@ def test_isolated_environment_updates_environ() -> None:
     with isolated_environment(environ={"NEW_VAR": "new_value"}):
         assert os.environ["NEW_VAR"] == "new_value"
     assert "NEW_VAR" not in os.environ
+
+
+def test_switch_working_directory_restores_original_cwd_on_error(tmp_path) -> None:
+    original_cwd = os.getcwd()
+
+    with pytest.raises(RuntimeError):
+        with switch_working_directory(tmp_path):
+            assert os.getcwd() == str(tmp_path)
+            raise RuntimeError("boom")
+
+    assert os.getcwd() == original_cwd
+
+
+def test_switch_working_directory_remove_deletes_directory(tmp_path) -> None:
+    temp_dir = tmp_path / "temp-working-dir"
+    temp_dir.mkdir()
+
+    with switch_working_directory(temp_dir, remove=True):
+        assert os.getcwd() == str(temp_dir)
+        assert temp_dir.exists()
+
+    assert not temp_dir.exists()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -55,7 +55,10 @@ def test_isolated_environment_updates_environ() -> None:
     assert "NEW_VAR" not in os.environ
 
 
-@pytest.mark.parametrize(("remove", "raise_error"), [(False, False), (False, True), (True, False), (True, True)])
+@pytest.mark.parametrize(
+    ("remove", "raise_error"),
+    [(False, False), (False, True), (True, False), (True, True)],
+)
 def test_switch_working_directory_changes_restores_and_removes(
     tmp_path: Path, remove: bool, raise_error: bool
 ) -> None:
@@ -64,10 +67,12 @@ def test_switch_working_directory_changes_restores_and_removes(
     temp_dir.mkdir()
 
     if raise_error:
-        with pytest.raises(RuntimeError):
-            with switch_working_directory(temp_dir, remove=remove):
-                assert os.getcwd() == str(temp_dir)
-                raise RuntimeError("boom")
+        with (
+            pytest.raises(RuntimeError),
+            switch_working_directory(temp_dir, remove=remove),
+        ):
+            assert os.getcwd() == str(temp_dir)
+            raise RuntimeError("boom")
     else:
         with switch_working_directory(temp_dir, remove=remove):
             assert os.getcwd() == str(temp_dir)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -55,10 +55,8 @@ def test_isolated_environment_updates_environ() -> None:
     assert "NEW_VAR" not in os.environ
 
 
-@pytest.mark.parametrize(
-    ("remove", "raise_error"),
-    [(False, False), (False, True), (True, False), (True, True)],
-)
+@pytest.mark.parametrize("remove", [False, True])
+@pytest.mark.parametrize("raise_error", [False, True])
 def test_switch_working_directory_changes_restores_and_removes(
     tmp_path: Path, remove: bool, raise_error: bool
 ) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -55,24 +55,22 @@ def test_isolated_environment_updates_environ() -> None:
     assert "NEW_VAR" not in os.environ
 
 
-def test_switch_working_directory_restores_original_cwd_on_error(
-    tmp_path: Path,
+@pytest.mark.parametrize(("remove", "raise_error"), [(False, False), (False, True), (True, False), (True, True)])
+def test_switch_working_directory_changes_restores_and_removes(
+    tmp_path: Path, remove: bool, raise_error: bool
 ) -> None:
     original_cwd = os.getcwd()
-
-    with pytest.raises(RuntimeError), switch_working_directory(tmp_path):
-        assert os.getcwd() == str(tmp_path)
-        raise RuntimeError("boom")
-
-    assert os.getcwd() == original_cwd
-
-
-def test_switch_working_directory_remove_deletes_directory(tmp_path: Path) -> None:
-    temp_dir = tmp_path / "temp-working-dir"
+    temp_dir = tmp_path / f"temp-working-dir-{remove}-{raise_error}"
     temp_dir.mkdir()
 
-    with switch_working_directory(temp_dir, remove=True):
-        assert os.getcwd() == str(temp_dir)
-        assert temp_dir.exists()
+    if raise_error:
+        with pytest.raises(RuntimeError):
+            with switch_working_directory(temp_dir, remove=remove):
+                assert os.getcwd() == str(temp_dir)
+                raise RuntimeError("boom")
+    else:
+        with switch_working_directory(temp_dir, remove=remove):
+            assert os.getcwd() == str(temp_dir)
 
-    assert not temp_dir.exists()
+    assert os.getcwd() == original_cwd
+    assert temp_dir.exists() is (not remove)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
+
+from typing import TYPE_CHECKING
 
 import pytest
 
 from tests.helpers import flatten_dict
 from tests.helpers import isolated_environment
 from tests.helpers import switch_working_directory
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_flatten_dict() -> None:
@@ -50,13 +55,14 @@ def test_isolated_environment_updates_environ() -> None:
     assert "NEW_VAR" not in os.environ
 
 
-def test_switch_working_directory_restores_original_cwd_on_error(tmp_path: Path) -> None:
+def test_switch_working_directory_restores_original_cwd_on_error(
+    tmp_path: Path,
+) -> None:
     original_cwd = os.getcwd()
 
-    with pytest.raises(RuntimeError):
-        with switch_working_directory(tmp_path):
-            assert os.getcwd() == str(tmp_path)
-            raise RuntimeError("boom")
+    with pytest.raises(RuntimeError), switch_working_directory(tmp_path):
+        assert os.getcwd() == str(tmp_path)
+        raise RuntimeError("boom")
 
     assert os.getcwd() == original_cwd
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -49,7 +50,7 @@ def test_isolated_environment_updates_environ() -> None:
     assert "NEW_VAR" not in os.environ
 
 
-def test_switch_working_directory_restores_original_cwd_on_error(tmp_path) -> None:
+def test_switch_working_directory_restores_original_cwd_on_error(tmp_path: Path) -> None:
     original_cwd = os.getcwd()
 
     with pytest.raises(RuntimeError):
@@ -60,7 +61,7 @@ def test_switch_working_directory_restores_original_cwd_on_error(tmp_path) -> No
     assert os.getcwd() == original_cwd
 
 
-def test_switch_working_directory_remove_deletes_directory(tmp_path) -> None:
+def test_switch_working_directory_remove_deletes_directory(tmp_path: Path) -> None:
     temp_dir = tmp_path / "temp-working-dir"
     temp_dir.mkdir()
 


### PR DESCRIPTION
## Summary
- add test that `switch_working_directory()` restores the original cwd when an exception is raised
- add test that `remove=True` deletes the temporary working directory after exiting the context manager

Related to python-poetry/poetry#9161

## Summary by Sourcery

Add coverage for the switch_working_directory helper behavior.

Tests:
- Add a test ensuring switch_working_directory restores the original working directory when an exception is raised inside the context.
- Add a test ensuring switch_working_directory removes the temporary working directory when used with remove=True.