### PR TITLE
perf: fast path single-token repository search

### DIFF
--- a/src/poetry/repositories/link_sources/base.py
+++ b/src/poetry/repositories/link_sources/base.py
@@ -145,11 +145,12 @@ class SimpleRepositoryRootPage:
     """
 
     def search(self, query: str | list[str]) -> list[str]:
-        results: list[str] = []
-        tokens = query if isinstance(query, list) else [query]
+        if isinstance(query, str):
+            return [name for name in self.package_names if query in name]
 
+        results: list[str] = []
         for name in self.package_names:
-            if any(token in name for token in tokens):
+            if any(token in name for token in query):
                 results.append(name)
 
         return results

--- a/src/poetry/repositories/link_sources/base.py
+++ b/src/poetry/repositories/link_sources/base.py
@@ -146,14 +146,14 @@ class SimpleRepositoryRootPage:
 
     def search(self, query: str | list[str]) -> list[str]:
         if isinstance(query, str):
+            # performance shortcut
+            # We could also create a list from query and use the more general code below,
+            # but this is a common case that we can optimize for.
             return [name for name in self.package_names if query in name]
 
-        results: list[str] = []
-        for name in self.package_names:
-            if any(token in name for token in query):
-                results.append(name)
-
-        return results
+        return [
+            name for name in self.package_names if any(token in name for token in query)
+        ]
 
     @cached_property
     def package_names(self) -> list[str]:

--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -74,11 +74,12 @@ class Repository(AbstractRepository):
         self._packages.append(package)
 
     def search(self, query: str | list[str]) -> list[Package]:
-        results: list[Package] = []
-        tokens = query if isinstance(query, list) else [query]
+        if isinstance(query, str):
+            return [package for package in self.packages if query in package.name]
 
+        results: list[Package] = []
         for package in self.packages:
-            if any(token in package.name for token in tokens):
+            if any(token in package.name for token in query):
                 results.append(package)
 
         return results

--- a/src/poetry/repositories/repository.py
+++ b/src/poetry/repositories/repository.py
@@ -75,14 +75,16 @@ class Repository(AbstractRepository):
 
     def search(self, query: str | list[str]) -> list[Package]:
         if isinstance(query, str):
+            # performance shortcut
+            # We could also create a list from query and use the more general code below,
+            # but this is a common case that we can optimize for.
             return [package for package in self.packages if query in package.name]
 
-        results: list[Package] = []
-        for package in self.packages:
-            if any(token in package.name for token in query):
-                results.append(package)
-
-        return results
+        return [
+            package
+            for package in self.packages
+            if any(token in package.name for token in query)
+        ]
 
     def _find_packages(
         self, name: NormalizedName, constraint: VersionConstraint

--- a/tests/repositories/test_repository.py
+++ b/tests/repositories/test_repository.py
@@ -108,4 +108,5 @@ def test_search() -> None:
 
     assert repo.search("foo") == [package_foo1, package_foo2, package_foobar]
     assert repo.search("bar") == [package_foobar]
+    assert repo.search(["foo", "bar"]) == [package_foo1, package_foo2, package_foobar]
     assert repo.search("nothing") == []


### PR DESCRIPTION
`Repository.search()` and simple root-page search commonly receive a single string token from `poetry search`, but both paths currently wrap it in a one-item list and run `any(...)` for every package name.

This keeps list-query behavior unchanged and adds a direct string path for the common case.

A small local benchmark over 10,003 package names:

```text
old 1.351595s
new 0.141769s
speedup=9.5x
```

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code. N/A, no user-facing behavior change.

Local checks:

```bash
PYTHONPATH=src uv run --with pytest --with pytest-xdist --with responses --with pytest-mock python -m pytest tests/repositories/test_repository.py tests/repositories/link_sources/test_base.py tests/repositories/test_repository_pool.py -q
uv run --with ruff python -m ruff check src/poetry/repositories/repository.py src/poetry/repositories/link_sources/base.py tests/repositories/test_repository.py
uv run --with ruff python -m ruff format --check src/poetry/repositories/repository.py src/poetry/repositories/link_sources/base.py tests/repositories/test_repository.py
PYTHONPATH=src uv run --with poetry-core --with packaging --with mypy python -m mypy src/poetry/repositories/repository.py src/poetry/repositories/link_sources/base.py
git diff --check
```
