### PR TITLE
perf: use `os.path.abspath()` instead of `Path.resolve()`

### DIFF
--- a/src/poetry/installation/wheel_installer.py
+++ b/src/poetry/installation/wheel_installer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import platform
 import sys
 
@@ -14,7 +15,6 @@ from installer.sources import _WheelFileValidationError
 
 from poetry.__version__ import __version__
 from poetry.utils._compat import WINDOWS
-from poetry.utils._compat import is_relative_to
 
 
 logger = logging.getLogger(__name__)
@@ -45,14 +45,20 @@ class WheelDestination(SchemeDictionaryDestination):
         from installer.utils import copyfileobj_with_hashing
         from installer.utils import make_file_executable
 
-        target_dir = Path(self.scheme_dict[scheme]).resolve()
-        target_path = (target_dir / path).resolve()
+        # See https://docs.python.org/3/library/zipfile.html#zipfile.Path:
+        #  When handling untrusted archives,
+        #  consider resolving filenames using os.path.abspath()
+        #  and checking against the target directory with os.path.commonpath().
+        #
+        # Attention: Path.absolute() is not sufficient because it does not
+        #  normalize, i.e. does not remove "..".
+        #
+        # We want to avoid Path.resolve() because it is significantly slower
+        # than os.path.abspath()!
+        target_dir = Path(os.path.abspath(self.scheme_dict[scheme]))
+        target_path = Path(os.path.abspath(target_dir / path))
 
-        # Use is_relative_to() instead of Path.is_relative_to()
-        # because the latter does not work if one of both paths
-        # has a Windows long path prefix and the other path has not.
-        # (A long path prefix may be added when calling resolve().)
-        if not is_relative_to(target_path, target_dir):
+        if not target_path.is_relative_to(target_dir):
             raise ValueError(
                 f"Attempting to write {path} outside of the target directory\n"
                 f"Target directory: {target_dir}\n"

--- a/tests/installation/test_wheel_installer.py
+++ b/tests/installation/test_wheel_installer.py
@@ -10,6 +10,7 @@ import pytest
 from poetry.core.constraints.version import parse_constraint
 
 from poetry.installation.wheel_installer import WheelInstaller
+from poetry.utils._compat import WINDOWS
 from poetry.utils.env import MockEnv
 
 
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def env(tmp_path: Path) -> MockEnv:
-    return MockEnv(path=tmp_path)
+    return MockEnv(path=tmp_path / "env")
 
 
 @pytest.fixture(scope="module")
@@ -97,14 +98,20 @@ def test_install_dir_is_symlink(tmp_path: Path, demo_wheel: Path) -> None:
     assert (Path(env.paths["purelib"]) / "demo").exists()
 
 
-@pytest.fixture
-def wheel_with_path_traversal(tmp_path: Path) -> Path:
+@pytest.fixture(params=[False, True])  # relative path
+def wheel_with_path_traversal(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
     import zipfile
+
+    traversal_path = (
+        "../../traversal.txt"
+        if request.param
+        else (tmp_path / "traversal.txt").as_posix()
+    )
 
     wheel = tmp_path / "traversal-0.1-py3-none-any.whl"
     files = {
         "traversal/__init__.py": b"",
-        "../../traversal.txt": b"",
+        traversal_path: b"path traversal",
         "traversal-0.1.dist-info/WHEEL": (
             b"Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
         ),
@@ -124,8 +131,90 @@ def wheel_with_path_traversal(tmp_path: Path) -> Path:
     return wheel
 
 
-def test_path_traversal(env: MockEnv, wheel_with_path_traversal: Path) -> None:
+@pytest.mark.parametrize("existing", [False, True])
+def test_no_path_traversal(
+    env: MockEnv, wheel_with_path_traversal: Path, existing: bool
+) -> None:
+    target = env.path.parent / "traversal.txt"
+    if existing:
+        target.write_text("original", encoding="utf-8")
     installer = WheelInstaller(env)
     with pytest.raises(ValueError):
         installer.install(wheel_with_path_traversal)
-    assert not (env.path.parent / "traversal.txt").exists()
+
+    if existing:
+        assert target.exists()
+        assert target.read_text(encoding="utf-8") == "original"
+    else:
+        assert not target.exists()
+
+
+@pytest.fixture(params=[False, True])  # relative path
+def wheel_with_symlink(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
+    import stat
+    import zipfile
+
+    wheel = tmp_path / "symlink-0.1-py3-none-any.whl"
+    files = {
+        "symlink/__init__.py": b"",
+        "symlink-0.1.dist-info/WHEEL": (
+            b"Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        ),
+        "symlink-0.1.dist-info/METADATA": (
+            b"Metadata-Version: 2.1\nName: symlink-pkg\nVersion: 0.1\n"
+        ),
+    }
+
+    symlink_entry = "symlink/traversal_link"
+    symlink_target = (
+        b"../../target"
+        if request.param
+        else (tmp_path / "target").as_posix().encode("utf-8")
+    )
+    traversal_file = "symlink/traversal_link/traversal.txt"
+
+    record_lines = [f"{k},," for k in files]
+    record_lines.append(f"{symlink_entry},,")
+    record_lines.append(f"{traversal_file},,")
+    record_lines.append("symlink-0.1.dist-info/RECORD,,")
+    files["symlink-0.1.dist-info/RECORD"] = ("\n".join(record_lines) + "\n").encode()
+
+    with zipfile.ZipFile(wheel, "w") as z:
+        for k, v in files.items():
+            z.writestr(k, v)
+
+        # Add a ZIP entry whose external attributes mark it as a symlink.
+        # The entry's data is the symlink target, pointing outside the
+        # installation directory.
+        info = zipfile.ZipInfo(symlink_entry)
+        info.create_system = 3  # unix
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        z.writestr(info, symlink_target)
+
+        z.writestr(traversal_file, b"path traversal")
+
+    return wheel
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_no_path_traversal_via_symlink(
+    tmp_path: Path, env: MockEnv, wheel_with_symlink: Path, existing: bool
+) -> None:
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    target = target_dir / "traversal.txt"
+    if existing:
+        target.write_text("original", encoding="utf-8")
+
+    installer = WheelInstaller(env)
+    with pytest.raises(FileNotFoundError if WINDOWS else NotADirectoryError):
+        installer.install(wheel_with_symlink)
+
+    traversal_link = Path(env.paths["purelib"]) / "symlink" / "traversal_link"
+    assert traversal_link.exists()
+    assert not traversal_link.is_symlink()  # not even extracted as symlink
+    assert target_dir.exists()
+    if existing:
+        assert target.read_text(encoding="utf-8") == "original"
+    else:
+        assert not list(target_dir.iterdir())


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

There is a significant performance regression due to #10792, which is mostly caused by the two calls of `Path.resolve()`.

The time to install a sample project with some dependencies increased from 8 seconds (Poetry 2.3.2) to 13 seconds (Poetry 2.3.3).

With the fix, installation is almost as fast as before (less than half a second slower).

It should be safe to use `os.path.abspath()` instead of `Path.resolve()`.  At least, I could not craft a wheel that triggers a path traversal via symlinks (see new test). Further, `os.path.abspath()` is recommended in https://docs.python.org/3/library/zipfile.html#zipfile.Path and (if I do not miss anything) pip also uses `os.path.abspath()` (and not `Path.resolve()`): https://github.com/pypa/pip/blob/8c5468dc9695c023c0a6428e630126aa14c9db4e/src/pip/_internal/utils/unpacking.py#L79-L87
