### PR TITLE
test: cover config migration dry run

### DIFF
--- a/tests/config/test_config_source.py
+++ b/tests/config/test_config_source.py
@@ -11,7 +11,8 @@ from poetry.config.config_source import ConfigSourceMigration
 from poetry.config.dict_config_source import DictConfigSource
 
 
-def make_config_source() -> DictConfigSource:
+@pytest.fixture
+def config_source() -> DictConfigSource:
     config_source = DictConfigSource()
     config_source._config = {
         "virtualenvs": {
@@ -23,9 +24,7 @@ def make_config_source() -> DictConfigSource:
     return config_source
 
 
-def test_config_source_migration_rename_key() -> None:
-    config_source = make_config_source()
-
+def test_config_source_migration_rename_key(config_source: DictConfigSource) -> None:
     migration = ConfigSourceMigration(
         old_key="virtualenvs.prefer-active-python",
         new_key="virtualenvs.use-poetry-python",
@@ -41,9 +40,7 @@ def test_config_source_migration_rename_key() -> None:
     }
 
 
-def test_config_source_migration_remove_key() -> None:
-    config_source = make_config_source()
-
+def test_config_source_migration_remove_key(config_source: DictConfigSource) -> None:
     migration = ConfigSourceMigration(
         old_key="virtualenvs.prefer-active-python",
         new_key=None,
@@ -57,9 +54,7 @@ def test_config_source_migration_remove_key() -> None:
     }
 
 
-def test_config_source_migration_unset_value() -> None:
-    config_source = make_config_source()
-
+def test_config_source_migration_unset_value(config_source: DictConfigSource) -> None:
     migration = ConfigSourceMigration(
         old_key="virtualenvs.prefer-active-python",
         new_key="virtualenvs.use-poetry-python",
@@ -74,9 +69,9 @@ def test_config_source_migration_unset_value() -> None:
     }
 
 
-def test_config_source_migration_complex_migration() -> None:
-    config_source = make_config_source()
-
+def test_config_source_migration_complex_migration(
+    config_source: DictConfigSource,
+) -> None:
     migration = ConfigSourceMigration(
         old_key="virtualenvs.prefer-active-python",
         new_key="virtualenvs.use-poetry-python",
@@ -138,11 +133,11 @@ def test_config_source_migration_complex_migration() -> None:
     ],
 )
 def test_config_source_migration_dry_run(
+    config_source: DictConfigSource,
     migration: ConfigSourceMigration,
     expected_result: bool,
     expected_output: str,
 ) -> None:
-    config_source = make_config_source()
     original_config = deepcopy(config_source._config)
     io = BufferedIO()
 

--- a/tests/config/test_config_source.py
+++ b/tests/config/test_config_source.py
@@ -97,8 +97,10 @@ def test_config_source_migration_complex_migration(
                 new_key="virtualenvs.use-poetry-python",
             ),
             True,
-            "virtualenvs.prefer-active-python = true -> "
-            "virtualenvs.use-poetry-python = true",
+            (
+                "virtualenvs.prefer-active-python = true -> "
+                "virtualenvs.use-poetry-python = true"
+            ),
             id="rename-key",
         ),
         pytest.param(
@@ -117,8 +119,10 @@ def test_config_source_migration_complex_migration(
                 value_migration={True: UNSET, False: True},
             ),
             True,
-            "virtualenvs.prefer-active-python = true -> "
-            "virtualenvs.use-poetry-python = Not explicit set",
+            (
+                "virtualenvs.prefer-active-python = true -> "
+                "virtualenvs.use-poetry-python = Not explicit set"
+            ),
             id="unset-value",
         ),
         pytest.param(

--- a/tests/config/test_config_source.py
+++ b/tests/config/test_config_source.py
@@ -32,7 +32,7 @@ def test_config_source_migration_rename_key(config_source: DictConfigSource) -> 
 
     migration.apply(config_source)
 
-    assert config_source._config == {
+    assert config_source.config == {
         "virtualenvs": {
             "use-poetry-python": True,
         },
@@ -48,7 +48,7 @@ def test_config_source_migration_remove_key(config_source: DictConfigSource) -> 
 
     migration.apply(config_source)
 
-    assert config_source._config == {
+    assert config_source.config == {
         "virtualenvs": {},
         "system-git-client": True,
     }
@@ -63,7 +63,7 @@ def test_config_source_migration_unset_value(config_source: DictConfigSource) ->
 
     migration.apply(config_source)
 
-    assert config_source._config == {
+    assert config_source.config == {
         "virtualenvs": {},
         "system-git-client": True,
     }
@@ -80,7 +80,7 @@ def test_config_source_migration_complex_migration(
 
     migration.apply(config_source)
 
-    assert config_source._config == {
+    assert config_source.config == {
         "virtualenvs": {
             "use-poetry-python": None,
         },
@@ -138,9 +138,9 @@ def test_config_source_migration_dry_run(
     expected_result: bool,
     expected_output: str,
 ) -> None:
-    original_config = deepcopy(config_source._config)
+    original_config = deepcopy(config_source.config)
     io = BufferedIO()
 
     assert migration.dry_run(config_source, io) is expected_result
     assert io.fetch_output().strip() == expected_output
-    assert config_source._config == original_config
+    assert config_source.config == original_config

--- a/tests/config/test_config_source.py
+++ b/tests/config/test_config_source.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
+from cleo.io.buffered_io import BufferedIO
+
 from poetry.config.config_source import UNSET
 from poetry.config.config_source import ConfigSourceMigration
 from poetry.config.dict_config_source import DictConfigSource
 
 
-def test_config_source_migration_rename_key() -> None:
-    config_data = {
+def make_config_source() -> DictConfigSource:
+    config_source = DictConfigSource()
+    config_source._config = {
         "virtualenvs": {
             "prefer-active-python": True,
         },
         "system-git-client": True,
     }
 
-    config_source = DictConfigSource()
-    config_source._config = config_data
+    return config_source
+
+
+def test_config_source_migration_rename_key() -> None:
+    config_source = make_config_source()
 
     migration = ConfigSourceMigration(
         old_key="virtualenvs.prefer-active-python",
@@ -32,15 +40,7 @@ def test_config_source_migration_rename_key() -> None:
 
 
 def test_config_source_migration_remove_key() -> None:
-    config_data = {
-        "virtualenvs": {
-            "prefer-active-python": True,
-        },
-        "system-git-client": True,
-    }
-
-    config_source = DictConfigSource()
-    config_source._config = config_data
+    config_source = make_config_source()
 
     migration = ConfigSourceMigration(
         old_key="virtualenvs.prefer-active-python",
@@ -56,15 +56,7 @@ def test_config_source_migration_remove_key() -> None:
 
 
 def test_config_source_migration_unset_value() -> None:
-    config_data = {
-        "virtualenvs": {
-            "prefer-active-python": True,
-        },
-        "system-git-client": True,
-    }
-
-    config_source = DictConfigSource()
-    config_source._config = config_data
+    config_source = make_config_source()
 
     migration = ConfigSourceMigration(
         old_key="virtualenvs.prefer-active-python",
@@ -81,15 +73,7 @@ def test_config_source_migration_unset_value() -> None:
 
 
 def test_config_source_migration_complex_migration() -> None:
-    config_data = {
-        "virtualenvs": {
-            "prefer-active-python": True,
-        },
-        "system-git-client": True,
-    }
-
-    config_source = DictConfigSource()
-    config_source._config = config_data
+    config_source = make_config_source()
 
     migration = ConfigSourceMigration(
         old_key="virtualenvs.prefer-active-python",
@@ -105,3 +89,73 @@ def test_config_source_migration_complex_migration() -> None:
         },
         "system-git-client": True,
     }
+
+
+def test_config_source_migration_dry_run_rename_key() -> None:
+    config_source = make_config_source()
+    original_config = deepcopy(config_source._config)
+    io = BufferedIO()
+
+    migration = ConfigSourceMigration(
+        old_key="virtualenvs.prefer-active-python",
+        new_key="virtualenvs.use-poetry-python",
+    )
+
+    assert migration.dry_run(config_source, io) is True
+    assert (
+        io.fetch_output() == "virtualenvs.prefer-active-python = true -> "
+        "virtualenvs.use-poetry-python = true\n"
+    )
+    assert config_source._config == original_config
+
+
+def test_config_source_migration_dry_run_remove_key() -> None:
+    config_source = make_config_source()
+    original_config = deepcopy(config_source._config)
+    io = BufferedIO()
+
+    migration = ConfigSourceMigration(
+        old_key="virtualenvs.prefer-active-python",
+        new_key=None,
+    )
+
+    assert migration.dry_run(config_source, io) is True
+    assert (
+        io.fetch_output()
+        == "virtualenvs.prefer-active-python = true -> Removed from config\n"
+    )
+    assert config_source._config == original_config
+
+
+def test_config_source_migration_dry_run_unset_value() -> None:
+    config_source = make_config_source()
+    original_config = deepcopy(config_source._config)
+    io = BufferedIO()
+
+    migration = ConfigSourceMigration(
+        old_key="virtualenvs.prefer-active-python",
+        new_key="virtualenvs.use-poetry-python",
+        value_migration={True: UNSET, False: True},
+    )
+
+    assert migration.dry_run(config_source, io) is True
+    assert (
+        io.fetch_output() == "virtualenvs.prefer-active-python = true -> "
+        "virtualenvs.use-poetry-python = Not explicit set\n"
+    )
+    assert config_source._config == original_config
+
+
+def test_config_source_migration_dry_run_missing_key() -> None:
+    config_source = make_config_source()
+    original_config = deepcopy(config_source._config)
+    io = BufferedIO()
+
+    migration = ConfigSourceMigration(
+        old_key="virtualenvs.missing-key",
+        new_key="virtualenvs.use-poetry-python",
+    )
+
+    assert migration.dry_run(config_source, io) is False
+    assert io.fetch_output() == ""
+    assert config_source._config == original_config

--- a/tests/config/test_config_source.py
+++ b/tests/config/test_config_source.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+import pytest
+
 from cleo.io.buffered_io import BufferedIO
 
 from poetry.config.config_source import UNSET
@@ -91,71 +93,59 @@ def test_config_source_migration_complex_migration() -> None:
     }
 
 
-def test_config_source_migration_dry_run_rename_key() -> None:
+@pytest.mark.parametrize(
+    ("migration", "expected_result", "expected_output"),
+    [
+        pytest.param(
+            ConfigSourceMigration(
+                old_key="virtualenvs.prefer-active-python",
+                new_key="virtualenvs.use-poetry-python",
+            ),
+            True,
+            "virtualenvs.prefer-active-python = true -> "
+            "virtualenvs.use-poetry-python = true",
+            id="rename-key",
+        ),
+        pytest.param(
+            ConfigSourceMigration(
+                old_key="virtualenvs.prefer-active-python",
+                new_key=None,
+            ),
+            True,
+            "virtualenvs.prefer-active-python = true -> Removed from config",
+            id="remove-key",
+        ),
+        pytest.param(
+            ConfigSourceMigration(
+                old_key="virtualenvs.prefer-active-python",
+                new_key="virtualenvs.use-poetry-python",
+                value_migration={True: UNSET, False: True},
+            ),
+            True,
+            "virtualenvs.prefer-active-python = true -> "
+            "virtualenvs.use-poetry-python = Not explicit set",
+            id="unset-value",
+        ),
+        pytest.param(
+            ConfigSourceMigration(
+                old_key="virtualenvs.missing-key",
+                new_key="virtualenvs.use-poetry-python",
+            ),
+            False,
+            "",
+            id="missing-key",
+        ),
+    ],
+)
+def test_config_source_migration_dry_run(
+    migration: ConfigSourceMigration,
+    expected_result: bool,
+    expected_output: str,
+) -> None:
     config_source = make_config_source()
     original_config = deepcopy(config_source._config)
     io = BufferedIO()
 
-    migration = ConfigSourceMigration(
-        old_key="virtualenvs.prefer-active-python",
-        new_key="virtualenvs.use-poetry-python",
-    )
-
-    assert migration.dry_run(config_source, io) is True
-    assert (
-        io.fetch_output() == "virtualenvs.prefer-active-python = true -> "
-        "virtualenvs.use-poetry-python = true\n"
-    )
-    assert config_source._config == original_config
-
-
-def test_config_source_migration_dry_run_remove_key() -> None:
-    config_source = make_config_source()
-    original_config = deepcopy(config_source._config)
-    io = BufferedIO()
-
-    migration = ConfigSourceMigration(
-        old_key="virtualenvs.prefer-active-python",
-        new_key=None,
-    )
-
-    assert migration.dry_run(config_source, io) is True
-    assert (
-        io.fetch_output()
-        == "virtualenvs.prefer-active-python = true -> Removed from config\n"
-    )
-    assert config_source._config == original_config
-
-
-def test_config_source_migration_dry_run_unset_value() -> None:
-    config_source = make_config_source()
-    original_config = deepcopy(config_source._config)
-    io = BufferedIO()
-
-    migration = ConfigSourceMigration(
-        old_key="virtualenvs.prefer-active-python",
-        new_key="virtualenvs.use-poetry-python",
-        value_migration={True: UNSET, False: True},
-    )
-
-    assert migration.dry_run(config_source, io) is True
-    assert (
-        io.fetch_output() == "virtualenvs.prefer-active-python = true -> "
-        "virtualenvs.use-poetry-python = Not explicit set\n"
-    )
-    assert config_source._config == original_config
-
-
-def test_config_source_migration_dry_run_missing_key() -> None:
-    config_source = make_config_source()
-    original_config = deepcopy(config_source._config)
-    io = BufferedIO()
-
-    migration = ConfigSourceMigration(
-        old_key="virtualenvs.missing-key",
-        new_key="virtualenvs.use-poetry-python",
-    )
-
-    assert migration.dry_run(config_source, io) is False
-    assert io.fetch_output() == ""
+    assert migration.dry_run(config_source, io) is expected_result
+    assert io.fetch_output().strip() == expected_output
     assert config_source._config == original_config


### PR DESCRIPTION
## Summary
- add focused tests for `ConfigSourceMigration.dry_run()` output
- verify dry runs leave the config untouched for rename, removal, unset, and missing-key paths

## Tests
- `.venv/bin/ruff format tests/config/test_config_source.py`
- `.venv/bin/ruff check tests/config/test_config_source.py`
- `.venv/bin/python -m pytest tests/config/test_config_source.py -n 0`

Relates-to: #3155