### PR TITLE
fix: use set with backtracking for tree circular dependency detection

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -554,7 +554,7 @@ lists all packages available."""
             self._write_tree_line(io, info)
 
             tree_bar = tree_bar.replace("└", " ")
-            packages_in_tree = [package.name, dependency.name]
+            packages_in_tree = {package.name, dependency.name}
 
             self._display_tree(
                 io,
@@ -570,7 +570,7 @@ lists all packages available."""
         io: IO,
         dependency: Dependency,
         installed_packages: list[Package],
-        packages_in_tree: list[NormalizedName],
+        packages_in_tree: set[NormalizedName],
         previous_tree_bar: str = "├",
         level: int = 1,
     ) -> None:
@@ -590,7 +590,6 @@ lists all packages available."""
         tree_bar = previous_tree_bar + "   ├"
         total = len(dependencies)
         for i, dependency in enumerate(dependencies, 1):
-            current_tree = packages_in_tree
             if i == total:
                 tree_bar = previous_tree_bar + "   └"
 
@@ -598,7 +597,7 @@ lists all packages available."""
             color = self.colors[color_ident]
 
             circular_warn = ""
-            if dependency.name in current_tree:
+            if dependency.name in packages_in_tree:
                 circular_warn = "(circular dependency aborted here)"
 
             info = (
@@ -609,17 +608,19 @@ lists all packages available."""
 
             tree_bar = tree_bar.replace("└", " ")
 
-            if dependency.name not in current_tree:
-                current_tree.append(dependency.name)
+            if dependency.name not in packages_in_tree:
+                packages_in_tree.add(dependency.name)
 
                 self._display_tree(
                     io,
                     dependency,
                     installed_packages,
-                    current_tree,
+                    packages_in_tree,
                     tree_bar,
                     level + 1,
                 )
+
+                packages_in_tree.discard(dependency.name)
 
     def _write_tree_line(self, io: IO, line: str) -> None:
         if not io.output.supports_utf8():

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -610,17 +610,17 @@ lists all packages available."""
 
             if dependency.name not in packages_in_tree:
                 packages_in_tree.add(dependency.name)
-
-                self._display_tree(
-                    io,
-                    dependency,
-                    installed_packages,
-                    packages_in_tree,
-                    tree_bar,
-                    level + 1,
-                )
-
-                packages_in_tree.discard(dependency.name)
+                try:
+                    self._display_tree(
+                        io,
+                        dependency,
+                        installed_packages,
+                        packages_in_tree,
+                        tree_bar,
+                        level + 1,
+                    )
+                finally:
+                    packages_in_tree.discard(dependency.name)
 
     def _write_tree_line(self, io: IO, line: str) -> None:
         if not io.output.supports_utf8():

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -2069,6 +2069,91 @@ a 0.0.1
     assert tester.io.fetch_output() == expected
 
 
+def test_show_tree_shared_dependency_not_marked_circular(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+) -> None:
+    """When siblings share a dependency, it must not be flagged as circular.
+
+    a depends on b, which depends on c and d.  Both c and d depend on e.
+    Because c and d are siblings under b, e appearing under d is not circular
+    — only a true ancestor cycle should trigger the warning.
+    """
+    poetry.package.add_dependency(Factory.create_dependency("a", "=0.0.1"))
+
+    a = get_package("a", "0.0.1")
+    a.add_dependency(Factory.create_dependency("b", "=0.0.1"))
+    installed.add_package(a)
+
+    b = get_package("b", "0.0.1")
+    b.add_dependency(Factory.create_dependency("c", "=0.0.1"))
+    b.add_dependency(Factory.create_dependency("d", "=0.0.1"))
+    installed.add_package(b)
+
+    c = get_package("c", "0.0.1")
+    c.add_dependency(Factory.create_dependency("e", "=0.0.1"))
+    installed.add_package(c)
+
+    d = get_package("d", "0.0.1")
+    d.add_dependency(Factory.create_dependency("e", "=0.0.1"))
+    installed.add_package(d)
+
+    e = get_package("e", "0.0.1")
+    installed.add_package(e)
+
+    assert isinstance(poetry.locker, TestLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "a",
+                    "version": "0.0.1",
+                    "dependencies": {"b": "=0.0.1"},
+                    "python-versions": "*",
+                    "optional": False,
+                },
+                {
+                    "name": "b",
+                    "version": "0.0.1",
+                    "dependencies": {"c": "=0.0.1", "d": "=0.0.1"},
+                    "python-versions": "*",
+                    "optional": False,
+                },
+                {
+                    "name": "c",
+                    "version": "0.0.1",
+                    "dependencies": {"e": "=0.0.1"},
+                    "python-versions": "*",
+                    "optional": False,
+                },
+                {
+                    "name": "d",
+                    "version": "0.0.1",
+                    "dependencies": {"e": "=0.0.1"},
+                    "python-versions": "*",
+                    "optional": False,
+                },
+                {
+                    "name": "e",
+                    "version": "0.0.1",
+                    "python-versions": "*",
+                    "optional": False,
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"a": [], "b": [], "c": [], "d": [], "e": []},
+            },
+        }
+    )
+
+    tester.execute("--tree", supports_utf8=False)
+
+    output = tester.io.fetch_output()
+    assert "circular" not in output
+
+
 def test_show_tree_why(
     tester: CommandTester, poetry: Poetry, installed: Repository
 ) -> None:


### PR DESCRIPTION
packages_in_tree was a shared mutable list — siblings' subtrees would pollute each other, causing false circular dependency warnings. Changed to a set (correct data structure for membership checks) with backtracking (discard after recursion) to isolate sibling branches.

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary by Sourcery

Fix circular dependency detection in the `poetry show --tree` command to avoid false positives when dependencies are shared between sibling nodes.

Bug Fixes:
- Prevent shared dependencies between sibling packages in the tree view from being incorrectly reported as circular dependencies.

Tests:
- Add a regression test to ensure shared dependencies between sibling nodes are not flagged as circular in the tree output.