### PR TITLE
fix: use SeparateBodyFileCache for file caching

### DIFF
--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -119,7 +119,7 @@ class Authenticator:
             SeparateBodyFileCache(
                 self._config.repository_cache_directory
                 / (cache_id or "_default_cache")
-                / "_http"
+                / "_http2"
             )
             if not disable_cache
             else None

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -119,7 +119,7 @@ class Authenticator:
             SeparateBodyFileCache(
                 self._config.repository_cache_directory
                 / (cache_id or "_default_cache")
-                / "_http2"
+                / "_http_"
             )
             if not disable_cache
             else None

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -115,6 +115,10 @@ class Authenticator:
             dict[str, AuthenticatorRepositoryConfig] | None
         ) = None
         self._password_manager = PasswordManager(self._config)
+
+        # Poetry < 2.4: FileCache -> directory "_http"
+        # Poetry >= 2.4: SeparateBodyCache -> directory "_http_"
+        # See https://github.com/python-poetry/poetry/pull/10816 for details.
         self._cache_control = (
             SeparateBodyFileCache(
                 self._config.repository_cache_directory
@@ -124,6 +128,7 @@ class Authenticator:
             if not disable_cache
             else None
         )
+
         self.get_repository_config_for_url = functools.lru_cache(maxsize=None)(
             self._get_repository_config_for_url
         )

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -17,7 +17,7 @@ import requests.auth
 import requests.exceptions
 
 from cachecontrol import CacheControlAdapter
-from cachecontrol.caches import FileCache
+from cachecontrol.caches import SeparateBodyFileCache
 from requests_toolbelt import user_agent
 
 from poetry.__version__ import __version__
@@ -116,7 +116,7 @@ class Authenticator:
         ) = None
         self._password_manager = PasswordManager(self._config)
         self._cache_control = (
-            FileCache(
+            SeparateBodyFileCache(
                 self._config.repository_cache_directory
                 / (cache_id or "_default_cache")
                 / "_http"

--- a/tests/repositories/test_pypi_repository.py
+++ b/tests/repositories/test_pypi_repository.py
@@ -324,7 +324,9 @@ def test_invalid_versions_ignored(pypi_repository: PyPiRepository) -> None:
 def test_get_should_invalid_cache_on_too_many_redirects_error(
     mocker: MockerFixture,
 ) -> None:
-    delete_cache = mocker.patch("cachecontrol.caches.file_cache.FileCache.delete")
+    delete_cache = mocker.patch(
+        "cachecontrol.caches.file_cache.SeparateBodyFileCache.delete"
+    )
 
     response = Response()
     response.status_code = 200


### PR DESCRIPTION
Use `SeparateBodyFileCache` instead of `FileCache` for caching. `FileCache` attempts to serialize the HTTP response body along with the rest of the response which can cause a `ValueError: memoryview is too large` for files larger than 2 GiB. `cachecontrol` provides `SeparateBodyFileCache` which is better suited for caching large responses and does not cause this issue.

# Pull Request Checklist

Resolves: #10814

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Summary by Sourcery

Bug Fixes:
- Prevent failures when caching HTTP responses for files larger than 2 GiB by avoiding serialization of large response bodies.