### PR TITLE
chore: update json and html fixtures

### DIFF
--- a/tests/repositories/fixtures/legacy/black.html
+++ b/tests/repositories/fixtures/legacy/black.html
@@ -5,9 +5,9 @@
 <body>
     <h1>Links for black</h1>
     <a href="https://files.pythonhosted.org/packages/fd/bb/ad34bbc93d1bea3de086d7c59e528d4a503ac8fe318bd1fa48605584c3d2/black-19.10b0-py36-none-any.whl#sha256=13001c5b7dbc81137164b43137320a1785e95ce84e4db849279786877ac6d7f6" data-requires-python=">=3.6">black-19.10b0-py36-none-any.whl</a>
-    <a href="https://files.pythonhosted.org/packages/b0/dc/ecd83b973fb7b82c34d828aad621a6e5865764d52375b8ac1d7a45e23c8d/black-19.10b0.tar.gz#sha256=c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539" data-requires-python="&gt;=3.6" >black-19.10b0.tar.gz</a>
+    <a href="https://files.pythonhosted.org/packages/b0/dc/ecd83b973fb7b82c34d828aad621a6e5865764d52375b8ac1d7a45e23c8d/black-19.10b0.tar.gz#sha256=6cada614d5d2132698c6d5fff384657273d922c4fffa6a2f0de9e03e25b8913a" data-requires-python="&gt;=3.6" >black-19.10b0.tar.gz</a>
     <a href="https://files.pythonhosted.org/packages/3d/ad/1cf514e7f9ee4c3d8df7c839d7977f7605ad76557f3fca741ec67f76dba6/black-21.11b0-py3-none-any.whl#sha256=38f6ad54069912caf2fa2d4f25d0c5dedef4b2338a0cb545dbe2fdf54a6a8891" data-requires-python=">=3.6.2" data-yanked="Broken regex dependency. Use 21.11b1 instead.">black-21.11b0-py3-none-any.whl</a>
-    <a href="https://files.pythonhosted.org/packages/2f/db/03e8cef689ab0ff857576ee2ee288d1ff2110ef7f3a77cac62e61f18acaf/black-21.11b0.tar.gz#sha256=83f3852301c8dcb229e9c444dd79f573c8d31c7c2dad9bbaaa94c808630e32aa" data-requires-python="&gt;=3.6.2" data-yanked="Broken regex dependency. Use 21.11b1 instead." >black-21.11b0.tar.gz</a>
+    <a href="https://files.pythonhosted.org/packages/2f/db/03e8cef689ab0ff857576ee2ee288d1ff2110ef7f3a77cac62e61f18acaf/black-21.11b0.tar.gz#sha256=f23c482185d842e2f19d506e55c004061167e3c677c063ecd721042c62086ada" data-requires-python="&gt;=3.6.2" data-yanked="Broken regex dependency. Use 21.11b1 instead." >black-21.11b0.tar.gz</a>
     </body>
 </html>
 <!--SERIAL 6044498-->

--- a/tests/repositories/fixtures/pypi.org/json/attrs/17.4.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/attrs/17.4.0.json
@@ -71,6 +71,10 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "attrs",
+    "roles": []
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/black/19.10b0.json
+++ b/tests/repositories/fixtures/pypi.org/json/black/19.10b0.json
@@ -61,6 +61,31 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "JelleZijlstra"
+      },
+      {
+        "role": "Owner",
+        "user": "ambv"
+      },
+      {
+        "role": "Owner",
+        "user": "cooperlees"
+      },
+      {
+        "role": "Owner",
+        "user": "willingc"
+      },
+      {
+        "role": "Owner",
+        "user": "zsolzsol"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/black/21.11b0.json
+++ b/tests/repositories/fixtures/pypi.org/json/black/21.11b0.json
@@ -71,6 +71,31 @@
     "yanked_reason": "Broken regex dependency. Use 21.11b1 instead."
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "JelleZijlstra"
+      },
+      {
+        "role": "Owner",
+        "user": "ambv"
+      },
+      {
+        "role": "Owner",
+        "user": "cooperlees"
+      },
+      {
+        "role": "Owner",
+        "user": "willingc"
+      },
+      {
+        "role": "Owner",
+        "user": "zsolzsol"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/cleo/1.0.0a5.json
+++ b/tests/repositories/fixtures/pypi.org/json/cleo/1.0.0a5.json
@@ -48,6 +48,19 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "poetry",
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "neersighted"
+      },
+      {
+        "role": "Maintainer",
+        "user": "secrus"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/clikit/0.2.4.json
+++ b/tests/repositories/fixtures/pypi.org/json/clikit/0.2.4.json
@@ -53,6 +53,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "SDisPater"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/colorama/0.3.9.json
+++ b/tests/repositories/fixtures/pypi.org/json/colorama/0.3.9.json
@@ -56,6 +56,19 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "tartley"
+      },
+      {
+        "role": "Owner",
+        "user": "wiggin15"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/discord-py/2.0.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/discord-py/2.0.0.json
@@ -71,6 +71,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "rapptz"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/filecache/0.81.json
+++ b/tests/repositories/fixtures/pypi.org/json/filecache/0.81.json
@@ -47,6 +47,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "ubershmekel"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/funcsigs/1.0.2.json
+++ b/tests/repositories/fixtures/pypi.org/json/funcsigs/1.0.2.json
@@ -55,6 +55,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "Aaron.Iles"
+      },
+      {
+        "role": "Owner",
+        "user": "Joshua.Harlow"
+      },
+      {
+        "role": "Owner",
+        "user": "lifeless"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/futures/3.2.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/futures/3.2.0.json
@@ -45,6 +45,19 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "agronholm"
+      },
+      {
+        "role": "Owner",
+        "user": "bquinlan"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/hbmqtt/0.9.6.json
+++ b/tests/repositories/fixtures/pypi.org/json/hbmqtt/0.9.6.json
@@ -50,6 +50,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "njouanin"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/importlib-metadata/1.7.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/importlib-metadata/1.7.0.json
@@ -55,6 +55,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "barry"
+      },
+      {
+        "role": "Owner",
+        "user": "brettcannon"
+      },
+      {
+        "role": "Owner",
+        "user": "jaraco"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/ipython/4.1.0rc1.json
+++ b/tests/repositories/fixtures/pypi.org/json/ipython/4.1.0rc1.json
@@ -81,6 +81,43 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "jupyter",
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "bgranger"
+      },
+      {
+        "role": "Owner",
+        "user": "fperez"
+      },
+      {
+        "role": "Owner",
+        "user": "ivanov"
+      },
+      {
+        "role": "Owner",
+        "user": "minrk"
+      },
+      {
+        "role": "Owner",
+        "user": "takowl"
+      },
+      {
+        "role": "Maintainer",
+        "user": "krassowski"
+      },
+      {
+        "role": "Maintainer",
+        "user": "mbussonn"
+      },
+      {
+        "role": "Maintainer",
+        "user": "trallard"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/ipython/5.7.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/ipython/5.7.0.json
@@ -90,6 +90,43 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "jupyter",
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "bgranger"
+      },
+      {
+        "role": "Owner",
+        "user": "fperez"
+      },
+      {
+        "role": "Owner",
+        "user": "ivanov"
+      },
+      {
+        "role": "Owner",
+        "user": "minrk"
+      },
+      {
+        "role": "Owner",
+        "user": "takowl"
+      },
+      {
+        "role": "Maintainer",
+        "user": "krassowski"
+      },
+      {
+        "role": "Maintainer",
+        "user": "mbussonn"
+      },
+      {
+        "role": "Maintainer",
+        "user": "trallard"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/ipython/7.5.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/ipython/7.5.0.json
@@ -93,6 +93,43 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "jupyter",
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "bgranger"
+      },
+      {
+        "role": "Owner",
+        "user": "fperez"
+      },
+      {
+        "role": "Owner",
+        "user": "ivanov"
+      },
+      {
+        "role": "Owner",
+        "user": "minrk"
+      },
+      {
+        "role": "Owner",
+        "user": "takowl"
+      },
+      {
+        "role": "Maintainer",
+        "user": "krassowski"
+      },
+      {
+        "role": "Maintainer",
+        "user": "mbussonn"
+      },
+      {
+        "role": "Maintainer",
+        "user": "trallard"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/isodate/0.7.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/isodate/0.7.0.json
@@ -54,6 +54,15 @@
     "yanked_reason": "fails for py2.7 but is not marked as py3 only."
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "gweis"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/isort/4.3.4.json
+++ b/tests/repositories/fixtures/pypi.org/json/isort/4.3.4.json
@@ -55,6 +55,19 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "static"
+      },
+      {
+        "role": "Owner",
+        "user": "timothycrosley"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/jupyter/1.0.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/jupyter/1.0.0.json
@@ -50,6 +50,43 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "jupyter",
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "Kyle.Kelley"
+      },
+      {
+        "role": "Owner",
+        "user": "bgranger"
+      },
+      {
+        "role": "Owner",
+        "user": "darian"
+      },
+      {
+        "role": "Owner",
+        "user": "fperez"
+      },
+      {
+        "role": "Owner",
+        "user": "jtp"
+      },
+      {
+        "role": "Owner",
+        "user": "mbussonn"
+      },
+      {
+        "role": "Owner",
+        "user": "minrk"
+      },
+      {
+        "role": "Owner",
+        "user": "takowl"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/more-itertools/4.1.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/more-itertools/4.1.0.json
@@ -53,6 +53,19 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "erikrose"
+      },
+      {
+        "role": "Maintainer",
+        "user": "bbayles"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/pastel/0.1.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/pastel/0.1.0.json
@@ -49,6 +49,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "SDisPater"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/pluggy/0.6.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/pluggy/0.6.0.json
@@ -56,6 +56,35 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "The_Compiler"
+      },
+      {
+        "role": "Owner",
+        "user": "flub"
+      },
+      {
+        "role": "Owner",
+        "user": "goodboy"
+      },
+      {
+        "role": "Owner",
+        "user": "hpk"
+      },
+      {
+        "role": "Owner",
+        "user": "nicoddemus"
+      },
+      {
+        "role": "Owner",
+        "user": "ronny"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/poetry-core/1.5.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/poetry-core/1.5.0.json
@@ -52,6 +52,10 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "poetry",
+    "roles": []
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/poetry-core/2.0.1.json
+++ b/tests/repositories/fixtures/pypi.org/json/poetry-core/2.0.1.json
@@ -50,6 +50,10 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "poetry",
+    "roles": []
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/py/1.5.3.json
+++ b/tests/repositories/fixtures/pypi.org/json/py/1.5.3.json
@@ -57,6 +57,35 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "pytest-dev",
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "The_Compiler"
+      },
+      {
+        "role": "Owner",
+        "user": "anatoly"
+      },
+      {
+        "role": "Owner",
+        "user": "flub"
+      },
+      {
+        "role": "Owner",
+        "user": "hpk"
+      },
+      {
+        "role": "Owner",
+        "user": "pfctdayelise"
+      },
+      {
+        "role": "Owner",
+        "user": "ronny"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/pylev/1.3.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/pylev/1.3.0.json
@@ -46,6 +46,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "daniellindsley"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/pytest/3.5.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/pytest/3.5.0.json
@@ -64,6 +64,39 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "The_Compiler"
+      },
+      {
+        "role": "Owner",
+        "user": "anatoly"
+      },
+      {
+        "role": "Owner",
+        "user": "flub"
+      },
+      {
+        "role": "Owner",
+        "user": "hpk"
+      },
+      {
+        "role": "Owner",
+        "user": "nicoddemus"
+      },
+      {
+        "role": "Owner",
+        "user": "pfctdayelise"
+      },
+      {
+        "role": "Owner",
+        "user": "ronny"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/pytest/3.5.1.json
+++ b/tests/repositories/fixtures/pypi.org/json/pytest/3.5.1.json
@@ -66,6 +66,39 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "The_Compiler"
+      },
+      {
+        "role": "Owner",
+        "user": "anatoly"
+      },
+      {
+        "role": "Owner",
+        "user": "flub"
+      },
+      {
+        "role": "Owner",
+        "user": "hpk"
+      },
+      {
+        "role": "Owner",
+        "user": "nicoddemus"
+      },
+      {
+        "role": "Owner",
+        "user": "pfctdayelise"
+      },
+      {
+        "role": "Owner",
+        "user": "ronny"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/python-language-server/0.21.2.json
+++ b/tests/repositories/fixtures/pypi.org/json/python-language-server/0.21.2.json
@@ -38,6 +38,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "palantir-pypi"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/pyyaml/3.13.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/pyyaml/3.13.0.json
@@ -52,6 +52,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "ingy"
+      },
+      {
+        "role": "Owner",
+        "user": "nitzmahone"
+      },
+      {
+        "role": "Owner",
+        "user": "tinita"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/requests/2.18.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/requests/2.18.0.json
@@ -63,6 +63,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "Lukasa"
+      },
+      {
+        "role": "Owner",
+        "user": "graffatcolmingov"
+      },
+      {
+        "role": "Owner",
+        "user": "nateprewitt"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/requests/2.18.1.json
+++ b/tests/repositories/fixtures/pypi.org/json/requests/2.18.1.json
@@ -63,6 +63,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "Lukasa"
+      },
+      {
+        "role": "Owner",
+        "user": "graffatcolmingov"
+      },
+      {
+        "role": "Owner",
+        "user": "nateprewitt"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/requests/2.18.2.json
+++ b/tests/repositories/fixtures/pypi.org/json/requests/2.18.2.json
@@ -63,6 +63,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "Lukasa"
+      },
+      {
+        "role": "Owner",
+        "user": "graffatcolmingov"
+      },
+      {
+        "role": "Owner",
+        "user": "nateprewitt"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/requests/2.18.3.json
+++ b/tests/repositories/fixtures/pypi.org/json/requests/2.18.3.json
@@ -63,6 +63,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "Lukasa"
+      },
+      {
+        "role": "Owner",
+        "user": "graffatcolmingov"
+      },
+      {
+        "role": "Owner",
+        "user": "nateprewitt"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/requests/2.18.4.json
+++ b/tests/repositories/fixtures/pypi.org/json/requests/2.18.4.json
@@ -62,6 +62,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "Lukasa"
+      },
+      {
+        "role": "Owner",
+        "user": "graffatcolmingov"
+      },
+      {
+        "role": "Owner",
+        "user": "nateprewitt"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/requests/2.19.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/requests/2.19.0.json
@@ -62,6 +62,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "Lukasa"
+      },
+      {
+        "role": "Owner",
+        "user": "graffatcolmingov"
+      },
+      {
+        "role": "Owner",
+        "user": "nateprewitt"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/setuptools/39.2.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/setuptools/39.2.0.json
@@ -58,6 +58,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "jaraco"
+      },
+      {
+        "role": "Maintainer",
+        "user": "abravalheri"
+      },
+      {
+        "role": "Maintainer",
+        "user": "dstufft"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/setuptools/67.6.1.json
+++ b/tests/repositories/fixtures/pypi.org/json/setuptools/67.6.1.json
@@ -96,6 +96,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "jaraco"
+      },
+      {
+        "role": "Maintainer",
+        "user": "abravalheri"
+      },
+      {
+        "role": "Maintainer",
+        "user": "dstufft"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/six/1.11.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/six/1.11.0.json
@@ -45,6 +45,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "gutworth"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/sqlalchemy/1.2.12.json
+++ b/tests/repositories/fixtures/pypi.org/json/sqlalchemy/1.2.12.json
@@ -48,6 +48,19 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "sqlalchemy",
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "CaselIT"
+      },
+      {
+        "role": "Owner",
+        "user": "zzzeek"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/toga/0.3.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/toga/0.3.0.json
@@ -62,6 +62,10 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "beeware",
+    "roles": []
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/toga/0.3.0dev1.json
+++ b/tests/repositories/fixtures/pypi.org/json/toga/0.3.0dev1.json
@@ -55,6 +55,10 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "beeware",
+    "roles": []
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/toga/0.3.0dev2.json
+++ b/tests/repositories/fixtures/pypi.org/json/toga/0.3.0dev2.json
@@ -55,6 +55,10 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "beeware",
+    "roles": []
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/toga/0.4.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/toga/0.4.0.json
@@ -62,6 +62,10 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "beeware",
+    "roles": []
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/tomlkit/0.5.2.json
+++ b/tests/repositories/fixtures/pypi.org/json/tomlkit/0.5.2.json
@@ -52,6 +52,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "poetry",
+    "roles": [
+      {
+        "role": "Maintainer",
+        "user": "neersighted"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/tomlkit/0.5.3.json
+++ b/tests/repositories/fixtures/pypi.org/json/tomlkit/0.5.3.json
@@ -52,6 +52,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "poetry",
+    "roles": [
+      {
+        "role": "Maintainer",
+        "user": "neersighted"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/twisted/18.9.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/twisted/18.9.0.json
@@ -45,6 +45,10 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "twisted",
+    "roles": []
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/wheel/0.40.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/wheel/0.40.0.json
@@ -54,6 +54,23 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": "pypa",
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "agronholm"
+      },
+      {
+        "role": "Owner",
+        "user": "joeforker"
+      },
+      {
+        "role": "Owner",
+        "user": "natefoo"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",

--- a/tests/repositories/fixtures/pypi.org/json/zipp/3.5.0.json
+++ b/tests/repositories/fixtures/pypi.org/json/zipp/3.5.0.json
@@ -57,6 +57,15 @@
     "yanked_reason": null
   },
   "last_serial": 0,
+  "ownership": {
+    "organization": null,
+    "roles": [
+      {
+        "role": "Owner",
+        "user": "jaraco"
+      }
+    ]
+  },
   "urls": [
     {
       "comment_text": "",


### PR DESCRIPTION
## Summary by Sourcery

Refresh PyPI fixture data for HTML and JSON responses used in repository tests.

Tests:
- Update legacy HTML fixture for black to reflect current download URLs and digests.
- Regenerate multiple PyPI JSON fixtures for various packages and versions to match updated upstream metadata.