### PR TITLE
test: cover module entrypoint

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,9 @@ import runpy
 import pytest
 
 
-def test_module_entrypoint_exits_with_application_status(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_module_entrypoint_exits_with_application_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[None] = []
 
     def main() -> int:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import runpy
+
+import pytest
+
+
+def test_module_entrypoint_exits_with_application_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[None] = []
+
+    def main() -> int:
+        calls.append(None)
+        return 17
+
+    monkeypatch.setattr("poetry.console.application.main", main)
+
+    with pytest.raises(SystemExit) as e:
+        runpy.run_module("poetry", run_name="__main__", alter_sys=True)
+
+    assert e.value.code == 17
+    assert calls == [None]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,22 +2,20 @@ from __future__ import annotations
 
 import runpy
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 
-def test_module_entrypoint_exits_with_application_status(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    calls: list[None] = []
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
-    def main() -> int:
-        calls.append(None)
-        return 17
 
-    monkeypatch.setattr("poetry.console.application.main", main)
+def test_module_entrypoint_exits_with_application_status(mocker: MockerFixture) -> None:
+    main_mock = mocker.patch("poetry.console.application.main", side_effect=lambda: 17)
 
     with pytest.raises(SystemExit) as e:
-        runpy.run_module("poetry", run_name="__main__", alter_sys=True)
+        runpy.run_module("poetry", run_name="__main__")
 
     assert e.value.code == 17
-    assert calls == [None]
+    assert main_mock.call_count == 1


### PR DESCRIPTION
## Summary
- add a focused regression test for the `python -m poetry` module entrypoint
- assert the entrypoint delegates to `poetry.console.application.main()` and exits with its status code

## Tests
- `.venv/bin/python -m pytest tests/test_main.py -n 0`

Relates-to: #3155