### PR TITLE
perf: cache supported wheel tags set

### DIFF
--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -80,6 +80,7 @@ class Env(ABC):
 
         self._site_packages: SitePackages | None = None
         self._supported_tags: list[Tag] | None = None
+        self._supported_tags_set: set[Tag] | None = None
         self._purelib: Path | None = None
         self._platlib: Path | None = None
         self._script_dirs: list[Path] | None = None
@@ -358,6 +359,13 @@ class Env(ABC):
             self._supported_tags = self.get_supported_tags()
 
         return self._supported_tags
+
+    @property
+    def supported_tags_set(self) -> set[Tag]:
+        if self._supported_tags_set is None:
+            self._supported_tags_set = set(self.supported_tags)
+
+        return self._supported_tags_set
 
     @classmethod
     def get_base_prefix(cls) -> Path:

--- a/src/poetry/utils/env/mock_env.py
+++ b/src/poetry/utils/env/mock_env.py
@@ -41,6 +41,8 @@ class MockEnv(NullEnv):
         self._sys_path = sys_path
         self._mock_marker_env = marker_env
         self._supported_tags = supported_tags
+        # _supported_tags_set should not be set at this point.
+        # We reset it after setting _supported_tags just to be sure.
         self._supported_tags_set = None
 
     @property

--- a/src/poetry/utils/env/mock_env.py
+++ b/src/poetry/utils/env/mock_env.py
@@ -41,6 +41,7 @@ class MockEnv(NullEnv):
         self._sys_path = sys_path
         self._mock_marker_env = marker_env
         self._supported_tags = supported_tags
+        self._supported_tags_set = None
 
     @property
     def platform(self) -> str:

--- a/src/poetry/utils/wheel.py
+++ b/src/poetry/utils/wheel.py
@@ -44,4 +44,4 @@ class Wheel:
         return min(indexes) if indexes else None
 
     def is_supported_by_environment(self, env: Env) -> bool:
-        return bool(set(env.supported_tags).intersection(self.tags))
+        return not self.tags.isdisjoint(env.supported_tags_set)

--- a/tests/utils/test_wheel.py
+++ b/tests/utils/test_wheel.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from packaging.tags import Tag
+
+from poetry.utils.env import MockEnv
+from poetry.utils.wheel import Wheel
+
+
+@pytest.mark.parametrize(
+    ("filename", "supported_tags", "expected"),
+    [
+        ("demo-1.0.0-py3-none-any.whl", [Tag("py3", "none", "any")], True),
+        ("demo-1.0.0-cp312-cp312-win_amd64.whl", [Tag("py3", "none", "any")], False),
+        ("demo-1.0.0-py3-none-any.whl", [], False),
+        (
+            "demo-1.0.0-py3-none-any.whl",
+            [Tag("cp310", "none", "any"), Tag("py3", "none", "any")],
+            True,
+        ),
+    ],
+)
+def test_wheel_is_supported_by_environment(
+    filename: str, supported_tags: list[Tag], expected: bool
+) -> None:
+    env = MockEnv(supported_tags=supported_tags)
+
+    assert Wheel(filename).is_supported_by_environment(env) is expected
+
+
+def test_env_supported_tags_set_is_cached() -> None:
+    env = MockEnv(supported_tags=[Tag("py3", "none", "any")])
+
+    assert env.supported_tags_set == set(env.supported_tags)
+    assert env.supported_tags_set is env.supported_tags_set


### PR DESCRIPTION
`Wheel.is_supported_by_environment()` currently builds `set(env.supported_tags)` for every wheel candidate. Real environments can expose more than a thousand supported tags, and chooser sorting/checking can call this repeatedly while selecting installation candidates.

This keeps the existing supported tag list and adds a cached set on the environment, so wheel compatibility checks can test the small wheel tag set against that cached set.

A small local benchmark over `packaging.tags.sys_tags()` on this machine:

```text
hit_first: old=0.482923s new=0.000166s speedup=2904.3x
hit_late: old=0.379382s new=0.000160s speedup=2376.5x
miss_one: old=0.446329s new=0.000184s speedup=2426.1x
miss_many: old=0.362172s new=0.001444s speedup=250.8x
```

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code. N/A, no user-facing behavior change.

Local checks:

```bash
PYTHONPATH=src uv run --with pytest --with pytest-xdist --with responses --with pytest-mock python -m pytest tests/utils/test_wheel.py tests/installation/test_chooser.py -q
uv run --with ruff python -m ruff check src/poetry/utils/env/base_env.py src/poetry/utils/env/mock_env.py src/poetry/utils/wheel.py tests/utils/test_wheel.py
uv run --with ruff python -m ruff format --check src/poetry/utils/env/base_env.py src/poetry/utils/env/mock_env.py src/poetry/utils/wheel.py tests/utils/test_wheel.py
PYTHONPATH=src uv run --with poetry-core --with packaging --with mypy python -m mypy src/poetry/utils/env/base_env.py src/poetry/utils/env/mock_env.py src/poetry/utils/wheel.py
git diff --check
```
