### PR TITLE
dont sign commits in tests

### DIFF
--- a/tests/vcs/git/test_backend.py
+++ b/tests/vcs/git/test_backend.py
@@ -314,6 +314,7 @@ def test_clone_annotated_tag(tmp_path: Path) -> None:
         message=b"Initial commit",
         author=b"Test <test@example.com>",
         committer=b"Test <test@example.com>",
+        sign=False,
     )
 
     # Create an annotated tag
@@ -375,6 +376,7 @@ def test_clone_nested_annotated_tags(tmp_path: Path) -> None:
         message=b"Initial commit",
         committer=b"Test <test@example.com>",
         author=b"Test <test@example.com>",
+        sign=False,
     )
 
     # Create first annotated tag pointing to the commit


### PR DESCRIPTION
I saw tests failing because I was being asked to provide a password to allow signing.