### PR TITLE
feat: add builtin uninstaller as alternative to calling pip

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,6 +307,21 @@ values, usage instructions and warnings.
 
 Use parallel execution when using the new (`>=1.1.0`) installer.
 
+### `installer.builtin-uninstall`
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+**Environment Variable**: `POETRY_INSTALLER_BUILTIN_UNINSTALL`
+
+*Introduced in 2.5.0*
+
+If set to `true`, Poetry uninstalls packages using its own built-in routine instead of
+invoking `pip uninstall` as a subprocess. This avoids the overhead of spawning pip.
+Behavior is otherwise equivalent: confirmation is automatic, and files outside the
+target environment's prefix are never removed.
+
 ### `installer.build-config-settings.<package-name>`
 
 **Type**: `Serialised JSON with string or list of string properties`

--- a/src/poetry/config/config.py
+++ b/src/poetry/config/config.py
@@ -174,6 +174,7 @@ class Config:
             "no-binary": None,
             "only-binary": None,
             "build-config-settings": {},
+            "builtin-uninstall": False,
         },
         "python": {"installation-dir": os.path.join("{data-dir}", "python")},
         "solver": {
@@ -396,6 +397,7 @@ class Config:
             "virtualenvs.use-poetry-python",
             "installer.re-resolve",
             "installer.parallel",
+            "installer.builtin-uninstall",
             "solver.lazy-wheel",
             "system-git-client",
             "keyring.enabled",

--- a/src/poetry/console/commands/config.py
+++ b/src/poetry/console/commands/config.py
@@ -93,6 +93,7 @@ To remove a repository (repo is a short alias for repositories):
             "requests.max-retries": (lambda val: int(val) >= 0, int_normalizer),
             "installer.re-resolve": (boolean_validator, boolean_normalizer),
             "installer.parallel": (boolean_validator, boolean_normalizer),
+            "installer.builtin-uninstall": (boolean_validator, boolean_normalizer),
             "installer.max-workers": (lambda val: int(val) > 0, int_normalizer),
             "installer.no-binary": (
                 PackageFilterPolicy.validator,

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -21,6 +21,7 @@ from poetry.installation.chooser import Chooser
 from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall
 from poetry.installation.operations import Update
+from poetry.installation.uninstaller import uninstall_distribution
 from poetry.installation.wheel_installer import WheelInstaller
 from poetry.puzzle.exceptions import SolverProblemError
 from poetry.utils._compat import decode
@@ -78,6 +79,9 @@ class Executor:
         self._verbose = False
         self._wheel_installer = WheelInstaller(self._env)
         self._build_constraints = build_constraints or {}
+        self._use_builtin_uninstall: bool = config.get(
+            "installer.builtin-uninstall", False
+        )
 
         if parallel is None:
             parallel = config.get("installer.parallel", True)
@@ -627,6 +631,12 @@ class Executor:
             src_dir = self._env.path / "src" / package.name
             if src_dir.exists():
                 remove_directory(src_dir, force=True)
+
+        if self._use_builtin_uninstall:
+            pathset = uninstall_distribution(self._env, package.name)
+            if pathset is not None:
+                pathset.commit()
+            return 0
 
         try:
             return self.run_pip("uninstall", package.name, "-y")

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -21,6 +21,7 @@ from poetry.installation.chooser import Chooser
 from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall
 from poetry.installation.operations import Update
+from poetry.installation.uninstaller import UninstallPathSet
 from poetry.installation.uninstaller import uninstall_distribution
 from poetry.installation.wheel_installer import WheelInstaller
 from poetry.puzzle.exceptions import SolverProblemError
@@ -607,15 +608,27 @@ class Executor:
         )
         self._write(operation, message)
 
+        old_pathset: UninstallPathSet | None = None
         try:
             if operation.job_type == "update":
-                # Uninstall first
-                # TODO: Make an uninstaller and find a way to rollback in case
-                # the new package can't be installed
                 assert isinstance(operation, Update)
-                self._remove(operation.initial_package)
+                result = self._uninstall(operation.initial_package)
+                if isinstance(result, UninstallPathSet):
+                    old_pathset = result
+                elif result != 0:
+                    # pip uninstall was interrupted; surface that code
+                    # instead of attempting the install.
+                    return result
 
-            self._wheel_installer.install(archive)
+            try:
+                self._wheel_installer.install(archive)
+            except BaseException:  # rollback also on KeyboardInterrupt
+                if old_pathset is not None:
+                    old_pathset.rollback()
+                raise
+
+            if old_pathset is not None:
+                old_pathset.commit()
         finally:
             if cleanup_archive:
                 archive.unlink()
@@ -626,7 +639,25 @@ class Executor:
         return self._install(operation)
 
     def _remove(self, package: Package) -> int:
-        # If we have a VCS package, remove its source directory
+        result = self._uninstall(package)
+        if isinstance(result, int):
+            return result
+        result.commit()
+        return 0
+
+    def _uninstall(self, package: Package) -> int | UninstallPathSet:
+        """Stash an installed package's files.
+
+        Returns either an ``UninstallPathSet`` (builtin installer)
+        so the caller can ``.commit()`` to finalize the removal or
+        ``.rollback()`` to restore the files, or an ``int`` return code
+        (legacy pip path, or builtin path when nothing needs uninstalling).
+        ``-2`` means pip was interrupted; ``0`` means success.
+
+        The git VCS source directory (``<env>/src/<pkg>/``) is removed
+        eagerly and is not part of the returned pathset; it is not
+        restored on rollback.
+        """
         if package.source_type == "git":
             src_dir = self._env.path / "src" / package.name
             if src_dir.exists():
@@ -634,17 +665,17 @@ class Executor:
 
         if self._use_builtin_uninstall:
             pathset = uninstall_distribution(self._env, package.name)
-            if pathset is not None:
-                pathset.commit()
-            return 0
+            # uninstall_distribution returns None when there is nothing to
+            # uninstall (not installed, outside env, in stdlib, missing
+            # RECORD). Treat that as a successful no-op.
+            return pathset if pathset is not None else 0
 
         try:
             return self.run_pip("uninstall", package.name, "-y")
         except EnvCommandError as e:
-            if "not installed" in str(e):
-                return 0
-
-            raise
+            if "not installed" not in str(e):
+                raise
+            return 0
 
     def _prepare_archive(
         self, operation: Install | Update, *, output_dir: Path | None = None

--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -612,13 +612,11 @@ class Executor:
         try:
             if operation.job_type == "update":
                 assert isinstance(operation, Update)
-                result = self._uninstall(operation.initial_package)
-                if isinstance(result, UninstallPathSet):
-                    old_pathset = result
-                elif result != 0:
+                result_code, old_pathset = self._uninstall(operation.initial_package)
+                if result_code != 0:
                     # pip uninstall was interrupted; surface that code
                     # instead of attempting the install.
-                    return result
+                    return result_code
 
             try:
                 self._wheel_installer.install(archive)
@@ -639,20 +637,22 @@ class Executor:
         return self._install(operation)
 
     def _remove(self, package: Package) -> int:
-        result = self._uninstall(package)
-        if isinstance(result, int):
-            return result
-        result.commit()
+        result_code, pathset = self._uninstall(package)
+        if result_code != 0:
+            return result_code
+        if pathset is not None:
+            pathset.commit()
         return 0
 
-    def _uninstall(self, package: Package) -> int | UninstallPathSet:
+    def _uninstall(self, package: Package) -> tuple[int, UninstallPathSet | None]:
         """Stash an installed package's files.
 
-        Returns either an ``UninstallPathSet`` (builtin installer)
-        so the caller can ``.commit()`` to finalize the removal or
-        ``.rollback()`` to restore the files, or an ``int`` return code
-        (legacy pip path, or builtin path when nothing needs uninstalling).
-        ``-2`` means pip was interrupted; ``0`` means success.
+        Returns a tuple of ``(return_code, pathset)`` where ``pathset`` is an
+        ``UninstallPathSet`` (builtin installer) so the caller can ``.commit()``
+        to finalize the removal or ``.rollback()`` to restore the files, or
+        ``None`` (legacy pip path, or builtin path when nothing needs
+        uninstalling). ``return_code`` is ``-2`` when pip was interrupted, or
+        ``0`` on success.
 
         The git VCS source directory (``<env>/src/<pkg>/``) is removed
         eagerly and is not part of the returned pathset; it is not
@@ -668,14 +668,14 @@ class Executor:
             # uninstall_distribution returns None when there is nothing to
             # uninstall (not installed, outside env, in stdlib, missing
             # RECORD). Treat that as a successful no-op.
-            return pathset if pathset is not None else 0
+            return 0, pathset
 
         try:
-            return self.run_pip("uninstall", package.name, "-y")
+            return self.run_pip("uninstall", package.name, "-y"), None
         except EnvCommandError as e:
             if "not installed" not in str(e):
                 raise
-            return 0
+            return 0, None
 
     def _prepare_archive(
         self, operation: Install | Update, *, output_dir: Path | None = None

--- a/src/poetry/installation/uninstaller.py
+++ b/src/poetry/installation/uninstaller.py
@@ -31,13 +31,11 @@ import tempfile
 from importlib.util import cache_from_source
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Any
 
 from poetry.utils._compat import is_relative_to
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from collections.abc import Iterable
     from collections.abc import Iterator
     from importlib import metadata
@@ -142,19 +140,6 @@ class _AdjacentTempDirectory(_TempDirectory):
                     yield new_name
 
 
-def _unique(fn: Callable[..., Iterator[Any]]) -> Callable[..., Iterator[Any]]:
-    @functools.wraps(fn)
-    def unique(*args: Any, **kw: Any) -> Iterator[Any]:
-        seen: set[Any] = set()
-        for item in fn(*args, **kw):
-            if item not in seen:
-                seen.add(item)
-                yield item
-
-    return unique
-
-
-@_unique
 def _uninstallation_paths(
     dist_files: list[PackagePath], location: str | Path
 ) -> Iterator[str]:

--- a/src/poetry/installation/uninstaller.py
+++ b/src/poetry/installation/uninstaller.py
@@ -1,0 +1,473 @@
+"""Builtin package uninstaller.
+
+Entry point is the ``uninstall_distribution`` function.
+
+Adapted from pip's ``pip._internal.req.req_uninstall`` so Poetry can uninstall
+packages without invoking ``pip uninstall`` as a subprocess. The module is
+self-contained and does not import from pip.
+
+Most methods and classes are borrowed from pip with minimal adaptations.
+The env-prefix and stdlib guards that pip applies in
+``UninstallPathSet.from_dist`` have been moved to ``uninstall_distribution``,
+along with all legacy-install branches (setuptools flat installs,
+easy_install eggs, develop-egg links) being dropped entirely — Poetry should
+only see modern ``.dist-info`` installs.
+
+ATTENTION: Do not convert os.path to pathlib lightly in this module!
+    pathlib is often slower and some path operations
+    are called for each file that has to be removed.
+"""
+
+from __future__ import annotations
+
+import errno
+import functools
+import itertools
+import logging
+import os
+import shutil
+import tempfile
+
+from importlib.util import cache_from_source
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+
+from poetry.utils._compat import is_relative_to
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Iterable
+    from collections.abc import Iterator
+    from importlib import metadata
+    from importlib.metadata import PackagePath
+
+    from poetry.utils.env import Env
+
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_path(path: str | Path, resolve_symlinks: bool = True) -> str:
+    path = os.path.expanduser(path)
+    path = os.path.realpath(path) if resolve_symlinks else os.path.abspath(path)
+    return os.path.normcase(path)
+
+
+def _renames(old: str, new: str) -> None:
+    """Like os.renames(), but handles renaming across devices."""
+    # Implementation borrowed from os.renames().
+    head, tail = os.path.split(new)
+    if head and tail and not os.path.exists(head):
+        os.makedirs(head)
+
+    shutil.move(old, new)
+
+    head, tail = os.path.split(old)
+    if head and tail:
+        try:  # noqa: SIM105 (performance)
+            os.removedirs(head)
+        except OSError:
+            pass
+
+
+class _TempDirectory:
+    """Owns and cleans up a temporary directory."""
+
+    def __init__(self) -> None:
+        self._path = self._create()
+        logger.debug("Created temporary directory: %s", self._path)
+
+    def _create(self) -> str:
+        """Create a temporary directory and store its path in self.path"""
+        return tempfile.mkdtemp(prefix="poetry-uninstall-")
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    def cleanup(self) -> None:
+        if os.path.exists(self._path):
+            shutil.rmtree(self._path, ignore_errors=True)
+
+
+class _AdjacentTempDirectory(_TempDirectory):
+    """Creates a temporary directory adjacent to ``original``."""
+
+    LEADING_CHARS = "-~.=%0123456789"
+
+    def __init__(self, original: str) -> None:
+        self.original = original.rstrip("/\\")
+        super().__init__()
+
+    def _create(self) -> str:
+        root, name = os.path.split(self.original)
+        for candidate in self._generate_names(name):
+            path = os.path.join(root, candidate)
+            try:
+                os.mkdir(path)
+            except OSError as ex:
+                # Continue if the name exists already
+                if ex.errno != errno.EEXIST:
+                    raise
+            else:
+                return path
+        return super()._create()
+
+    @classmethod
+    def _generate_names(cls, name: str) -> Iterator[str]:
+        """Generates a series of temporary names.
+
+        The algorithm replaces the leading characters in the name
+        with ones that are valid filesystem characters, but are not
+        valid package names (for both Python and pip definitions of
+        package).
+        """
+        for i in range(1, len(name)):
+            for candidate in itertools.combinations_with_replacement(
+                cls.LEADING_CHARS, i - 1
+            ):
+                new_name = "~" + "".join(candidate) + name[i:]
+                if new_name != name:
+                    yield new_name
+
+        # If we make it this far, we will have to make a longer name
+        for i in range(len(cls.LEADING_CHARS)):
+            for candidate in itertools.combinations_with_replacement(
+                cls.LEADING_CHARS, i
+            ):
+                new_name = "~" + "".join(candidate) + name
+                if new_name != name:
+                    yield new_name
+
+
+def _unique(fn: Callable[..., Iterator[Any]]) -> Callable[..., Iterator[Any]]:
+    @functools.wraps(fn)
+    def unique(*args: Any, **kw: Any) -> Iterator[Any]:
+        seen: set[Any] = set()
+        for item in fn(*args, **kw):
+            if item not in seen:
+                seen.add(item)
+                yield item
+
+    return unique
+
+
+@_unique
+def _uninstallation_paths(
+    dist_files: list[PackagePath], location: str | Path
+) -> Iterator[str]:
+    """Yield all uninstallation paths declared in the distribution's RECORD.
+
+    For each .py file in RECORD, also yield the sibling .pyc/.pyo. The
+    ``UninstallPathSet.add`` method handles ``__pycache__`` discovery.
+    """
+    for entry in dist_files:
+        path = os.path.join(location, str(entry))
+        yield path
+        if path.endswith(".py"):
+            dn, fn = os.path.split(path)
+            base = fn[:-3]
+            yield os.path.join(dn, base + ".pyc")
+            yield os.path.join(dn, base + ".pyo")
+
+
+def compact(paths: Iterable[str]) -> set[str]:
+    """Compact a path set to contain the minimal number of paths
+    necessary to contain all paths in the set. If /a/path/ and
+    /a/path/to/a/file.txt are both in the set, leave only the
+    shorter path."""
+
+    sep = os.path.sep
+    short_paths: set[str] = set()
+    for path in sorted(paths, key=len):
+        should_skip = any(
+            path.startswith(shortpath.rstrip("*"))
+            and path[len(shortpath.rstrip("*").rstrip(sep))] == sep
+            for shortpath in short_paths
+        )
+        if not should_skip:
+            short_paths.add(path)
+    return short_paths
+
+
+def compress_for_rename(paths: Iterable[str]) -> set[str]:
+    """Returns a set containing the paths that need to be renamed.
+
+    This set may include directories when the original sequence of paths
+    included every file on disk.
+    """
+    case_map = {os.path.normcase(p): p for p in paths}
+    remaining = set(case_map)
+    unchecked = sorted({os.path.split(p)[0] for p in case_map.values()}, key=len)
+    wildcards: set[str] = set()
+
+    def norm_join(*a: str) -> str:
+        return os.path.normcase(os.path.join(*a))
+
+    for root in unchecked:
+        if any(os.path.normcase(root).startswith(w) for w in wildcards):
+            # This directory has already been handled.
+            continue
+
+        all_files: set[str] = set()
+        all_subdirs: set[str] = set()
+        for dirname, subdirs, files in os.walk(root):
+            all_subdirs.update(norm_join(root, dirname, d) for d in subdirs)
+            all_files.update(norm_join(root, dirname, f) for f in files)
+        # If all the files we found are in our remaining set of files to
+        # remove, then remove them from the latter set and add a wildcard
+        # for the directory.
+        if not (all_files - remaining):
+            remaining.difference_update(all_files)
+            wildcards.add(root + os.sep)
+
+    return set(map(case_map.__getitem__, remaining)) | wildcards
+
+
+class StashedUninstallPathSet:
+    """A set of file rename operations to stash files while
+    tentatively uninstalling them."""
+
+    def __init__(self) -> None:
+        # Mapping from source file root to [Adjacent]TempDirectory
+        # for files under that directory.
+        self._save_dirs: dict[str, _TempDirectory] = {}
+        # (old path, new path) tuples for each move that may need
+        # to be undone.
+        self._moves: list[tuple[str, str]] = []
+
+    def _get_directory_stash(self, path: str) -> str:
+        """Stashes a directory.
+
+        Directories are stashed adjacent to their original location if
+        possible, or else moved/copied into the user's temp dir."""
+        save_dir: _TempDirectory
+        try:
+            save_dir = _AdjacentTempDirectory(path)
+        except OSError:
+            save_dir = _TempDirectory()
+        self._save_dirs[os.path.normcase(path)] = save_dir
+        return save_dir.path
+
+    def _get_file_stash(self, path: str) -> str:
+        """Stashes a file.
+
+        If no root has been provided, one will be created for the directory
+        in the user's temp directory."""
+        path = os.path.normcase(path)
+        head, old_head = os.path.dirname(path), None
+
+        while head != old_head:
+            try:
+                save_dir = self._save_dirs[head]
+                break
+            except KeyError:
+                pass
+            head, old_head = os.path.dirname(head), head
+        else:
+            # Did not find any suitable root
+            head = os.path.dirname(path)
+            save_dir = _TempDirectory()
+            self._save_dirs[head] = save_dir
+
+        relpath = os.path.relpath(path, head)
+        if relpath and relpath != os.path.curdir:
+            return os.path.join(save_dir.path, relpath)
+        return save_dir.path
+
+    def stash(self, path: str) -> str:
+        """Stashes the directory or file and returns its new location.
+        Handle symlinks as files to avoid modifying the symlink targets.
+        """
+        path_is_dir = os.path.isdir(path) and not os.path.islink(path)
+        if path_is_dir:
+            new_path = self._get_directory_stash(path)
+        else:
+            new_path = self._get_file_stash(path)
+
+        self._moves.append((path, new_path))
+        if path_is_dir and os.path.isdir(new_path):
+            # If we're moving a directory, we need to
+            # remove the destination first or else it will be
+            # moved to inside the existing directory.
+            # We just created new_path ourselves, so it will
+            # be removable.
+            os.rmdir(new_path)
+        _renames(path, new_path)
+        return new_path
+
+    def commit(self) -> None:
+        """Commits the uninstall by removing stashed files."""
+        for save_dir in self._save_dirs.values():
+            save_dir.cleanup()
+        self._moves = []
+        self._save_dirs = {}
+
+    def rollback(self) -> None:
+        """Undoes the uninstall by moving stashed files back."""
+        for p in self._moves:
+            logger.debug("Moving to %s\n from %s", *p)
+
+        for new_path, path in self._moves:
+            try:
+                logger.debug("Replacing %s from %s", new_path, path)
+                if os.path.isfile(new_path) or os.path.islink(new_path):
+                    os.unlink(new_path)
+                elif os.path.isdir(new_path):
+                    shutil.rmtree(new_path)
+                _renames(path, new_path)
+            except OSError as ex:
+                logger.error("Failed to restore %s", new_path)
+                logger.debug("Exception: %s", ex)
+
+        self.commit()
+
+    @property
+    def can_rollback(self) -> bool:
+        return bool(self._moves)
+
+
+class UninstallPathSet:
+    """A set of file paths to be removed when uninstalling a distribution."""
+
+    def __init__(self, dist: metadata.Distribution, env_path: Path) -> None:
+        self._paths: set[str] = set()
+        self._refuse: set[str] = set()
+        # Read identifying metadata eagerly so log messages still work after
+        # remove() stashes the .dist-info directory.
+        self._dist_name = dist.name
+        self._dist_version = dist.metadata["Version"]
+        # Append os.sep so the startswith() check in _permitted() does not
+        # spuriously match a sibling directory whose name starts with env_path
+        # (e.g. env_path="/tmp/.venv" would otherwise match "/tmp/.venv-other").
+        self._env_prefix = _normalize_path(env_path) + os.sep
+        self._moved_paths = StashedUninstallPathSet()
+        # Create local cache of normalize_path results. Creating an UninstallPathSet
+        # can result in hundreds/thousands of redundant calls to normalize_path with
+        # the same args, which hurts performance.
+        self._normalize_path_cached = functools.lru_cache(_normalize_path)
+
+    @property
+    def paths(self) -> set[str]:
+        return self._paths
+
+    @property
+    def refused(self) -> set[str]:
+        return self._refuse
+
+    def _permitted(self, path: str) -> bool:
+        """Return True if ``path`` is inside the env prefix."""
+        return path.startswith(self._env_prefix)
+
+    def add(self, path: str | Path) -> None:
+        head, tail = os.path.split(path)
+
+        # We normalize the head to resolve parent directory symlinks, but not
+        # the tail, since we only want to uninstall symlinks, not their targets.
+        norm_path = os.path.join(
+            self._normalize_path_cached(head), os.path.normcase(tail)
+        )
+
+        if not os.path.exists(norm_path):
+            return
+        if self._permitted(norm_path):
+            self._paths.add(norm_path)
+        else:
+            self._refuse.add(norm_path)
+
+        # ``__pycache__`` entries may not exist until after RECORD is written.
+        if os.path.splitext(norm_path)[1] == ".py":
+            self.add(cache_from_source(norm_path))
+
+    def remove(self) -> None:
+        """Stash every path so the uninstall can be committed or rolled back."""
+        if not self._paths:
+            logger.warning(
+                "Cannot uninstall '%s'. No files were found to uninstall.",
+                self._dist_name,
+            )
+            return
+
+        logger.debug("Uninstalling %s %s.", self._dist_name, self._dist_version)
+
+        moved = self._moved_paths
+        for_rename = compress_for_rename(self._paths)
+
+        for path in sorted(compact(for_rename)):
+            moved.stash(path)
+            logger.debug("Removing file or directory %s", path)
+
+        logger.debug(
+            "Successfully uninstalled %s %s", self._dist_name, self._dist_version
+        )
+
+    def rollback(self) -> None:
+        """Undo a prior remove()."""
+        if not self._moved_paths.can_rollback:
+            logger.error(
+                "Cannot roll back %s; was not uninstalled",
+                self._dist_name,
+            )
+            return
+        logger.info("Rolling back uninstall of %s", self._dist_name)
+        self._moved_paths.rollback()
+
+    def commit(self) -> None:
+        """Finalize the uninstall; rollback will no longer be possible."""
+        self._moved_paths.commit()
+
+
+def uninstall_distribution(env: Env, package_name: str) -> UninstallPathSet | None:
+    """Uninstall ``package_name`` from ``env``.
+
+    Returns the pathset (the caller is responsible for calling ``.commit()``
+    or ``.rollback()``), or ``None`` if the package is not installed.
+    """
+    dist = next(iter(env.site_packages.distributions(name=package_name)), None)
+
+    if dist is None:
+        logger.warning("Skipping %s as it is not installed.", package_name)
+        return None
+
+    logger.debug("Found existing installation: %s", package_name)
+
+    dist_info_path: Path = dist._path  # type: ignore[attr-defined]
+    dist_parent = dist_info_path.parent
+
+    if not is_relative_to(dist_parent, env.path):
+        logger.error(
+            "Not uninstalling %s at %s, outside environment %s",
+            dist.name,
+            dist_parent,
+            env.path,
+        )
+        return None
+
+    stdlib_paths = {
+        Path(p) for p in {env.paths.get("stdlib"), env.paths.get("platstdlib")} if p
+    }
+    if dist_parent in stdlib_paths:
+        logger.error(
+            "Not uninstalling %s at %s, as it is in the standard library.",
+            dist.name,
+            dist_parent,
+        )
+        return None
+
+    dist_files = dist.files
+    if dist_files is None:
+        logger.error(
+            "Cannot uninstall %s: RECORD file is missing or unreadable.",
+            dist.name,
+        )
+        return None
+
+    path_set = UninstallPathSet(dist, env.path)
+    for path in _uninstallation_paths(dist_files, dist_parent):
+        path_set.add(path)
+
+    path_set.remove()
+
+    return path_set

--- a/src/poetry/installation/uninstaller.py
+++ b/src/poetry/installation/uninstaller.py
@@ -173,25 +173,6 @@ def _uninstallation_paths(
             yield os.path.join(dn, base + ".pyo")
 
 
-def compact(paths: Iterable[str]) -> set[str]:
-    """Compact a path set to contain the minimal number of paths
-    necessary to contain all paths in the set. If /a/path/ and
-    /a/path/to/a/file.txt are both in the set, leave only the
-    shorter path."""
-
-    sep = os.path.sep
-    short_paths: set[str] = set()
-    for path in sorted(paths, key=len):
-        should_skip = any(
-            path.startswith(shortpath.rstrip("*"))
-            and path[len(shortpath.rstrip("*").rstrip(sep))] == sep
-            for shortpath in short_paths
-        )
-        if not should_skip:
-            short_paths.add(path)
-    return short_paths
-
-
 def compress_for_rename(paths: Iterable[str]) -> set[str]:
     """Returns a set containing the paths that need to be renamed.
 
@@ -221,6 +202,7 @@ def compress_for_rename(paths: Iterable[str]) -> set[str]:
         # for the directory.
         if not (all_files - remaining):
             remaining.difference_update(all_files)
+            remaining.difference_update(all_subdirs)
             wildcards.add(root + os.sep)
 
     return set(map(case_map.__getitem__, remaining)) | wildcards
@@ -395,7 +377,7 @@ class UninstallPathSet:
         moved = self._moved_paths
         for_rename = compress_for_rename(self._paths)
 
-        for path in sorted(compact(for_rename)):
+        for path in sorted(for_rename):
             moved.stash(path)
             logger.debug("Removing file or directory %s", path)
 

--- a/tests/console/commands/test_config.py
+++ b/tests/console/commands/test_config.py
@@ -66,6 +66,7 @@ def test_list_displays_default_value_if_not_set(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
+installer.builtin-uninstall = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -104,6 +105,7 @@ def test_list_displays_set_get_setting(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
+installer.builtin-uninstall = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -163,6 +165,7 @@ def test_unset_setting(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
+installer.builtin-uninstall = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -200,6 +203,7 @@ def test_unset_repo_setting(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
+installer.builtin-uninstall = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -384,6 +388,7 @@ def test_list_displays_set_get_local_setting(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
+installer.builtin-uninstall = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null
@@ -430,6 +435,7 @@ def test_list_must_not_display_sources_from_pyproject_toml(
     venv_path = json.dumps(os.path.join("{cache-dir}", "virtualenvs"))
     expected = f"""cache-dir = {cache_dir}
 data-dir = {data_dir}
+installer.builtin-uninstall = false
 installer.max-workers = null
 installer.no-binary = null
 installer.only-binary = null

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1960,3 +1960,60 @@ def test_executor_no_supported_hash_types(
     assert return_code == 1, f"\noutput: {output}\nerror: {error}\n"
     assert "No usable hash type(s) for demo" in output
     assert "hash_blah:1234567890abcdefghijklmnopqrstyzwxyz" in output
+
+
+def test_executor_remove_uses_run_pip_by_default(
+    config: Config,
+    pool: RepositoryPool,
+    io: BufferedIO,
+    env: MockEnv,
+) -> None:
+    executor = Executor(env, pool, config, io)
+    package = Package("attrs", "17.4.0")
+
+    assert executor._remove(package) == 0
+    assert len(env.executed) == 1
+    assert env.executed[0][-3:] == ["uninstall", "attrs", "-y"]
+
+
+def test_executor_remove_uses_builtin_when_enabled(
+    config: Config,
+    pool: RepositoryPool,
+    io: BufferedIO,
+    env: MockEnv,
+    mocker: MockerFixture,
+) -> None:
+    config.merge({"installer": {"builtin-uninstall": True}})
+    fake_pathset = mocker.MagicMock()
+    uninstall_mock = mocker.patch(
+        "poetry.installation.executor.uninstall_distribution",
+        return_value=fake_pathset,
+    )
+
+    executor = Executor(env, pool, config, io)
+    package = Package("attrs", "17.4.0")
+
+    assert executor._remove(package) == 0
+    assert env.executed == []
+    uninstall_mock.assert_called_once_with(env, "attrs")
+    fake_pathset.commit.assert_called_once()
+
+
+def test_executor_remove_builtin_skips_when_not_installed(
+    config: Config,
+    pool: RepositoryPool,
+    io: BufferedIO,
+    env: MockEnv,
+    mocker: MockerFixture,
+) -> None:
+    config.merge({"installer": {"builtin-uninstall": True}})
+    mocker.patch(
+        "poetry.installation.executor.uninstall_distribution",
+        return_value=None,
+    )
+
+    executor = Executor(env, pool, config, io)
+    package = Package("ghost", "1.0.0")
+
+    assert executor._remove(package) == 0
+    assert env.executed == []

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -29,6 +29,7 @@ from poetry.installation.executor import Executor
 from poetry.installation.operations import Install
 from poetry.installation.operations import Uninstall
 from poetry.installation.operations import Update
+from poetry.installation.uninstaller import UninstallPathSet
 from poetry.installation.wheel_installer import WheelInstaller
 from poetry.repositories.repository_pool import RepositoryPool
 from poetry.utils.cache import ArtifactCache
@@ -2017,3 +2018,123 @@ def test_executor_remove_builtin_skips_when_not_installed(
 
     assert executor._remove(package) == 0
     assert env.executed == []
+
+
+def _make_update_op(tmp_path: Path) -> Update:
+    initial = Package(
+        "demo",
+        "1.0.0",
+        source_type="file",
+        source_url=str(tmp_path / "demo-1.0.0-py3-none-any.whl"),
+    )
+    target = Package(
+        "demo",
+        "2.0.0",
+        source_type="file",
+        source_url=str(tmp_path / "demo-2.0.0-py3-none-any.whl"),
+    )
+    return Update(initial, target)
+
+
+def test_update_commits_uninstall_when_install_succeeds(
+    config: Config,
+    pool: RepositoryPool,
+    io: BufferedIO,
+    env: MockEnv,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    config.merge({"installer": {"builtin-uninstall": True}})
+    fake_pathset = mocker.MagicMock(spec=UninstallPathSet)
+    mocker.patch(
+        "poetry.installation.executor.uninstall_distribution",
+        return_value=fake_pathset,
+    )
+    mocker.patch.object(WheelInstaller, "install")
+    fake_archive = tmp_path / "demo-2.0.0-py3-none-any.whl"
+    fake_archive.write_bytes(b"")
+    mocker.patch.object(Executor, "_prepare_archive", return_value=fake_archive)
+
+    executor = Executor(env, pool, config, io)
+    assert executor._install(_make_update_op(tmp_path)) == 0
+
+    fake_pathset.commit.assert_called_once()
+    fake_pathset.rollback.assert_not_called()
+
+
+def test_update_rolls_back_uninstall_when_install_fails(
+    config: Config,
+    pool: RepositoryPool,
+    io: BufferedIO,
+    env: MockEnv,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    config.merge({"installer": {"builtin-uninstall": True}})
+    fake_pathset = mocker.MagicMock(spec=UninstallPathSet)
+    mocker.patch(
+        "poetry.installation.executor.uninstall_distribution",
+        return_value=fake_pathset,
+    )
+    mocker.patch.object(
+        WheelInstaller, "install", side_effect=RuntimeError("install blew up")
+    )
+    fake_archive = tmp_path / "demo-2.0.0-py3-none-any.whl"
+    fake_archive.write_bytes(b"")
+    mocker.patch.object(Executor, "_prepare_archive", return_value=fake_archive)
+
+    executor = Executor(env, pool, config, io)
+    with pytest.raises(RuntimeError, match="install blew up"):
+        executor._install(_make_update_op(tmp_path))
+
+    fake_pathset.rollback.assert_called_once()
+    fake_pathset.commit.assert_not_called()
+
+
+def test_update_propagates_pip_uninstall_interrupt(
+    config: Config,
+    pool: RepositoryPool,
+    io: BufferedIO,
+    env: MockEnv,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    # pip path; pip uninstall is interrupted (-2). _install must surface
+    # that code without attempting the subsequent wheel install.
+    mocker.patch.object(Executor, "run_pip", return_value=-2)
+    wheel_install = mocker.patch.object(WheelInstaller, "install")
+    fake_archive = tmp_path / "demo-2.0.0-py3-none-any.whl"
+    fake_archive.write_bytes(b"")
+    mocker.patch.object(Executor, "_prepare_archive", return_value=fake_archive)
+
+    executor = Executor(env, pool, config, io)
+    assert executor._install(_make_update_op(tmp_path)) == -2
+    wheel_install.assert_not_called()
+
+
+def test_update_does_not_attempt_rollback_with_pip_path(
+    config: Config,
+    pool: RepositoryPool,
+    io: BufferedIO,
+    env: MockEnv,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    # Default config: builtin-uninstall is False, so _uninstall returns None and
+    # there is no pathset to roll back. The original failure must still propagate.
+    uninstall_mock = mocker.patch("poetry.installation.executor.uninstall_distribution")
+    mocker.patch.object(
+        WheelInstaller, "install", side_effect=RuntimeError("install blew up")
+    )
+    fake_archive = tmp_path / "demo-2.0.0-py3-none-any.whl"
+    fake_archive.write_bytes(b"")
+    mocker.patch.object(Executor, "_prepare_archive", return_value=fake_archive)
+
+    executor = Executor(env, pool, config, io)
+    with pytest.raises(RuntimeError, match="install blew up"):
+        executor._install(_make_update_op(tmp_path))
+
+    # builtin uninstaller must not be involved on the pip path
+    uninstall_mock.assert_not_called()
+    # pip uninstall was invoked for the initial version
+    assert any(cmd[-3:] == ["uninstall", "demo", "-y"] for cmd in env.executed)

--- a/tests/installation/test_uninstaller.py
+++ b/tests/installation/test_uninstaller.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import csv
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from poetry.installation.uninstaller import StashedUninstallPathSet
+from poetry.installation.uninstaller import UninstallPathSet
+from poetry.installation.uninstaller import _normalize_path
+from poetry.installation.uninstaller import _uninstallation_paths
+from poetry.installation.uninstaller import compact
+from poetry.installation.uninstaller import compress_for_rename
+from poetry.installation.uninstaller import uninstall_distribution
+from poetry.utils.env import MockEnv
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _make_env(tmp_path: Path) -> MockEnv:
+    env_path = tmp_path / "env"
+    env_path.mkdir()
+    purelib = env_path / "purelib"
+    purelib.mkdir()
+    scripts = env_path / "scripts"
+    scripts.mkdir()
+    env = MockEnv(path=env_path, is_venv=True, sys_path=[str(purelib)])
+    env.paths["purelib"] = str(purelib)
+    env.paths["platlib"] = str(purelib)
+    env.paths["scripts"] = str(scripts)
+    env.set_paths()
+    return env
+
+
+def _install_fake_distribution(
+    env: MockEnv,
+    name: str = "demo",
+    version: str = "1.0.0",
+    *,
+    with_script: bool = True,
+    extra_files: list[tuple[str, str]] | None = None,
+) -> tuple[Path, list[Path]]:
+    """Create a fake installed distribution under env's purelib.
+
+    Returns ``(dist_info_dir, installed_paths)``.
+    """
+    purelib = Path(env.paths["purelib"])
+    scripts = Path(env.paths["scripts"])
+
+    pkg_dir = purelib / name
+    pkg_dir.mkdir()
+    init_py = pkg_dir / "__init__.py"
+    init_py.write_text(f"# {name}\n", encoding="utf-8")
+    module_py = pkg_dir / "module.py"
+    module_py.write_text("x = 1\n", encoding="utf-8")
+
+    dist_info = purelib / f"{name}-{version}.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n", encoding="utf-8"
+    )
+    (dist_info / "INSTALLER").write_text("Poetry\n", encoding="utf-8")
+
+    installed: list[Path] = [init_py, module_py]
+    record_rows = [
+        (f"{name}/__init__.py", "", ""),
+        (f"{name}/module.py", "", ""),
+        (f"{name}-{version}.dist-info/METADATA", "", ""),
+        (f"{name}-{version}.dist-info/INSTALLER", "", ""),
+    ]
+
+    if with_script:
+        script_path = scripts / f"{name}-cli"
+        script_path.write_text("#!/usr/bin/env python\nprint('hi')\n", encoding="utf-8")
+        installed.append(script_path)
+        entry_points = dist_info / "entry_points.txt"
+        entry_points.write_text(
+            f"[console_scripts]\n{name}-cli = {name}.module:main\n", encoding="utf-8"
+        )
+        record_rows.append((f"{name}-{version}.dist-info/entry_points.txt", "", ""))
+        record_rows.append((f"../scripts/{name}-cli", "", ""))
+
+    if extra_files:
+        for relpath, content in extra_files:
+            target = purelib / relpath
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+            installed.append(target)
+            record_rows.append((relpath, "", ""))
+
+    record_path = dist_info / "RECORD"
+    with record_path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        for row in record_rows:
+            writer.writerow(row)
+        writer.writerow((f"{name}-{version}.dist-info/RECORD", "", ""))
+
+    installed.append(dist_info)
+    return dist_info, installed
+
+
+def test_uninstall_distribution_removes_files(tmp_path: Path) -> None:
+    env = _make_env(tmp_path)
+    dist_info, installed = _install_fake_distribution(env)
+
+    pathset = uninstall_distribution(env, "demo")
+    assert pathset is not None
+    pathset.commit()
+
+    for path in installed:
+        assert not path.exists(), f"{path} should have been removed"
+    assert not dist_info.exists()
+
+
+def test_uninstall_distribution_returns_none_when_missing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    env = _make_env(tmp_path)
+    pathset = uninstall_distribution(env, "ghost")
+    assert pathset is None
+    assert any("ghost" in record.message for record in caplog.records)
+
+
+def test_uninstall_distribution_refuses_dist_outside_env(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Build a normal env, then point purelib at a location outside env.path so
+    # the discovered dist fails the env-prefix guard in uninstall_distribution.
+    env = _make_env(tmp_path)
+    elsewhere = tmp_path / "elsewhere" / "site-packages"
+    elsewhere.mkdir(parents=True)
+    env.paths["purelib"] = str(elsewhere)
+    env.paths["platlib"] = str(elsewhere)
+
+    dist_info, installed = _install_fake_distribution(env, with_script=False)
+
+    pathset = uninstall_distribution(env, "demo")
+
+    assert pathset is None
+    assert dist_info.exists()
+    for path in installed:
+        assert path.exists()
+    assert any("outside environment" in r.message for r in caplog.records)
+
+
+def test_uninstall_distribution_refuses_dist_in_stdlib(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    env = _make_env(tmp_path)
+    dist_info, installed = _install_fake_distribution(env, with_script=False)
+    # Make the stdlib guard trip by claiming purelib IS the stdlib.
+    env.paths["stdlib"] = env.paths["purelib"]
+
+    pathset = uninstall_distribution(env, "demo")
+
+    assert pathset is None
+    assert dist_info.exists()
+    for path in installed:
+        assert path.exists()
+    assert any("standard library" in r.message for r in caplog.records)
+
+
+def test_uninstall_distribution_refuses_dist_without_record(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    env = _make_env(tmp_path)
+    dist_info, installed = _install_fake_distribution(env, with_script=False)
+    # Remove RECORD so importlib.metadata reports dist.files as None.
+    (dist_info / "RECORD").unlink()
+
+    pathset = uninstall_distribution(env, "demo")
+
+    assert pathset is None
+    assert dist_info.exists()
+    for path in installed:
+        assert path.exists()
+    assert any("RECORD file is missing" in r.message for r in caplog.records)
+
+
+def test_uninstall_distribution_does_not_match_prefix_sibling(
+    tmp_path: Path,
+) -> None:
+    # env.path = "<tmp>/env"; a sibling directory "<tmp>/env-sibling/..."
+    # must not be treated as inside the env just because its absolute path
+    # startswith env.path. Exercises the os.sep guard in _permitted().
+    env = _make_env(tmp_path)
+    _install_fake_distribution(env, with_script=False)
+
+    # Create a sibling directory next to env.path that shares a name prefix.
+    sibling_root = env.path.with_name(env.path.name + "-sibling")
+    sibling_root.mkdir()
+    stray = sibling_root / "stray.py"
+    stray.write_text("# outside, but env.path is a prefix string\n", encoding="utf-8")
+
+    dist = next(iter(env.site_packages.distributions(name="demo")))
+    pathset = UninstallPathSet(dist, env.path)
+    pathset.add(str(stray))
+
+    # The sibling-path must be refused, not added for removal.
+    assert not any(str(stray) in p for p in pathset.paths)
+    assert pathset.refused == {_normalize_path(stray)}
+
+
+def test_uninstall_distribution_collects_console_script(tmp_path: Path) -> None:
+    env = _make_env(tmp_path)
+    _install_fake_distribution(env, with_script=True)
+
+    pathset = uninstall_distribution(env, "demo")
+    assert pathset is not None
+
+    scripts_dir = env.paths["scripts"]
+    assert any(p.startswith(_normalize_path(scripts_dir)) for p in pathset.paths)
+
+    pathset.commit()
+    assert not (Path(scripts_dir) / "demo-cli").exists()
+
+
+def test_rollback_restores_files(tmp_path: Path) -> None:
+    env = _make_env(tmp_path)
+    _, installed = _install_fake_distribution(env)
+
+    pathset = uninstall_distribution(env, "demo")
+    assert pathset is not None
+
+    for path in installed:
+        if path.is_file():
+            assert not path.exists()
+
+    pathset.rollback()
+
+    for path in installed:
+        assert path.exists(), f"{path} should have been restored"
+
+
+def test_refuses_paths_outside_env_prefix(tmp_path: Path) -> None:
+    env = _make_env(tmp_path)
+    _install_fake_distribution(env)
+
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "stray.py"
+    outside_file.write_text("# outside\n", encoding="utf-8")
+
+    dist = next(iter(env.site_packages.distributions(name="demo")))
+    dist_parent = dist._path.parent  # type: ignore[attr-defined]
+    pathset = UninstallPathSet(dist, env.path)
+    for path in _uninstallation_paths(dist.files, dist_parent):
+        pathset.add(path)
+    pathset.add(str(outside_file))
+
+    assert all("demo" in p for p in pathset.paths)
+    assert pathset.refused == {_normalize_path(outside_file)}
+
+    pathset.remove()
+    pathset.commit()
+    assert outside_file.exists(), "files outside the env prefix must not be removed"
+
+
+def test_compact_keeps_only_shortest_paths() -> None:
+    paths = {_normalize_path(p) for p in {"/a/b", "/a/b/c", "/a/b/c/d", "/a/e"}}
+    expected = {_normalize_path(p) for p in {"/a/b", "/a/e"}}
+    assert compact(paths) == expected
+
+
+def test_stashed_path_set_stashes_and_rolls_back_individual_file(
+    tmp_path: Path,
+) -> None:
+    # When stashing a regular file (not a whole directory), stash() goes
+    # through _get_file_stash, which allocates a TempDirectory per parent
+    # and computes a relpath inside it. A second file under the same parent
+    # reuses the previously-allocated TempDirectory (the break branch in
+    # _get_file_stash). Verify the round-trip for both.
+    target_dir = tmp_path / "site"
+    target_dir.mkdir()
+    file_a = target_dir / "a.txt"
+    file_a.write_text("AAA", encoding="utf-8")
+    file_b = target_dir / "b.txt"
+    file_b.write_text("BBB", encoding="utf-8")
+    sibling = target_dir / "sibling.txt"
+    sibling.write_text("untouched", encoding="utf-8")
+
+    stashed = StashedUninstallPathSet()
+    new_path_a = stashed.stash(str(file_a))
+    new_path_b = stashed.stash(str(file_b))
+
+    assert not file_a.exists()
+    assert not file_b.exists()
+    assert Path(new_path_a).read_text() == "AAA"
+    assert Path(new_path_b).read_text() == "BBB"
+    # Both files share the same stash root (the existing save_dir is reused).
+    assert Path(new_path_a).parent == Path(new_path_b).parent
+    # Stashing files must not touch unrelated siblings in the same directory.
+    assert sibling.exists()
+    assert sibling.read_text() == "untouched"
+    assert stashed.can_rollback
+
+    stashed.rollback()
+
+    assert file_a.exists() and file_a.read_text() == "AAA"
+    assert file_b.exists() and file_b.read_text() == "BBB"
+    assert sibling.exists()
+    assert not stashed.can_rollback
+
+
+def test_compress_for_rename_collapses_full_directory(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    f1 = pkg / "a.py"
+    f1.touch()
+    f2 = pkg / "b.py"
+    f2.touch()
+
+    result = compress_for_rename([str(f1), str(f2)])
+    assert any(r.rstrip("/\\").endswith("pkg") for r in result)

--- a/tests/installation/test_uninstaller.py
+++ b/tests/installation/test_uninstaller.py
@@ -262,6 +262,7 @@ def test_refuses_paths_outside_env_prefix(tmp_path: Path) -> None:
     dist = next(iter(env.site_packages.distributions(name="demo")))
     dist_parent = dist._path.parent  # type: ignore[attr-defined]
     pathset = UninstallPathSet(dist, env.path)
+    assert dist.files
     for path in _uninstallation_paths(dist.files, dist_parent):
         pathset.add(path)
     pathset.add(str(outside_file))

--- a/tests/installation/test_uninstaller.py
+++ b/tests/installation/test_uninstaller.py
@@ -3,20 +3,17 @@ from __future__ import annotations
 import csv
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+import pytest
 
 from poetry.installation.uninstaller import StashedUninstallPathSet
 from poetry.installation.uninstaller import UninstallPathSet
 from poetry.installation.uninstaller import _normalize_path
 from poetry.installation.uninstaller import _uninstallation_paths
-from poetry.installation.uninstaller import compact
 from poetry.installation.uninstaller import compress_for_rename
 from poetry.installation.uninstaller import uninstall_distribution
+from poetry.utils._compat import WINDOWS
 from poetry.utils.env import MockEnv
-
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def _make_env(tmp_path: Path) -> MockEnv:
@@ -41,6 +38,7 @@ def _install_fake_distribution(
     *,
     with_script: bool = True,
     extra_files: list[tuple[str, str]] | None = None,
+    extra_symlinked_dirs: list[str] | None = None,
 ) -> tuple[Path, list[Path]]:
     """Create a fake installed distribution under env's purelib.
 
@@ -88,6 +86,24 @@ def _install_fake_distribution(
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(content, encoding="utf-8")
             installed.append(target)
+            record_rows.append((relpath, "", ""))
+
+    if extra_symlinked_dirs:
+        link_target = purelib / f"{name}-symlink-target"
+        link_target.mkdir(exist_ok=True)
+        for relpath in extra_symlinked_dirs:
+            link = purelib / relpath
+            link.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                link.symlink_to(link_target, target_is_directory=True)
+            except OSError:
+                if WINDOWS:
+                    pytest.skip(
+                        "Symlink creation requires privileges or developer mode"
+                        " on Windows."
+                    )
+                raise
+            installed.append(link)
             record_rows.append((relpath, "", ""))
 
     record_path = dist_info / "RECORD"
@@ -258,10 +274,33 @@ def test_refuses_paths_outside_env_prefix(tmp_path: Path) -> None:
     assert outside_file.exists(), "files outside the env prefix must not be removed"
 
 
-def test_compact_keeps_only_shortest_paths() -> None:
-    paths = {_normalize_path(p) for p in {"/a/b", "/a/b/c", "/a/b/c/d", "/a/e"}}
-    expected = {_normalize_path(p) for p in {"/a/b", "/a/e"}}
-    assert compact(paths) == expected
+def test_uninstall_distribution_with_symlinked_directory(tmp_path: Path) -> None:
+    # A RECORD that lists a symlink to a directory is what makes subtracting
+    # all_subdirs in compress_for_rename() relevant.
+    # Without it, remove() stashes the whole package dir first and then
+    # raises FileNotFoundError trying to stash the now-missing symlink.
+    env = _make_env(tmp_path)
+    _, installed = _install_fake_distribution(
+        env, with_script=False, extra_symlinked_dirs=["demo/datalink"]
+    )
+
+    purelib = Path(env.paths["purelib"])
+    link = purelib / "demo" / "datalink"
+    link_target = purelib / "demo-symlink-target"
+    assert link.is_symlink()
+    assert link_target.is_dir()
+
+    pathset = uninstall_distribution(env, "demo")
+    assert pathset is not None
+    pathset.commit()
+
+    assert not (purelib / "demo").exists()
+    assert not link.exists()
+    for path in installed:
+        assert not path.exists(), f"{path} should have been removed"
+    # The symlink is removed, but its target directory must be left untouched —
+    # the uninstaller removes links, not the things they point at.
+    assert link_target.is_dir()
 
 
 def test_stashed_path_set_stashes_and_rolls_back_individual_file(


### PR DESCRIPTION
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Introduce a builtin uninstaller (adapted from pip's code) so that we do not have to run a pip subprocess for each uninstall. This makes uninstalls (and updates) faster. The new builtin uninstaller is not used by default. You have to set `installer.builtin-uninstall` to use it. (We can switch it later and remove the setting even later, just as we did with `installer.modern-installation`.)

The second commit makes use of the rollback mechanism in case of an error. Further, it fixes an issue in the legacy pip path where the return code of pip is not checked.
