### PR TITLE
fix: retry upload after package registration instead of raising

### DIFF
--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -204,6 +204,8 @@ class Uploader:
         file: Path,
         dry_run: bool = False,
         skip_existing: bool = False,
+        *,
+        registered: bool = False,
     ) -> None:
         from cleo.ui.progress_bar import ProgressBar
 
@@ -254,7 +256,16 @@ class Uploader:
                         "Is the URL missing a trailing slash?"
                     )
                 elif resp.status_code == 400 and "was ever registered" in resp.text:
-                    self._register(session, url)
+                    if not registered:
+                        self._register(session, url)
+                        return self._upload_file(
+                            session,
+                            url,
+                            file,
+                            dry_run,
+                            skip_existing,
+                            registered=True,
+                        )
                     resp.raise_for_status()
                 elif skip_existing and self._is_file_exists_error(resp):
                     bar.set_format(

--- a/tests/publishing/test_uploader.py
+++ b/tests/publishing/test_uploader.py
@@ -225,6 +225,29 @@ def test_uploader_registers_with_sdist_for_appropriate_400_errors(
     assert b"bdist_wheel" not in bodies[1]
 
 
+def test_uploader_retries_upload_after_register(
+    http: responses.RequestsMock, uploader: Uploader
+) -> None:
+    """After registering a package, the upload must be retried.
+
+    The server returns 400 "was ever registered" on the first upload,
+    then 200 on the registration and the retried upload.
+    """
+    http.post("https://foo.com", status=400, body="No package was ever registered")
+    http.post("https://foo.com", status=200)  # register
+    http.post("https://foo.com", status=200)  # retry upload (first file)
+    http.post("https://foo.com", status=200)  # upload second file
+
+    uploader.upload("https://foo.com")
+
+    assert len(http.calls) == 4
+    bodies = [c.request.body or b"" for c in http.calls]
+    assert b'name=":action"\r\n\r\nfile_upload\r\n' in bodies[0]
+    assert b'name=":action"\r\n\r\nsubmit\r\n' in bodies[1]
+    assert b'name=":action"\r\n\r\nfile_upload\r\n' in bodies[2]
+    assert b'name=":action"\r\n\r\nfile_upload\r\n' in bodies[3]
+
+
 def test_uploader_register_uses_wheel_if_no_sdist(
     http: responses.RequestsMock, poetry: Poetry, tmp_path: Path
 ) -> None:

--- a/tests/publishing/test_uploader.py
+++ b/tests/publishing/test_uploader.py
@@ -248,6 +248,31 @@ def test_uploader_retries_upload_after_register(
     assert b'name=":action"\r\n\r\nfile_upload\r\n' in bodies[3]
 
 
+def test_uploader_retries_upload_after_register_but_does_not_loop_infinitely(
+    http: responses.RequestsMock, uploader: Uploader
+) -> None:
+    """After registering a package, the upload must be retried but only once.
+
+    The server returns 400 "was ever registered" on the first upload,
+    then 200 on the registration,
+    but then again 400 "was ever registered" on the second upload.
+    """
+    http.post("https://foo.com", status=400, body="No package was ever registered")
+    http.post("https://foo.com", status=200)  # register
+    http.post(  # retry upload
+        "https://foo.com", status=400, body="No package was ever registered"
+    )
+
+    with pytest.raises(UploadError):
+        uploader.upload("https://foo.com")
+
+    assert len(http.calls) == 3
+    bodies = [c.request.body or b"" for c in http.calls]
+    assert b'name=":action"\r\n\r\nfile_upload\r\n' in bodies[0]
+    assert b'name=":action"\r\n\r\nsubmit\r\n' in bodies[1]
+    assert b'name=":action"\r\n\r\nfile_upload\r\n' in bodies[2]
+
+
 def test_uploader_register_uses_wheel_if_no_sdist(
     http: responses.RequestsMock, poetry: Poetry, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
After _register() succeeded, resp.raise_for_status() raised on the original 400 response, so the upload was never retried. Now retries the upload once after registration, with a guard against infinite recursion if the server keeps returning 400.

Another from copilot.  Borderline bug or enhancement, but the retry surely makes sense.

## Summary by Sourcery

Ensure package uploads are retried once after successful registration when the server initially responds with a 400 indicating the package was never registered.

Bug Fixes:
- Prevent failed uploads when registration succeeds but the initial 400 response would previously halt the process instead of retrying the upload.

Tests:
- Add coverage to verify that an upload is retried after registration and that multiple files are uploaded in the correct sequence.