### PR TITLE
fix: respect verify=False in authenticator requests

### DIFF
--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -206,7 +206,9 @@ class Authenticator:
         stream: bool | None = kwargs.get("stream")
 
         certs = self.get_certs_for_url(url)
-        verify: bool | str | Path = kwargs.get("verify") or certs.cert or certs.verify
+        verify: bool | str | Path | None = kwargs.get("verify")
+        if verify is None:
+            verify = certs.cert or certs.verify
         cert: str | Path | None = kwargs.get("cert") or certs.client_cert
 
         if cert is not None:

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -448,7 +448,7 @@ def test_authenticator_request_verify_is_respected(
     kwargs = session_send.call_args[1]
 
     if verify is None:
-        assert kwargs["verify"] == "/path/to/cert"
+        assert kwargs["verify"] == str(Path("/path/to/cert"))
     else:
         assert kwargs["verify"] is verify
 

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -422,6 +422,32 @@ def test_authenticator_uses_certs_from_config_if_not_provided(
     assert Path(kwargs["cert"]) == Path(client_cert or configured_client_cert)
 
 
+def test_authenticator_request_verify_false_is_respected(
+    config: Config,
+    mock_remote: responses.RequestsMock,
+    mock_config: Config,
+    http: responses.RequestsMock,
+    mocker: MockerFixture,
+) -> None:
+    """verify=False must not be overridden by configured certificates."""
+    mock_config.merge(
+        {
+            "certificates": {
+                "foo": {"cert": "/path/to/cert", "client-cert": "/path/to/client-cert"}
+            },
+        }
+    )
+
+    authenticator = Authenticator(mock_config, NullIO())
+    url = "https://foo.bar/files/foo-0.1.0.tar.gz"
+    session = authenticator.get_session(url)
+    session_send = mocker.patch.object(session, "send")
+    authenticator.request("get", url, verify=False)
+    kwargs = session_send.call_args[1]
+
+    assert kwargs["verify"] is False
+
+
 def test_authenticator_uses_credentials_from_config_matched_by_url_path(
     config: Config, mock_remote: None, http: responses.RequestsMock
 ) -> None:

--- a/tests/utils/test_authenticator.py
+++ b/tests/utils/test_authenticator.py
@@ -422,14 +422,16 @@ def test_authenticator_uses_certs_from_config_if_not_provided(
     assert Path(kwargs["cert"]) == Path(client_cert or configured_client_cert)
 
 
-def test_authenticator_request_verify_false_is_respected(
+@pytest.mark.parametrize("verify", [True, False, None])
+def test_authenticator_request_verify_is_respected(
     config: Config,
     mock_remote: responses.RequestsMock,
     mock_config: Config,
     http: responses.RequestsMock,
     mocker: MockerFixture,
+    verify: bool | None,
 ) -> None:
-    """verify=False must not be overridden by configured certificates."""
+    """especially verify=False must not be overridden by configured certificates."""
     mock_config.merge(
         {
             "certificates": {
@@ -442,10 +444,13 @@ def test_authenticator_request_verify_false_is_respected(
     url = "https://foo.bar/files/foo-0.1.0.tar.gz"
     session = authenticator.get_session(url)
     session_send = mocker.patch.object(session, "send")
-    authenticator.request("get", url, verify=False)
+    authenticator.request("get", url, verify=verify)
     kwargs = session_send.call_args[1]
 
-    assert kwargs["verify"] is False
+    if verify is None:
+        assert kwargs["verify"] == "/path/to/cert"
+    else:
+        assert kwargs["verify"] is verify
 
 
 def test_authenticator_uses_credentials_from_config_matched_by_url_path(


### PR DESCRIPTION
kwargs.get("verify") or certs.cert evaluated False as falsy, silently overriding an explicit verify=False with configured certificates. Use a None check to distinguish "not passed" from "explicitly False".

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Ensure authenticator requests honor explicit SSL verification settings from callers.

Bug Fixes:
- Prevent configured certificates from overriding an explicit verify=False in authenticator requests.

Tests:
- Add a regression test verifying that authenticator requests preserve verify=False when provided.