### PR TITLE
Fix `publish --build` prompt behavior in non-interactive mode

### DIFF
--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -73,18 +73,19 @@ the config command.
         # Building package first, if told
         if self.option("build"):
             if publisher.files:
-                if self.io.is_interactive() and not self.confirm(
-                    f"There are <info>{len(publisher.files)}</info> files ready for"
-                    " publishing. Build anyway?"
-                ):
-                    self.line_error("<error>Aborted!</error>")
+                if self.io.is_interactive():
+                    if not self.confirm(
+                        f"There are <info>{len(publisher.files)}</info> files ready for"
+                        f" publishing in {dist_dir}. Build anyway?"
+                    ):
+                        self.line_error("<error>Aborted!</error>")
 
-                    return 1
+                        return 1
 
-                if not self.io.is_interactive():
+                else:
                     self.line(
-                        "<warning>Warning: Existing distribution files were found in "
-                        f"{dist_dir}; continuing because --no-interaction was set.</warning>"
+                        f"<warning>Warning: There are <info>{len(publisher.files)}</info> files "
+                        f"ready for publishing in {dist_dir}. Build anyway!</warning>"
                     )
 
             self.call("build", args=f"--output {dist_dir}")

--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -72,17 +72,20 @@ the config command.
 
         # Building package first, if told
         if self.option("build"):
-            if (
-                publisher.files
-                and self.io.is_interactive()
-                and not self.confirm(
+            if publisher.files:
+                if self.io.is_interactive() and not self.confirm(
                     f"There are <info>{len(publisher.files)}</info> files ready for"
                     " publishing. Build anyway?"
-                )
-            ):
-                self.line_error("<error>Aborted!</error>")
+                ):
+                    self.line_error("<error>Aborted!</error>")
 
-                return 1
+                    return 1
+
+                if not self.io.is_interactive():
+                    self.line_error(
+                        "<warning>Warning: Existing distribution files were found in "
+                        f"{dist_dir}; continuing because --no-interaction was set.</warning>"
+                    )
 
             self.call("build", args=f"--output {dist_dir}")
 

--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -72,9 +72,13 @@ the config command.
 
         # Building package first, if told
         if self.option("build"):
-            if publisher.files and not self.confirm(
-                f"There are <info>{len(publisher.files)}</info> files ready for"
-                " publishing. Build anyway?"
+            if (
+                publisher.files
+                and self.io.is_interactive()
+                and not self.confirm(
+                    f"There are <info>{len(publisher.files)}</info> files ready for"
+                    " publishing. Build anyway?"
+                )
             ):
                 self.line_error("<error>Aborted!</error>")
 

--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -82,7 +82,7 @@ the config command.
                     return 1
 
                 if not self.io.is_interactive():
-                    self.line_error(
+                    self.line(
                         "<warning>Warning: Existing distribution files were found in "
                         f"{dist_dir}; continuing because --no-interaction was set.</warning>"
                     )

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -215,3 +215,18 @@ def test_publish_dist_dir_and_build_options(
     assert "Publishing simple-project (1.2.3) to PyPI" in output
     assert "- Uploading simple_project-1.2.3.tar.gz" in error
     assert "- Uploading simple_project-1.2.3-py2.py3-none-any.whl" in error
+
+
+def test_publish_build_no_interaction_skips_confirmation(
+    app_tester: ApplicationTester, mocker: MockerFixture
+) -> None:
+    confirm = mocker.patch("poetry.console.commands.publish.PublishCommand.confirm")
+    command_call = mocker.patch("poetry.console.commands.publish.PublishCommand.call")
+    publisher_publish = mocker.patch("poetry.publishing.Publisher.publish")
+
+    exit_code = app_tester.execute("publish --build --no-interaction --dry-run")
+
+    assert exit_code == 0
+    confirm.assert_not_called()
+    command_call.assert_called_once_with("build", args="--output dist")
+    assert publisher_publish.call_count == 1

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -239,5 +239,9 @@ def test_publish_build_no_interaction_skips_confirmation(
     confirm.assert_not_called()
     assert "Build anyway?" not in output
     assert "Build anyway?" not in error
+    assert (
+        "Warning: Existing distribution files were found in dist; continuing because"
+        " --no-interaction was set."
+    ) in error
     command_call.assert_called_once_with("build", args="--output dist")
     assert publisher_publish.call_count == 1

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -233,6 +233,11 @@ def test_publish_build_no_interaction_skips_confirmation(
     exit_code = app_tester.execute("publish --build --no-interaction --dry-run")
 
     assert exit_code == 0
+    output = app_tester.io.fetch_output()
+    error = app_tester.io.fetch_error()
+
     confirm.assert_not_called()
+    assert "Build anyway?" not in output
+    assert "Build anyway?" not in error
     command_call.assert_called_once_with("build", args="--output dist")
     assert publisher_publish.call_count == 1

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -5,6 +5,7 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import NoReturn
+from unittest.mock import PropertyMock
 
 import pytest
 import requests
@@ -220,6 +221,11 @@ def test_publish_dist_dir_and_build_options(
 def test_publish_build_no_interaction_skips_confirmation(
     app_tester: ApplicationTester, mocker: MockerFixture
 ) -> None:
+    mocker.patch(
+        "poetry.publishing.publisher.Publisher.files",
+        new_callable=PropertyMock,
+        return_value=[Path("dist/simple_project-1.2.3-py2.py3-none-any.whl")],
+    )
     confirm = mocker.patch("poetry.console.commands.publish.PublishCommand.confirm")
     command_call = mocker.patch("poetry.console.commands.publish.PublishCommand.call")
     publisher_publish = mocker.patch("poetry.publishing.Publisher.publish")

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -240,8 +240,7 @@ def test_publish_build_no_interaction_skips_confirmation(
     assert "Build anyway?" not in output
     assert "Build anyway?" not in error
     assert (
-        "Warning: Existing distribution files were found in dist; continuing because"
-        " --no-interaction was set."
+        "Warning: There are 1 files ready for publishing in dist. Build anyway!"
     ) in output
     command_call.assert_called_once_with("build", args="--output dist")
     assert publisher_publish.call_count == 1

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -242,6 +242,6 @@ def test_publish_build_no_interaction_skips_confirmation(
     assert (
         "Warning: Existing distribution files were found in dist; continuing because"
         " --no-interaction was set."
-    ) in error
+    ) in output
     command_call.assert_called_once_with("build", args="--output dist")
     assert publisher_publish.call_count == 1


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10760

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Summary

- Respect `--no-interaction` in `poetry publish --build` when `dist/` already contains artifacts.
- In non-interactive mode, skip the confirmation prompt and proceed with the build/publish flow.
- Keep interactive behavior unchanged (still asks before rebuilding existing artifacts).

## Testing

- `poetry run pytest tests/console/commands/test_publish.py -q`
  - Added coverage for pre-existing `dist/` artifacts under non-interactive execution.
  - Existing prompt behavior remains covered for interactive mode.

## Summary by Sourcery

Tests:
- Add regression test ensuring `poetry publish --build --no-interaction` skips the confirmation prompt and still performs the build/publish flow when artifacts already exist in `dist/`.