### PR TITLE
Update init & new commands for PEP 639 (License)

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -166,7 +166,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         license_name = self.option("license")
         if not license_name and is_interactive:
-            license_name = self.ask(self.create_question("License []: ", default=""))
+            license_name = self.ask(self.create_question("License: ", default=""))
 
         python = self.option("python")
         if not python:

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -166,7 +166,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         license_name = self.option("license")
         if not license_name and is_interactive:
-            license_name = self.ask(self.create_question("License: ", default=""))
+            license_name = self.ask(self.create_question("License []: ", default=""))
 
         python = self.option("python")
         if not python:

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -32,7 +32,7 @@ version = ""
 description = ""
 authors = [
 ]
-license = {}
+license = ""
 readme = ""
 requires-python = ""
 dependencies = [
@@ -158,7 +158,7 @@ class Layout:
             project_content["authors"].append(author)
 
         if self._license:
-            project_content["license"]["text"] = self._license
+            project_content["license"] = self._license
         else:
             project_content.remove("license")
 

--- a/tests/console/commands/conftest.py
+++ b/tests/console/commands/conftest.py
@@ -30,7 +30,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.6"
 """
@@ -55,7 +55,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -145,7 +145,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "pendulum (>=2.0.0,<3.0.0)",
@@ -201,7 +201,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 """
 
@@ -269,7 +269,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "demo @ git+https://github.com/demo/demo.git"
@@ -364,7 +364,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "demo @ git+https://github.com/demo/demo.git@develop"
@@ -412,7 +412,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "demo @ git+https://github.com/demo/pyproject-demo.git"
@@ -467,7 +467,7 @@ description = "This is a description"
 authors = [
     {{name = "Your Name",email = "you@example.com"}}
 ]
-license = {{text = "MIT"}}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "demo @ {demo_uri}"
@@ -521,7 +521,7 @@ description = "This is a description"
 authors = [
     {{name = "Your Name",email = "you@example.com"}}
 ]
-license = {{text = "MIT"}}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "demo @ {demo_uri}"
@@ -576,7 +576,7 @@ description = "This is a description"
 authors = [
     {{name = "Your Name",email = "you@example.com"}}
 ]
-license = {{text = "MIT"}}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "demo @ {demo_uri}"
@@ -623,7 +623,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.8"
 dependencies = [
     "foo (==1.19.2)",
@@ -660,7 +660,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 """
 
@@ -691,7 +691,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "pendulum (>=2.0.0,<3.0.0)"
@@ -733,7 +733,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
     "pendulum (>=2.0.0,<3.0.0)",
@@ -768,7 +768,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
 ]
@@ -814,7 +814,7 @@ description = "This is a description"
 authors = [
     {name = "Your Name",email = "you@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.6"
 dependencies = [
 ]
@@ -861,7 +861,7 @@ description = "This is a description"
 authors = [
     {name = "Foo Bar",email = "foo@example.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.8"
 dependencies = [
     "pendulum (>=2.0.0,<3.0.0)"


### PR DESCRIPTION
# Pull Request Check List

Resolves: N/A

- [x] Updated **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Poetry was already updated to support this in
https://github.com/python-poetry/poetry/pull/10413. But the layout needed to be updated for it to get generated in the `init` and `new` commands.

This also updates the relevant tests.

## Summary by Sourcery

Align project layout and init/new command outputs with PEP 639 license field expectations.

Bug Fixes:
- Update generated pyproject.toml license field to use a simple string instead of a nested table for license text.
- Adjust interactive init prompt to remove the empty default indicator for the license question.

Tests:
- Update init and new command tests to assert the new license string format in generated pyproject.toml files.