### PR TITLE
Use configured env for activation command

### DIFF
--- a/src/poetry/console/commands/env/activate.py
+++ b/src/poetry/console/commands/env/activate.py
@@ -25,14 +25,12 @@ class EnvActivateCommand(EnvCommand):
     description = "Print the command to activate a virtual environment."
 
     def handle(self) -> int:
-        env = self.env
-
         try:
             shell, _ = shellingham.detect_shell()
         except shellingham.ShellDetectionFailure:
             shell = ""
 
-        if command := self._get_activate_command(env, shell):
+        if command := self._get_activate_command(self.env, shell):
             self.line(command)
             return 0
 

--- a/src/poetry/console/commands/env/activate.py
+++ b/src/poetry/console/commands/env/activate.py
@@ -25,9 +25,7 @@ class EnvActivateCommand(EnvCommand):
     description = "Print the command to activate a virtual environment."
 
     def handle(self) -> int:
-        from poetry.utils.env import EnvManager
-
-        env = EnvManager(self.poetry).get()
+        env = self.env
 
         try:
             shell, _ = shellingham.detect_shell()

--- a/tests/console/commands/env/test_activate.py
+++ b/tests/console/commands/env/test_activate.py
@@ -19,8 +19,13 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def tester(command_tester_factory: CommandTesterFactory) -> CommandTester:
-    return command_tester_factory("env activate")
+def tester(
+    command_tester_factory: CommandTesterFactory, tmp_venv: VirtualEnv
+) -> CommandTester:
+    tester = command_tester_factory("env activate")
+    assert isinstance(tester.command, EnvActivateCommand)
+    tester.command.set_env(tmp_venv)
+    return tester
 
 
 @pytest.mark.parametrize(
@@ -44,8 +49,6 @@ def test_env_activate_prints_correct_script(
     ext: str,
 ) -> None:
     mocker.patch("shellingham.detect_shell", return_value=(shell, None))
-    assert isinstance(tester.command, EnvActivateCommand)
-    tester.command.set_env(tmp_venv)
 
     if WINDOWS and shell in {"csh", "tcsh"}:
         with pytest.raises(ShellNotSupportedError):
@@ -76,8 +79,6 @@ def test_env_activate_prints_correct_script_for_windows_shells(
     ext: str,
 ) -> None:
     mocker.patch("shellingham.detect_shell", return_value=(shell, None))
-    assert isinstance(tester.command, EnvActivateCommand)
-    tester.command.set_env(tmp_venv)
 
     tester.execute()
 
@@ -113,8 +114,6 @@ def test_env_activate_uses_configured_environment(
         "poetry.utils.env.EnvManager.get",
         side_effect=AssertionError("env activate should use the configured env"),
     )
-    assert isinstance(tester.command, EnvActivateCommand)
-    tester.command.set_env(tmp_venv)
 
     tester.execute()
 

--- a/tests/console/commands/env/test_activate.py
+++ b/tests/console/commands/env/test_activate.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poetry.console.commands.env.activate import EnvActivateCommand
 from poetry.console.commands.env.activate import ShellNotSupportedError
 from poetry.utils._compat import WINDOWS
 
@@ -43,7 +44,8 @@ def test_env_activate_prints_correct_script(
     ext: str,
 ) -> None:
     mocker.patch("shellingham.detect_shell", return_value=(shell, None))
-    mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
+    assert isinstance(tester.command, EnvActivateCommand)
+    tester.command.set_env(tmp_venv)
 
     if WINDOWS and shell in {"csh", "tcsh"}:
         with pytest.raises(ShellNotSupportedError):
@@ -74,7 +76,8 @@ def test_env_activate_prints_correct_script_for_windows_shells(
     ext: str,
 ) -> None:
     mocker.patch("shellingham.detect_shell", return_value=(shell, None))
-    mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
+    assert isinstance(tester.command, EnvActivateCommand)
+    tester.command.set_env(tmp_venv)
 
     tester.execute()
 
@@ -91,10 +94,30 @@ def test_no_additional_output_in_verbose_mode(
     verbosity: str,
 ) -> None:
     mocker.patch("shellingham.detect_shell", return_value=("pwsh", None))
-    mocker.patch("poetry.utils.env.EnvManager.get", return_value=tmp_venv)
+    mocker.patch("poetry.utils.env.EnvManager.create_venv", return_value=tmp_venv)
 
     # use an AppTester instead of a CommandTester to catch additional output
     app_tester.execute(f"env activate {verbosity}")
 
     lines = app_tester.io.fetch_output().splitlines()
     assert len(lines) == 1
+
+
+def test_env_activate_uses_configured_environment(
+    tmp_venv: VirtualEnv,
+    mocker: MockerFixture,
+    tester: CommandTester,
+) -> None:
+    mocker.patch("shellingham.detect_shell", return_value=("bash", None))
+    get_env = mocker.patch(
+        "poetry.utils.env.EnvManager.get",
+        side_effect=AssertionError("env activate should use the configured env"),
+    )
+    assert isinstance(tester.command, EnvActivateCommand)
+    tester.command.set_env(tmp_venv)
+
+    tester.execute()
+
+    assert not get_env.called
+    line = tester.io.fetch_output().rstrip("\n")
+    assert line == f"source {tmp_venv.bin_dir.as_posix()}/activate"


### PR DESCRIPTION
Resolves: #10423

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

`env activate` now uses the environment selected during command setup instead of resolving a fresh environment. This preserves the compatible virtualenv chosen when the active Python does not satisfy the project constraint, and avoids looking at the incompatible active `VIRTUAL_ENV` again.

Tests:
- `./.bootstrap-venv/bin/python -m pytest tests/console/commands/env/test_activate.py -q`
- `UV_CACHE_DIR=$PWD/.uv-cache uvx ruff==0.15.12 check src/poetry/console/commands/env/activate.py tests/console/commands/env/test_activate.py`
- `UV_CACHE_DIR=$PWD/.uv-cache uvx ruff==0.15.12 format --check src/poetry/console/commands/env/activate.py tests/console/commands/env/test_activate.py`
- `git diff --check`