### PR TITLE
fix: close ZipFile in _prefetch_metadata with context manager

### DIFF
--- a/src/poetry/inspection/lazy_wheel.py
+++ b/src/poetry/inspection/lazy_wheel.py
@@ -716,29 +716,29 @@ class LazyWheelOverHTTP(LazyFileOverHTTP):
         # This may perform further requests if __init__() did not pull in the entire
         # central directory at the end of the file (although _initial_chunk_length()
         # should be set large enough to avoid this).
-        zf = ZipFile(self)
-
-        filename = ""
-        for info in zf.infolist():
+        with ZipFile(self) as zf:
+            filename = ""
+            for info in zf.infolist():
+                if start is None:
+                    if self._metadata_regex.search(info.filename):
+                        filename = info.filename
+                        start = info.header_offset
+                        continue
+                else:
+                    # The last .dist-info/ entry may be before the end of the file if
+                    # the wheel's entries are sorted lexicographically (which is
+                    # unusual).
+                    if not self._metadata_regex.search(info.filename):
+                        end = info.header_offset
+                        break
             if start is None:
-                if self._metadata_regex.search(info.filename):
-                    filename = info.filename
-                    start = info.header_offset
-                    continue
-            else:
-                # The last .dist-info/ entry may be before the end of the file if the
-                # wheel's entries are sorted lexicographically (which is unusual).
-                if not self._metadata_regex.search(info.filename):
-                    end = info.header_offset
-                    break
-        if start is None:
-            raise UnsupportedWheelError(
-                f"no {self._metadata_regex!r} found for {name} in {self.name}"
-            )
-        # If it is the last entry of the zip, then give us everything
-        # until the start of the central directory.
-        if end is None:
-            end = zf.start_dir
+                raise UnsupportedWheelError(
+                    f"no {self._metadata_regex!r} found for {name} in {self.name}"
+                )
+            # If it is the last entry of the zip, then give us everything
+            # until the start of the central directory.
+            if end is None:
+                end = zf.start_dir
         logger.debug(f"fetch {filename}")
         self._ensure_downloaded(start, end)
         logger.debug("done prefetching METADATA for %s", name)

--- a/tests/inspection/test_lazy_wheel.py
+++ b/tests/inspection/test_lazy_wheel.py
@@ -469,3 +469,33 @@ def test_metadata_from_wheel_url_handles_unexpected_errors(
             "https://runtime-error.com/demo_missing_dist_info-0.1.0-py2.py3-none-any.whl",
             requests.Session(),
         )
+
+
+def test_prefetch_metadata_closes_zipfile_on_error() -> None:
+    """ZipFile opened in _prefetch_metadata must be closed even if an error occurs."""
+    import re
+
+    from unittest.mock import MagicMock
+    from unittest.mock import patch
+    from zipfile import ZipInfo
+
+    from poetry.inspection.lazy_wheel import LazyWheelOverHTTP
+
+    lazy = object.__new__(LazyWheelOverHTTP)
+    lazy._metadata_regex = re.compile(r"\.dist-info/METADATA$")
+    lazy._file = MagicMock()
+    lazy._file.name = "test.whl"
+
+    mock_zf = MagicMock()
+    # Return entries that don't match the metadata regex, triggering UnsupportedWheelError
+    mock_zf.infolist.return_value = [ZipInfo("pkg/data.txt")]
+
+    mock_zf.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("poetry.inspection.lazy_wheel.ZipFile", return_value=mock_zf),
+        pytest.raises(Exception, match=r"no .* found for"),
+    ):
+        lazy._prefetch_metadata("test-pkg")
+
+    mock_zf.__exit__.assert_called_once()

--- a/tests/inspection/test_lazy_wheel.py
+++ b/tests/inspection/test_lazy_wheel.py
@@ -20,6 +20,7 @@ from poetry.inspection.lazy_wheel import HTTPRangeRequestUnsupportedError
 from poetry.inspection.lazy_wheel import InvalidWheelError
 from poetry.inspection.lazy_wheel import LazyWheelOverHTTP
 from poetry.inspection.lazy_wheel import LazyWheelUnsupportedError
+from poetry.inspection.lazy_wheel import UnsupportedWheelError
 from poetry.inspection.lazy_wheel import metadata_from_wheel_url
 from tests.helpers import http_setup_redirect
 
@@ -482,7 +483,7 @@ def test_prefetch_metadata_closes_zipfile_on_error(mocker: MockerFixture) -> Non
 
     lazy = LazyWheelOverHTTP("url", requests.Session())
 
-    with pytest.raises(Exception, match=r"no .* found for"):
+    with pytest.raises(UnsupportedWheelError, match=r"no .* found for"):
         lazy._prefetch_metadata("test-pkg")
 
     mock_zf.__exit__.assert_called_once()

--- a/tests/inspection/test_lazy_wheel.py
+++ b/tests/inspection/test_lazy_wheel.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Protocol
 from urllib.parse import urlparse
+from zipfile import ZipInfo
 
 import pytest
 import requests
@@ -17,6 +18,7 @@ from requests import codes
 from poetry.inspection.lazy_wheel import HTTPRangeRequestNotRespectedError
 from poetry.inspection.lazy_wheel import HTTPRangeRequestUnsupportedError
 from poetry.inspection.lazy_wheel import InvalidWheelError
+from poetry.inspection.lazy_wheel import LazyWheelOverHTTP
 from poetry.inspection.lazy_wheel import LazyWheelUnsupportedError
 from poetry.inspection.lazy_wheel import metadata_from_wheel_url
 from tests.helpers import http_setup_redirect
@@ -471,31 +473,16 @@ def test_metadata_from_wheel_url_handles_unexpected_errors(
         )
 
 
-def test_prefetch_metadata_closes_zipfile_on_error() -> None:
+def test_prefetch_metadata_closes_zipfile_on_error(mocker: MockerFixture) -> None:
     """ZipFile opened in _prefetch_metadata must be closed even if an error occurs."""
-    import re
-
-    from unittest.mock import MagicMock
-    from unittest.mock import patch
-    from zipfile import ZipInfo
-
-    from poetry.inspection.lazy_wheel import LazyWheelOverHTTP
-
-    lazy = object.__new__(LazyWheelOverHTTP)
-    lazy._metadata_regex = re.compile(r"\.dist-info/METADATA$")
-    lazy._file = MagicMock()
-    lazy._file.name = "test.whl"
-
-    mock_zf = MagicMock()
+    mock_zf = mocker.MagicMock()
     # Return entries that don't match the metadata regex, triggering UnsupportedWheelError
     mock_zf.infolist.return_value = [ZipInfo("pkg/data.txt")]
+    mocker.patch("poetry.inspection.lazy_wheel.ZipFile", return_value=mock_zf)
 
-    mock_zf.__exit__ = MagicMock(return_value=False)
+    lazy = LazyWheelOverHTTP("url", requests.Session())
 
-    with (
-        patch("poetry.inspection.lazy_wheel.ZipFile", return_value=mock_zf),
-        pytest.raises(Exception, match=r"no .* found for"),
-    ):
+    with pytest.raises(Exception, match=r"no .* found for"):
         lazy._prefetch_metadata("test-pkg")
 
     mock_zf.__exit__.assert_called_once()


### PR DESCRIPTION
ZipFile opened in _prefetch_metadata was never closed. If an UnsupportedWheelError was raised, the handle leaked. Changed bare ZipFile() assignment to a with statement for proper cleanup.

github and whitespace do not make a pretty diff, nothing has changed in the main body of what happens

## Summary by Sourcery

Ensure wheel metadata prefetching closes ZipFile handles even when errors occur.

Bug Fixes:
- Prevent ZipFile handle leaks in _prefetch_metadata by using a context manager for opening wheels.

Tests:
- Add a regression test verifying that ZipFile is closed when _prefetch_metadata raises an error.