### PR TITLE
Fix MetadataNotFound from importlib.metadata on Python 3.15+

### DIFF
--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -270,7 +270,12 @@ class InstalledRepository(Repository):
                 if path in skipped:
                     continue
 
-                dist_metadata = distribution.metadata  # type: ignore[attr-defined]
+                try:
+                    dist_metadata = distribution.metadata  # type: ignore[attr-defined]
+                except FileNotFoundError:
+                    # Python 3.15+ raises MetadataNotFound (a FileNotFoundError subclass)
+                    # when a dist-info directory has no METADATA file
+                    dist_metadata = None
                 name = (
                     dist_metadata.get("name")  # type: ignore[attr-defined]
                     if dist_metadata


### PR DESCRIPTION
In Python 3.15, importlib.metadata raises MetadataNotFound
(a FileNotFoundError subclass) when a dist-info directory has no
METADATA file. Previously, it returned None.

CPython change: https://github.com/python/cpython/pull/146234

There is nothing new to test - it's gonna be tested once Python 3.15 is in CI here. Also, there is nothing to add to the documentation.