### PR TITLE
Fix contributing guide label links

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -111,8 +111,7 @@ constantly evolving, and this means that sometimes our documentation has gaps. Y
 editing the existing content to be more accessible, or creating new content such as tutorials, FAQs, etc.
 
 {{% note %}}
-GitHub [Discussions](https://github.com/python-poetry/poetry/discussions) and the
-[kind/question label](https://github.com/python-poetry/poetry/labels/kind/question) are excellent sources for FAQ
+GitHub [Discussions] and the [kind/question label] are excellent sources for FAQ
 candidates.
 {{% /note %}}
 
@@ -265,8 +264,8 @@ pipx install --suffix @pr1234 git+https://github.com/python-poetry/poetry.git@re
   [Documentation]: {{< ref "/docs" >}}
   [FAQ]: {{< relref "faq" >}}
   [Issue Tracker]: https://github.com/python-poetry/poetry/issues
-  [area/docs label]: https://github.com/python-poetry/poetry/labels/area/docs
-  [kind/question label]: https://github.com/python-poetry/poetry/labels/kind/question
+  [area/docs label]: https://github.com/python-poetry/poetry/labels/area%2Fdocs
+  [kind/question label]: https://github.com/python-poetry/poetry/labels/kind%2Fquestion
   [Issue Template]: https://github.com/python-poetry/poetry/issues/new/choose
   [Discussions]: https://github.com/python-poetry/poetry/discussions
   [Discord]: https://discord.com/invite/awxPgve

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -111,7 +111,8 @@ constantly evolving, and this means that sometimes our documentation has gaps. Y
 editing the existing content to be more accessible, or creating new content such as tutorials, FAQs, etc.
 
 {{% note %}}
-GitHub [Discussions] and the [kind/question label] are excellent sources for FAQ
+GitHub [Discussions](https://github.com/python-poetry/poetry/discussions) and the
+[kind/question label](https://github.com/python-poetry/poetry/labels/kind%2Fquestion) are excellent sources for FAQ
 candidates.
 {{% /note %}}
 
@@ -265,7 +266,6 @@ pipx install --suffix @pr1234 git+https://github.com/python-poetry/poetry.git@re
   [FAQ]: {{< relref "faq" >}}
   [Issue Tracker]: https://github.com/python-poetry/poetry/issues
   [area/docs label]: https://github.com/python-poetry/poetry/labels/area%2Fdocs
-  [kind/question label]: https://github.com/python-poetry/poetry/labels/kind%2Fquestion
   [Issue Template]: https://github.com/python-poetry/poetry/issues/new/choose
   [Discussions]: https://github.com/python-poetry/poetry/discussions
   [Discord]: https://discord.com/invite/awxPgve


### PR DESCRIPTION
## Summary

Fix the contributing guide links for the `kind/question` and `area/docs` GitHub labels.

The label names contain `/`, so the label URLs need `%2F` encoding. The `kind/question` link is kept inline inside the note shortcode so the generated website can render it correctly.

Fixes #10765.

## Validation

- `git diff --check HEAD~1..HEAD`
- GitHub API metadata checked for `kind%2Fquestion` and `area%2Fdocs`
- Remote checks green on `af9f0b1`: `Detect changed files`, `Status`, `Tests / FreeBSD Status`, `pre-commit.ci - pr`, and `Sourcery review`
- Full test matrix skipped as docs-only; `Documentation Preview` skipped on the follow-up push