### PR TITLE
perf: avoid urljoin for absolute urls

### DIFF
--- a/src/poetry/repositories/link_sources/json.py
+++ b/src/poetry/repositories/link_sources/json.py
@@ -28,7 +28,14 @@ class SimpleJsonPage(LinkSource):
     def _link_cache(self) -> LinkCache:
         links: LinkCache = defaultdict(lambda: defaultdict(list))
         for file in self.content["files"]:
-            url = self.clean_link(urllib.parse.urljoin(self._url, file["url"]))
+            file_url = file["url"]
+            # This is just a performance shortcut.
+            # urljoin would work just fine for absolute URLs as well,
+            # but it is much faster to skip urljoin in that case.
+            # (Links on pypi.org are absolute.)
+            if not file_url.startswith(("http://", "https://", "file://")):
+                file_url = urllib.parse.urljoin(self._url, file_url)
+            url = self.clean_link(file_url)
             requires_python = file.get("requires-python")
             hashes = file.get("hashes", {})
             yanked = file.get("yanked", False)


### PR DESCRIPTION
This makes locking 15 % faster in some cases.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
