### PR TITLE
perf: avoid urljoin for absolute HTML links

### DIFF
--- a/src/poetry/repositories/link_sources/base.py
+++ b/src/poetry/repositories/link_sources/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import urllib.parse
 
 from functools import cached_property
 from typing import TYPE_CHECKING
@@ -28,14 +29,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-ABSOLUTE_LINK_PREFIXES = ("http://", "https://", "file://")
-
-
-def is_absolute_url_fast_path(url: str) -> bool:
+def make_absolute_url(url: str, base_url: str) -> str:
+    """Makes a URL absolute by joining it with a base URL
+    if it is not already absolute.
+    """
     # This shortcut covers the absolute URL schemes commonly emitted by simple
     # repository pages. Other absolute forms still go through urljoin, which
     # preserves correct handling for protocol-relative URLs and uncommon schemes.
-    return url.startswith(ABSOLUTE_LINK_PREFIXES)
+    if url.startswith(("http://", "https://", "file://")):
+        return url
+    return urllib.parse.urljoin(base_url, url)
 
 
 class LinkSource:

--- a/src/poetry/repositories/link_sources/base.py
+++ b/src/poetry/repositories/link_sources/base.py
@@ -28,6 +28,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+ABSOLUTE_LINK_PREFIXES = ("http://", "https://", "file://")
+
+
+def is_absolute_url_fast_path(url: str) -> bool:
+    # This shortcut covers the absolute URL schemes commonly emitted by simple
+    # repository pages. Other absolute forms still go through urljoin, which
+    # preserves correct handling for protocol-relative URLs and uncommon schemes.
+    return url.startswith(ABSOLUTE_LINK_PREFIXES)
+
+
 class LinkSource:
     VERSION_REGEX = re.compile(r"(?i)([a-z0-9_\-.]+?)-(?=\d)([a-z0-9_.!+-]+)")
     CLEAN_REGEX = re.compile(r"[^a-z0-9$&+,/:;=?@.#%_\\|-]", re.I)

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import urllib.parse
-
 from collections import defaultdict
 from functools import cached_property
 from html import unescape
@@ -11,7 +9,7 @@ from poetry.core.packages.utils.link import Link
 
 from poetry.repositories.link_sources.base import LinkSource
 from poetry.repositories.link_sources.base import SimpleRepositoryRootPage
-from poetry.repositories.link_sources.base import is_absolute_url_fast_path
+from poetry.repositories.link_sources.base import make_absolute_url
 from poetry.repositories.parsers.html_page_parser import HTMLPageParser
 
 
@@ -34,9 +32,7 @@ class HTMLPage(LinkSource):
         base_url = self._base_url or self._url
         for anchor in self._parsed:
             if href := anchor.get("href"):
-                if not is_absolute_url_fast_path(href):
-                    href = urllib.parse.urljoin(base_url, href)
-                url = self.clean_link(href)
+                url = self.clean_link(make_absolute_url(href, base_url))
                 pyrequire = anchor.get("data-requires-python")
                 pyrequire = unescape(pyrequire) if pyrequire else None
                 yanked_value = anchor.get("data-yanked")

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -11,14 +11,12 @@ from poetry.core.packages.utils.link import Link
 
 from poetry.repositories.link_sources.base import LinkSource
 from poetry.repositories.link_sources.base import SimpleRepositoryRootPage
+from poetry.repositories.link_sources.base import is_absolute_url_fast_path
 from poetry.repositories.parsers.html_page_parser import HTMLPageParser
 
 
 if TYPE_CHECKING:
     from poetry.repositories.link_sources.base import LinkCache
-
-
-ABSOLUTE_LINK_PREFIXES = ("http://", "https://", "file://")
 
 
 class HTMLPage(LinkSource):
@@ -36,7 +34,7 @@ class HTMLPage(LinkSource):
         base_url = self._base_url or self._url
         for anchor in self._parsed:
             if href := anchor.get("href"):
-                if not href.startswith(ABSOLUTE_LINK_PREFIXES):
+                if not is_absolute_url_fast_path(href):
                     href = urllib.parse.urljoin(base_url, href)
                 url = self.clean_link(href)
                 pyrequire = anchor.get("data-requires-python")

--- a/src/poetry/repositories/link_sources/html.py
+++ b/src/poetry/repositories/link_sources/html.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     from poetry.repositories.link_sources.base import LinkCache
 
 
+ABSOLUTE_LINK_PREFIXES = ("http://", "https://", "file://")
+
+
 class HTMLPage(LinkSource):
     def __init__(self, url: str, content: str) -> None:
         super().__init__(url=url)
@@ -30,11 +33,12 @@ class HTMLPage(LinkSource):
     @cached_property
     def _link_cache(self) -> LinkCache:
         links: LinkCache = defaultdict(lambda: defaultdict(list))
+        base_url = self._base_url or self._url
         for anchor in self._parsed:
             if href := anchor.get("href"):
-                url = self.clean_link(
-                    urllib.parse.urljoin(self._base_url or self._url, href)
-                )
+                if not href.startswith(ABSOLUTE_LINK_PREFIXES):
+                    href = urllib.parse.urljoin(base_url, href)
+                url = self.clean_link(href)
                 pyrequire = anchor.get("data-requires-python")
                 pyrequire = unescape(pyrequire) if pyrequire else None
                 yanked_value = anchor.get("data-yanked")

--- a/src/poetry/repositories/link_sources/json.py
+++ b/src/poetry/repositories/link_sources/json.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import urllib.parse
-
 from collections import defaultdict
 from functools import cached_property
 from typing import TYPE_CHECKING
@@ -11,7 +9,7 @@ from poetry.core.packages.utils.link import Link
 
 from poetry.repositories.link_sources.base import LinkSource
 from poetry.repositories.link_sources.base import SimpleRepositoryRootPage
-from poetry.repositories.link_sources.base import is_absolute_url_fast_path
+from poetry.repositories.link_sources.base import make_absolute_url
 
 
 if TYPE_CHECKING:
@@ -29,10 +27,7 @@ class SimpleJsonPage(LinkSource):
     def _link_cache(self) -> LinkCache:
         links: LinkCache = defaultdict(lambda: defaultdict(list))
         for file in self.content["files"]:
-            file_url = file["url"]
-            if not is_absolute_url_fast_path(file_url):
-                file_url = urllib.parse.urljoin(self._url, file_url)
-            url = self.clean_link(file_url)
+            url = self.clean_link(make_absolute_url(file["url"], self._url))
             requires_python = file.get("requires-python")
             hashes = file.get("hashes", {})
             yanked = file.get("yanked", False)

--- a/src/poetry/repositories/link_sources/json.py
+++ b/src/poetry/repositories/link_sources/json.py
@@ -11,6 +11,7 @@ from poetry.core.packages.utils.link import Link
 
 from poetry.repositories.link_sources.base import LinkSource
 from poetry.repositories.link_sources.base import SimpleRepositoryRootPage
+from poetry.repositories.link_sources.base import is_absolute_url_fast_path
 
 
 if TYPE_CHECKING:
@@ -29,11 +30,7 @@ class SimpleJsonPage(LinkSource):
         links: LinkCache = defaultdict(lambda: defaultdict(list))
         for file in self.content["files"]:
             file_url = file["url"]
-            # This is just a performance shortcut.
-            # urljoin would work just fine for absolute URLs as well,
-            # but it is much faster to skip urljoin in that case.
-            # (Links on pypi.org are absolute.)
-            if not file_url.startswith(("http://", "https://", "file://")):
+            if not is_absolute_url_fast_path(file_url):
                 file_url = urllib.parse.urljoin(self._url, file_url)
             url = self.clean_link(file_url)
             requires_python = file.get("requires-python")

--- a/tests/repositories/link_sources/test_base.py
+++ b/tests/repositories/link_sources/test_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import urllib.parse
+
 from collections import defaultdict
 from functools import cached_property
 from typing import TYPE_CHECKING
@@ -14,6 +16,7 @@ from poetry.core.packages.utils.link import Link
 
 from poetry.repositories.link_sources.base import LinkSource
 from poetry.repositories.link_sources.base import SimpleRepositoryRootPage
+from poetry.repositories.link_sources.base import make_absolute_url
 
 
 if TYPE_CHECKING:
@@ -126,3 +129,66 @@ def test_root_page_search(
     root_page: SimpleRepositoryRootPage, query: str | list[str], expected: list[str]
 ) -> None:
     assert root_page.search(query) == expected
+
+
+@pytest.mark.parametrize(
+    ("url", "base_url", "expected", "urljoin_called"),
+    [
+        (
+            "https://files.example.org/demo-1.0.0.whl",
+            "https://example.org/simple/demo/",
+            "https://files.example.org/demo-1.0.0.whl",
+            False,
+        ),
+        (
+            "file:///tmp/demo-1.0.0.tar.gz",
+            "https://example.org/simple/demo/",
+            "file:///tmp/demo-1.0.0.tar.gz",
+            False,
+        ),
+        (
+            "demo-1.0.0.tar.gz",
+            "https://example.org/simple/demo/",
+            "https://example.org/simple/demo/demo-1.0.0.tar.gz",
+            True,
+        ),
+        (
+            "/packages/demo-1.0.0.tar.gz",
+            "https://example.org/simple/demo/",
+            "https://example.org/packages/demo-1.0.0.tar.gz",
+            True,
+        ),
+        (
+            "../demo-1.0.0.tar.gz",
+            "https://example.org/simple/demo/",
+            "https://example.org/simple/demo-1.0.0.tar.gz",
+            True,
+        ),
+        (
+            "//cdn.example.org/demo-1.0.0.whl",
+            "https://example.org/simple/demo/",
+            "https://cdn.example.org/demo-1.0.0.whl",
+            True,
+        ),
+        (
+            "ftp://files.example.org/demo-1.0.0.whl",
+            "https://example.org/simple/demo/",
+            "ftp://files.example.org/demo-1.0.0.whl",
+            True,
+        ),
+    ],
+)
+def test_make_absolute_url(
+    url: str,
+    base_url: str,
+    expected: str,
+    urljoin_called: bool,
+    mocker: MockerFixture,
+) -> None:
+    urljoin_spy = mocker.spy(urllib.parse, "urljoin")
+
+    assert make_absolute_url(url, base_url) == expected
+    if urljoin_called:
+        urljoin_spy.assert_called_once_with(base_url, url)
+    else:
+        urljoin_spy.assert_not_called()

--- a/tests/repositories/link_sources/test_html.py
+++ b/tests/repositories/link_sources/test_html.py
@@ -8,7 +8,6 @@ from packaging.utils import canonicalize_name
 from poetry.core.constraints.version import Version
 from poetry.core.packages.utils.link import Link
 
-from poetry.repositories.link_sources.base import ABSOLUTE_LINK_PREFIXES
 from poetry.repositories.link_sources.html import HTMLPage
 from poetry.repositories.link_sources.html import SimpleRepositoryHTMLRootPage
 
@@ -95,29 +94,6 @@ def test_hash_from_url(html_page_content: HTMLPageGetter) -> None:
     assert len(list(page.links)) == 1
     link = next(iter(page.links))
     assert link.hashes == {"sha256": "abcd1234"}
-
-
-@pytest.mark.parametrize("prefix", ABSOLUTE_LINK_PREFIXES)
-def test_absolute_url_skips_urljoin(
-    html_page_content: HTMLPageGetter, monkeypatch: pytest.MonkeyPatch, prefix: str
-) -> None:
-    def fail_urljoin(base: str, url: str) -> str:
-        raise AssertionError("urljoin should not be called for absolute URLs")
-
-    monkeypatch.setattr(
-        "poetry.repositories.link_sources.html.urllib.parse.urljoin", fail_urljoin
-    )
-
-    anchor = (
-        f'<a href="{prefix}files.pythonhosted.org/packages/demo-0.1.whl">'
-        "demo-0.1.whl</a><br/>"
-    )
-    content = html_page_content(anchor)
-    page = HTMLPage("https://example.org/simple/demo/", content)
-
-    assert (
-        next(page.links).url == f"{prefix}files.pythonhosted.org/packages/demo-0.1.whl"
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/repositories/link_sources/test_html.py
+++ b/tests/repositories/link_sources/test_html.py
@@ -8,6 +8,7 @@ from packaging.utils import canonicalize_name
 from poetry.core.constraints.version import Version
 from poetry.core.packages.utils.link import Link
 
+from poetry.repositories.link_sources.base import ABSOLUTE_LINK_PREFIXES
 from poetry.repositories.link_sources.html import HTMLPage
 from poetry.repositories.link_sources.html import SimpleRepositoryHTMLRootPage
 
@@ -96,8 +97,9 @@ def test_hash_from_url(html_page_content: HTMLPageGetter) -> None:
     assert link.hashes == {"sha256": "abcd1234"}
 
 
+@pytest.mark.parametrize("prefix", ABSOLUTE_LINK_PREFIXES)
 def test_absolute_url_skips_urljoin(
-    html_page_content: HTMLPageGetter, monkeypatch: pytest.MonkeyPatch
+    html_page_content: HTMLPageGetter, monkeypatch: pytest.MonkeyPatch, prefix: str
 ) -> None:
     def fail_urljoin(base: str, url: str) -> str:
         raise AssertionError("urljoin should not be called for absolute URLs")
@@ -107,14 +109,14 @@ def test_absolute_url_skips_urljoin(
     )
 
     anchor = (
-        '<a href="https://files.pythonhosted.org/packages/demo-0.1.whl">'
+        f'<a href="{prefix}files.pythonhosted.org/packages/demo-0.1.whl">'
         "demo-0.1.whl</a><br/>"
     )
     content = html_page_content(anchor)
     page = HTMLPage("https://example.org/simple/demo/", content)
 
     assert (
-        next(page.links).url == "https://files.pythonhosted.org/packages/demo-0.1.whl"
+        next(page.links).url == f"{prefix}files.pythonhosted.org/packages/demo-0.1.whl"
     )
 
 

--- a/tests/repositories/link_sources/test_html.py
+++ b/tests/repositories/link_sources/test_html.py
@@ -96,6 +96,28 @@ def test_hash_from_url(html_page_content: HTMLPageGetter) -> None:
     assert link.hashes == {"sha256": "abcd1234"}
 
 
+def test_absolute_url_skips_urljoin(
+    html_page_content: HTMLPageGetter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_urljoin(base: str, url: str) -> str:
+        raise AssertionError("urljoin should not be called for absolute URLs")
+
+    monkeypatch.setattr(
+        "poetry.repositories.link_sources.html.urllib.parse.urljoin", fail_urljoin
+    )
+
+    anchor = (
+        '<a href="https://files.pythonhosted.org/packages/demo-0.1.whl">'
+        "demo-0.1.whl</a><br/>"
+    )
+    content = html_page_content(anchor)
+    page = HTMLPage("https://example.org/simple/demo/", content)
+
+    assert (
+        next(page.links).url == "https://files.pythonhosted.org/packages/demo-0.1.whl"
+    )
+
+
 @pytest.mark.parametrize(
     "yanked_attrs, expected",
     [


### PR DESCRIPTION
This mirrors the JSON Simple API shortcut from #10896 for HTML Simple API pages: absolute file links do not need `urllib.parse.urljoin()`, and PyPI-style repository pages commonly use absolute links.

A small local benchmark over absolute `https://` links showed the prefix check avoiding `urljoin()` is significantly faster:

```text
old_s min/med/max=0.177560/0.236734/0.484216
new_s min/med/max=0.000984/0.001196/0.008956
speedup=198.0x
```

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code. N/A, no user-facing behavior change.

Local checks:

```bash
PYTHONPATH=src uv run --with pytest --with pytest-xdist --with responses --with pytest-mock python -m pytest tests/repositories/link_sources/test_html.py tests/repositories/link_sources/test_json.py -q
uv run --with ruff python -m ruff check src/poetry/repositories/link_sources/base.py src/poetry/repositories/link_sources/html.py src/poetry/repositories/link_sources/json.py tests/repositories/link_sources/test_html.py
uv run --with ruff python -m ruff format --check src/poetry/repositories/link_sources/base.py src/poetry/repositories/link_sources/html.py src/poetry/repositories/link_sources/json.py tests/repositories/link_sources/test_html.py
PYTHONPATH=src uv run --with poetry-core --with packaging --with mypy python -m mypy src/poetry/repositories/link_sources/base.py src/poetry/repositories/link_sources/html.py src/poetry/repositories/link_sources/json.py
git diff --check
```
