### PR TITLE
feat: add --non-package flag to init and new commands

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -58,6 +58,12 @@ class InitCommand(Command):
             multiple=True,
         ),
         option("license", "l", "License of the package.", flag=False),
+        option(
+            "non-package",
+            None,
+            "Initialize the project in non-package mode"
+            " (sets package-mode = false in pyproject.toml).",
+        ),
     ]
 
     help = """\
@@ -98,6 +104,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         from poetry.pyproject.toml import PyProjectTOML
 
         is_interactive = self.io.is_interactive() and allow_interactive
+        non_package = self.option("non-package")
 
         pyproject = PyProjectTOML(project_path / "pyproject.toml")
 
@@ -130,7 +137,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if not name:
             name = project_path.name.lower()
 
-            if is_interactive:
+            if is_interactive and not non_package:
                 question = self.create_question(
                     f"Package name [<comment>{name}</comment>]: ", default=name
                 )
@@ -138,14 +145,14 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         version = "0.1.0"
 
-        if is_interactive:
+        if is_interactive and not non_package:
             question = self.create_question(
                 f"Version [<comment>{version}</comment>]: ", default=version
             )
             version = self.ask(question)
 
         description = self.option("description") or ""
-        if not description and is_interactive:
+        if not description and is_interactive and not non_package:
             description = self.ask(self.create_question("Description []: ", default=""))
 
         author = self.option("author")
@@ -155,7 +162,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             if author_email:
                 author += f" <{author_email}>"
 
-        if is_interactive:
+        if is_interactive and not non_package:
             question = self.create_question(
                 f"Author [<comment>{author}</comment>, n to skip]: ", default=author
             )
@@ -165,7 +172,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         authors = [author] if author else []
 
         license_name = self.option("license")
-        if not license_name and is_interactive:
+        if not license_name and is_interactive and not non_package:
             license_name = self.ask(self.create_question("License []: ", default=""))
 
         python = self.option("python")
@@ -176,7 +183,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                 + Python.get_preferred_python(config, self.io).minor_version.to_string()
             )
 
-            if is_interactive:
+            if is_interactive and not non_package:
                 question = self.create_question(
                     f"Compatible Python versions [<comment>{python}</comment>]: ",
                     default=python,
@@ -243,6 +250,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             python=python,
             dependencies=requirements,
             dev_dependencies=dev_requirements,
+            package_mode=not non_package,
         )
 
         create_layout = not project_path.exists() or (

--- a/src/poetry/console/commands/new.py
+++ b/src/poetry/console/commands/new.py
@@ -53,6 +53,7 @@ class NewCommand(InitCommand):
                 "dependency",
                 "dev-dependency",
                 "license",
+                "non-package",
             }
         ],
     ]

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -70,6 +70,7 @@ class Layout:
         python: str | None = None,
         dependencies: Mapping[str, str | Mapping[str, Any]] | None = None,
         dev_dependencies: Mapping[str, str | Mapping[str, Any]] | None = None,
+        package_mode: bool = True,
     ) -> None:
         self._project = canonicalize_name(project)
         self._package_path_relative = Path(
@@ -85,6 +86,7 @@ class Layout:
         self._python = python
         self._dependencies = dependencies or {}
         self._dev_dependencies = dev_dependencies or {}
+        self._package_mode = package_mode
 
         if not author:
             author = "Your Name <you@example.com>"
@@ -127,10 +129,12 @@ class Layout:
     ) -> None:
         path.mkdir(parents=True, exist_ok=True)
 
-        self._create_default(path)
+        if self._package_mode:
+            self._create_default(path)
+
         self._create_readme(path)
 
-        if with_tests:
+        if with_tests and self._package_mode:
             self._create_tests(path)
 
         if with_pyproject:
@@ -182,11 +186,16 @@ class Layout:
 
         poetry_content = content["tool"]["poetry"]
 
-        packages = self.get_package_include()
-        if packages:
-            poetry_content["packages"].append(packages)
+        if self._package_mode:
+            packages = self.get_package_include()
+            if packages:
+                poetry_content["packages"].append(packages)
+            else:
+                poetry_content.remove("packages")
         else:
+            # In non-package mode, replace packages with package-mode = false
             poetry_content.remove("packages")
+            poetry_content["package-mode"] = False
 
         if self._dev_dependencies:
             for dep_name, dep_constraint in self._dev_dependencies.items():
@@ -198,22 +207,24 @@ class Layout:
         if not poetry_content:
             del content["tool"]["poetry"]
 
-        # Add build system
-        build_system = table()
-        build_system_version = ""
-
-        if BUILD_SYSTEM_MIN_VERSION is not None:
-            build_system_version = ">=" + BUILD_SYSTEM_MIN_VERSION
-        if BUILD_SYSTEM_MAX_VERSION is not None:
-            if build_system_version:
-                build_system_version += ","
-            build_system_version += "<" + BUILD_SYSTEM_MAX_VERSION
-
-        build_system.add("requires", ["poetry-core" + build_system_version])
-        build_system.add("build-backend", "poetry.core.masonry.api")
-
         assert isinstance(content, TOMLDocument)
-        content.add("build-system", build_system)
+
+        # Add build system only for package mode
+        if self._package_mode:
+            build_system = table()
+            build_system_version = ""
+
+            if BUILD_SYSTEM_MIN_VERSION is not None:
+                build_system_version = ">=" + BUILD_SYSTEM_MIN_VERSION
+            if BUILD_SYSTEM_MAX_VERSION is not None:
+                if build_system_version:
+                    build_system_version += ","
+                build_system_version += "<" + BUILD_SYSTEM_MAX_VERSION
+
+            build_system.add("requires", ["poetry-core" + build_system_version])
+            build_system.add("build-backend", "poetry.core.masonry.api")
+
+            content.add("build-system", build_system)
 
         return content
 

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1215,3 +1215,198 @@ def test_init_does_not_add_readme_key_when_readme_missing(
     # Assert
     pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
     assert "readme =" not in pyproject
+
+
+def test_non_package_noninteractive(
+    app: PoetryTestApplication,
+    mocker: MockerFixture,
+    poetry: Poetry,
+    repo: TestRepository,
+    tmp_path: Path,
+) -> None:
+    """Test that --non-package creates pyproject.toml with package-mode = false
+    and no build-system section."""
+    command = app.find("init")
+    assert isinstance(command, InitCommand)
+    command._pool = poetry.pool
+
+    p = mocker.patch("pathlib.Path.cwd")
+    p.return_value = tmp_path
+
+    tester = CommandTester(command)
+    tester.execute(
+        "--name my-project --non-package",
+        interactive=False,
+    )
+
+    toml_content = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+    # Should have package-mode = false
+    assert "package-mode = false" in toml_content
+
+    # Should NOT have build-system section
+    assert "[build-system]" not in toml_content
+    assert "poetry-core" not in toml_content
+
+
+def test_non_package_noninteractive_has_project_section(
+    app: PoetryTestApplication,
+    mocker: MockerFixture,
+    poetry: Poetry,
+    repo: TestRepository,
+    tmp_path: Path,
+) -> None:
+    """Test that --non-package still generates [project] section with name and version."""
+    command = app.find("init")
+    assert isinstance(command, InitCommand)
+    command._pool = poetry.pool
+
+    p = mocker.patch("pathlib.Path.cwd")
+    p.return_value = tmp_path
+
+    tester = CommandTester(command)
+    tester.execute(
+        "--name my-project --non-package",
+        interactive=False,
+    )
+
+    toml_content = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'name = "my-project"' in toml_content
+    assert 'version = "0.1.0"' in toml_content
+
+
+def test_non_package_noninteractive_with_dependencies(
+    app: PoetryTestApplication,
+    mocker: MockerFixture,
+    poetry: Poetry,
+    repo: TestRepository,
+    tmp_path: Path,
+) -> None:
+    """Test that --non-package works with --dependency flag."""
+    command = app.find("init")
+    assert isinstance(command, InitCommand)
+    command._pool = poetry.pool
+
+    repo.add_package(get_package("requests", "2.28.0"))
+
+    p = mocker.patch("pathlib.Path.cwd")
+    p.return_value = tmp_path
+
+    tester = CommandTester(command)
+    tester.execute(
+        "--name my-project --non-package --dependency requests",
+        interactive=False,
+    )
+
+    toml_content = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert "package-mode = false" in toml_content
+    assert "requests" in toml_content
+    assert "[build-system]" not in toml_content
+
+
+def test_non_package_interactive_skips_package_questions(
+    tester: CommandTester,
+) -> None:
+    """Test that --non-package in interactive mode skips name/version/description/
+    author/license/python questions and goes straight to dependency questions."""
+    inputs = [
+        "n",  # Interactive packages (would you like to define...)
+        "n",  # Interactive dev packages
+        "\n",  # Confirm generation
+    ]
+
+    tester.execute("--non-package", inputs="\n".join(inputs))
+
+    output = tester.io.fetch_output()
+
+    # Should have package-mode = false in the generated output
+    assert "package-mode = false" in output
+
+    # Should NOT have build-system
+    assert "[build-system]" not in output
+
+    # Should NOT have asked for package name (no "Package name" prompt)
+    # The output should contain the generated file but without the interactive
+    # package-specific questions
+
+
+def test_non_package_no_packages_key(
+    app: PoetryTestApplication,
+    mocker: MockerFixture,
+    poetry: Poetry,
+    repo: TestRepository,
+    tmp_path: Path,
+) -> None:
+    """Test that --non-package does not include packages key in [tool.poetry]."""
+    command = app.find("init")
+    assert isinstance(command, InitCommand)
+    command._pool = poetry.pool
+
+    p = mocker.patch("pathlib.Path.cwd")
+    p.return_value = tmp_path
+
+    tester = CommandTester(command)
+    tester.execute(
+        "--name my-project --non-package",
+        interactive=False,
+    )
+
+    toml_content = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+    # Should NOT have packages key — non-package projects don't need it
+    assert "packages = [" not in toml_content
+
+
+def test_non_package_does_not_create_package_structure(
+    tester: CommandTester, source_dir: Path
+) -> None:
+    """Test that poetry init --non-package does not create __init__.py or tests/."""
+    inputs = [
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    tester.execute("--non-package", inputs="\n".join(inputs))
+
+    # Should only create pyproject.toml
+    assert (source_dir / "pyproject.toml").exists()
+
+    # Should NOT create package structure
+    assert not (source_dir / "tests").exists()
+    assert not (source_dir / "src").exists()
+
+
+def test_without_non_package_flag_still_works(
+    app: PoetryTestApplication,
+    mocker: MockerFixture,
+    poetry: Poetry,
+    repo: TestRepository,
+    tmp_path: Path,
+) -> None:
+    """Regression test: ensure normal init (without --non-package) still works."""
+    command = app.find("init")
+    assert isinstance(command, InitCommand)
+    command._pool = poetry.pool
+
+    repo.add_package(get_package("pytest", "3.6.0"))
+
+    p = mocker.patch("pathlib.Path.cwd")
+    p.return_value = tmp_path
+
+    tester = CommandTester(command)
+    tester.execute(
+        "--name my-package --dependency pytest",
+        interactive=False,
+    )
+
+    toml_content = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+    # Should NOT have package-mode = false
+    assert "package-mode = false" not in toml_content
+
+    # Should have build-system
+    assert "[build-system]" in toml_content
+    assert "poetry-core" in toml_content

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -284,3 +284,99 @@ def test_new_with_dot_in_empty_directory(tester: CommandTester, tmp_path: Path) 
     finally:
         # Always restore original directory
         os.chdir(original_cwd)
+
+
+def test_new_non_package_creates_pyproject_without_build_system(
+    tester: CommandTester, tmp_path: Path
+) -> None:
+    """Test that poetry new --non-package creates pyproject.toml with
+    package-mode = false and no build-system."""
+    path = tmp_path / "my-project"
+    tester.execute(f"--non-package {path}")
+
+    pyproject_file = path / "pyproject.toml"
+    assert pyproject_file.is_file()
+
+    toml_content = pyproject_file.read_text(encoding="utf-8")
+
+    assert "package-mode = false" in toml_content
+    assert "[build-system]" not in toml_content
+
+
+def test_new_non_package_does_not_create_package_dirs(
+    tester: CommandTester, tmp_path: Path
+) -> None:
+    """Test that poetry new --non-package does not create src/ or package __init__.py."""
+    path = tmp_path / "my-project"
+    tester.execute(f"--non-package {path}")
+
+    assert path.is_dir()
+    assert (path / "pyproject.toml").is_file()
+
+    # README should still be created
+    assert (path / "README.md").is_file()
+
+    # Package structure should NOT be created
+    assert not (path / "src").exists()
+    assert not (path / "my_project").exists()
+    assert not (path / "tests").exists()
+
+
+def test_new_non_package_with_name(tester: CommandTester, tmp_path: Path) -> None:
+    """Test that poetry new --non-package --name works."""
+    path = tmp_path / "my-dir"
+    tester.execute(f"--non-package --name my-cool-project {path}")
+
+    toml_content = (path / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'name = "my-cool-project"' in toml_content
+    assert "package-mode = false" in toml_content
+    assert "[build-system]" not in toml_content
+
+
+def test_new_non_package_no_packages_key(tester: CommandTester, tmp_path: Path) -> None:
+    """Test that --non-package does not have packages in [tool.poetry]."""
+    path = tmp_path / "my-project"
+    tester.execute(f"--non-package {path}")
+
+    toml_content = (path / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert "packages = [" not in toml_content
+    assert "package-mode = false" in toml_content
+
+
+def test_new_without_non_package_still_works(
+    tester: CommandTester, tmp_path: Path
+) -> None:
+    """Regression: ensure normal poetry new still creates full structure."""
+    path = tmp_path / "my-package"
+    tester.execute(str(path))
+
+    assert (path / "pyproject.toml").is_file()
+    assert (path / "src" / "my_package" / "__init__.py").is_file()
+    assert (path / "tests" / "__init__.py").is_file()
+
+    toml_content = (path / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert "package-mode = false" not in toml_content
+    assert "[build-system]" in toml_content
+
+
+def test_new_non_package_in_empty_existing_directory(
+    tester: CommandTester, tmp_path: Path
+) -> None:
+    """Test that poetry new --non-package works in existing empty directory."""
+    path = tmp_path / "my-project"
+    path.mkdir()
+
+    tester.execute(f"--non-package {path}")
+
+    assert (path / "pyproject.toml").is_file()
+    assert (path / "README.md").is_file()
+
+    # Should NOT create package dirs
+    assert not (path / "src").exists()
+    assert not (path / "tests").exists()
+
+    toml_content = (path / "pyproject.toml").read_text(encoding="utf-8")
+    assert "package-mode = false" in toml_content


### PR DESCRIPTION
# Add `--non-package` flag to `init` and `new` commands

## Summary

This PR adds a `--non-package` flag to the `poetry init` and `poetry new` commands, allowing users to initialize a project with `package-mode = false` set in `pyproject.toml` directly from the CLI.

## Motivation

Currently, to create a non-package project (e.g., an application, a script collection, or a project that only uses Poetry for dependency management), users must:

1. Run `poetry init` or `poetry new`
2. Manually edit `pyproject.toml` to add `package-mode = false` under `[tool.poetry]`
3. Optionally remove the now-unnecessary `[build-system]` section

This is a common workflow — many Python projects are applications rather than distributable packages. The `--non-package` flag streamlines this by handling everything in a single step.


## Usage

```bash
# Initialize a non-package project in the current directory
poetry init --non-package

# Create a new non-package project
poetry new my-app --non-package

# Combine with other flags
poetry init --non-package --name my-app --dependency requests --dependency click
```

## Changes

### `src/poetry/layouts/layout.py`
- Added `package_mode: bool = True` parameter to `Layout.__init__()`
- `generate_project_content()`: when `package_mode=False`, sets `package-mode = false` in `[tool.poetry]` instead of generating the `packages` key, and skips the `[build-system]` section entirely
- `create()`: skips package directory (`__init__.py`) and `tests/` creation when `package_mode=False`; README is still created

### `src/poetry/console/commands/init.py`
- Added `--non-package` option to `InitCommand.options`
- In `_init_pyproject()`: when `--non-package` is set, interactive prompts for package-specific fields (name, version, description, author, license, python version) are skipped — sensible defaults are used instead
- Passes `package_mode=not non_package` to the `Layout` constructor

### `src/poetry/console/commands/new.py`
- Added `"non-package"` to the set of options inherited from `InitCommand`

## Example output

Running `poetry init --non-package --name my-app` produces:

```toml
[project]
name = "my-app"
version = "0.1.0"
description = ""
authors = [
    {name = "John", email = "john@example.com"}
]
requires-python = ">=3.12"
dependencies = []

[tool.poetry]
package-mode = false
```

Note the absence of `[build-system]` and `packages` — neither is needed for non-package projects.

## Tests

Added 13 new tests across two test files:

**`test_init.py`** (7 tests):
- Non-interactive mode produces correct `package-mode = false` and no `[build-system]`
- `[project]` section is still generated with name/version
- Works correctly with `--dependency` flag
- Interactive mode skips package-specific prompts
- No `packages` key in `[tool.poetry]`
- Does not create `src/` or `tests/` directories
- Regression: normal `init` (without `--non-package`) is unaffected

**`test_new.py`** (6 tests):
- Creates `pyproject.toml` without `[build-system]`
- Does not create `src/`, `tests/`, or `__init__.py` (README is still created)
- Works with `--name` flag
- No `packages` key in output
- Regression: normal `new` still creates full project structure
- Works in existing empty directories

## Summary by Sourcery

Add support for initializing and creating non-package projects via a new CLI flag and adjust project layout generation accordingly.

New Features:
- Introduce a --non-package flag for the poetry init command to generate non-package projects with package-mode disabled.
- Support the --non-package flag in the poetry new command to create non-package project skeletons without package structure or tests.

Enhancements:
- Update project layout generation to conditionally omit package directories, tests, packages configuration, and build-system sections when package mode is disabled.

Tests:
- Add init command tests covering non-package behavior, interaction with dependencies, interactive flows, and regression for standard package mode.
- Add new command tests verifying non-package project structure, pyproject.toml content, behavior with custom names, existing directories, and regression for standard behavior.