### PR TITLE
fix(publish): normalize legacy repository URL trailing slash (#6687)

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -447,6 +447,8 @@ typically different to the same one provided by the repository for the simple AP
 in the example of [Test PyPI](https://test.pypi.org/), both the host (`test.pypi.org`) as
 well as the path (`/legacy`) are different to its simple API (`https://test.pypi.org/simple`).
 
+While the examples show URLs with a trailing slash (e.g., `https://test.pypi.org/legacy/`), Poetry automatically normalizes legacy repository URLs by adding a trailing slash if one is missing. This means both `https://test.pypi.org/legacy` and `https://test.pypi.org/legacy/` will work correctly when publishing.
+
 {{% /note %}}
 
 ## Configuring Credentials

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+def _normalize_legacy_repository_url(url: str) -> str:
+    if url.endswith("/legacy"):
+        url += "/"
+    return url
 
 class Publisher:
     """
@@ -52,6 +56,7 @@ class Publisher:
             url = self._poetry.config.get(f"repositories.{repository_name}.url")
             if url is None:
                 raise RuntimeError(f"Repository {repository_name} is not defined")
+            url = _normalize_legacy_repository_url(url)
 
         if not (username and password):
             # Check if we have a token first

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -17,10 +17,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 def _normalize_legacy_repository_url(url: str) -> str:
     if url.endswith("/legacy"):
         url += "/"
     return url
+
 
 class Publisher:
     """

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -210,3 +210,45 @@ def test_publish_read_from_environment_variable(
         ("https://foo.bar",),
         {"cert": True, "client_cert": None, "dry_run": False, "skip_existing": False},
     ]
+
+@pytest.mark.parametrize(
+    ("configured_url", "expected_url"),
+    [
+        # Missing trailing slash — should be added
+        ("https://test.pypi.org/legacy", "https://test.pypi.org/legacy/"),
+        # Already has trailing slash — should not double up
+        ("https://test.pypi.org/legacy/", "https://test.pypi.org/legacy/"),
+        # Non-legacy URL — should be unchanged
+        ("https://test.pypi.org/simple", "https://test.pypi.org/simple"),
+    ],
+)
+def test_publish_normalizes_legacy_repository_url(
+    fixture_dir: FixtureDirGetter,
+    mocker: MockerFixture,
+    config: Config,
+    configured_url: str,
+    expected_url: str,
+) -> None:
+    uploader_auth = mocker.patch("poetry.publishing.uploader.Uploader.auth")
+    uploader_upload = mocker.patch("poetry.publishing.uploader.Uploader.upload")
+
+    poetry = Factory().create_poetry(fixture_dir("sample_project"))
+    poetry._config = config
+    poetry.config.merge(
+        {
+            "repositories": {"testpypi": {"url": configured_url}},
+            "http-basic": {"testpypi": {"username": "foo", "password": "bar"}},
+        }
+    )
+
+    publisher = Publisher(poetry, NullIO())
+    publisher.publish("testpypi", None, None)
+
+    uploader_auth.assert_called_once_with("foo", "bar")
+    uploader_upload.assert_called_once_with(
+        expected_url,
+        cert=True,
+        client_cert=None,
+        dry_run=False,
+        skip_existing=False,
+    )

--- a/tests/publishing/test_publisher.py
+++ b/tests/publishing/test_publisher.py
@@ -211,6 +211,7 @@ def test_publish_read_from_environment_variable(
         {"cert": True, "client_cert": None, "dry_run": False, "skip_existing": False},
     ]
 
+
 @pytest.mark.parametrize(
     ("configured_url", "expected_url"),
     [


### PR DESCRIPTION
Fixes #6687

When a PEP 503 legacy repository is configured without a trailing slash
(e.g. `https://test.pypi.org/legacy`), uploads silently fail because the
server expects the `/legacy/` path.

This PR normalizes the URL before publishing.

Changes:
- Simplify `_normalize_legacy_repository_url` to a one-liner per
  @radoering's suggestion in #10732 (removes urllib.parse import)
- Fix broken `call_args` assertions in test — replaced with
  `assert_called_once_with` which actually validates the call
- Parametrize the test to cover three cases:
  1. Missing trailing slash → slash appended ✓
  2. Already has trailing slash → no double slash ✓  
  3. Non-legacy URL → unchanged ✓

Note: This supersedes #10732 which had reviewer feedback pending.

## Summary by Sourcery

Normalize configured legacy repository URLs during publishing to ensure uploads target the correct endpoint.

Bug Fixes:
- Ensure legacy repository URLs without a trailing slash are corrected so uploads no longer silently fail.

Tests:
- Add a parametrized publishing test that verifies legacy URLs are normalized and other URLs remain unchanged.