### PR TITLE
docs: note VCS ignore interaction with `packages`

### DIFF
--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -699,6 +699,15 @@ Poetry is clever enough to detect Python subpackages.
 Thus, you only have to specify the directory where your root package resides.
 {{% /note %}}
 
+{{% warning %}}
+If a VCS is being used, files matched by its ignore settings (for example by
+`.gitignore` for git) are excluded from the built distributions even when their
+parent directory is listed under `packages`. This can be surprising if a
+`packages` entry points at generated code or another path that is intentionally
+kept out of version control. To ship such files, add them back via
+[`include`]({{< relref "#exclude-and-include" >}}) with an explicit `format`.
+{{% /warning %}}
+
 ### exclude and include
 
 {{% note %}}

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -700,8 +700,8 @@ Thus, you only have to specify the directory where your root package resides.
 {{% /note %}}
 
 {{% warning %}}
-If a VCS is being used, files matched by its ignore settings (for example by
-`.gitignore` for git) are excluded from the built distributions even when their
+If a VCS is being used, files matched by its ignore settings (for example, by
+`.gitignore` for Git) are excluded from the built distributions even when their
 parent directory is listed under `packages`. This can be surprising if a
 `packages` entry points at generated code or another path that is intentionally
 kept out of version control. To ship such files, add them back via


### PR DESCRIPTION
Resolves #10831

## What

Adds a short warning block to the `packages` subsection of `docs/pyproject.md` explaining that files matched by VCS ignore settings (e.g. `.gitignore`) are excluded from the built distributions even when their parent directory is listed under `packages`, and points readers to `exclude and include` for the include-with-format workaround.

## Why

On #10831 the reporter listed a generated-code directory under `packages` but had the same directory in `.gitignore`, and `poetry build` silently produced empty `sdist`/`wheel` archives. @dimbleby correctly pointed out that the behaviour is documented in the `exclude and include` subsection, but the reporter noted (and I agree) that the `packages` subsection itself does not mention the cross-talk — which is exactly where a user going from "I want to include this directory" to "my build is empty" lands first.

Quoting the reporter's refined ask on 2026-04-09:

> However, the documentation for [packages](https://python-poetry.org/docs/pyproject/#packages) **does not** mention this cross-talk with the version control. If this is intended behaviour, I suggest putting a warning there, similar to that in the exclude-and-include section.

## Diff

```diff
 Thus, you only have to specify the directory where your root package resides.
 {{% /note %}}
 
+{{% warning %}}
+If a VCS is being used, files matched by its ignore settings (for example by
+`.gitignore` for git) are excluded from the built distributions even when their
+parent directory is listed under `packages`. This can be surprising if a
+`packages` entry points at generated code or another path that is intentionally
+kept out of version control. To ship such files, add them back via
+[`include`]({{< relref "#exclude-and-include" >}}) with an explicit `format`.
+{{% /warning %}}
+
 ### exclude and include
```

No code change, no behaviour change — docs-only, 9 lines added.