### PR TITLE
chore: remove outdated type ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,15 +162,10 @@ exclude = [
     "tests/utils/fixtures",
 ]
 
-# use of importlib-metadata backport makes it impossible to satisfy mypy
-# without some ignores: but we get different sets of ignores at different
-# python versions.
+# ignores that are only required for some Python versions
 [[tool.mypy.overrides]]
 module = [
     'poetry.repositories.installed_repository',
-    'tests.console.commands.self.test_show_plugins',
-    'tests.repositories.test_installed_repository',
-    'tests.helpers',
 ]
 warn_unused_ignores = false
 

--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -271,7 +271,7 @@ class InstalledRepository(Repository):
                     continue
 
                 try:
-                    dist_metadata = distribution.metadata  # type: ignore[attr-defined]
+                    dist_metadata = distribution.metadata
                 except FileNotFoundError:
                     # Python 3.15+ raises MetadataNotFound (a FileNotFoundError subclass)
                     # when a dist-info directory has no METADATA file

--- a/tests/console/commands/self/test_show_plugins.py
+++ b/tests/console/commands/self/test_show_plugins.py
@@ -83,7 +83,7 @@ def plugin_distro(plugin_package: Package, tmp_path: Path) -> metadata.Distribut
         def locate_file(self, path: str | PathLike[str]) -> Path:
             return tmp_path / path
 
-    return MockDistribution()  # type: ignore[no-untyped-call]
+    return MockDistribution()
 
 
 @pytest.fixture
@@ -104,7 +104,7 @@ def entry_points(
 ) -> Callable[..., list[metadata.EntryPoint]]:
     by_group = {
         key: [
-            EntryPoint(  # type: ignore[no-untyped-call]
+            EntryPoint(
                 name=entry_point_name,
                 group=key,
                 value=value,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -265,7 +265,7 @@ def make_entry_point_from_plugin(
     )
 
     if dist:
-        ep = ep._for(dist)  # type: ignore[attr-defined,no-untyped-call]
+        ep = ep._for(dist)  # type: ignore[attr-defined]
         return ep
 
     return ep

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -65,10 +65,7 @@ def installed_results(
         metadata.PathDistribution(site_purelib / "cleo-0.7.6.dist-info"),
         metadata.PathDistribution(src_dir / "pendulum" / "pendulum.egg-info"),
         metadata.PathDistribution(
-            zipfile.Path(  # type: ignore[arg-type]
-                site_purelib / "foo-0.1.0-py3.8.egg",
-                "EGG-INFO",
-            )
+            zipfile.Path(site_purelib / "foo-0.1.0-py3.8.egg", "EGG-INFO")
         ),
         metadata.PathDistribution(site_purelib / "standard-1.2.3.dist-info"),
         metadata.PathDistribution(site_purelib / "editable-2.3.4.dist-info"),


### PR DESCRIPTION
We do not use the importlib-metadata backport anymore since dropping support for Python 3.9 in #10634
