### PR TITLE
fix: add trailing slash to tag ref prefix in Git._clone

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -373,7 +373,7 @@ class Git:
 
         for base, prefix in {
             (Ref(b"refs/remotes/origin"), b"refs/heads/"),
-            (Ref(b"refs/tags"), b"refs/tags"),
+            (Ref(b"refs/tags"), b"refs/tags/"),
         }:
             try:
                 local.refs.import_refs(


### PR DESCRIPTION
The tag import prefix was b"refs/tags" (no trailing slash), so stripping it from e.g. b"refs/tags/v1.0" produced b"/v1.0" instead of b"v1.0", creating malformed local refs.

Another in the copilot series.  It failed to find a testcase for this one - it seems as though in most paths, it works out anyway.  But the fix seems trivially correct and consistent with "refs/heads/"

## Summary by Sourcery

Bug Fixes:
- Correct Git tag ref prefix to include a trailing slash so imported tag refs are normalized without an extra leading slash.