### PR TITLE
fix(init): validate version constraint in interactive prompt

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -382,7 +382,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                         "(or leave blank to use the latest version):"
                     )
                     question.set_max_attempts(3)
-                    question.set_validator(lambda x: (x or "").strip() or None)
+                    question.set_validator(self._validate_version_constraint)
 
                     package_constraint = self.ask(question)
 
@@ -520,6 +520,21 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             raise ValueError("Invalid package definition.")
 
         return package
+
+    @staticmethod
+    def _validate_version_constraint(constraint: str | None) -> str | None:
+        from poetry.core.constraints.version import parse_constraint
+
+        constraint = (constraint or "").strip() or None
+        if constraint is None:
+            return None
+
+        try:
+            parse_constraint(constraint)
+        except ValueError as e:
+            raise ValueError(f"Invalid version constraint: {constraint}") from e
+
+        return constraint
 
     def _get_pool(self) -> RepositoryPool:
         from poetry.config.config import Config

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -525,8 +525,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
     def _validate_version_constraint(constraint: str | None) -> str | None:
         from poetry.core.constraints.version import parse_constraint
 
-        constraint = (constraint or "").strip() or None
-        if constraint is None:
+        constraint = (constraint or "").strip()
+        if not constraint:
             return None
 
         try:

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1017,6 +1017,38 @@ def test_validate_package_invalid(name: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("constraint", "expected"),
+    [
+        ("^1.0", "^1.0"),
+        ("  ^1.0 ", "^1.0"),
+        ("==1.2.3", "==1.2.3"),
+        (">=1,<2", ">=1,<2"),
+        ("", None),
+        (None, None),
+        ("   ", None),
+    ],
+)
+def test_validate_version_constraint_accepts_valid_inputs(
+    constraint: str | None, expected: str | None
+) -> None:
+    assert InitCommand._validate_version_constraint(constraint) == expected
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        "latest",
+        "isort",
+        "==1.,",
+        "not-a-version",
+    ],
+)
+def test_validate_version_constraint_rejects_invalid_inputs(invalid: str) -> None:
+    with pytest.raises(ValueError, match="Invalid version constraint"):
+        InitCommand._validate_version_constraint(invalid)
+
+
+@pytest.mark.parametrize(
     "author",
     [
         str(b"Jos\x65\xcc\x81 Duarte", "utf-8"),
@@ -1217,35 +1249,3 @@ def test_init_does_not_add_readme_key_when_readme_missing(
     # Assert
     pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
     assert "readme =" not in pyproject
-
-
-@pytest.mark.parametrize(
-    ("constraint", "expected"),
-    [
-        ("^1.0", "^1.0"),
-        ("  ^1.0 ", "^1.0"),
-        ("==1.2.3", "==1.2.3"),
-        (">=1,<2", ">=1,<2"),
-        ("", None),
-        (None, None),
-        ("   ", None),
-    ],
-)
-def test_validate_version_constraint_accepts_valid_inputs(
-    constraint: str | None, expected: str | None
-) -> None:
-    assert InitCommand._validate_version_constraint(constraint) == expected
-
-
-@pytest.mark.parametrize(
-    "invalid",
-    [
-        "latest",
-        "isort",
-        "==1.,",
-        "not-a-version",
-    ],
-)
-def test_validate_version_constraint_rejects_invalid_inputs(invalid: str) -> None:
-    with pytest.raises(ValueError, match="Invalid version constraint"):
-        InitCommand._validate_version_constraint(invalid)

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1223,6 +1223,7 @@ def test_init_does_not_add_readme_key_when_readme_missing(
     ("constraint", "expected"),
     [
         ("^1.0", "^1.0"),
+        ("  ^1.0 ", "^1.0"),
         ("==1.2.3", "==1.2.3"),
         (">=1,<2", ">=1,<2"),
         ("", None),

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1217,3 +1217,34 @@ def test_init_does_not_add_readme_key_when_readme_missing(
     # Assert
     pyproject = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
     assert "readme =" not in pyproject
+
+
+@pytest.mark.parametrize(
+    ("constraint", "expected"),
+    [
+        ("^1.0", "^1.0"),
+        ("==1.2.3", "==1.2.3"),
+        (">=1,<2", ">=1,<2"),
+        ("", None),
+        (None, None),
+        ("   ", None),
+    ],
+)
+def test_validate_version_constraint_accepts_valid_inputs(
+    constraint: str | None, expected: str | None
+) -> None:
+    assert InitCommand._validate_version_constraint(constraint) == expected
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        "latest",
+        "isort",
+        "==1.,",
+        "not-a-version",
+    ],
+)
+def test_validate_version_constraint_rejects_invalid_inputs(invalid: str) -> None:
+    with pytest.raises(ValueError, match="Invalid version constraint"):
+        InitCommand._validate_version_constraint(invalid)


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8797

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

The version-constraint prompt in `poetry init` (and `poetry add -i`) only stripped whitespace, so invalid PEP 440 strings like `latest`, `1.0,!2.0`, or `==1.,` were accepted and written verbatim into `pyproject.toml`. The error only surfaced at the next `poetry lock` / `install`.

The validator now calls `poetry-core`'s `parse_constraint` and raises `ValueError("Invalid version constraint: <value>")` on failure, chained from the underlying parser error via `from e`. The existing `set_max_attempts(3)` re-prompts the user. Same pattern as `_validate_author` / `_validate_package` in the same file. Blank input still returns `None` (skip).

Hard rejection (vs the reporter's suggestion of "ask for confirmation") was chosen for consistency with the two other validators in `init.py`. Tests in `tests/console/commands/test_init.py` cover valid, invalid, and blank inputs.