### PR TITLE
fix: reset Indicator.CONTEXT on exception with try/finally

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -93,9 +93,10 @@ class Indicator(ProgressIndicator):
         def _set_context(context: str | None) -> None:
             Indicator.CONTEXT = context
 
-        yield _set_context
-
-        _set_context(None)
+        try:
+            yield _set_context
+        finally:
+            _set_context(None)
 
     def _formatter_context(self) -> str:
         if Indicator.CONTEXT is None:

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -1069,3 +1069,14 @@ def test_source_dependency_is_not_satisfied_by_incompatible_direct_origin(
     dep.source_name = repository.name
 
     assert provider.search_for(dep) == [repo_package]
+
+
+def test_indicator_context_resets_on_exception() -> None:
+    from poetry.puzzle.provider import Indicator
+
+    with pytest.raises(RuntimeError), Indicator.context() as set_context:
+        set_context("downloading something")
+        assert Indicator.CONTEXT == "downloading something"
+        raise RuntimeError("network error")
+
+    assert Indicator.CONTEXT is None


### PR DESCRIPTION
Indicator.context() cleaned up CONTEXT after yield, but if the with block raised an exception the cleanup was skipped, leaving a stale value on the class variable. Wrapped yield in try/finally to guarantee cleanup.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Ensure indicator context is always cleared after use, even when an exception occurs within the context manager.

Bug Fixes:
- Fix stale Indicator.CONTEXT values by guaranteeing cleanup in the context() manager when exceptions are raised.

Tests:
- Add a regression test verifying Indicator.CONTEXT is reset to None when an exception occurs inside Indicator.context().