### PR TITLE
fix: wrap string config setting values in list before iterating

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -353,7 +353,10 @@ class Executor:
 
                         if config_settings := self._build_config_settings.get(pkg.name):
                             for setting in config_settings:
-                                for setting_value in config_settings[setting]:
+                                values = config_settings[setting]
+                                if isinstance(values, str):
+                                    values = [values]
+                                for setting_value in values:
                                     pip_command += f" --config-settings='{setting}={setting_value}'"
 
                         message = e.generate_message(

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1589,7 +1589,10 @@ def test_build_backend_error_includes_config_settings_in_pip_command(
         {
             "installer": {
                 "build-config-settings": {
-                    "simple-project": {"CC": "gcc"},
+                    "simple-project": {
+                        "CC": "gcc",
+                        "--build-option": ["--one", "--two"],
+                    },
                 },
             },
         }
@@ -1605,6 +1608,8 @@ def test_build_backend_error_includes_config_settings_in_pip_command(
 
     output = io.fetch_output()
     assert "--config-settings='CC=gcc'" in output
+    assert "--config-settings='--build-option=--one'" in output
+    assert "--config-settings='--build-option=--two'" in output
 
 
 @pytest.mark.parametrize("encoding", ["utf-8", "latin-1"])

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1572,6 +1572,41 @@ You can verify this by running {expected_pip_command}.
     assert io.fetch_output() == expected_output
 
 
+def test_build_backend_error_includes_config_settings_in_pip_command(
+    mocker: MockerFixture,
+    config: Config,
+    pool: RepositoryPool,
+    io: BufferedIO,
+    env: MockEnv,
+    fixture_dir: FixtureDirGetter,
+) -> None:
+    """String config setting values must not be iterated per-character."""
+    error = BuildBackendException(Exception("build failed"), description="build failed")
+    mocker.patch.object(ProjectBuilder, "build", side_effect=error)
+    io.set_verbosity(Verbosity.NORMAL)
+
+    config.merge(
+        {
+            "installer": {
+                "build-config-settings": {
+                    "simple-project": {"CC": "gcc"},
+                },
+            },
+        }
+    )
+
+    executor = Executor(env, pool, config, io)
+    source_url = fixture_dir("simple_project").resolve().as_posix()
+    package = Package(
+        "simple-project", "1.2.3", source_type="directory", source_url=source_url
+    )
+
+    executor.execute([Install(package)])
+
+    output = io.fetch_output()
+    assert "--config-settings='CC=gcc'" in output
+
+
 @pytest.mark.parametrize("encoding", ["utf-8", "latin-1"])
 @pytest.mark.parametrize("stderr", [None, "Errör on stderr"])
 def test_build_backend_errors_are_reported_correctly_if_caused_by_subprocess_encoding(


### PR DESCRIPTION
When a config setting value is a plain str (e.g. "CC": "gcc"), iterating it directly yields one character per iteration, producing garbled --config-settings flags in the error message pip command.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Ensure build backend error reporting correctly formats build config settings in generated pip commands.

Bug Fixes:
- Prevent iteration over string-valued build config settings that previously produced malformed --config-settings flags in pip command error messages.

Tests:
- Add regression test asserting that string-valued build config settings are rendered as whole values in the pip command within build backend error output.