### PR TITLE
fix: assign str.replace result and fix refs/head typo in _clone_legacy

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -301,8 +301,8 @@ class Git:
             )
 
         if revision:
-            revision.replace("refs/head/", "")
-            revision.replace("refs/tags/", "")
+            revision = revision.removeprefix("refs/heads/")
+            revision = revision.removeprefix("refs/tags/")
 
         try:
             SystemGit.checkout(revision, target)

--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -424,3 +424,32 @@ def test_clone_nested_annotated_tags(tmp_path: Path) -> None:
     assert (clone_dir / ".git").is_dir()
     assert (clone_dir / "test.txt").exists()
     assert (clone_dir / "test.txt").read_text(encoding="utf-8") == "nested tag test"
+
+
+@pytest.mark.parametrize(
+    ("revision_input", "expected_checkout"),
+    [
+        ("refs/heads/main", "main"),
+        ("refs/tags/v1.0", "v1.0"),
+        ("abc123", "abc123"),
+        ("HEAD", "HEAD"),
+    ],
+)
+def test_clone_legacy_strips_ref_prefixes(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    revision_input: str,
+    expected_checkout: str,
+) -> None:
+    """_clone_legacy must strip refs/heads/ and refs/tags/ before checkout."""
+    mock_clone = mocker.patch("poetry.vcs.git.system.SystemGit.clone")
+    mock_checkout = mocker.patch("poetry.vcs.git.system.SystemGit.checkout")
+    mocker.patch("poetry.vcs.git.backend.Repo")
+
+    target = tmp_path / "repo"
+    refspec = GitRefSpec(revision=revision_input)
+
+    Git._clone_legacy("https://example.com/repo.git", refspec, target)
+
+    mock_clone.assert_called_once()
+    mock_checkout.assert_called_once_with(expected_checkout, target)


### PR DESCRIPTION
str.replace() returns a new string; the result was discarded so the revision was never actually stripped. Also refs/head/ was misspelled (should be refs/heads/). Switched to removeprefix() for clarity.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Fix legacy Git clone revision handling to correctly strip ref prefixes before checkout.

Bug Fixes:
- Correct revision normalization in _clone_legacy by properly removing refs/heads/ and refs/tags/ prefixes before checkout.

Tests:
- Add parameterized tests verifying that _clone_legacy strips refs/heads/ and refs/tags/ prefixes and leaves non-ref revisions unchanged.