### PR TITLE
Resolve relative direct URLs for local sources

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -922,7 +922,7 @@ class Executor:
 
         assert package.source_url is not None
         return {
-            "url": Path(package.source_url).as_uri(),
+            "url": self._path_to_file_url(package.source_url),
             "archive_info": archive_info,
         }
 
@@ -934,9 +934,17 @@ class Executor:
 
         assert package.source_url is not None
         return {
-            "url": Path(package.source_url).as_uri(),
+            "url": self._path_to_file_url(package.source_url),
             "dir_info": dir_info,
         }
+
+    @staticmethod
+    def _path_to_file_url(path: str) -> str:
+        source = Path(path)
+        if not source.is_absolute():
+            source = source.resolve()
+
+        return source.as_uri()
 
     def _get_archive_info(self, package: Package) -> dict[str, Any]:
         """

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -166,6 +166,13 @@ def pool(pypi_repository: PyPiRepository) -> RepositoryPool:
 
 
 @pytest.fixture
+def executor(
+    env: MockEnv, pool: RepositoryPool, config: Config, io: BufferedIO
+) -> Executor:
+    return Executor(env, pool, config, io)
+
+
+@pytest.fixture
 def copy_wheel(tmp_path: Path, fixture_dir: FixtureDirGetter) -> Callable[[], Path]:
     def _copy_wheel() -> Path:
         tmp_name = tempfile.mktemp()
@@ -950,15 +957,12 @@ def test_executor_should_write_pep610_url_references_for_directories(
 
 
 def test_executor_should_create_pep610_url_reference_for_relative_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, executor: Executor
 ) -> None:
     source = tmp_path / "source"
     source.mkdir()
-    monkeypatch.chdir(tmp_path)
 
     package = Package("demo", "0.1.2", source_type="directory", source_url="source")
-
-    executor = object.__new__(Executor)
 
     assert executor._create_directory_url_reference(package) == {
         "dir_info": {},
@@ -967,16 +971,12 @@ def test_executor_should_create_pep610_url_reference_for_relative_directory(
 
 
 def test_executor_should_create_pep610_url_reference_for_relative_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, executor: Executor
 ) -> None:
     source = tmp_path / "source.tar.gz"
     source.write_bytes(b"archive")
-    monkeypatch.chdir(tmp_path)
 
     package = Package("demo", "0.1.2", source_type="file", source_url="source.tar.gz")
-
-    executor = object.__new__(Executor)
-    executor._hashes = {}
 
     assert executor._create_file_url_reference(package) == {
         "archive_info": {},

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -966,6 +966,24 @@ def test_executor_should_create_pep610_url_reference_for_relative_directory(
     }
 
 
+def test_executor_should_create_pep610_url_reference_for_relative_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.tar.gz"
+    source.write_bytes(b"archive")
+    monkeypatch.chdir(tmp_path)
+
+    package = Package("demo", "0.1.2", source_type="file", source_url="source.tar.gz")
+
+    executor = object.__new__(Executor)
+    executor._hashes = {}
+
+    assert executor._create_file_url_reference(package) == {
+        "archive_info": {},
+        "url": source.as_uri(),
+    }
+
+
 def test_executor_should_write_pep610_url_references_for_editable_directories(
     tmp_venv: VirtualEnv,
     pool: RepositoryPool,

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -949,6 +949,23 @@ def test_executor_should_write_pep610_url_references_for_directories(
     assert not prepare_spy.spy_return.exists(), "archive not cleaned up"
 
 
+def test_executor_should_create_pep610_url_reference_for_relative_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    package = Package("demo", "0.1.2", source_type="directory", source_url="source")
+
+    executor = object.__new__(Executor)
+
+    assert executor._create_directory_url_reference(package) == {
+        "dir_info": {},
+        "url": source.as_uri(),
+    }
+
+
 def test_executor_should_write_pep610_url_references_for_editable_directories(
     tmp_venv: VirtualEnv,
     pool: RepositoryPool,


### PR DESCRIPTION
Resolves: #10830

When Poetry writes PEP 610 `direct_url.json` metadata for local directory or file sources, it now resolves relative source paths before converting them to file URIs. This avoids `Path.as_uri()` raising for relative paths such as repositories cloned under a relative virtualenvs path.

Added a regression test for relative directory source URLs and kept the existing file/directory direct-url behavior covered.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.