### PR TITLE
docs: fix SHA wording in git backend comment

### DIFF
--- a/src/poetry/vcs/git/backend.py
+++ b/src/poetry/vcs/git/backend.py
@@ -147,7 +147,7 @@ class GitRefSpec:
 
     def _set_head(self, remote_refs: FetchPackResult, repo: Repo) -> None:
         """
-        Internal helper method to populate ref and set it's sha as the remote's head
+        Internal helper method to populate ref and set its SHA as the remote's head
         and default ref.
         """
         self.ref = remote_refs.symrefs[Ref(b"HEAD")]


### PR DESCRIPTION
## Summary
- Fix the possessive wording in the git backend head comment.

## Related issue
- N/A

## Guideline alignment
- Kept this to one focused text-only change in a single file.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this comment-only change.
