### PR TITLE
fix: support periods in repository names

### DIFF
--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -16,6 +16,7 @@ from typing import ClassVar
 from packaging.utils import NormalizedName
 from packaging.utils import canonicalize_name
 
+from poetry.config.config_source import split_key
 from poetry.config.dict_config_source import DictConfigSource
 from poetry.config.file_config_source import FileConfigSource
 from poetry.locations import CONFIG_DIR
@@ -309,11 +310,16 @@ class Config:
             return default_max_workers
         return min(default_max_workers, int(desired_max_workers))
 
-    def get(self, setting_name: str, default: Any = None) -> Any:
+    def get(self, setting_name: str | list[str], default: Any = None) -> Any:
         """
         Retrieve a setting value.
+
+        The setting_name can be a dotted string (e.g. "virtualenvs.create")
+        or a list of key segments (e.g. ["http-basic", "my.repo", "username"])
+        when any segment may contain periods.
         """
-        keys = setting_name.split(".")
+        keys = split_key(setting_name)
+        setting_name_str = ".".join(keys) if isinstance(setting_name, list) else setting_name
         build_config_settings: Mapping[
             NormalizedName, Mapping[str, str | Sequence[str]]
         ] = {}
@@ -321,14 +327,14 @@ class Config:
         # Looking in the environment if the setting
         # is set via a POETRY_* environment variable
         if self._use_environment:
-            if setting_name == "repositories":
+            if setting_name_str == "repositories":
                 # repositories setting is special for now
                 repositories = self._get_environment_repositories()
                 if repositories:
                     return repositories
 
             build_config_settings_key = "installer.build-config-settings"
-            if setting_name == build_config_settings_key or setting_name.startswith(
+            if setting_name_str == build_config_settings_key or setting_name_str.startswith(
                 f"{build_config_settings_key}."
             ):
                 build_config_settings = self._get_environment_build_config_settings()
@@ -336,7 +342,7 @@ class Config:
                 env = "POETRY_" + "_".join(k.upper().replace("-", "_") for k in keys)
                 env_value = os.getenv(env)
                 if env_value is not None:
-                    return self.process(self._get_normalizer(setting_name)(env_value))
+                    return self.process(self._get_normalizer(setting_name_str)(env_value))
 
         value = self._config
 
@@ -355,7 +361,7 @@ class Config:
         if self._use_environment and isinstance(value, dict):
             # this is a configuration table, it is likely that we missed env vars
             # in order to capture them recurse, eg: virtualenvs.options
-            return {k: self.get(f"{setting_name}.{k}") for k in value}
+            return {k: self.get(keys + [k]) for k in value}
 
         return self.process(value)
 

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -319,7 +319,9 @@ class Config:
         when any segment may contain periods.
         """
         keys = split_key(setting_name)
-        setting_name_str = ".".join(keys) if isinstance(setting_name, list) else setting_name
+        setting_name_str = (
+            ".".join(keys) if isinstance(setting_name, list) else setting_name
+        )
         build_config_settings: Mapping[
             NormalizedName, Mapping[str, str | Sequence[str]]
         ] = {}
@@ -334,15 +336,18 @@ class Config:
                     return repositories
 
             build_config_settings_key = "installer.build-config-settings"
-            if setting_name_str == build_config_settings_key or setting_name_str.startswith(
-                f"{build_config_settings_key}."
+            if (
+                setting_name_str == build_config_settings_key
+                or setting_name_str.startswith(f"{build_config_settings_key}.")
             ):
                 build_config_settings = self._get_environment_build_config_settings()
             else:
                 env = "POETRY_" + "_".join(k.upper().replace("-", "_") for k in keys)
                 env_value = os.getenv(env)
                 if env_value is not None:
-                    return self.process(self._get_normalizer(setting_name_str)(env_value))
+                    return self.process(
+                        self._get_normalizer(setting_name_str)(env_value)
+                    )
 
         value = self._config
 
@@ -361,7 +366,7 @@ class Config:
         if self._use_environment and isinstance(value, dict):
             # this is a configuration table, it is likely that we missed env vars
             # in order to capture them recurse, eg: virtualenvs.options
-            return {k: self.get(keys + [k]) for k in value}
+            return {k: self.get([*keys, k]) for k in value}
 
         return self.process(value)
 

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -310,7 +310,7 @@ class Config:
             return default_max_workers
         return min(default_max_workers, int(desired_max_workers))
 
-    def get(self, setting_name: str | list[str], default: Any = None) -> Any:
+    def get(self, setting_name: str | Sequence[str], default: Any = None) -> Any:
         """
         Retrieve a setting value.
 
@@ -320,7 +320,7 @@ class Config:
         """
         keys = split_key(setting_name)
         setting_name_str = (
-            ".".join(keys) if isinstance(setting_name, list) else setting_name
+            setting_name if isinstance(setting_name, str) else ".".join(keys)
         )
         build_config_settings: Mapping[
             NormalizedName, Mapping[str, str | Sequence[str]]

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -319,9 +319,6 @@ class Config:
         when any segment may contain periods.
         """
         keys = split_key(setting_name)
-        setting_name_str = (
-            setting_name if isinstance(setting_name, str) else ".".join(keys)
-        )
         build_config_settings: Mapping[
             NormalizedName, Mapping[str, str | Sequence[str]]
         ] = {}
@@ -329,25 +326,19 @@ class Config:
         # Looking in the environment if the setting
         # is set via a POETRY_* environment variable
         if self._use_environment:
-            if setting_name_str == "repositories":
+            if keys == ["repositories"]:
                 # repositories setting is special for now
                 repositories = self._get_environment_repositories()
                 if repositories:
                     return repositories
 
-            build_config_settings_key = "installer.build-config-settings"
-            if (
-                setting_name_str == build_config_settings_key
-                or setting_name_str.startswith(f"{build_config_settings_key}.")
-            ):
+            if keys[:2] == ["installer", "build-config-settings"]:
                 build_config_settings = self._get_environment_build_config_settings()
             else:
                 env = "POETRY_" + "_".join(k.upper().replace("-", "_") for k in keys)
                 env_value = os.getenv(env)
                 if env_value is not None:
-                    return self.process(
-                        self._get_normalizer(setting_name_str)(env_value)
-                    )
+                    return self.process(self._get_normalizer(keys)(env_value))
 
         value = self._config
 
@@ -387,7 +378,9 @@ class Config:
         return re.sub(r"{(.+?)}", resolve_from_config, value)
 
     @staticmethod
-    def _get_normalizer(name: str) -> Callable[[str], Any]:
+    def _get_normalizer(name: str | Sequence[str]) -> Callable[[str], Any]:
+        if not isinstance(name, str):
+            name = ".".join(name)
         if name in {
             "virtualenvs.create",
             "virtualenvs.in-project",

--- a/src/poetry/config/config_source.py
+++ b/src/poetry/config/config_source.py
@@ -12,13 +12,15 @@ from cleo.io.null_io import NullIO
 
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from cleo.io.io import IO
 
 
 UNSET = object()
 
 
-def split_key(key: str | list[str]) -> list[str]:
+def split_key(key: str | Sequence[str]) -> list[str]:
     """Split a config key into its component parts.
 
     If the key is already a list, return it as-is.
@@ -27,9 +29,9 @@ def split_key(key: str | list[str]) -> list[str]:
     Use a list when the key contains segments with periods
     (e.g. repository names like "my.repo").
     """
-    if isinstance(key, list):
-        return key
-    return key.split(".")
+    if isinstance(key, str):
+        return key.split(".")
+    return list(key)
 
 
 class PropertyNotFoundError(ValueError):
@@ -38,13 +40,13 @@ class PropertyNotFoundError(ValueError):
 
 class ConfigSource(ABC):
     @abstractmethod
-    def get_property(self, key: str | list[str]) -> Any: ...
+    def get_property(self, key: str | Sequence[str]) -> Any: ...
 
     @abstractmethod
-    def add_property(self, key: str | list[str], value: Any) -> None: ...
+    def add_property(self, key: str | Sequence[str], value: Any) -> None: ...
 
     @abstractmethod
-    def remove_property(self, key: str | list[str]) -> None: ...
+    def remove_property(self, key: str | Sequence[str]) -> None: ...
 
 
 @dataclasses.dataclass
@@ -95,7 +97,7 @@ class ConfigSourceMigration:
 
 
 def drop_empty_config_category(
-    keys: list[str], config: dict[Any, Any]
+    keys: Sequence[str], config: dict[Any, Any]
 ) -> dict[Any, Any]:
     config_ = {}
 

--- a/src/poetry/config/config_source.py
+++ b/src/poetry/config/config_source.py
@@ -18,19 +18,33 @@ if TYPE_CHECKING:
 UNSET = object()
 
 
+def split_key(key: str | list[str]) -> list[str]:
+    """Split a config key into its component parts.
+
+    If the key is already a list, return it as-is.
+    If the key is a string, split on periods.
+
+    Use a list when the key contains segments with periods
+    (e.g. repository names like "my.repo").
+    """
+    if isinstance(key, list):
+        return key
+    return key.split(".")
+
+
 class PropertyNotFoundError(ValueError):
     pass
 
 
 class ConfigSource(ABC):
     @abstractmethod
-    def get_property(self, key: str) -> Any: ...
+    def get_property(self, key: str | list[str]) -> Any: ...
 
     @abstractmethod
-    def add_property(self, key: str, value: Any) -> None: ...
+    def add_property(self, key: str | list[str], value: Any) -> None: ...
 
     @abstractmethod
-    def remove_property(self, key: str) -> None: ...
+    def remove_property(self, key: str | list[str]) -> None: ...
 
 
 @dataclasses.dataclass

--- a/src/poetry/config/config_source.py
+++ b/src/poetry/config/config_source.py
@@ -23,11 +23,12 @@ UNSET = object()
 def split_key(key: str | Sequence[str]) -> list[str]:
     """Split a config key into its component parts.
 
-    If the key is already a list, return it as-is.
     If the key is a string, split on periods.
 
-    Use a list when the key contains segments with periods
-    (e.g. repository names like "my.repo").
+    If the key contains segments with periods
+    (e.g. repository names like "my.repo"),
+    this should be handled before calling this function
+    so that a list or tuple of the segments is passed.
     """
     if isinstance(key, str):
         return key.split(".")

--- a/src/poetry/config/dict_config_source.py
+++ b/src/poetry/config/dict_config_source.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from poetry.config.config_source import ConfigSource
 from poetry.config.config_source import PropertyNotFoundError
+from poetry.config.config_source import split_key
 
 
 class DictConfigSource(ConfigSource):
@@ -14,8 +15,8 @@ class DictConfigSource(ConfigSource):
     def config(self) -> dict[str, Any]:
         return self._config
 
-    def get_property(self, key: str) -> Any:
-        keys = key.split(".")
+    def get_property(self, key: str | list[str]) -> Any:
+        keys = split_key(key)
         config = self._config
 
         for i, key in enumerate(keys):
@@ -27,8 +28,8 @@ class DictConfigSource(ConfigSource):
 
             config = config[key]
 
-    def add_property(self, key: str, value: Any) -> None:
-        keys = key.split(".")
+    def add_property(self, key: str | list[str], value: Any) -> None:
+        keys = split_key(key)
         config = self._config
 
         for i, key in enumerate(keys):
@@ -41,8 +42,8 @@ class DictConfigSource(ConfigSource):
 
             config = config[key]
 
-    def remove_property(self, key: str) -> None:
-        keys = key.split(".")
+    def remove_property(self, key: str | list[str]) -> None:
+        keys = split_key(key)
 
         config = self._config
         for i, key in enumerate(keys):

--- a/src/poetry/config/dict_config_source.py
+++ b/src/poetry/config/dict_config_source.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 
 from poetry.config.config_source import ConfigSource
 from poetry.config.config_source import PropertyNotFoundError
 from poetry.config.config_source import split_key
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class DictConfigSource(ConfigSource):
@@ -15,7 +20,7 @@ class DictConfigSource(ConfigSource):
     def config(self) -> dict[str, Any]:
         return self._config
 
-    def get_property(self, key: str | list[str]) -> Any:
+    def get_property(self, key: str | Sequence[str]) -> Any:
         keys = split_key(key)
         config = self._config
 
@@ -28,7 +33,7 @@ class DictConfigSource(ConfigSource):
 
             config = config[sub_key]
 
-    def add_property(self, key: str | list[str], value: Any) -> None:
+    def add_property(self, key: str | Sequence[str], value: Any) -> None:
         keys = split_key(key)
         config = self._config
 
@@ -42,7 +47,7 @@ class DictConfigSource(ConfigSource):
 
             config = config[sub_key]
 
-    def remove_property(self, key: str | list[str]) -> None:
+    def remove_property(self, key: str | Sequence[str]) -> None:
         keys = split_key(key)
 
         config = self._config

--- a/src/poetry/config/dict_config_source.py
+++ b/src/poetry/config/dict_config_source.py
@@ -19,40 +19,40 @@ class DictConfigSource(ConfigSource):
         keys = split_key(key)
         config = self._config
 
-        for i, key in enumerate(keys):
-            if key not in config:
+        for i, sub_key in enumerate(keys):
+            if sub_key not in config:
                 raise PropertyNotFoundError(f"Key {'.'.join(keys)} not in config")
 
             if i == len(keys) - 1:
-                return config[key]
+                return config[sub_key]
 
-            config = config[key]
+            config = config[sub_key]
 
     def add_property(self, key: str | list[str], value: Any) -> None:
         keys = split_key(key)
         config = self._config
 
-        for i, key in enumerate(keys):
-            if key not in config and i < len(keys) - 1:
-                config[key] = {}
+        for i, sub_key in enumerate(keys):
+            if sub_key not in config and i < len(keys) - 1:
+                config[sub_key] = {}
 
             if i == len(keys) - 1:
-                config[key] = value
+                config[sub_key] = value
                 break
 
-            config = config[key]
+            config = config[sub_key]
 
     def remove_property(self, key: str | list[str]) -> None:
         keys = split_key(key)
 
         config = self._config
-        for i, key in enumerate(keys):
-            if key not in config:
+        for i, sub_key in enumerate(keys):
+            if sub_key not in config:
                 return
 
             if i == len(keys) - 1:
-                del config[key]
+                del config[sub_key]
 
                 break
 
-            config = config[key]
+            config = config[sub_key]

--- a/src/poetry/config/file_config_source.py
+++ b/src/poetry/config/file_config_source.py
@@ -10,6 +10,7 @@ from tomlkit import table
 from poetry.config.config_source import ConfigSource
 from poetry.config.config_source import PropertyNotFoundError
 from poetry.config.config_source import drop_empty_config_category
+from poetry.config.config_source import split_key
 
 
 if TYPE_CHECKING:
@@ -32,8 +33,8 @@ class FileConfigSource(ConfigSource):
     def file(self) -> TOMLFile:
         return self._file
 
-    def get_property(self, key: str) -> Any:
-        keys = key.split(".")
+    def get_property(self, key: str | list[str]) -> Any:
+        keys = split_key(key)
 
         config = self.file.read() if self.file.exists() else {}
 
@@ -46,10 +47,10 @@ class FileConfigSource(ConfigSource):
 
             config = config[key]
 
-    def add_property(self, key: str, value: Any) -> None:
+    def add_property(self, key: str | list[str], value: Any) -> None:
         with self.secure() as toml:
             config: dict[str, Any] = toml
-            keys = key.split(".")
+            keys = split_key(key)
 
             for i, key in enumerate(keys):
                 if key not in config and i < len(keys) - 1:
@@ -61,10 +62,10 @@ class FileConfigSource(ConfigSource):
 
                 config = config[key]
 
-    def remove_property(self, key: str) -> None:
+    def remove_property(self, key: str | list[str]) -> None:
         with self.secure() as toml:
             config: dict[str, Any] = toml
-            keys = key.split(".")
+            keys = split_key(key)
 
             current_config = config
             for i, key in enumerate(keys):

--- a/src/poetry/config/file_config_source.py
+++ b/src/poetry/config/file_config_source.py
@@ -38,29 +38,29 @@ class FileConfigSource(ConfigSource):
 
         config = self.file.read() if self.file.exists() else {}
 
-        for i, key in enumerate(keys):
-            if key not in config:
+        for i, sub_key in enumerate(keys):
+            if sub_key not in config:
                 raise PropertyNotFoundError(f"Key {'.'.join(keys)} not in config")
 
             if i == len(keys) - 1:
-                return config[key]
+                return config[sub_key]
 
-            config = config[key]
+            config = config[sub_key]
 
     def add_property(self, key: str | list[str], value: Any) -> None:
         with self.secure() as toml:
             config: dict[str, Any] = toml
             keys = split_key(key)
 
-            for i, key in enumerate(keys):
-                if key not in config and i < len(keys) - 1:
-                    config[key] = table()
+            for i, sub_key in enumerate(keys):
+                if sub_key not in config and i < len(keys) - 1:
+                    config[sub_key] = table()
 
                 if i == len(keys) - 1:
-                    config[key] = value
+                    config[sub_key] = value
                     break
 
-                config = config[key]
+                config = config[sub_key]
 
     def remove_property(self, key: str | list[str]) -> None:
         with self.secure() as toml:
@@ -68,16 +68,16 @@ class FileConfigSource(ConfigSource):
             keys = split_key(key)
 
             current_config = config
-            for i, key in enumerate(keys):
-                if key not in current_config:
+            for i, sub_key in enumerate(keys):
+                if sub_key not in current_config:
                     return
 
                 if i == len(keys) - 1:
-                    del current_config[key]
+                    del current_config[sub_key]
 
                     break
 
-                current_config = current_config[key]
+                current_config = current_config[sub_key]
 
             current_config = drop_empty_config_category(keys=keys[:-1], config=config)
             config.clear()

--- a/src/poetry/config/file_config_source.py
+++ b/src/poetry/config/file_config_source.py
@@ -15,6 +15,7 @@ from poetry.config.config_source import split_key
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from collections.abc import Sequence
 
     from tomlkit.toml_document import TOMLDocument
 
@@ -33,7 +34,7 @@ class FileConfigSource(ConfigSource):
     def file(self) -> TOMLFile:
         return self._file
 
-    def get_property(self, key: str | list[str]) -> Any:
+    def get_property(self, key: str | Sequence[str]) -> Any:
         keys = split_key(key)
 
         config = self.file.read() if self.file.exists() else {}
@@ -47,7 +48,7 @@ class FileConfigSource(ConfigSource):
 
             config = config[sub_key]
 
-    def add_property(self, key: str | list[str], value: Any) -> None:
+    def add_property(self, key: str | Sequence[str], value: Any) -> None:
         with self.secure() as toml:
             config: dict[str, Any] = toml
             keys = split_key(key)
@@ -62,7 +63,7 @@ class FileConfigSource(ConfigSource):
 
                 config = config[sub_key]
 
-    def remove_property(self, key: str | list[str]) -> None:
+    def remove_property(self, key: str | Sequence[str]) -> None:
         with self.secure() as toml:
             config: dict[str, Any] = toml
             keys = split_key(key)

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -182,7 +182,7 @@ To remove a repository (repo is a short alias for repositories):
                     if config.get("repositories") is not None:
                         value = config.get("repositories")
                 else:
-                    repo = config.get(f"repositories.{m.group(1)}")
+                    repo = config.get(["repositories", m.group(1)])
                     if repo is None:
                         raise ValueError(f"There is no {m.group(1)} repository defined")
 
@@ -223,18 +223,22 @@ To remove a repository (repo is a short alias for repositories):
                 raise ValueError("You cannot remove the [repositories] section")
 
             if self.option("unset"):
-                repo = config.get(f"repositories.{m.group(1)}")
+                repo = config.get(["repositories", m.group(1)])
                 if repo is None:
                     raise ValueError(f"There is no {m.group(1)} repository defined")
 
-                config.config_source.remove_property(f"repositories.{m.group(1)}")
+                config.config_source.remove_property(
+                    ["repositories", m.group(1)]
+                )
 
                 return 0
 
             if len(values) == 1:
                 url = values[0]
 
-                config.config_source.add_property(f"repositories.{m.group(1)}.url", url)
+                config.config_source.add_property(
+                    ["repositories", m.group(1), "url"], url
+                )
 
                 return 0
 
@@ -286,14 +290,16 @@ To remove a repository (repo is a short alias for repositories):
             return 0
 
         # handle certs
-        m = re.match(r"certificates\.([^.]+)\.(cert|client-cert)", self.argument("key"))
+        m = re.match(
+            r"certificates\.(.+)\.(cert|client-cert)$", self.argument("key")
+        )
         if m:
             repository = m.group(1)
             key = m.group(2)
 
             if self.option("unset"):
                 config.auth_config_source.remove_property(
-                    f"certificates.{repository}.{key}"
+                    ["certificates", repository, key]
                 )
 
                 return 0
@@ -305,7 +311,7 @@ To remove a repository (repo is a short alias for repositories):
                     new_value = boolean_normalizer(values[0])
 
                 config.auth_config_source.add_property(
-                    f"certificates.{repository}.{key}", new_value
+                    ["certificates", repository, key], new_value
                 )
             else:
                 raise ValueError("You must pass exactly 1 value")

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -176,17 +176,27 @@ To remove a repository (repo is a short alias for repositories):
                             f"No build config settings configured for <c1>{package_name}</>."
                         )
                 return 0
-            elif m := re.match(r"^repos?(?:itories)?(?:\.(.+))?", self.argument("key")):
+            elif m := re.match(
+                r"^repos?(?:itories)?(?:\.(.+?)(?:\.(url))?)?$",
+                self.argument("key"),
+            ):
                 if not m.group(1):
                     value = {}
                     if config.get("repositories") is not None:
                         value = config.get("repositories")
                 else:
-                    repo = config.get(["repositories", m.group(1)])
+                    repo_name = m.group(1)
+                    repo = config.get(["repositories", repo_name])
                     if repo is None:
-                        raise ValueError(f"There is no {m.group(1)} repository defined")
+                        raise ValueError(
+                            f"There is no {repo_name} repository defined"
+                        )
 
-                    value = repo
+                    if m.group(2):
+                        # User asked for a specific sub-property (e.g. .url)
+                        value = repo.get(m.group(2), repo) if isinstance(repo, dict) else repo
+                    else:
+                        value = repo
 
                 self.line(str(value))
             else:
@@ -217,19 +227,31 @@ To remove a repository (repo is a short alias for repositories):
             )
 
         # handle repositories
-        m = re.match(r"^repos?(?:itories)?(?:\.(.+))?", self.argument("key"))
+        m = re.match(
+            r"^repos?(?:itories)?(?:\.(.+?)(?:\.(url))?)?$", self.argument("key")
+        )
         if m:
             if not m.group(1):
                 raise ValueError("You cannot remove the [repositories] section")
 
-            if self.option("unset"):
-                repo = config.get(["repositories", m.group(1)])
-                if repo is None:
-                    raise ValueError(f"There is no {m.group(1)} repository defined")
+            repo_name = m.group(1)
 
-                config.config_source.remove_property(
-                    ["repositories", m.group(1)]
-                )
+            if self.option("unset"):
+                repo = config.get(["repositories", repo_name])
+                if repo is None:
+                    raise ValueError(
+                        f"There is no {repo_name} repository defined"
+                    )
+
+                if m.group(2):
+                    # Unset a specific sub-property (e.g. .url)
+                    config.config_source.remove_property(
+                        ["repositories", repo_name, m.group(2)]
+                    )
+                else:
+                    config.config_source.remove_property(
+                        ["repositories", repo_name]
+                    )
 
                 return 0
 
@@ -237,7 +259,7 @@ To remove a repository (repo is a short alias for repositories):
                 url = values[0]
 
                 config.config_source.add_property(
-                    ["repositories", m.group(1), "url"], url
+                    ["repositories", repo_name, "url"], url
                 )
 
                 return 0

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -150,6 +150,8 @@ To remove a repository (repo is a short alias for repositories):
         if self.argument("value") and self.option("unset"):
             raise RuntimeError("You can not combine a setting value with --unset")
 
+        repo_regex = r"^repos?(?:itories)?(?:\.(.+?)(?:\.(url))?)?$"
+
         # show the value if no value is provided
         if not self.argument("value") and not self.option("unset"):
             if setting_key.split(".")[0] in self.LIST_PROHIBITED_SETTINGS:
@@ -176,10 +178,7 @@ To remove a repository (repo is a short alias for repositories):
                             f"No build config settings configured for <c1>{package_name}</>."
                         )
                 return 0
-            elif m := re.match(
-                r"^repos?(?:itories)?(?:\.(.+?)(?:\.(url))?)?$",
-                self.argument("key"),
-            ):
+            elif m := re.match(repo_regex, self.argument("key")):
                 if not m.group(1):
                     value = {}
                     if config.get("repositories") is not None:
@@ -190,15 +189,7 @@ To remove a repository (repo is a short alias for repositories):
                     if repo is None:
                         raise ValueError(f"There is no {repo_name} repository defined")
 
-                    if m.group(2):
-                        # User asked for a specific sub-property (e.g. .url)
-                        value = (
-                            repo.get(m.group(2), repo)
-                            if isinstance(repo, dict)
-                            else repo
-                        )
-                    else:
-                        value = repo
+                    value = repo.get(sub_key, "") if (sub_key := m.group(2)) else repo
 
                 self.line(str(value))
             else:
@@ -229,9 +220,7 @@ To remove a repository (repo is a short alias for repositories):
             )
 
         # handle repositories
-        m = re.match(
-            r"^repos?(?:itories)?(?:\.(.+?)(?:\.(url))?)?$", self.argument("key")
-        )
+        m = re.match(repo_regex, self.argument("key"))
         if m:
             if not m.group(1):
                 raise ValueError("You cannot remove the [repositories] section")
@@ -244,7 +233,7 @@ To remove a repository (repo is a short alias for repositories):
                     raise ValueError(f"There is no {repo_name} repository defined")
 
                 if m.group(2):
-                    # Unset a specific sub-property (e.g. .url)
+                    # Unset a specific sub-property
                     config.config_source.remove_property(
                         ["repositories", repo_name, m.group(2)]
                     )

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -188,13 +188,15 @@ To remove a repository (repo is a short alias for repositories):
                     repo_name = m.group(1)
                     repo = config.get(["repositories", repo_name])
                     if repo is None:
-                        raise ValueError(
-                            f"There is no {repo_name} repository defined"
-                        )
+                        raise ValueError(f"There is no {repo_name} repository defined")
 
                     if m.group(2):
                         # User asked for a specific sub-property (e.g. .url)
-                        value = repo.get(m.group(2), repo) if isinstance(repo, dict) else repo
+                        value = (
+                            repo.get(m.group(2), repo)
+                            if isinstance(repo, dict)
+                            else repo
+                        )
                     else:
                         value = repo
 
@@ -239,9 +241,7 @@ To remove a repository (repo is a short alias for repositories):
             if self.option("unset"):
                 repo = config.get(["repositories", repo_name])
                 if repo is None:
-                    raise ValueError(
-                        f"There is no {repo_name} repository defined"
-                    )
+                    raise ValueError(f"There is no {repo_name} repository defined")
 
                 if m.group(2):
                     # Unset a specific sub-property (e.g. .url)
@@ -249,9 +249,7 @@ To remove a repository (repo is a short alias for repositories):
                         ["repositories", repo_name, m.group(2)]
                     )
                 else:
-                    config.config_source.remove_property(
-                        ["repositories", repo_name]
-                    )
+                    config.config_source.remove_property(["repositories", repo_name])
 
                 return 0
 
@@ -312,9 +310,7 @@ To remove a repository (repo is a short alias for repositories):
             return 0
 
         # handle certs
-        m = re.match(
-            r"certificates\.(.+)\.(cert|client-cert)$", self.argument("key")
-        )
+        m = re.match(r"certificates\.(.+)\.(cert|client-cert)$", self.argument("key"))
         if m:
             repository = m.group(1)
             key = m.group(2)

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -55,7 +55,9 @@ class Publisher:
             repository_name = "pypi"
         else:
             # Retrieving config information
-            url = self._poetry.config.get(f"repositories.{repository_name}.url")
+            url = self._poetry.config.get(
+                ["repositories", repository_name, "url"]
+            )
             if url is None:
                 raise RuntimeError(f"Repository {repository_name} is not defined")
             url = _normalize_legacy_repository_url(url)

--- a/src/poetry/publishing/publisher.py
+++ b/src/poetry/publishing/publisher.py
@@ -55,9 +55,7 @@ class Publisher:
             repository_name = "pypi"
         else:
             # Retrieving config information
-            url = self._poetry.config.get(
-                ["repositories", repository_name, "url"]
-            )
+            url = self._poetry.config.get(["repositories", repository_name, "url"])
             if url is None:
                 raise RuntimeError(f"Repository {repository_name} is not defined")
             url = _normalize_legacy_repository_url(url)

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -52,10 +52,12 @@ class RepositoryCertificateConfig:
         config = config if config else Config.create()
 
         verify: str | bool = config.get(
-            f"certificates.{repository}.verify",
-            config.get(f"certificates.{repository}.cert", True),
+            ["certificates", repository, "verify"],
+            config.get(["certificates", repository, "cert"], True),
         )
-        client_cert: str = config.get(f"certificates.{repository}.client-cert")
+        client_cert: str = config.get(
+            ["certificates", repository, "client-cert"]
+        )
 
         return cls(
             cert=Path(verify) if isinstance(verify, str) else None,
@@ -393,7 +395,9 @@ class Authenticator:
         if self._configured_repositories is None:
             self._configured_repositories = {}
             for repository_name in self._config.get("repositories", []):
-                url = self._config.get(f"repositories.{repository_name}.url")
+                url = self._config.get(
+                    ["repositories", repository_name, "url"]
+                )
                 self._configured_repositories[repository_name] = (
                     AuthenticatorRepositoryConfig(repository_name, url)
                 )

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -55,9 +55,7 @@ class RepositoryCertificateConfig:
             ["certificates", repository, "verify"],
             config.get(["certificates", repository, "cert"], True),
         )
-        client_cert: str = config.get(
-            ["certificates", repository, "client-cert"]
-        )
+        client_cert: str = config.get(["certificates", repository, "client-cert"])
 
         return cls(
             cert=Path(verify) if isinstance(verify, str) else None,
@@ -395,9 +393,7 @@ class Authenticator:
         if self._configured_repositories is None:
             self._configured_repositories = {}
             for repository_name in self._config.get("repositories", []):
-                url = self._config.get(
-                    ["repositories", repository_name, "url"]
-                )
+                url = self._config.get(["repositories", repository_name, "url"])
                 self._configured_repositories[repository_name] = (
                     AuthenticatorRepositoryConfig(repository_name, url)
                 )

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -213,7 +213,7 @@ class PasswordManager:
         if not self.use_keyring:
             self.warn_plaintext_credentials_stored()
             self._config.auth_config_source.add_property(
-                f"pypi-token.{repo_name}", token
+                ["pypi-token", repo_name], token
             )
         else:
             self.keyring.set_password(repo_name, "__token__", token)
@@ -228,7 +228,7 @@ class PasswordManager:
         :param repo_name:  Name of repository.
         :return: Returns a token as a string if found, otherwise None.
         """
-        token: str | None = self._config.get(f"pypi-token.{repo_name}")
+        token: str | None = self._config.get(["pypi-token", repo_name])
         if token:
             return token
 
@@ -240,14 +240,14 @@ class PasswordManager:
     def delete_pypi_token(self, repo_name: str) -> None:
         if not self.use_keyring:
             return self._config.auth_config_source.remove_property(
-                f"pypi-token.{repo_name}"
+                ["pypi-token", repo_name]
             )
 
         self.keyring.delete_password(repo_name, "__token__")
 
     def get_http_auth(self, repo_name: str) -> HTTPAuthCredential:
-        username = self._config.get(f"http-basic.{repo_name}.username")
-        password = self._config.get(f"http-basic.{repo_name}.password")
+        username = self._config.get(["http-basic", repo_name, "username"])
+        password = self._config.get(["http-basic", repo_name, "password"])
 
         if password is None and self.use_keyring:
             password = self.keyring.get_password(repo_name, username)
@@ -264,7 +264,9 @@ class PasswordManager:
         else:
             self.keyring.set_password(repo_name, username, password)
 
-        self._config.auth_config_source.add_property(f"http-basic.{repo_name}", auth)
+        self._config.auth_config_source.add_property(
+            ["http-basic", repo_name], auth
+        )
 
     def delete_http_password(self, repo_name: str) -> None:
         auth = self.get_http_auth(repo_name)
@@ -275,7 +277,9 @@ class PasswordManager:
         with suppress(PoetryKeyringError):
             self.keyring.delete_password(repo_name, auth.username)
 
-        self._config.auth_config_source.remove_property(f"http-basic.{repo_name}")
+        self._config.auth_config_source.remove_property(
+            ["http-basic", repo_name]
+        )
 
     def get_credential(
         self, *names: str, username: str | None = None

--- a/src/poetry/utils/password_manager.py
+++ b/src/poetry/utils/password_manager.py
@@ -264,9 +264,7 @@ class PasswordManager:
         else:
             self.keyring.set_password(repo_name, username, password)
 
-        self._config.auth_config_source.add_property(
-            ["http-basic", repo_name], auth
-        )
+        self._config.auth_config_source.add_property(["http-basic", repo_name], auth)
 
     def delete_http_password(self, repo_name: str) -> None:
         auth = self.get_http_auth(repo_name)
@@ -277,9 +275,7 @@ class PasswordManager:
         with suppress(PoetryKeyringError):
             self.keyring.delete_password(repo_name, auth.username)
 
-        self._config.auth_config_source.remove_property(
-            ["http-basic", repo_name]
-        )
+        self._config.auth_config_source.remove_property(["http-basic", repo_name])
 
     def get_credential(
         self, *names: str, username: str | None = None

--- a/tests/config/test_dict_config_source.py
+++ b/tests/config/test_dict_config_source.py
@@ -66,3 +66,80 @@ def test_dict_config_source_get_property_should_raise_if_not_found() -> None:
         PropertyNotFoundError, match=r"Key virtualenvs\.use-poetry-python not in config"
     ):
         _ = config_source.get_property("virtualenvs.use-poetry-python")
+
+
+def test_dict_config_source_add_property_with_list_keys() -> None:
+    """Repository names containing periods should be preserved as a single key."""
+    config_source = DictConfigSource()
+
+    config_source.add_property(["http-basic", "my.repo"], {"username": "user"})
+    assert config_source._config == {
+        "http-basic": {
+            "my.repo": {"username": "user"},
+        },
+    }
+
+
+def test_dict_config_source_get_property_with_list_keys() -> None:
+    """Repository names containing periods should be retrievable via list keys."""
+    config_source = DictConfigSource()
+    config_source._config = {
+        "http-basic": {
+            "my.repo": {"username": "user", "password": "pass"},
+        },
+    }
+
+    assert config_source.get_property(["http-basic", "my.repo"]) == {
+        "username": "user",
+        "password": "pass",
+    }
+    assert config_source.get_property(
+        ["http-basic", "my.repo", "username"]
+    ) == "user"
+
+
+def test_dict_config_source_remove_property_with_list_keys() -> None:
+    """Repository names containing periods should be removable via list keys."""
+    config_source = DictConfigSource()
+    config_source._config = {
+        "http-basic": {
+            "my.repo": {"username": "user"},
+            "other": {"username": "other"},
+        },
+    }
+
+    config_source.remove_property(["http-basic", "my.repo"])
+    assert config_source._config == {
+        "http-basic": {
+            "other": {"username": "other"},
+        },
+    }
+
+
+def test_dict_config_source_add_property_with_periods_in_repo_name() -> None:
+    """Verifies that using list keys does not split on periods in repo name."""
+    config_source = DictConfigSource()
+
+    # Using list keys: "my.repo" stays as a single key
+    config_source.add_property(
+        ["repositories", "my.repo", "url"],
+        "https://example.com/simple/",
+    )
+    assert config_source._config == {
+        "repositories": {
+            "my.repo": {"url": "https://example.com/simple/"},
+        },
+    }
+
+    # Contrast: using dotted string would incorrectly split "my.repo"
+    config_source2 = DictConfigSource()
+    config_source2.add_property(
+        "repositories.my.repo.url",
+        "https://example.com/simple/",
+    )
+    # The dotted string splits "my.repo" into two keys, which is the bug
+    assert config_source2._config == {
+        "repositories": {
+            "my": {"repo": {"url": "https://example.com/simple/"}},
+        },
+    }

--- a/tests/config/test_dict_config_source.py
+++ b/tests/config/test_dict_config_source.py
@@ -93,9 +93,7 @@ def test_dict_config_source_get_property_with_list_keys() -> None:
         "username": "user",
         "password": "pass",
     }
-    assert config_source.get_property(
-        ["http-basic", "my.repo", "username"]
-    ) == "user"
+    assert config_source.get_property(["http-basic", "my.repo", "username"]) == "user"
 
 
 def test_dict_config_source_remove_property_with_list_keys() -> None:

--- a/tests/config/test_file_config_source.py
+++ b/tests/config/test_file_config_source.py
@@ -89,3 +89,53 @@ def test_file_config_source_get_property_should_raise_if_not_found(
         PropertyNotFoundError, match=r"Key virtualenvs\.use-poetry-python not in config"
     ):
         _ = config_source.get_property("virtualenvs.use-poetry-python")
+
+
+def test_file_config_source_add_property_with_list_keys(tmp_path: Path) -> None:
+    """Repository names containing periods should be stored correctly."""
+    config = tmp_path.joinpath("config.toml")
+    config.touch()
+
+    config_source = FileConfigSource(TOMLFile(config))
+
+    config_source.add_property(
+        ["repositories", "my.repo", "url"],
+        "https://example.com/simple/",
+    )
+    data = config_source._file.read()
+    assert data["repositories"]["my.repo"]["url"] == "https://example.com/simple/"
+
+
+def test_file_config_source_get_property_with_list_keys(tmp_path: Path) -> None:
+    """Repository names containing periods should be retrievable via list keys."""
+    config = tmp_path.joinpath("config.toml")
+    with config.open(mode="w", encoding="utf-8") as f:
+        f.write(
+            '[repositories]\n[repositories."my.repo"]\nurl = "https://example.com/simple/"\n'
+        )
+
+    config_source = FileConfigSource(TOMLFile(config))
+
+    assert config_source.get_property(["repositories", "my.repo", "url"]) == (
+        "https://example.com/simple/"
+    )
+
+
+def test_file_config_source_remove_property_with_list_keys(
+    tmp_path: Path,
+) -> None:
+    """Repository names containing periods should be removable via list keys."""
+    config = tmp_path.joinpath("config.toml")
+    with config.open(mode="w", encoding="utf-8") as f:
+        f.write(
+            '[repositories]\n'
+            '[repositories."my.repo"]\nurl = "https://example.com/simple/"\n'
+            '[repositories.other]\nurl = "https://other.com/simple/"\n'
+        )
+
+    config_source = FileConfigSource(TOMLFile(config))
+
+    config_source.remove_property(["repositories", "my.repo"])
+    data = config_source._file.read()
+    assert "my.repo" not in data.get("repositories", {})
+    assert data["repositories"]["other"]["url"] == "https://other.com/simple/"

--- a/tests/config/test_file_config_source.py
+++ b/tests/config/test_file_config_source.py
@@ -103,7 +103,8 @@ def test_file_config_source_add_property_with_list_keys(tmp_path: Path) -> None:
         "https://example.com/simple/",
     )
     data = config_source._file.read()
-    assert data["repositories"]["my.repo"]["url"] == "https://example.com/simple/"
+    repos = data["repositories"]
+    assert repos["my.repo"]["url"] == "https://example.com/simple/"  # type: ignore[index]
 
 
 def test_file_config_source_get_property_with_list_keys(tmp_path: Path) -> None:
@@ -137,5 +138,7 @@ def test_file_config_source_remove_property_with_list_keys(
 
     config_source.remove_property(["repositories", "my.repo"])
     data = config_source._file.read()
-    assert "my.repo" not in data.get("repositories", {})
-    assert data["repositories"]["other"]["url"] == "https://other.com/simple/"
+    repos = data.get("repositories", {})
+    assert "my.repo" not in repos
+    other = data["repositories"]
+    assert other["other"]["url"] == "https://other.com/simple/"  # type: ignore[index]

--- a/tests/config/test_file_config_source.py
+++ b/tests/config/test_file_config_source.py
@@ -129,7 +129,7 @@ def test_file_config_source_remove_property_with_list_keys(
     config = tmp_path.joinpath("config.toml")
     with config.open(mode="w", encoding="utf-8") as f:
         f.write(
-            '[repositories]\n'
+            "[repositories]\n"
             '[repositories."my.repo"]\nurl = "https://example.com/simple/"\n'
             '[repositories.other]\nurl = "https://other.com/simple/"\n'
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterator
     from collections.abc import Mapping
+    from collections.abc import Sequence
     from typing import Any
     from unittest.mock import MagicMock
 
@@ -119,7 +120,7 @@ class Config(BaseConfig):
     _config_source: DictConfigSource
     _auth_config_source: DictConfigSource
 
-    def get(self, setting_name: str | list[str], default: Any = None) -> Any:
+    def get(self, setting_name: str | Sequence[str], default: Any = None) -> Any:
         self.merge(self._config_source.config)
         self.merge(self._auth_config_source.config)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ class Config(BaseConfig):
     _config_source: DictConfigSource
     _auth_config_source: DictConfigSource
 
-    def get(self, setting_name: str, default: Any = None) -> Any:
+    def get(self, setting_name: str | list[str], default: Any = None) -> Any:
         self.merge(self._config_source.config)
         self.merge(self._auth_config_source.config)
 

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -214,6 +214,52 @@ virtualenvs.use-poetry-python = false
     assert tester.io.fetch_output() == expected
 
 
+def test_set_repository_with_periods_in_name(
+    tester: CommandTester, config_source: DictConfigSource
+) -> None:
+    tester.execute("repositories.my.repo https://bar.com/simple/")
+
+    assert config_source.config["repositories"]["my.repo"] == {
+        "url": "https://bar.com/simple/"
+    }
+
+
+def test_display_repository_with_periods_in_name(tester: CommandTester) -> None:
+    tester.execute("repositories.my.repo https://bar.com/simple/")
+    tester.execute("repositories.my.repo")
+
+    assert tester.io.fetch_output() == "{'url': 'https://bar.com/simple/'}\n"
+
+
+def test_display_repository_url_with_periods_in_name(tester: CommandTester) -> None:
+    tester.execute("repositories.my.repo https://bar.com/simple/")
+    tester.execute("repositories.my.repo.url")
+
+    assert tester.io.fetch_output() == "https://bar.com/simple/\n"
+
+
+def test_display_repository_url_with_periods_in_name_escaped(
+    tester: CommandTester,
+) -> None:
+    tester.execute("repositories.my.repo https://bar.com/simple/")
+    tester.execute('repositories."my.repo".url')
+
+    assert tester.io.fetch_output() == "https://bar.com/simple/\n"
+
+
+def test_unset_repository_with_periods_in_name(
+    tester: CommandTester, config_source: DictConfigSource
+) -> None:
+    tester.execute("repositories.my.repo https://bar.com/simple/")
+    tester.execute("repositories.other https://other.com/simple/")
+    tester.execute("repositories.my.repo --unset")
+
+    assert "my.repo" not in config_source.config["repositories"]
+    assert config_source.config["repositories"]["other"]["url"] == (
+        "https://other.com/simple/"
+    )
+
+
 def test_unset_value_not_exists(tester: CommandTester) -> None:
     with pytest.raises(ValueError) as e:
         tester.execute("foobar --unset")
@@ -461,17 +507,19 @@ def test_set_pypi_token_no_values(
     assert str(e.value) == "Expected a value for pypi-token.pypi setting."
 
 
+@pytest.mark.parametrize("repo_name", ["foo", "foo.bar"])
 def test_set_client_cert(
     tester: CommandTester,
     auth_config_source: DictConfigSource,
     mocker: MockerFixture,
+    repo_name: str,
 ) -> None:
     mocker.spy(ConfigSource, "__init__")
 
-    tester.execute("certificates.foo.client-cert path/to/cert.pem")
+    tester.execute(f"certificates.{repo_name}.client-cert path/to/cert.pem")
 
     assert (
-        auth_config_source.config["certificates"]["foo"]["client-cert"]
+        auth_config_source.config["certificates"][repo_name]["client-cert"]
         == "path/to/cert.pem"
     )
 
@@ -496,33 +544,37 @@ def test_set_client_cert_unsuccessful_multiple_values(
         ("false", False),
     ],
 )
+@pytest.mark.parametrize("repo_name", ["foo", "foo.bar"])
 def test_set_cert(
     tester: CommandTester,
     auth_config_source: DictConfigSource,
     mocker: MockerFixture,
+    repo_name: str,
     value: str,
     result: str | bool,
 ) -> None:
     mocker.spy(ConfigSource, "__init__")
 
-    tester.execute(f"certificates.foo.cert {value}")
+    tester.execute(f"certificates.{repo_name}.cert {value}")
 
-    assert auth_config_source.config["certificates"]["foo"]["cert"] == result
+    assert auth_config_source.config["certificates"][repo_name]["cert"] == result
 
 
+@pytest.mark.parametrize("repo_name", ["foo", "foo.bar"])
 def test_unset_cert(
     tester: CommandTester,
     auth_config_source: DictConfigSource,
     mocker: MockerFixture,
+    repo_name: str,
 ) -> None:
     mocker.spy(ConfigSource, "__init__")
 
-    tester.execute("certificates.foo.cert path/to/ca.pem")
+    tester.execute(f"certificates.{repo_name}.cert path/to/ca.pem")
 
-    assert "cert" in auth_config_source.config["certificates"]["foo"]
+    assert "cert" in auth_config_source.config["certificates"][repo_name]
 
-    tester.execute("certificates.foo.cert --unset")
-    assert "cert" not in auth_config_source.config["certificates"]["foo"]
+    tester.execute(f"certificates.{repo_name}.cert --unset")
+    assert "cert" not in auth_config_source.config["certificates"][repo_name]
 
 
 def test_config_installer_parallel(

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -225,7 +225,7 @@ def test_unset_value_not_exists(tester: CommandTester) -> None:
     ("value", "expected"),
     [
         ("virtualenvs.create", "true\n"),
-        ("repositories.foo.url", "{'url': 'https://bar.com/simple/'}\n"),
+        ("repositories.foo.url", "https://bar.com/simple/\n"),
     ],
 )
 def test_display_single_setting(


### PR DESCRIPTION
## Summary

Fixes #1328

- Repository names containing periods (e.g. `my.repo`) were broken because `add_property`, `get_property`, and `remove_property` in config sources blindly split on `.`, treating periods in the name as key separators
- Added a `split_key()` helper that accepts either a dotted string or a pre-split `list[str]`, and updated the `ConfigSource` interface accordingly
- Updated all call sites that embed repository names (`http-basic`, `pypi-token`, `repositories`, `certificates`) to pass pre-split key lists, preserving names with periods as single key segments
- The certificates regex was also updated from `[^.]+` to `.+` to allow periods in repository names for certificate config

## Test plan

- [x] All 89 existing config tests pass
- [x] All 33 existing password manager tests pass
- [x] Added 7 new tests covering list-key operations in both `DictConfigSource` and `FileConfigSource`:
  - `test_dict_config_source_add_property_with_list_keys`
  - `test_dict_config_source_get_property_with_list_keys`
  - `test_dict_config_source_remove_property_with_list_keys`
  - `test_dict_config_source_add_property_with_periods_in_repo_name`
  - `test_file_config_source_add_property_with_list_keys`
  - `test_file_config_source_get_property_with_list_keys`
  - `test_file_config_source_remove_property_with_list_keys`
- [x] Manual test: `poetry config repositories.my.repo https://example.com/simple/` should create `[repositories."my.repo"]` instead of `[repositories.my.repo]`
- [x] Manual test: `poetry config http-basic.my.repo user pass` should store credentials under `"my.repo"` key