### PR TITLE
fix long path issue on Windows

### DIFF
--- a/src/poetry/console/commands/env/remove.py
+++ b/src/poetry/console/commands/env/remove.py
@@ -7,6 +7,7 @@ from cleo.helpers import argument
 from cleo.helpers import option
 
 from poetry.console.commands.command import Command
+from poetry.utils._compat import is_relative_to
 
 
 if TYPE_CHECKING:
@@ -54,8 +55,8 @@ class EnvRemoveCommand(Command):
             self.line(f"Deleted virtualenv: <comment>{venv.path}</comment>")
         if remove_all_envs or is_in_project:
             for venv in manager.list():
-                if not is_in_project or venv.path.is_relative_to(
-                    self.poetry.pyproject_path.parent
+                if not is_in_project or is_relative_to(
+                    venv.path, self.poetry.pyproject_path.parent
                 ):
                     manager.remove_venv(venv.path)
                     self.line(f"Deleted virtualenv: <comment>{venv.path}</comment>")

--- a/src/poetry/console/commands/python/list.py
+++ b/src/poetry/console/commands/python/list.py
@@ -10,6 +10,7 @@ from poetry.core.version.exceptions import InvalidVersionError
 
 from poetry.config.config import Config
 from poetry.console.commands.command import Command
+from poetry.utils._compat import is_relative_to
 from poetry.utils.env.python import Python
 
 
@@ -107,9 +108,8 @@ class PythonListCommand(Command):
             implementation = implementations.get(
                 pv.implementation.lower(), pv.implementation
             )
-            is_poetry_managed = (
-                pv.executable is None
-                or pv.executable.resolve().is_relative_to(python_installation_path)
+            is_poetry_managed = pv.executable is None or is_relative_to(
+                pv.executable.resolve(), python_installation_path
             )
 
             if self.option("managed") and not is_poetry_managed:

--- a/src/poetry/installation/wheel_installer.py
+++ b/src/poetry/installation/wheel_installer.py
@@ -14,6 +14,7 @@ from installer.sources import _WheelFileValidationError
 
 from poetry.__version__ import __version__
 from poetry.utils._compat import WINDOWS
+from poetry.utils._compat import is_relative_to
 
 
 logger = logging.getLogger(__name__)
@@ -47,9 +48,15 @@ class WheelDestination(SchemeDictionaryDestination):
         target_dir = Path(self.scheme_dict[scheme]).resolve()
         target_path = (target_dir / path).resolve()
 
-        if not target_path.is_relative_to(target_dir):
+        # Use is_relative_to() instead of Path.is_relative_to()
+        # because the latter does not work if one of both paths
+        # has a Windows long path prefix and the other path has not.
+        # (A long path prefix may be added when calling resolve().)
+        if not is_relative_to(target_path, target_dir):
             raise ValueError(
-                f"Attempting to write {path} outside of the target directory"
+                f"Attempting to write {path} outside of the target directory\n"
+                f"Target directory: {target_dir}\n"
+                f"Target path: {target_path}"
             )
 
         if target_path.exists():

--- a/src/poetry/utils/_compat.py
+++ b/src/poetry/utils/_compat.py
@@ -5,6 +5,7 @@ import sys
 import warnings
 
 from contextlib import suppress
+from pathlib import Path
 
 
 if sys.version_info < (3, 11):
@@ -50,6 +51,33 @@ def getencoding() -> str:
         return locale.getpreferredencoding()
     else:
         return locale.getencoding()
+
+
+def is_relative_to(path1: Path, path2: Path) -> bool:
+    """
+    Checks if path1 is relative to path2.
+
+    Works also if one of both paths has a Windows long path prefix.
+    A long path prefix may be added when calling Path.resolve().
+    """
+    if WINDOWS:
+        # Work around an issue that is_relative_to() does not work if
+        # one of both paths has a long path prefix and the other path has not.
+        long_path_prefix = "\\\\?\\"
+        long_path_unc_prefix = f"{long_path_prefix}UNC\\"
+
+        def remove_long_path_prefix(path: Path) -> Path:
+            if (path_str := str(path)).startswith(long_path_prefix):
+                if path_str.startswith(long_path_unc_prefix):
+                    path = Path("\\\\" + path_str.removeprefix(long_path_unc_prefix))
+                else:
+                    path = Path(path_str.removeprefix(long_path_prefix))
+            return path
+
+        path1 = remove_long_path_prefix(path1)
+        path2 = remove_long_path_prefix(path2)
+
+    return path1.is_relative_to(path2)
 
 
 def __getattr__(name: str) -> object:

--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -23,6 +23,7 @@ from poetry.core.constraints.version import Version
 from poetry.core.constraints.version import VersionConstraint
 from poetry.core.constraints.version import parse_constraint
 
+from poetry.utils._compat import is_relative_to
 from poetry.utils.env.python.exceptions import NoCompatiblePythonVersionFoundError
 from poetry.utils.env.python.providers import PoetryPythonPathProvider
 from poetry.utils.env.python.providers import ShutilWhichPythonProvider
@@ -87,7 +88,7 @@ class Python:
             Path(venv) if (venv := os.environ.get("VIRTUAL_ENV")) else None
         )
         for python in findpython.find_all():
-            if venv_path and python.executable.is_relative_to(venv_path):
+            if venv_path and is_relative_to(python.executable, venv_path):
                 continue
             yield cls(python=python)
 

--- a/tests/utils/test_compat.py
+++ b/tests/utils/test_compat.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sys
+
+from pathlib import Path
+
+import pytest
+
+from poetry.utils._compat import is_relative_to
+
+
+@pytest.mark.parametrize(
+    ("path1", "path2", "expected"),
+    [
+        ("a", "a", True),
+        ("a/b", "a/b", True),
+        ("a/b", "a", True),
+        ("a", "a/b", False),
+        ("a/b/c/d", "a/b", True),
+        ("a/b", "a/b/c/d", False),
+    ],
+)
+def test_is_relative_to(path1: str, path2: str, expected: bool) -> None:
+    assert is_relative_to(Path(path1), Path(path2)) is expected
+
+
+@pytest.mark.parametrize(
+    ("path1", "path2", "expected"),
+    [
+        ("/", "/", True),
+        ("/a/b", "/a/b", True),
+        ("/a/b", "/a", True),
+        ("/a", "/a/b", False),
+        ("/a/b/c/d", "/a/b", True),
+        ("/a/b", "/a/b/c/d", False),
+    ],
+)
+@pytest.mark.skipif(sys.platform == "win32", reason="non-Windows paths")
+def test_is_relative_to_non_win32(path1: str, path2: str, expected: bool) -> None:
+    assert is_relative_to(Path(path1), Path(path2)) is expected
+
+
+@pytest.mark.parametrize(
+    ("path1", "path2", "expected"),
+    [
+        ("C:\\", "C:\\", True),
+        (r"C:\a\b", r"C:\a\b", True),
+        (r"C:\a\b", r"C:\a", True),
+        (r"C:\a", r"C:\a\b", False),
+        (r"C:\a\b\c\d", r"C:\a\b", True),
+        (r"C:\a\b", r"C:\a\b\c\d", False),
+        (r"C:\a\b", r"D:\a", False),
+        (r"C:\a\b", "D:\\", False),
+        (r"\\server\a\b", r"\\server\a", True),
+        (r"\\server\a", r"\\server\a\b", False),
+        (r"\\server2\a\b", r"\\server\a", False),
+        # long path prefix
+        (r"\\?\C:\a\b", r"\\?\C:\a", True),
+        (r"\\?\C:\a\b", r"C:\a", True),
+        (r"C:\a\b", r"\\?\C:\a", True),
+        (r"\\?\C:\a", r"\\?\C:\a\b", False),
+        # long path UNC prefix
+        (r"\\?\UNC\server\a\b", r"\\?\UNC\server\a", True),
+        (r"\\?\UNC\server\a\b", r"\\server\a", True),
+        (r"\\server\a\b", r"\\?\UNC\server\a", True),
+        (r"\\?\UNC\server\a", r"\\?\UNC\server\a\b", False),
+    ],
+)
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows paths")
+def test_is_relative_to_win32(path1: str, path2: str, expected: bool) -> None:
+    assert is_relative_to(Path(path1), Path(path2)) is expected


### PR DESCRIPTION
# Pull Request Check List

#10792 introduced an issue with long paths on Windows that causes sporadic test failures that look like:

```
[68](https://github.com/radoering/poetry/actions/runs/23705665774/job/69057056580#step:5:6069)
E           Attempting to write py.test.exe outside of the target directory
E           Target directory: C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\popen-gw0\test_execute_prints_warning_fo1\.venv\scripts
E           Target path: \\?\C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\popen-gw0\test_execute_prints_warning_fo1\.venv\scripts\py.test.exe
```

This change works around this issue. To be consistent, I replaced all uses of `Path.is_relative_to()` with the method that works around the issue.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Add a cross-platform path relativity helper and adopt it to avoid Windows long-path issues.

Bug Fixes:
- Prevent incorrect path relativity checks on Windows when long-path or UNC prefixes are involved, avoiding erroneous writes outside target directories and misclassification of environments.

Enhancements:
- Introduce a shared is_relative_to() helper in the compatibility module and use it across path-related checks in installation and environment management code.
- Include more detailed error information when attempting to write outside the wheel installation target directory.

Tests:
- Add unit tests for the is_relative_to() helper covering POSIX paths, Windows drive-letter paths, and Windows long-path and UNC-prefixed paths.