### PR TITLE
fix(env): treat empty VIRTUAL_ENV/CONDA_PREFIX as unset

### DIFF
--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -251,12 +251,8 @@ class EnvManager:
 
             return VirtualEnv(venv)
 
-        if env_prefix:
-            prefix = Path(env_prefix)
-            base_prefix = None
-        else:
-            prefix = Path(sys.prefix)
-            base_prefix = self.get_base_prefix()
+        prefix = Path(env_prefix)
+        base_prefix = None
 
         return VirtualEnv(prefix, base_prefix)
 

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -251,10 +251,8 @@ class EnvManager:
 
             return VirtualEnv(venv)
 
-        prefix = Path(env_prefix)
-        base_prefix = None
-
-        return VirtualEnv(prefix, base_prefix)
+        assert env_prefix
+        return VirtualEnv(Path(env_prefix))
 
     def list(self, name: str | None = None) -> list[VirtualEnv]:
         if name is None:

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -159,7 +159,7 @@ class EnvManager:
 
         # Create if needed
         if not venv.exists() or create:
-            in_venv = os.environ.get("VIRTUAL_ENV") is not None
+            in_venv = bool(os.environ.get("VIRTUAL_ENV"))
             if in_venv or not venv.exists():
                 create = True
 
@@ -214,7 +214,9 @@ class EnvManager:
         conda_env_name = os.environ.get("CONDA_DEFAULT_ENV")
         # It's probably not a good idea to pollute Conda's global "base" env, since
         # most users have it activated all the time.
-        in_venv = env_prefix is not None and conda_env_name != "base"
+        # Treat an empty env_prefix as if no virtualenv is active, since conda
+        # can leave CONDA_PREFIX set to an empty string after deactivation.
+        in_venv = bool(env_prefix) and conda_env_name != "base"
 
         if not in_venv or env is not None:
             # Checking if a local virtualenv exists
@@ -249,7 +251,7 @@ class EnvManager:
 
             return VirtualEnv(venv)
 
-        if env_prefix is not None:
+        if env_prefix:
             prefix = Path(env_prefix)
             base_prefix = None
         else:

--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -84,7 +84,9 @@ class Python:
     @classmethod
     def find_all(cls) -> Iterator[Python]:
         venv_path: Path | None = (
-            Path(os.environ["VIRTUAL_ENV"]) if "VIRTUAL_ENV" in os.environ else None
+            Path(os.environ["VIRTUAL_ENV"])
+            if os.environ.get("VIRTUAL_ENV")
+            else None
         )
         for python in findpython.find_all():
             if venv_path and python.executable.is_relative_to(venv_path):

--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -84,9 +84,7 @@ class Python:
     @classmethod
     def find_all(cls) -> Iterator[Python]:
         venv_path: Path | None = (
-            Path(os.environ["VIRTUAL_ENV"])
-            if os.environ.get("VIRTUAL_ENV")
-            else None
+            Path(venv) if (venv := os.environ.get("VIRTUAL_ENV")) else None
         )
         for python in findpython.find_all():
             if venv_path and python.executable.is_relative_to(venv_path):

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -577,10 +577,7 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     assert env.base == Path(sys.base_prefix)
 
 
-@pytest.mark.parametrize(
-    "env_var",
-    ["VIRTUAL_ENV", "CONDA_PREFIX"],
-)
+@pytest.mark.parametrize("env_var", ["VIRTUAL_ENV", "CONDA_PREFIX"])
 def test_get_ignores_empty_env_prefix(
     manager: EnvManager,
     poetry: Poetry,

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -600,11 +600,8 @@ def test_get_ignores_empty_env_prefix(
         "poetry.utils.env.virtual_env.VirtualEnv.__init__",
         lambda self, *args, **kwargs: setattr(self, "_path", args[0]),
     )
-    try:
-        venv = manager.get()
-        assert venv.path == in_project_venv_dir
-    finally:
-        del os.environ[env_var]
+    venv = manager.get()
+    assert venv.path == in_project_venv_dir
 
 
 def test_list(

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -577,6 +577,39 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
     assert env.base == Path(sys.base_prefix)
 
 
+@pytest.mark.parametrize(
+    "env_var",
+    ["VIRTUAL_ENV", "CONDA_PREFIX"],
+)
+def test_get_ignores_empty_env_prefix(
+    manager: EnvManager,
+    poetry: Poetry,
+    in_project_venv_dir: Path,
+    env_var: str,
+    mocker: MockerFixture,
+) -> None:
+    """An empty VIRTUAL_ENV or CONDA_PREFIX should be treated as unset.
+
+    After ``conda deactivate``, conda can leave CONDA_PREFIX set to an
+    empty string.  Poetry should not consider that as an active
+    virtualenv and should fall back to the in-project .venv instead.
+
+    See: https://github.com/python-poetry/poetry/issues/10770
+    """
+    os.environ.pop("VIRTUAL_ENV", None)
+    os.environ.pop("CONDA_PREFIX", None)
+    os.environ[env_var] = ""
+    mocker.patch(
+        "poetry.utils.env.virtual_env.VirtualEnv.__init__",
+        lambda self, *args, **kwargs: setattr(self, "_path", args[0]),
+    )
+    try:
+        venv = manager.get()
+        assert venv.path == in_project_venv_dir
+    finally:
+        del os.environ[env_var]
+
+
 def test_list(
     tmp_path: Path,
     manager: EnvManager,


### PR DESCRIPTION
## Summary

- After `conda deactivate`, conda can leave `CONDA_PREFIX` set to an empty string. Poetry previously only checked `is not None`, treating the empty string as an active virtualenv, causing `poetry env use` and other commands to fail.
- Changed all env-prefix checks to use truthiness (`bool(...)` / `if env_prefix:`) so an empty string is treated the same as an unset variable.
- Also applied the same fix to `VIRTUAL_ENV` checks in `env_manager.py` (line 162) and `python/manager.py` for consistency and defensive correctness.
- Added parametrized tests for both `VIRTUAL_ENV` and `CONDA_PREFIX` empty-string scenarios.

Fixes #10770

## Test plan

- [x] Added `test_get_ignores_empty_env_prefix` parametrized over `VIRTUAL_ENV` and `CONDA_PREFIX`
- [x] Both test cases verify that `manager.get()` falls back to the in-project `.venv` when the env variable is set to an empty string
- [x] Existing tests remain unaffected (the change is strictly more permissive — only empty strings are newly treated as unset)

## Summary by Sourcery

Handle empty virtual environment prefix variables as unset across environment detection and Python discovery.

Bug Fixes:
- Treat empty CONDA_PREFIX values as no active virtualenv when resolving the current environment.
- Treat empty VIRTUAL_ENV values as no active virtualenv when activating or discovering environments.

Enhancements:
- Align virtual environment detection logic to rely on truthiness of env-prefix variables for more robust behavior across backends.

Tests:
- Add parametrized tests ensuring empty VIRTUAL_ENV and CONDA_PREFIX values cause fallback to the in-project virtualenv instead of being treated as active.