### PR TITLE
fix: check all extras in version solver dependency filter

### DIFF
--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -535,7 +535,8 @@ class VersionSolver:
                 relevant_dependencies = [
                     r
                     for r in package.requires
-                    if not r.in_extras or r.in_extras[0] in dependency.extras
+                    if not r.in_extras
+                    or any(extra in dependency.extras for extra in r.in_extras)
                 ]
             has_deps = bool(relevant_dependencies)
             num_deps_upper_bound = sum(


### PR DESCRIPTION
in_extras[0] only checked the first extra. Dependencies tied to multiple extras were undercounted when requested via a secondary extra, affecting resolution priority ordering.

First in a series of copilot-found bugs and fixes.  This one is borderline for even being a bug - and I did not find a sensible testcase - but it looks right to me

## Summary by Sourcery

Bug Fixes:
- Fix undercounting of dependencies associated with multiple extras by checking all extras when filtering relevant dependencies in the version solver.