### PR TITLE
fix: abort publish when build command fails

### DIFF
--- a/src/poetry/console/commands/publish.py
+++ b/src/poetry/console/commands/publish.py
@@ -88,7 +88,9 @@ the config command.
                         f"ready for publishing in {dist_dir}. Build anyway!</warning>"
                     )
 
-            self.call("build", args=f"--output {dist_dir}")
+            exit_code = self.call("build", args=f"--output {dist_dir}")
+            if exit_code:
+                return exit_code
 
             publisher = Publisher(self.poetry, self.io, Path(dist_dir))
 

--- a/tests/console/commands/test_publish.py
+++ b/tests/console/commands/test_publish.py
@@ -227,7 +227,9 @@ def test_publish_build_no_interaction_skips_confirmation(
         return_value=[Path("dist/simple_project-1.2.3-py2.py3-none-any.whl")],
     )
     confirm = mocker.patch("poetry.console.commands.publish.PublishCommand.confirm")
-    command_call = mocker.patch("poetry.console.commands.publish.PublishCommand.call")
+    command_call = mocker.patch(
+        "poetry.console.commands.publish.PublishCommand.call", return_value=0
+    )
     publisher_publish = mocker.patch("poetry.publishing.Publisher.publish")
 
     exit_code = app_tester.execute("publish --build --no-interaction --dry-run")
@@ -244,3 +246,23 @@ def test_publish_build_no_interaction_skips_confirmation(
     ) in output
     command_call.assert_called_once_with("build", args="--output dist")
     assert publisher_publish.call_count == 1
+
+
+def test_publish_aborts_when_build_fails(
+    app_tester: ApplicationTester, mocker: MockerFixture
+) -> None:
+    mocker.patch(
+        "poetry.publishing.publisher.Publisher.files",
+        new_callable=PropertyMock,
+        return_value=[Path("dist/simple_project-1.2.3-py2.py3-none-any.whl")],
+    )
+    mocker.patch(
+        "poetry.console.commands.publish.PublishCommand.call",
+        return_value=1,
+    )
+    publisher_publish = mocker.patch("poetry.publishing.Publisher.publish")
+
+    exit_code = app_tester.execute("publish --build --no-interaction")
+
+    assert exit_code == 1
+    publisher_publish.assert_not_called()


### PR DESCRIPTION
publish --build ignored the exit code from the build command. If the build failed but stale artifacts existed in dist/, publishing would proceed with the old files. Now checks the return value and propagates the exit code.

Also fixed the existing test mock to return 0 instead of a MagicMock.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Abort publishing when the build step fails and add coverage for this behavior.

Bug Fixes:
- Ensure `publish --build` propagates the build command’s non-zero exit code instead of continuing with stale artifacts.

Tests:
- Adjust the existing publish-with-build test to use a successful build exit code and add a new test verifying that publishing aborts when the build command fails.