### PR TITLE
fix: refuse to write files outside the target directory during sdist extraction

### DIFF
--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -415,7 +415,7 @@ def extractall(source: Path, dest: Path, zip: bool) -> None:
     else:
         # These versions of python shipped with a broken tarfile data_filter, per
         # https://github.com/python/cpython/issues/107845.
-        broken_tarfile_filter = {(3, 9, 17), (3, 10, 12), (3, 11, 4)}
+        broken_tarfile_filter = {(3, 10, 12), (3, 11, 4)}
         with tarfile.open(source) as archive:
             if (
                 hasattr(tarfile, "data_filter")
@@ -423,4 +423,37 @@ def extractall(source: Path, dest: Path, zip: bool) -> None:
             ):
                 archive.extractall(dest, filter="data")
             else:
-                archive.extractall(dest)
+                # Validate all member paths before extraction
+                #
+                # Attention: Path.absolute() is not sufficient because it does not
+                #  normalize, i.e. does not remove "..".
+                #
+                # We want to avoid Path.resolve() because it is significantly slower
+                # than os.path.abspath()!
+                dest = Path(os.path.abspath(dest))
+                safe_members = []
+                for member in archive.getmembers():
+                    member_path = Path(os.path.abspath(dest / member.name))
+                    if not member_path.is_relative_to(dest):
+                        raise ValueError(
+                            f"Refusing to extract {member.name}: "
+                            f"would write outside {dest}"
+                        )
+                    if member.issym():
+                        link_target = Path(
+                            os.path.abspath(member_path.parent / member.linkname)
+                        )
+                        if not link_target.is_relative_to(dest):
+                            raise ValueError(
+                                f"Refusing symlink {member.name}: "
+                                f"target {member.linkname} outside {dest}"
+                            )
+                    elif member.islnk():
+                        link_target = Path(os.path.abspath(dest / member.linkname))
+                        if not link_target.is_relative_to(dest):
+                            raise ValueError(
+                                f"Refusing hardlink {member.name}: "
+                                f"target {member.linkname} outside {dest}"
+                            )
+                    safe_members.append(member)
+                archive.extractall(dest, members=safe_members)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1047,3 +1047,85 @@ def mocked_poetry_managed_python_register(
         return bin_dir
 
     return register
+
+
+@pytest.fixture(params=[False, True])  # relative path
+def wheel_with_path_traversal(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
+    import zipfile
+
+    traversal_path = (
+        "../../traversal.txt"
+        if request.param
+        else (tmp_path / "traversal.txt").as_posix()
+    )
+
+    wheel = tmp_path / "traversal-0.1-py3-none-any.whl"
+    files = {
+        "traversal/__init__.py": b"",
+        traversal_path: b"path traversal",
+        "traversal-0.1.dist-info/WHEEL": (
+            b"Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        ),
+        "traversal-0.1.dist-info/METADATA": (
+            b"Metadata-Version: 2.1\nName: traversal\nVersion: 0.1\n"
+        ),
+    }
+    files["traversal-0.1.dist-info/RECORD"] = (
+        "\n".join([f"{k},," for k in files] + ["traversal-0.1.dist-info/RECORD,,"])
+        + "\n"
+    ).encode()
+
+    with zipfile.ZipFile(wheel, "w") as z:
+        for k, v in files.items():
+            z.writestr(k, v)
+
+    return wheel
+
+
+@pytest.fixture(params=[False, True])  # relative path
+def wheel_with_path_traversal_via_symlink(
+    tmp_path: Path, request: pytest.FixtureRequest
+) -> Path:
+    import stat
+    import zipfile
+
+    wheel = tmp_path / "symlink-0.1-py3-none-any.whl"
+    files = {
+        "symlink/__init__.py": b"",
+        "symlink-0.1.dist-info/WHEEL": (
+            b"Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        ),
+        "symlink-0.1.dist-info/METADATA": (
+            b"Metadata-Version: 2.1\nName: symlink-pkg\nVersion: 0.1\n"
+        ),
+    }
+
+    symlink_entry = "symlink/traversal_link"
+    symlink_target = (
+        b"../../target"
+        if request.param
+        else (tmp_path / "target").as_posix().encode("utf-8")
+    )
+    traversal_file = "symlink/traversal_link/traversal.txt"
+
+    record_lines = [f"{k},," for k in files]
+    record_lines.append(f"{symlink_entry},,")
+    record_lines.append(f"{traversal_file},,")
+    record_lines.append("symlink-0.1.dist-info/RECORD,,")
+    files["symlink-0.1.dist-info/RECORD"] = ("\n".join(record_lines) + "\n").encode()
+
+    with zipfile.ZipFile(wheel, "w") as z:
+        for k, v in files.items():
+            z.writestr(k, v)
+
+        # Add a ZIP entry whose external attributes mark it as a symlink.
+        # The entry's data is the symlink target, pointing outside the
+        # installation directory.
+        info = zipfile.ZipInfo(symlink_entry)
+        info.create_system = 3  # unix
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        z.writestr(info, symlink_target)
+
+        z.writestr(traversal_file, b"path traversal")
+
+    return wheel

--- a/tests/installation/test_wheel_installer.py
+++ b/tests/installation/test_wheel_installer.py
@@ -98,43 +98,11 @@ def test_install_dir_is_symlink(tmp_path: Path, demo_wheel: Path) -> None:
     assert (Path(env.paths["purelib"]) / "demo").exists()
 
 
-@pytest.fixture(params=[False, True])  # relative path
-def wheel_with_path_traversal(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
-    import zipfile
-
-    traversal_path = (
-        "../../traversal.txt"
-        if request.param
-        else (tmp_path / "traversal.txt").as_posix()
-    )
-
-    wheel = tmp_path / "traversal-0.1-py3-none-any.whl"
-    files = {
-        "traversal/__init__.py": b"",
-        traversal_path: b"path traversal",
-        "traversal-0.1.dist-info/WHEEL": (
-            b"Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
-        ),
-        "traversal-0.1.dist-info/METADATA": (
-            b"Metadata-Version: 2.1\nName: traversal\nVersion: 0.1\n"
-        ),
-    }
-    files["traversal-0.1.dist-info/RECORD"] = (
-        "\n".join([f"{k},," for k in files] + ["traversal-0.1.dist-info/RECORD,,"])
-        + "\n"
-    ).encode()
-
-    with zipfile.ZipFile(wheel, "w") as z:
-        for k, v in files.items():
-            z.writestr(k, v)
-
-    return wheel
-
-
 @pytest.mark.parametrize("existing", [False, True])
 def test_no_path_traversal(
     env: MockEnv, wheel_with_path_traversal: Path, existing: bool
 ) -> None:
+    """see also test_extractall_wheel_no_path_traversal in test_helpers.py"""
     target = env.path.parent / "traversal.txt"
     if existing:
         target.write_text("original", encoding="utf-8")
@@ -149,57 +117,15 @@ def test_no_path_traversal(
         assert not target.exists()
 
 
-@pytest.fixture(params=[False, True])  # relative path
-def wheel_with_symlink(tmp_path: Path, request: pytest.FixtureRequest) -> Path:
-    import stat
-    import zipfile
-
-    wheel = tmp_path / "symlink-0.1-py3-none-any.whl"
-    files = {
-        "symlink/__init__.py": b"",
-        "symlink-0.1.dist-info/WHEEL": (
-            b"Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
-        ),
-        "symlink-0.1.dist-info/METADATA": (
-            b"Metadata-Version: 2.1\nName: symlink-pkg\nVersion: 0.1\n"
-        ),
-    }
-
-    symlink_entry = "symlink/traversal_link"
-    symlink_target = (
-        b"../../target"
-        if request.param
-        else (tmp_path / "target").as_posix().encode("utf-8")
-    )
-    traversal_file = "symlink/traversal_link/traversal.txt"
-
-    record_lines = [f"{k},," for k in files]
-    record_lines.append(f"{symlink_entry},,")
-    record_lines.append(f"{traversal_file},,")
-    record_lines.append("symlink-0.1.dist-info/RECORD,,")
-    files["symlink-0.1.dist-info/RECORD"] = ("\n".join(record_lines) + "\n").encode()
-
-    with zipfile.ZipFile(wheel, "w") as z:
-        for k, v in files.items():
-            z.writestr(k, v)
-
-        # Add a ZIP entry whose external attributes mark it as a symlink.
-        # The entry's data is the symlink target, pointing outside the
-        # installation directory.
-        info = zipfile.ZipInfo(symlink_entry)
-        info.create_system = 3  # unix
-        info.external_attr = (stat.S_IFLNK | 0o777) << 16
-        z.writestr(info, symlink_target)
-
-        z.writestr(traversal_file, b"path traversal")
-
-    return wheel
-
-
 @pytest.mark.parametrize("existing", [False, True])
 def test_no_path_traversal_via_symlink(
-    tmp_path: Path, env: MockEnv, wheel_with_symlink: Path, existing: bool
+    tmp_path: Path,
+    env: MockEnv,
+    wheel_with_path_traversal_via_symlink: Path,
+    existing: bool,
 ) -> None:
+    """see also test_extractall_wheel_no_path_traversal_via_symlink
+    in test_helpers.py"""
     target_dir = tmp_path / "target"
     target_dir.mkdir()
     target = target_dir / "traversal.txt"
@@ -208,7 +134,7 @@ def test_no_path_traversal_via_symlink(
 
     installer = WheelInstaller(env)
     with pytest.raises(FileNotFoundError if WINDOWS else NotADirectoryError):
-        installer.install(wheel_with_symlink)
+        installer.install(wheel_with_path_traversal_via_symlink)
 
     traversal_link = Path(env.paths["purelib"]) / "symlink" / "traversal_link"
     assert traversal_link.exists()

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import re
+import sys
+import tarfile
 
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -13,10 +16,12 @@ import responses
 from poetry.core.utils.helpers import parse_requires
 from requests.exceptions import ChunkedEncodingError
 
+from poetry.utils._compat import WINDOWS
 from poetry.utils.helpers import Downloader
 from poetry.utils.helpers import HTTPRangeRequestSupportedError
 from poetry.utils.helpers import download_file
 from poetry.utils.helpers import ensure_path
+from poetry.utils.helpers import extractall
 from poetry.utils.helpers import get_file_hash
 from poetry.utils.helpers import get_highest_priority_hash_type
 
@@ -341,3 +346,165 @@ def test_ensure_path_directory(tmp_path: Path) -> None:
 
     path.mkdir()
     assert ensure_path(path=path, is_directory=True) is path
+
+
+@pytest.mark.parametrize("relative", [False, True])
+@pytest.mark.parametrize("existing", [False, True])
+def test_extractall_sdist_no_path_traversal(
+    tmp_path: Path, relative: bool, existing: bool
+) -> None:
+    import io
+    import tarfile
+
+    archive = tmp_path / "traversal.tar.gz"
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    target = tmp_path / "traversal.txt"
+    if existing:
+        target.write_text("original", encoding="utf-8")
+
+    with tarfile.open(archive, "w:gz") as tar:
+        b = b"path traversal"
+        t = tarfile.TarInfo("../traversal.txt" if relative else target.as_posix())
+        t.size = len(b)
+        tar.addfile(t, io.BytesIO(b))
+
+    has_data_filter = hasattr(tarfile, "data_filter")
+    # The stdlib implementation just strips the leading "/" from absolute paths
+    # and extracts them relative to the target directory (except for Windows).
+    # We do not care and raise an error.
+    raises = (
+        relative
+        or WINDOWS
+        or not has_data_filter
+        or sys.version_info[:3] in {(3, 10, 12), (3, 11, 4)}
+    )
+    exceptions: tuple[type[Exception], ...]
+    if has_data_filter:
+        if relative:
+            exceptions = (tarfile.OutsideDestinationError, ValueError)
+        else:
+            exceptions = (tarfile.AbsolutePathError, ValueError)
+    else:
+        # tarfile.OutsideDestinationError does not exist
+        exceptions = (ValueError,)
+
+    with pytest.raises(exceptions) if raises else contextlib.nullcontext():
+        extractall(source=archive, dest=dest, zip=False)
+
+    if existing:
+        assert target.exists()
+        assert target.read_text(encoding="utf-8") == "original"
+    else:
+        assert not target.exists()
+    if not raises:
+        # check that expected location exists, otherwise we have to check
+        # that there is no traversal in an unexpected location
+        assert (dest / target.as_posix().lstrip("/")).exists()
+
+
+@pytest.mark.parametrize("link_type", [tarfile.SYMTYPE, tarfile.LNKTYPE])
+@pytest.mark.parametrize("relative", [False, True])
+@pytest.mark.parametrize("existing", [False, True])
+def test_extractall_sdist_no_symlink_path_traversal(
+    tmp_path: Path, link_type: bytes, relative: bool, existing: bool
+) -> None:
+    import io
+    import tarfile
+
+    archive = tmp_path / "traversal.tar.gz"
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    target = tmp_path / "traversal.txt"
+    if existing:
+        target.write_text("original", encoding="utf-8")
+
+    with tarfile.open(archive, "w:gz") as tar:
+        # We use a link in a subdirectory to test the difference
+        # between symlinks and hardlinks:
+        # symlinks are relative to the directory of the symlink,
+        # while hardlinks are relative to the root of the archive
+        s = tarfile.TarInfo("sub/link")
+        s.type = link_type
+        if relative:
+            s.linkname = (
+                "../../traversal.txt"
+                if link_type == tarfile.SYMTYPE
+                else "../traversal.txt"
+            )
+        else:
+            s.linkname = target.as_posix()
+        tar.addfile(s)
+        p = b"path traversal"
+        f = tarfile.TarInfo("sub/link")
+        f.size = len(p)
+        tar.addfile(f, io.BytesIO(p))
+
+    exceptions: tuple[type[Exception], ...]
+    if hasattr(tarfile, "data_filter"):
+        exceptions = (
+            tarfile.AbsoluteLinkError,
+            tarfile.LinkOutsideDestinationError,
+            ValueError,
+        )
+    else:
+        # tarfile.OutsideDestinationError does not exist
+        exceptions = (ValueError,)
+
+    with pytest.raises(exceptions):
+        extractall(source=archive, dest=dest, zip=False)
+
+    if existing:
+        assert target.exists()
+        assert target.read_text(encoding="utf-8") == "original"
+    else:
+        assert not target.exists()
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_extractall_wheel_no_path_traversal(
+    tmp_path: Path, wheel_with_path_traversal: Path, existing: bool
+) -> None:
+    """see also test_no_path_traversal in test_wheel_installer.py"""
+    dest = tmp_path / "dest" / "dir"
+    dest.mkdir(parents=True)
+    target = tmp_path / "traversal.txt"
+    if existing:
+        target.write_text("original", encoding="utf-8")
+
+    extractall(source=wheel_with_path_traversal, dest=dest, zip=True)
+
+    if existing:
+        assert target.exists()
+        assert target.read_text(encoding="utf-8") == "original"
+    else:
+        assert not target.exists()
+
+    # target is "../.." but also check ".." just to be sure
+    assert not (dest.parent / "traversal.txt").exists()
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_extractall_wheel_no_path_traversal_via_symlink(
+    tmp_path: Path, wheel_with_path_traversal_via_symlink: Path, existing: bool
+) -> None:
+    """see also test_no_path_traversal_via_symlink in test_wheel_installer.py"""
+    dest = tmp_path / "dest" / "dir"
+    dest.mkdir(parents=True)
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    target = target_dir / "traversal.txt"
+    if existing:
+        target.write_text("original", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError if WINDOWS else NotADirectoryError):
+        extractall(source=wheel_with_path_traversal_via_symlink, dest=dest, zip=True)
+
+    assert target_dir.exists()
+    if existing:
+        assert target.exists()
+        assert target.read_text(encoding="utf-8") == "original"
+    else:
+        assert not target.exists()


### PR DESCRIPTION
This has already been ensured with newer Python versions. Now, it is ensured with all supported versions, that means also with 3.10.0 - 3.10.12 and 3.11.0 - 3.11.4.

Further, 3.9.17 has been removed from `broken_tarfile_filter` because we do not support Python 3.9 anymore.

In addition, test coverage is increased.

Note: A path traversal during sdist extraction is not as critical as it might seem because after extracting the sdist the project is built, which may result in arbitrary code execution by design.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
