### PR TITLE
test: add unit tests for `CommandLoader.register_factory`

### DIFF
--- a/tests/console/test_command_loader.py
+++ b/tests/console/test_command_loader.py
@@ -25,19 +25,11 @@ def test_register_factory_adds_new_command() -> None:
     assert isinstance(loader.get("dummy"), _DummyCommand)
 
 
-def test_register_factory_raises_on_duplicate() -> None:
+def test_register_factory_rejects_duplicate() -> None:
     loader = CommandLoader({"dummy": _DummyCommand})
 
-    with pytest.raises(CleoLogicError) as exc_info:
+    with pytest.raises(CleoLogicError, match="dummy"):
         loader.register_factory("dummy", _OtherCommand)
 
-    assert "dummy" in str(exc_info.value)
-
-
-def test_register_factory_does_not_overwrite_on_duplicate() -> None:
-    loader = CommandLoader({"dummy": _DummyCommand})
-
-    with pytest.raises(CleoLogicError):
-        loader.register_factory("dummy", _OtherCommand)
-
+    # The originally registered factory must not have been replaced.
     assert isinstance(loader.get("dummy"), _DummyCommand)

--- a/tests/console/test_command_loader.py
+++ b/tests/console/test_command_loader.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from cleo.commands.command import Command
+from cleo.exceptions import CleoLogicError
+
+from poetry.console.command_loader import CommandLoader
+
+
+class _DummyCommand(Command):
+    name = "dummy"
+
+
+class _OtherCommand(Command):
+    name = "other"
+
+
+def test_register_factory_adds_new_command() -> None:
+    loader = CommandLoader({})
+
+    loader.register_factory("dummy", _DummyCommand)
+
+    assert loader.has("dummy")
+    assert isinstance(loader.get("dummy"), _DummyCommand)
+
+
+def test_register_factory_raises_on_duplicate() -> None:
+    loader = CommandLoader({"dummy": _DummyCommand})
+
+    with pytest.raises(CleoLogicError) as exc_info:
+        loader.register_factory("dummy", _OtherCommand)
+
+    assert "dummy" in str(exc_info.value)
+
+
+def test_register_factory_does_not_overwrite_on_duplicate() -> None:
+    loader = CommandLoader({"dummy": _DummyCommand})
+
+    with pytest.raises(CleoLogicError):
+        loader.register_factory("dummy", _OtherCommand)
+
+    assert isinstance(loader.get("dummy"), _DummyCommand)


### PR DESCRIPTION
## Summary
`CommandLoader.register_factory` enforces a uniqueness invariant on command
registration (raising `CleoLogicError` if a command name is already registered)
but had no direct unit tests. This PR adds three focused tests covering:

- successful registration of a new command name,
- the `CleoLogicError` raised when registering a duplicate name (and that the
  error message references the conflicting name),
- that the originally registered factory is preserved when a duplicate is
  rejected (no accidental partial overwrite).

No production code changes.

Relates-to: #3155