### PR TITLE
Support bare local file paths in dependency parsing

### DIFF
--- a/src/poetry/utils/dependency_specification.py
+++ b/src/poetry/utils/dependency_specification.py
@@ -71,12 +71,11 @@ class RequirementsParser:
 
     def parse(self, requirement: str) -> DependencySpec:
         requirement = requirement.strip()
+        is_explicit_path = os.path.sep in requirement or "/" in requirement
+        is_archive_file = requirement.lower().endswith(PACKAGE_ARCHIVE_EXTENSIONS)
+        is_path_like = is_explicit_path or is_archive_file
 
-        if (
-            os.path.sep not in requirement
-            and "/" not in requirement
-            and requirement.lower().endswith(PACKAGE_ARCHIVE_EXTENSIONS)
-        ):
+        if not is_explicit_path and is_archive_file:
             specification = self._parse_path(requirement)
             if specification is not None:
                 return specification
@@ -92,11 +91,10 @@ class RequirementsParser:
             extras = [e.strip() for e in extras_m.group(1).split(",")]
             requirement, _ = requirement.split("[")
 
-        specification = (
-            self._parse_url(requirement)
-            or self._parse_path(requirement)
-            or self._parse_simple(requirement)
-        )
+        specification = self._parse_url(requirement)
+        if specification is None and is_path_like:
+            specification = self._parse_path(requirement)
+        specification = specification or self._parse_simple(requirement)
 
         if specification:
             if extras:

--- a/src/poetry/utils/dependency_specification.py
+++ b/src/poetry/utils/dependency_specification.py
@@ -27,6 +27,7 @@ DependencySpec = dict[str, str | bool | dict[str, str | bool] | list[str]]
 BaseSpec = TypeVar("BaseSpec", DependencySpec, InlineTable)
 
 GIT_URL_SCHEMES = {"git+http", "git+https", "git+ssh"}
+PACKAGE_ARCHIVE_EXTENSIONS = (".whl", ".tar.gz", ".tar.bz2", ".tar.xz", ".zip")
 
 
 def dependency_to_specification(
@@ -71,7 +72,11 @@ class RequirementsParser:
     def parse(self, requirement: str) -> DependencySpec:
         requirement = requirement.strip()
 
-        if os.path.sep not in requirement and "/" not in requirement:
+        if (
+            os.path.sep not in requirement
+            and "/" not in requirement
+            and requirement.lower().endswith(PACKAGE_ARCHIVE_EXTENSIONS)
+        ):
             specification = self._parse_path(requirement)
             if specification is not None:
                 return specification
@@ -162,14 +167,11 @@ class RequirementsParser:
         relative_path = self._cwd.joinpath(requirement)
         is_explicit_path = os.path.sep in requirement or "/" in requirement
         is_relative_path = relative_path.exists()
-        is_relative_file = is_relative_path and relative_path.is_file()
-        is_absolute_path = path.exists() and path.is_absolute()
+        is_absolute_path = path.is_absolute() and path.exists()
 
         if (
-            (is_explicit_path and is_relative_path)
-            or is_relative_file
-            or is_absolute_path
-        ):
+            is_relative_path and (is_explicit_path or relative_path.is_file())
+        ) or is_absolute_path:
             is_absolute = path.is_absolute()
 
             if not path.is_absolute():

--- a/src/poetry/utils/dependency_specification.py
+++ b/src/poetry/utils/dependency_specification.py
@@ -71,6 +71,11 @@ class RequirementsParser:
     def parse(self, requirement: str) -> DependencySpec:
         requirement = requirement.strip()
 
+        if os.path.sep not in requirement and "/" not in requirement:
+            specification = self._parse_path(requirement)
+            if specification is not None:
+                return specification
+
         specification = self._parse_pep508(requirement)
 
         if specification is not None:
@@ -153,18 +158,22 @@ class RequirementsParser:
         return None
 
     def _parse_path(self, requirement: str) -> DependencySpec | None:
-        if (os.path.sep in requirement or "/" in requirement) and (
-            self._cwd.joinpath(requirement).exists()
-            or (
-                Path(requirement).expanduser().exists()
-                and Path(requirement).expanduser().is_absolute()
-            )
+        path = Path(requirement).expanduser()
+        relative_path = self._cwd.joinpath(requirement)
+        is_explicit_path = os.path.sep in requirement or "/" in requirement
+        is_relative_path = relative_path.exists()
+        is_relative_file = is_relative_path and relative_path.is_file()
+        is_absolute_path = path.exists() and path.is_absolute()
+
+        if (
+            (is_explicit_path and is_relative_path)
+            or is_relative_file
+            or is_absolute_path
         ):
-            path = Path(requirement).expanduser()
             is_absolute = path.is_absolute()
 
             if not path.is_absolute():
-                path = self._cwd.joinpath(requirement)
+                path = relative_path
 
             if path.is_file():
                 package = self._direct_origin.get_package_from_file(path.resolve())

--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -209,3 +209,15 @@ def test_parse_bare_local_file_dependency(
         "name": "demo",
         "path": path.name,
     }
+
+
+def test_parse_bare_package_name_does_not_check_path(
+    mocker: MockerFixture,
+    artifact_cache: ArtifactCache,
+) -> None:
+    exists = mocker.patch("pathlib.Path.exists")
+
+    assert RequirementsParser(artifact_cache=artifact_cache).parse("demo") == {
+        "name": "demo"
+    }
+    exists.assert_not_called()

--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -215,9 +215,8 @@ def test_parse_bare_package_name_does_not_check_path(
     mocker: MockerFixture,
     artifact_cache: ArtifactCache,
 ) -> None:
-    exists = mocker.patch("pathlib.Path.exists")
+    parser = RequirementsParser(artifact_cache=artifact_cache)
+    parse_path = mocker.patch.object(parser, "_parse_path", wraps=parser._parse_path)
 
-    assert RequirementsParser(artifact_cache=artifact_cache).parse("demo") == {
-        "name": "demo"
-    }
-    exists.assert_not_called()
+    assert parser.parse("demo") == {"name": "demo"}
+    parse_path.assert_not_called()

--- a/tests/utils/test_dependency_specification.py
+++ b/tests/utils/test_dependency_specification.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     from poetry.utils.cache import ArtifactCache
     from poetry.utils.dependency_specification import DependencySpec
+    from tests.types import FixtureDirGetter
 
 
 @pytest.mark.parametrize(
@@ -190,3 +191,21 @@ def test_parse_dependency_specification(
         )
         for specification in expected_variants
     )
+
+
+def test_parse_bare_local_file_dependency(
+    tmp_path: Path,
+    fixture_dir: FixtureDirGetter,
+    artifact_cache: ArtifactCache,
+) -> None:
+    source = fixture_dir("distributions") / "demo-0.1.2-py2.py3-none-any.whl"
+    path = tmp_path / source.name
+    path.write_bytes(source.read_bytes())
+
+    assert RequirementsParser(
+        artifact_cache=artifact_cache,
+        cwd=tmp_path,
+    ).parse(path.name) == {
+        "name": "demo",
+        "path": path.name,
+    }


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6951

## Summary
- accept an existing local file like `demo.whl` as a path dependency even when the argument has no directory separator
- keep separator-less directory names on the simple-package path, so this only broadens the file case reported in the issue
- add a regression test for a bare local wheel filename

## Validation
- Not run locally

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.