### PR TITLE
docs: fix pipx install directions link

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -40,7 +40,7 @@ See the **advanced** installation instructions to use a preview or alternate ver
 **Install pipx**
 
 If `pipx` is not already installed, you can follow any of the options in the
-[official pipx installation instructions](https://pipx.pypa.io/stable/installation/).
+[official pipx installation instructions](https://pipx.pypa.io/stable/how-to/install-pipx/).
 Any non-ancient version of `pipx` will do.
 
 {{< /step >}}


### PR DESCRIPTION
Noticed this while reading, I didn't see any open issues for it

## Summary by Sourcery

Documentation:
- Correct the pipx installation instructions link in the main documentation index page.