### PR TITLE
fix `poetry update <dep>` where <dep> is a transitive dependency

### DIFF
--- a/src/poetry/console/commands/update.py
+++ b/src/poetry/console/commands/update.py
@@ -67,8 +67,16 @@ class UpdateCommand(InstallerCommand):
                 )
                 return 1
 
-            # Validate that all specified packages are declared dependencies
+            # Validate that all specified packages appear somewhere in the
+            # project's dependency graph. We union two sources:
+            #   - declared deps in pyproject.toml (covers a freshly-edited
+            #     pyproject where the lockfile has not caught up yet)
+            #   - locked deps in poetry.lock (covers transitive deps that
+            #     are not declared directly in pyproject.toml)
             all_dependencies = {dep.name for dep in self.poetry.package.all_requires}
+            all_dependencies |= {
+                p.name for p in self.poetry.locker.locked_repository().packages
+            }
 
             invalid_packages = [
                 p for p in packages if canonicalize_name(p) not in all_dependencies

--- a/tests/console/commands/test_update.py
+++ b/tests/console/commands/test_update.py
@@ -145,6 +145,76 @@ def test_update_with_non_normalized_package_name(
     assert tester.io.fetch_error() == ""
 
 
+def test_update_with_transitive_dependency(
+    project_factory: ProjectFactory,
+    fixture_dir: FixtureDirGetter,
+    repo: DummyRepository,
+    command_tester_factory: CommandTesterFactory,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression test: `poetry update <pkg>` must work when <pkg> is a
+    transitive dependency present in the lockfile but not declared
+    directly in pyproject.toml. In the fixture, `requests` is pulled in
+    by `docker`.
+    """
+    source = fixture_dir("outdated_lock")
+    poetry = project_factory(
+        name="foobar",
+        pyproject_content=(source / "pyproject.toml").read_text(encoding="utf-8"),
+        poetry_lock_content=(source / "poetry.lock").read_text(encoding="utf-8"),
+        use_test_locker=False,
+    )
+
+    tester = command_tester_factory("update", poetry=poetry)
+    assert isinstance(tester.command, UpdateCommand)
+    mocker.patch.object(tester.command.installer, "run", return_value=0)
+
+    repo.add_package(get_package("requests", "2.25.0"))
+
+    status = tester.execute("requests")
+
+    assert status == 0
+    assert tester.io.fetch_error() == ""
+
+
+def test_update_with_dependency_added_to_pyproject_but_not_locked(
+    project_factory: ProjectFactory,
+    fixture_dir: FixtureDirGetter,
+    repo: DummyRepository,
+    command_tester_factory: CommandTesterFactory,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression test: a dependency that has been added to pyproject.toml but
+    is not yet present in the lockfile (because the user has not run
+    `poetry lock` yet) must still be acceptable to `poetry update`.
+    """
+    source = fixture_dir("outdated_lock")
+    pyproject_content = (source / "pyproject.toml").read_text(encoding="utf-8")
+    pyproject_content = pyproject_content.replace(
+        '"docker>=4.3.1",',
+        '"docker>=4.3.1",\n    "pendulum>=3.0.0",',
+    )
+    poetry = project_factory(
+        name="foobar",
+        pyproject_content=pyproject_content,
+        poetry_lock_content=(source / "poetry.lock").read_text(encoding="utf-8"),
+        use_test_locker=False,
+    )
+
+    tester = command_tester_factory("update", poetry=poetry)
+    assert isinstance(tester.command, UpdateCommand)
+    mocker.patch.object(tester.command.installer, "run", return_value=0)
+
+    repo.add_package(get_package("pendulum", "3.0.0"))
+
+    status = tester.execute("pendulum")
+
+    assert status == 0
+    assert tester.io.fetch_error() == ""
+
+
 def test_update_with_invalid_package_name_shows_error(
     poetry_with_outdated_lockfile: Poetry,
     command_tester_factory: CommandTesterFactory,


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

#10721 broke `poetry update <dep>` in cases where `<dep>` is not declared in pyproject.toml but only a transitive dependency. This PR fixes the regression.
