### PR TITLE
fix(add): include pyproject.toml path in "already present" message

### DIFF
--- a/src/poetry/console/commands/add.py
+++ b/src/poetry/console/commands/add.py
@@ -443,8 +443,8 @@ The add command adds required packages to your <comment>pyproject.toml</> and in
 
     def notify_about_existing_packages(self, existing_packages: list[str]) -> None:
         self.line(
-            "The following packages are already present in the pyproject.toml and will"
-            " be skipped:\n"
+            f"The following packages are already present in the pyproject.toml"
+            f" (<c2>{self.poetry.file.path}</c2>) and will be skipped:\n"
         )
         for name in existing_packages:
             self.line(f"  - <c1>{name}</c1>")

--- a/tests/console/commands/self/test_add_plugins.py
+++ b/tests/console/commands/self/test_add_plugins.py
@@ -203,8 +203,8 @@ poetry-plugin = "^1.2.3"
 
     assert isinstance(tester.command, AddCommand)
     expected = f"""\
-The following packages are already present in the pyproject.toml and will be\
- skipped:
+The following packages are already present in the pyproject.toml\
+ ({tester.command.poetry.file.path}) and will be skipped:
 
   - poetry-plugin
 {tester.command._hint_update_packages}

--- a/tests/console/commands/test_add.py
+++ b/tests/console/commands/test_add.py
@@ -1416,8 +1416,9 @@ def test_add_should_skip_when_adding_existing_package_with_no_constraint(
     repo.add_package(get_package("foo", "1.1.2"))
     tester.execute("foo")
 
-    expected = """\
-The following packages are already present in the pyproject.toml and will be skipped:
+    expected = f"""\
+The following packages are already present in the pyproject.toml\
+ ({app.poetry.file.path}) and will be skipped:
 
   - foo
 
@@ -1447,8 +1448,9 @@ def test_add_should_skip_when_adding_canonicalized_existing_package_with_no_cons
     repo.add_package(get_package("foo-bar", "1.1.2"))
     tester.execute("Foo_Bar")
 
-    expected = """\
-The following packages are already present in the pyproject.toml and will be skipped:
+    expected = f"""\
+The following packages are already present in the pyproject.toml\
+ ({app.poetry.file.path}) and will be skipped:
 
   - Foo_Bar
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10179

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

The "already present in the pyproject.toml and will be skipped" notice doesn't say _which_ `pyproject.toml`. With `poetry self add`, a poetry-managed project next to your own, or any non-cwd invocation, you have to go grep for the file.

`notify_about_existing_packages` now includes `self.poetry.file.path` in the message, styled with the same `<c2>` markup the `add` command uses elsewhere for paths. The two assertions in `tests/console/commands/test_add.py` were updated to interpolate the fixture's path.