### PR TITLE
release: bump version to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [2.4.1] - 2026-05-09
+
+### Changed
+
+- Re-allow `installer==0.7.0` ([#10887](https://github.com/python-poetry/poetry/pull/10887)).
+
+### Fixed
+
+- Fix an issue where `poetry update <package>` failed when `<package>` was a transitive dependency ([#10885](https://github.com/python-poetry/poetry/pull/10885)).
+
+
 ## [2.4.0] - 2026-05-03
 
 ### Added
@@ -2745,7 +2756,8 @@ Initial release
 
 
 
-[Unreleased]: https://github.com/python-poetry/poetry/compare/2.4.0...main
+[Unreleased]: https://github.com/python-poetry/poetry/compare/2.4.1...main
+[2.4.1]: https://github.com/python-poetry/poetry/releases/tag/2.4.1
 [2.4.0]: https://github.com/python-poetry/poetry/releases/tag/2.4.0
 [2.3.4]: https://github.com/python-poetry/poetry/releases/tag/2.3.4
 [2.3.3]: https://github.com/python-poetry/poetry/releases/tag/2.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry"
-version = "2.4.0"
+version = "2.4.1"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.10,<4.0"
 dependencies = [


### PR DESCRIPTION
### Changed

- Re-allow `installer==0.7.0` ([#10887](https://github.com/python-poetry/poetry/pull/10887)).

### Fixed

- Fix an issue where `poetry update <package>` failed when `<package>` was a transitive dependency ([#10885](https://github.com/python-poetry/poetry/pull/10885)).
