### PR TITLE
perf: use filename field instead of parsing filename from URL

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1401,15 +1401,19 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "poetry-core"
-version = "2.4.0"
+version = "2.4.1"
 description = "Poetry PEP 517 Build Backend"
 optional = false
-python-versions = "<4.0,>=3.10"
+python-versions = ">=3.10, <4.0"
 groups = ["main"]
-files = [
-    {file = "poetry_core-2.4.0-py3-none-any.whl", hash = "sha256:4305848477da00272bebd3f615bbec87f64bd117cdb858ab660b626a06a9d96c"},
-    {file = "poetry_core-2.4.0.tar.gz", hash = "sha256:4e8c7496cf797998ffc493f2e23eba4b038c894c08eadacdcdf688945de6b43a"},
-]
+files = []
+develop = false
+
+[package.source]
+type = "git"
+url = "https://github.com/python-poetry/poetry-core.git"
+reference = "HEAD"
+resolved_reference = "a1cebaca12deb17a5e23ae9a137fcf28908eb462"
 
 [[package]]
 name = "pre-commit"
@@ -2267,4 +2271,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "744c205ce298c167a6965c34382a9efc5309c6e4051cc9c5215adecf217244da"
+content-hash = "afaa5fde455af4891db15f45aeaab108a0e666284d10be763880d134f3ecf639"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.5.0.dev0"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "poetry-core (==2.4.0)",
+    "poetry-core @ git+https://github.com/python-poetry/poetry-core.git",
     "build (>=1.2.1,<2.0.0)",
     "cachecontrol[filecache] (>=0.14.0,<0.15.0)",
     "cleo (>=2.1.0,<3.0.0)",

--- a/src/poetry/repositories/link_sources/json.py
+++ b/src/poetry/repositories/link_sources/json.py
@@ -46,8 +46,10 @@ class SimpleJsonPage(LinkSource):
                         metadata = bool(metadata_value)
                     break
 
+            # use filename for performance (and strictly speaking also for correctness)
             link = Link(
                 url,
+                filename=file["filename"],
                 requires_python=requires_python,
                 hashes=hashes,
                 yanked=yanked,

--- a/tests/repositories/link_sources/test_json.py
+++ b/tests/repositories/link_sources/test_json.py
@@ -29,10 +29,11 @@ def test_attributes() -> None:
     content = {
         "files": [
             # minimal
-            {"url": "https://example.org/demo-0.1.whl"},
+            {"url": "https://example.org/demo-0.1.whl", "filename": "demo-0.1.whl"},
             # all (with non-default values)
             {
                 "url": "https://example.org/demo-0.1.tar.gz",
+                "filename": "demo-0.1.tar.gz",
                 "requires-python": ">=3.6",
                 "yanked": True,
                 "hashes": {"sha256": "abcd1234"},
@@ -79,8 +80,16 @@ def test_yanked(
 ) -> None:
     content = {
         "files": [
-            {"url": "https://example.org/demo-0.1.tar.gz", "yanked": yanked[0]},
-            {"url": "https://example.org/demo-0.1.whl", "yanked": yanked[1]},
+            {
+                "url": "https://example.org/demo-0.1.tar.gz",
+                "filename": "demo-0.1.tar.gz",
+                "yanked": yanked[0],
+            },
+            {
+                "url": "https://example.org/demo-0.1.whl",
+                "filename": "demo-0.1.whl",
+                "yanked": yanked[1],
+            },
         ]
     }
     if yanked[0] is None:
@@ -158,7 +167,15 @@ def test_metadata(
     expected_has_metadata: bool,
     expected_metadata_hashes: dict[str, str],
 ) -> None:
-    content = {"files": [{"url": "https://example.org/demo-0.1.whl", **metadata}]}
+    content = {
+        "files": [
+            {
+                "url": "https://example.org/demo-0.1.whl",
+                "filename": "demo-0.1.whl",
+                **metadata,
+            }
+        ]
+    }
     page = SimpleJsonPage("https://example.org", content)
 
     link = next(page.links)
@@ -182,6 +199,8 @@ def test_metadata(
     ),
 )
 def test_base_url(url: str, repo_url: str, expected: str) -> None:
-    page = SimpleJsonPage(repo_url, {"files": [{"url": url}]})
+    page = SimpleJsonPage(
+        repo_url, {"files": [{"url": url, "filename": url.rpartition("/")[-1]}]}
+    )
     link = next(iter(page.links))
     assert link.url == expected


### PR DESCRIPTION
This makes locking 15 % faster in some cases.

# Pull Request Check List

Requires: python-poetry/poetry-core#941

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
