### PR TITLE
fix: resolve falsy config values in string interpolation

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -363,11 +363,11 @@ class Config:
         if not isinstance(value, str):
             return value
 
-        def resolve_from_config(match: re.Match[str]) -> Any:
+        def resolve_from_config(match: re.Match[str]) -> str:
             key = match.group(1)
             config_value = self.get(key)
-            if config_value:
-                return config_value
+            if config_value is not None:
+                return str(config_value)
 
             # The key doesn't exist in the config but might be resolved later,
             # so we keep it as a format variable.

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -55,6 +55,12 @@ def test_config_get_processes_depended_on_values(
     assert str(config_cache_dir / "virtualenvs") == config.get("virtualenvs.path")
 
 
+def test_config_process_resolves_falsy_values(config: Config) -> None:
+    """Falsy config values (False, 0) must not be treated as missing
+    during string interpolation."""
+    assert config.process("{requests.max-retries}") == "0"
+
+
 def generate_environment_variable_tests() -> Iterator[tuple[str, str, str, bool]]:
     data: list[tuple[Normalizer, list[tuple[str, Any]]]] = [
         (


### PR DESCRIPTION
config.process() treated falsy values (0, False, empty string) as missing, returning the literal template string instead of the resolved value. Changed the check from 'if config_value:' to 'if config_value is not None:' and added str() conversion for re.sub compatibility. Fixed return type annotation on the inner callback to match its actual return type.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Ensure config string interpolation correctly handles falsy values and update its typing.

Bug Fixes:
- Treat falsy configuration values (such as 0 and False) as valid during string interpolation instead of considering them missing.

Tests:
- Add a regression test confirming that falsy configuration values are interpolated into strings as expected.