### PR TITLE
refactor: use helper for splitting suffixes

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -17,6 +17,7 @@ from poetry.core.constraints.version import Version
 from poetry.core.factory import Factory
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
+from poetry.core.packages.utils.utils import splitext
 from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.core.utils.helpers import parse_requires
 from poetry.core.version.markers import InvalidMarkerError
@@ -307,15 +308,8 @@ class PackageInfo:
 
         # Still not dependencies found
         # So, we unpack and introspect
-        suffix = path.suffix
+        _, suffix = splitext(path)
         zip = suffix == ".zip"
-
-        if suffix == ".bz2":
-            suffixes = path.suffixes
-            if len(suffixes) > 1 and suffixes[-2] == ".tar":
-                suffix = ".tar.bz2"
-        elif not zip:
-            suffix = ".tar.gz"
 
         with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_str:
             tmp = Path(tmp_str)

--- a/src/poetry/installation/chef.py
+++ b/src/poetry/installation/chef.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
+from poetry.core.packages.utils.utils import splitext
+
 from poetry.utils.helpers import extractall
 from poetry.utils.isolated_build import isolated_builder
 
@@ -96,7 +98,7 @@ class Chef:
     ) -> Path:
         from poetry.core.packages.utils.link import Link
 
-        suffix = archive.suffix
+        _, suffix = splitext(archive)
         zip = suffix == ".zip"
 
         with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:


### PR DESCRIPTION
The else branch in chef.py that is fixed seems to be an awkward edge case that might be completely irrelevant. That is why I call it refactor instead of fix.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
