### PR TITLE
fix: normalize src fallback for editable package paths

### DIFF
--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -77,7 +77,7 @@ class InstalledRepository(Repository):
                             path = lib.joinpath(path).resolve()
                         paths.add(path)
 
-        src_path = env.path / "src" / name
+        src_path = env.path / "src" / module_name(name)
         if not paths and src_path.exists():
             paths.add(src_path)
 

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -312,6 +312,16 @@ def test_load_editable_with_import_package(repository: InstalledRepository) -> N
     assert editable.source_url is None
 
 
+def test_get_package_paths_falls_back_to_normalized_src_directory(tmp_path: Path) -> None:
+    env = MockEnv(path=tmp_path)
+    src_path = tmp_path / "src" / "my_package"
+    src_path.mkdir(parents=True)
+
+    assert InstalledRepository.get_package_paths(env=env, name="My-Package") == {
+        src_path
+    }
+
+
 def test_load_standard_package_with_pth_file(repository: InstalledRepository) -> None:
     # test standard packages with .pth file is not treated as editable
     standard = get_package_from_repository("standard", repository)


### PR DESCRIPTION

**Repo:** python-poetry/poetry (⭐ 32000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +11/-1

## What
This change fixes Poetry's editable package inspection fallback for projects installed from a `src/` layout when no usable `.pth` file is present. `InstalledRepository.get_package_paths()` now normalizes the distribution name with `module_name()` before checking `env.path / "src" / ...`, and a regression test covers a package name like `My-Package` resolving to `src/my_package`.

## Why
Editable source directories usually follow normalized module naming rather than the raw distribution name. Using the unnormalized name in the `src/` fallback could cause Poetry to miss the source directory for distributions containing hyphens, dots, or capitalization differences, which in turn prevents correct source metadata detection. This is a small fix with direct user value in editable environment inspection.

## Testing
`pytest -n 0 tests/repositories/test_installed_repository.py -k normalized_src_directory` could not be run in this clone because the test dependency `responses` is not installed (`ModuleNotFoundError`). Verified the local source behavior with `PYTHONPATH=src python` by creating a temporary `src/my_package` directory and confirming `InstalledRepository.get_package_paths(MockEnv(...), "My-Package")` returns that normalized path.

## Risk
Low - the implementation changes a single fallback path calculation to use the same normalization helper already used elsewhere in this code path, and the added regression test targets only that case.
