### PR TITLE
fix unreliable unit test

### DIFF
--- a/tests/utils/test_threading.py
+++ b/tests/utils/test_threading.py
@@ -92,13 +92,13 @@ def run_in_threads(instance: Example, property_name: str) -> None:
     barrier = threading.Barrier(WORKER_COUNT)
 
     def access_property() -> None:
-        barrier.wait()
+        barrier.wait(10)
         results.append(instance.__getattribute__(property_name))
 
     executor = ThreadPoolExecutor(max_workers=WORKER_COUNT)
     futures = [executor.submit(access_property) for _ in range(WORKER_COUNT)]
 
-    wait(futures)
+    wait(futures, 10)
     assert len(results) == WORKER_COUNT
     assert all(result == (EXPECTED_VALUE + instance.value) for result in results)
 

--- a/tests/utils/test_threading.py
+++ b/tests/utils/test_threading.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import os
 import sys
+import threading
 import time
 
 from concurrent.futures import wait
@@ -84,8 +85,14 @@ def test_threading_single_thread_safe() -> None:
 
 def run_in_threads(instance: Example, property_name: str) -> None:
     results = []
+    # Synchronize thread start so all workers enter __get__ before any thread
+    # finishes computing the property. Without this, on Python 3.12+ where
+    # functools.cached_property is lockless, the test for maximum-contention
+    # call counts is racy.
+    barrier = threading.Barrier(WORKER_COUNT)
 
     def access_property() -> None:
+        barrier.wait()
         results.append(instance.__getattribute__(property_name))
 
     executor = ThreadPoolExecutor(max_workers=WORKER_COUNT)


### PR DESCRIPTION
The test asserted that every worker thread would call the underlying compute function (i.e., max contention). 

This only holds if all threads pass the descriptor's dict-check before any thread finishes computing.

Barrier added where it is does not strictly 100% guarantee success, but makes the likelihood of failure much much smaller (I have not seen it happen).
