### PR TITLE
release: bump version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Change Log
 
+## [2.4.0] - 2026-05-03
+
+### Added
+
+- Add `solver.min-release-age` setting to require package releases to be a certain number of days old before they are considered during dependency resolution ([#10824](https://github.com/python-poetry/poetry/pull/10824)).
+- Add `solver.min-release-age-exclude` to exclude selected packages from age filtering ([#10824](https://github.com/python-poetry/poetry/pull/10824)).
+- Add `solver.min-release-age-exclude-source` to exclude all packages from selected package indexes from age filtering ([#10824](https://github.com/python-poetry/poetry/pull/10824)).
+
+### Changed
+
+- Raise an error instead of silently ignoring a package name that is not a dependency when it is passed to `poetry update` ([#10721](https://github.com/python-poetry/poetry/pull/10721)).
+- Automatically add a trailing slash to legacy repository URLs (used for publishing) if missing ([#10785](https://github.com/python-poetry/poetry/pull/10785)).
+- Require `installer>=1.0.0` ([#10869](https://github.com/python-poetry/poetry/pull/10869)).
+- Allow `findpython>=0.8` ([#10874](https://github.com/python-poetry/poetry/pull/10874)).
+
+### Fixed
+
+- Fix an issue where `requires-plugins` fails on Windows if scheme paths are on different drives ([#10869](https://github.com/python-poetry/poetry/pull/10869)).
+- Fix an issue where the order of markers in the lock file was not deterministic ([#10720](https://github.com/python-poetry/poetry/pull/10720)).
+- Fix an issue where the wrong command was suggested when `poetry self` commands failed due to an outdated lock file ([#10715](https://github.com/python-poetry/poetry/pull/10715)).
+- Fix an issue where `poetry env activate` did not work for bash on Windows ([#10716](https://github.com/python-poetry/poetry/pull/10716)).
+- Fix an issue where `poetry debug resolve` failed when there was a package with a marker ([#10807](https://github.com/python-poetry/poetry/pull/10807)).
+- Fix an issue where the error message about a build backend failure contained garbled `--config-settings` ([#10804](https://github.com/python-poetry/poetry/pull/10804)).
+- Fix an issue where a false warning about a circular dependency was printed ([#10811](https://github.com/python-poetry/poetry/pull/10811)).
+- Fix an issue where falsy config values were incorrectly treated as not set ([#10808](https://github.com/python-poetry/poetry/pull/10808)).
+- Fix an issue where `poetry publish --build` ignored failing builds and uploaded stale artifacts ([#10802](https://github.com/python-poetry/poetry/pull/10802)).
+- Fix an issue where `poetry publish` was aborted instead of retrying after package registration ([#10801](https://github.com/python-poetry/poetry/pull/10801)).
+- Fix an issue where zip files were not closed after fetching metadata via `lazy-wheel` ([#10800](https://github.com/python-poetry/poetry/pull/10800)).
+- Fix an issue where data fetched via `lazy-wheel` was corrupted when part of it had already been cached ([#10806](https://github.com/python-poetry/poetry/pull/10806)).
+- Fix an issue where further packages were installed even though installation should be aborted ([#10742](https://github.com/python-poetry/poetry/pull/10742)).
+- Fix an issue where installed packages without a `METADATA` file caused an exception on Python 3.15+ ([#10860](https://github.com/python-poetry/poetry/pull/10860)).
+- Fix an issue where `http-basic` could not be set for repository names with periods ([#10845](https://github.com/python-poetry/poetry/pull/10845)).
+- Fix an issue where calculating the hash of large wheels failed with a memory error ([#10814](https://github.com/python-poetry/poetry/pull/10814)).
+
+### Docs
+
+- Clarify the precedence of configuration sources ([#10757](https://github.com/python-poetry/poetry/pull/10757)).
+- Add a note about the influence of `.gitignore` on `tool.poetry.packages` ([#10835](https://github.com/python-poetry/poetry/pull/10835)).
+
+### poetry-core ([`2.4.0`](https://github.com/python-poetry/poetry-core/releases/tag/2.4.0))
+
+- Update vendored `packaging` to `26.2` ([#936](https://github.com/python-poetry/poetry-core/pull/936)).
+
+
 ## [2.3.4] - 2026-04-12
 
 ### Fixed
@@ -2701,7 +2745,8 @@ Initial release
 
 
 
-[Unreleased]: https://github.com/python-poetry/poetry/compare/2.3.4...main
+[Unreleased]: https://github.com/python-poetry/poetry/compare/2.4.0...main
+[2.4.0]: https://github.com/python-poetry/poetry/releases/tag/2.4.0
 [2.3.4]: https://github.com/python-poetry/poetry/releases/tag/2.3.4
 [2.3.3]: https://github.com/python-poetry/poetry/releases/tag/2.3.3
 [2.3.2]: https://github.com/python-poetry/poetry/releases/tag/2.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry"
-version = "2.4.0.dev0"
+version = "2.4.0"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.10,<4.0"
 dependencies = [


### PR DESCRIPTION
### Added

- Add `solver.min-release-age` setting to require package releases to be a certain number of days old before they are considered during dependency resolution ([#10824](https://github.com/python-poetry/poetry/pull/10824)).
- Add `solver.min-release-age-exclude` to exclude selected packages from age filtering ([#10824](https://github.com/python-poetry/poetry/pull/10824)).
- Add `solver.min-release-age-exclude-source` to exclude all packages from selected package indexes from age filtering ([#10824](https://github.com/python-poetry/poetry/pull/10824)).

### Changed

- Raise an error instead of silently ignoring a package name that is not a dependency when it is passed to `poetry update` ([#10721](https://github.com/python-poetry/poetry/pull/10721)).
- Automatically add a trailing slash to legacy repository URLs (used for publishing) if missing ([#10785](https://github.com/python-poetry/poetry/pull/10785)).
- Require `installer>=1.0.0` ([#10869](https://github.com/python-poetry/poetry/pull/10869)).
- Allow `findpython>=0.8` ([#10874](https://github.com/python-poetry/poetry/pull/10874)).

### Fixed

- Fix an issue where `requires-plugins` fails on Windows if scheme paths are on different drives ([#10869](https://github.com/python-poetry/poetry/pull/10869)).
- Fix an issue where the order of markers in the lock file was not deterministic ([#10720](https://github.com/python-poetry/poetry/pull/10720)).
- Fix an issue where the wrong command was suggested when `poetry self` commands failed due to an outdated lock file ([#10715](https://github.com/python-poetry/poetry/pull/10715)).
- Fix an issue where `poetry env activate` did not work for bash on Windows ([#10716](https://github.com/python-poetry/poetry/pull/10716)).
- Fix an issue where `poetry debug resolve` failed when there was a package with a marker ([#10807](https://github.com/python-poetry/poetry/pull/10807)).
- Fix an issue where the error message about a build backend failure contained garbled `--config-settings` ([#10804](https://github.com/python-poetry/poetry/pull/10804)).
- Fix an issue where a false warning about a circular dependency was printed ([#10811](https://github.com/python-poetry/poetry/pull/10811)).
- Fix an issue where falsy config values were incorrectly treated as not set ([#10808](https://github.com/python-poetry/poetry/pull/10808)).
- Fix an issue where `poetry publish --build` ignored failing builds and uploaded stale artifacts ([#10802](https://github.com/python-poetry/poetry/pull/10802)).
- Fix an issue where `poetry publish` was aborted instead of retrying after package registration ([#10801](https://github.com/python-poetry/poetry/pull/10801)).
- Fix an issue where zip files were not closed after fetching metadata via `lazy-wheel` ([#10800](https://github.com/python-poetry/poetry/pull/10800)).
- Fix an issue where data fetched via `lazy-wheel` was corrupted when part of it had already been cached ([#10806](https://github.com/python-poetry/poetry/pull/10806)).
- Fix an issue where further packages were installed even though installation should be aborted ([#10742](https://github.com/python-poetry/poetry/pull/10742)).
- Fix an issue where installed packages without a `METADATA` file caused an exception on Python 3.15+ ([#10860](https://github.com/python-poetry/poetry/pull/10860)).
- Fix an issue where `http-basic` could not be set for repository names with periods ([#10845](https://github.com/python-poetry/poetry/pull/10845)).
- Fix an issue where calculating the hash of large wheels failed with a memory error ([#10814](https://github.com/python-poetry/poetry/pull/10814)).

### Docs

- Clarify the precedence of configuration sources ([#10757](https://github.com/python-poetry/poetry/pull/10757)).
- Add a note about the influence of `.gitignore` on `tool.poetry.packages` ([#10835](https://github.com/python-poetry/poetry/pull/10835)).

### poetry-core ([`2.4.0`](https://github.com/python-poetry/poetry-core/releases/tag/2.4.0))

- Update vendored `packaging` to `26.2` ([#936](https://github.com/python-poetry/poetry-core/pull/936)).