### PR TITLE
fix: use row.append instead of row[2] in debug resolve command

### DIFF
--- a/src/poetry/console/commands/debug/resolve.py
+++ b/src/poetry/console/commands/debug/resolve.py
@@ -141,7 +141,7 @@ class DebugResolveCommand(InitCommand):
             ]
 
             if not pkg.marker.is_any():
-                row[2] = str(pkg.marker)
+                row.append(str(pkg.marker))
 
             rows.append(row)
 

--- a/tests/console/commands/debug/test_resolve.py
+++ b/tests/console/commands/debug/test_resolve.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poetry.core.version.markers import parse_marker
+
 from poetry.factory import Factory
 from tests.helpers import get_package
 
@@ -60,6 +62,27 @@ Resolution results:
 
 cachy 0.2.0
 └── msgpack-python >=0.5 <0.6
+"""
+
+    assert tester.io.fetch_output() == expected
+
+
+def test_debug_resolve_shows_marker_when_present(
+    tester: CommandTester, repo: TestRepository
+) -> None:
+    """Packages with environment markers must show the marker in output."""
+    pkg = get_package("pathlib2", "2.3.0")
+    pkg.marker = parse_marker('sys_platform == "win32"')
+    repo.add_package(pkg)
+
+    tester.execute("pathlib2")
+
+    expected = """\
+Resolving dependencies...
+
+Resolution results:
+
+pathlib2 2.3.0 sys_platform == "win32"
 """
 
     assert tester.io.fetch_output() == expected


### PR DESCRIPTION
row is a 2-element list [name, version], so row[2] = str(pkg.marker) raises IndexError for any package with an environment marker. Use row.append() to correctly add the marker as a third column.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Fix debug resolve command output to correctly handle and display environment markers for dependencies.

Bug Fixes:
- Prevent IndexError in the debug resolve command when a package has an environment marker by correctly adding the marker as an additional column in the output.

Tests:
- Add a regression test ensuring packages with environment markers show the marker in the debug resolve command output.