### PR TITLE
fix: use removesuffix instead of rstrip for suffix stripping

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -327,7 +327,7 @@ class PackageInfo:
             if len(elements) == 1 and elements[0].is_dir():
                 sdist_dir = elements[0]
             else:
-                sdist_dir = tmp / path.name.rstrip(suffix)
+                sdist_dir = tmp / path.name.removesuffix(suffix)
                 if not sdist_dir.is_dir():
                     sdist_dir = tmp
 

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -108,7 +108,7 @@ class Chef:
             if len(elements) == 1 and elements[0].is_dir():
                 sdist_dir = elements[0]
             else:
-                sdist_dir = archive_dir / archive.name.rstrip(suffix)
+                sdist_dir = archive_dir / archive.name.removesuffix(suffix)
                 if not sdist_dir.is_dir():
                     sdist_dir = archive_dir
 

--- a/tests/inspection/test_info.py
+++ b/tests/inspection/test_info.py
@@ -196,6 +196,45 @@ def test_info_from_sdist_no_pkg_info(fixture_dir: FixtureDirGetter) -> None:
     assert info._source_url == path.resolve().as_posix()
 
 
+def test_info_from_sdist_name_ending_in_suffix_chars(tmp_path: Path) -> None:
+    """rstrip(".tar.gz") strips individual characters from the set {.,t,a,r,g,z}
+    rather than the suffix string.  This test uses a package name whose version
+    ends in 'a' (an alpha release) so that rstrip would eat the 'a', producing
+    the wrong directory name.  removesuffix does not have this problem.
+    """
+    import tarfile
+
+    # "pkg-1.0a" ends with 'a', which is in the char set {.,t,a,r,g,z}.
+    # rstrip(".tar.gz") would wrongly produce "pkg-1.0" instead of "pkg-1.0a".
+    sdist_name = "pkg-1.0a.tar.gz"
+    inner_dir = "pkg-1.0a"
+
+    # Build a minimal sdist with multiple top-level entries so the
+    # fallback path (name.removesuffix(suffix)) is exercised.
+    sdist_path = tmp_path / sdist_name
+    content_dir = tmp_path / "content"
+    pkg_dir = content_dir / inner_dir
+    pkg_dir.mkdir(parents=True)
+
+    pyproject = pkg_dir / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "pkg"\nversion = "1.0a"\n'
+        "[build-system]\n"
+        'requires = ["setuptools"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+    )
+    # Add a second top-level entry to force the fallback path
+    (content_dir / "extra-file.txt").write_text("force fallback")
+
+    with tarfile.open(sdist_path, "w:gz") as tf:
+        tf.add(pkg_dir, arcname=inner_dir)
+        tf.add(content_dir / "extra-file.txt", arcname="extra-file.txt")
+
+    info = PackageInfo.from_sdist(sdist_path)
+    assert info.name == "pkg"
+    assert info.version == "1.0a0"
+
+
 def test_info_from_wheel(demo_wheel: Path) -> None:
     info = PackageInfo.from_wheel(demo_wheel)
     demo_check_info(info)


### PR DESCRIPTION
rstrip(suffix) strips individual characters from the set, not the suffix string. For sdist names with versions ending in characters like 'a' (alpha releases), rstrip(".tar.gz") eats too much — e.g. "pkg-1.0a.tar.gz" becomes "pkg-1.0" instead of "pkg-1.0a".

Fixed in both info.py and chef.py.

copilot here only managed to hit one of the two fixes in unit tests, but I think it is sufficiently obviously correct that this is tolerable.

## Summary by Sourcery

Use correct suffix stripping for sdists to avoid misidentifying package directories when names end with characters in the archive suffix, and add coverage to prevent regressions.

Bug Fixes:
- Fix sdist directory detection by replacing character-based rstrip with suffix-based removesuffix in sdist handling code.

Tests:
- Add regression test ensuring sdists with versions ending in characters from the archive suffix are resolved to the correct package directory.