### PR TITLE
test: assert config migration results

### DIFF
--- a/tests/config/test_config_source.py
+++ b/tests/config/test_config_source.py
@@ -23,7 +23,7 @@ def test_config_source_migration_rename_key() -> None:
 
     migration.apply(config_source)
 
-    config_source._config = {
+    assert config_source._config == {
         "virtualenvs": {
             "use-poetry-python": True,
         },
@@ -49,7 +49,7 @@ def test_config_source_migration_remove_key() -> None:
 
     migration.apply(config_source)
 
-    config_source._config = {
+    assert config_source._config == {
         "virtualenvs": {},
         "system-git-client": True,
     }
@@ -74,7 +74,7 @@ def test_config_source_migration_unset_value() -> None:
 
     migration.apply(config_source)
 
-    config_source._config = {
+    assert config_source._config == {
         "virtualenvs": {},
         "system-git-client": True,
     }
@@ -99,7 +99,7 @@ def test_config_source_migration_complex_migration() -> None:
 
     migration.apply(config_source)
 
-    config_source._config = {
+    assert config_source._config == {
         "virtualenvs": {
             "use-poetry-python": None,
         },


### PR DESCRIPTION
## Summary
- replace accidental fixture reassignment in config migration tests with real assertions
- keep the test coverage focused on the existing migration behavior

## Tests
- `.venv/bin/python -m pytest tests/config/test_config_source.py -n 0`
- `.venv/bin/ruff check tests/config/test_config_source.py`

Relates-to: #3155