### PR TITLE
fix: seek to range_start in lazy_wheel _ensure_downloaded

### DIFF
--- a/src/poetry/inspection/lazy_wheel.py
+++ b/src/poetry/inspection/lazy_wheel.py
@@ -480,7 +480,7 @@ class LazyFileOverHTTP(ReadOnlyIOWrapper):
                 range_start,
                 range_end,
             ) in self._merge_intervals.minimal_intervals_covering(start, end):
-                self.seek(start)
+                self.seek(range_start)
                 for chunk in self._fetch_content_range(range_start, range_end):
                     self._file.write(chunk)
 

--- a/tests/inspection/test_lazy_wheel.py
+++ b/tests/inspection/test_lazy_wheel.py
@@ -487,3 +487,31 @@ def test_prefetch_metadata_closes_zipfile_on_error(mocker: MockerFixture) -> Non
         lazy._prefetch_metadata("test-pkg")
 
     mock_zf.__exit__.assert_called_once()
+
+
+def test_ensure_downloaded_writes_at_correct_offsets() -> None:
+    """_ensure_downloaded must seek to range_start, not start."""
+    from io import BytesIO
+    from unittest.mock import patch
+
+    from poetry.inspection.lazy_wheel import LazyFileOverHTTP
+    from poetry.inspection.lazy_wheel import MergeIntervals
+
+    content = bytes(range(100))
+
+    # Build a LazyFileOverHTTP without hitting the network
+    lazy = object.__new__(LazyFileOverHTTP)
+    lazy._file = BytesIO(b"\x00" * 100)
+    lazy._merge_intervals = MergeIntervals()
+
+    def fake_fetch(start: int, end: int) -> list[bytes]:
+        return [content[start : end + 1]]
+
+    with patch.object(lazy, "_fetch_content_range", side_effect=fake_fetch):
+        # Download bytes 0-49, then request 30-80 (overlap).
+        # Only 50-79 needs fetching; the bug wrote that data at offset 30.
+        lazy._ensure_downloaded(0, 50)
+        lazy._ensure_downloaded(30, 80)
+
+    lazy._file.seek(0)
+    assert lazy._file.read(80) == content[:80]

--- a/tests/inspection/test_lazy_wheel.py
+++ b/tests/inspection/test_lazy_wheel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 
 from enum import IntEnum
+from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Protocol
@@ -18,6 +19,7 @@ from requests import codes
 from poetry.inspection.lazy_wheel import HTTPRangeRequestNotRespectedError
 from poetry.inspection.lazy_wheel import HTTPRangeRequestUnsupportedError
 from poetry.inspection.lazy_wheel import InvalidWheelError
+from poetry.inspection.lazy_wheel import LazyFileOverHTTP
 from poetry.inspection.lazy_wheel import LazyWheelOverHTTP
 from poetry.inspection.lazy_wheel import LazyWheelUnsupportedError
 from poetry.inspection.lazy_wheel import UnsupportedWheelError
@@ -489,29 +491,27 @@ def test_prefetch_metadata_closes_zipfile_on_error(mocker: MockerFixture) -> Non
     mock_zf.__exit__.assert_called_once()
 
 
-def test_ensure_downloaded_writes_at_correct_offsets() -> None:
+def test_ensure_downloaded_writes_at_correct_offsets(mocker: MockerFixture) -> None:
     """_ensure_downloaded must seek to range_start, not start."""
-    from io import BytesIO
-    from unittest.mock import patch
-
-    from poetry.inspection.lazy_wheel import LazyFileOverHTTP
-    from poetry.inspection.lazy_wheel import MergeIntervals
-
     content = bytes(range(100))
 
-    # Build a LazyFileOverHTTP without hitting the network
-    lazy = object.__new__(LazyFileOverHTTP)
-    lazy._file = BytesIO(b"\x00" * 100)
-    lazy._merge_intervals = MergeIntervals()
+    mocker.patch(
+        "poetry.inspection.lazy_wheel.NamedTemporaryFile",
+        return_value=BytesIO(b"\x00" * 100),
+    )
+    lazy = LazyFileOverHTTP("url", requests.Session())
 
     def fake_fetch(start: int, end: int) -> list[bytes]:
         return [content[start : end + 1]]
 
-    with patch.object(lazy, "_fetch_content_range", side_effect=fake_fetch):
+    mocker.patch.object(lazy, "_fetch_content_length", return_value=100)
+    mocker.patch.object(lazy, "_fetch_content_range", side_effect=fake_fetch)
+
+    with lazy:
         # Download bytes 0-49, then request 30-80 (overlap).
         # Only 50-79 needs fetching; the bug wrote that data at offset 30.
         lazy._ensure_downloaded(0, 50)
         lazy._ensure_downloaded(30, 80)
 
-    lazy._file.seek(0)
-    assert lazy._file.read(80) == content[:80]
+        lazy._file.seek(0)
+        assert lazy._file.read(80) == content[:80]


### PR DESCRIPTION
_ensure_downloaded() was seeking to `start` (the beginning of the requested range) instead of `range_start` (the beginning of the sub-interval actually being fetched). When part of a range was already cached, data for later sub-ranges was written at the wrong file offset, corrupting the in-memory wheel file.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Fix lazy wheel HTTP range downloading to write fetched data at the correct offsets when only part of a range is cached.

Bug Fixes:
- Correct seeking in LazyFileOverHTTP so partially cached ranges are written starting from the actual fetched sub-range offset, preventing in-memory wheel corruption.

Tests:
- Add regression test verifying _ensure_downloaded writes overlapping HTTP range data at the correct file offsets.