### PR TITLE
deps: re-allow installer 0.7.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2267,4 +2267,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "aaa48ef867f604f545182fae11b744abdf8c1f4b0d75b47647d598140666a4c3"
+content-hash = "5cfdc2e870f25504fe57aa00e30688d352a4b6f9ad42d49ce20fcdb4f2c29a77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "cleo (>=2.1.0,<3.0.0)",
     "dulwich (>=0.25.0,<2)",
     "fastjsonschema (>=2.18.0,<3.0.0)",
-    "installer (>=1.0.0,<2.0.0)",
+    "installer (>=0.7.0,<2.0.0)",
     "keyring (>=25.1.0,<26.0.0)",
     # packaging uses calver, so version is unclamped
     "packaging (>=24.2)",  # PEP 639 support was added in 24.2


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10882

In #10869, we bumped the minimum required installer version because it fixes #10028.

However, there is another issue in the new installer version. See #10882 for details. Although the issue may not be relevant for Poetry itself, it is an issue for system package managers.

Re-allowing the older installer version should not hurt because it still works with Poetry (except for the specific use case described in #10028) and most users will get the latest version anyway.