### PR TITLE
Document package sources for self update

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -898,9 +898,8 @@ and this [discussion](https://discuss.python.org/t/fastly-interfering-with-pypi-
 The `self` namespace groups subcommands to manage the Poetry installation itself.
 
 {{% note %}}
-Use of these commands will create the required `pyproject.toml` and `poetry.lock` files in your
-[configuration directory]({{< relref "configuration#config-directory" >}}). The `pyproject.toml`
-file is the system project used by `poetry self` commands.
+Use of these commands will create the required `pyproject.toml` and `poetry.lock` files
+for Poetry's runtime environment in your [configuration directory]({{< relref "configuration" >}}).
 {{% /note %}}
 
 {{% warning %}}
@@ -917,8 +916,8 @@ also be used to upgrade Poetry's own dependencies or inject additional packages 
 environment
 
 {{% note %}}
-The `self add` command works exactly like the [`add` command](#add). However, is different in that the packages
-managed are for Poetry's runtime environment.
+The `self add` command works exactly like the [`add` command](#add).
+However, it is different in that the packages managed are for Poetry's runtime environment.
 
 The package specification formats supported by the `self add` command are the same as the ones supported
 by the [`add` command](#add).
@@ -956,8 +955,8 @@ The `self install` command ensures all additional packages specified are install
 runtime environment.
 
 {{% note %}}
-The `self install` command works similar to the [`install` command](#install). However,
-it is different in that the packages managed are for Poetry's runtime environment.
+The `self install` command works similar to the [`install` command](#install).
+However, it is different in that the packages managed are for Poetry's runtime environment.
 {{% /note %}}
 
 ```bash
@@ -971,12 +970,9 @@ poetry self install
 
 ### self lock
 
-The `self lock` command reads this Poetry installation's system `pyproject.toml` file. The system
-dependencies are locked in the corresponding `poetry.lock` file.
-
-The system `pyproject.toml` file is stored as `pyproject.toml` in Poetry's
-[configuration directory]({{< relref "configuration#config-directory" >}}). Poetry creates it
-when a `self` command needs it, for example `self lock`, `self add`, or `self update`.
+The `self lock` command reads this Poetry installation's `pyproject.toml` file
+located in the [configuration directory]({{< relref "configuration" >}}).
+Poetry's own dependencies are locked in the corresponding `poetry.lock` file.
 
 ```bash
 poetry self lock
@@ -1033,8 +1029,8 @@ The `self sync` command ensures all additional (and no other) packages specified
 are installed in the current runtime environment.
 
 {{% note %}}
-The `self sync` command works similar to the [`sync` command](#sync). However,
-it is different in that the packages managed are for Poetry's runtime environment.
+The `self sync` command works similar to the [`sync` command](#sync).
+However, it is different in that the packages managed are for Poetry's runtime environment.
 {{% /note %}}
 
 ```bash
@@ -1050,20 +1046,22 @@ poetry self sync
 The `self update` command updates Poetry version in its current runtime environment.
 
 {{% note %}}
-The `self update` command works exactly like the [`update` command](#update). However,
-is different in that the packages managed are for Poetry's runtime environment.
+The `self update` command works exactly like the [`update` command](#update).
+However, it is different in that the packages managed are for Poetry's runtime environment.
 {{% /note %}}
-
-`self update` uses the package sources configured for Poetry's system project. To update Poetry
-from a custom package source, add a `[[tool.poetry.source]]` entry to the system `pyproject.toml`
-in Poetry's [configuration directory]({{< relref "configuration#config-directory" >}}) using the
-same format as [Package Sources]({{< relref "repositories/#package-sources" >}}). Sources configured
-in the current project's `pyproject.toml` do not affect `self update`. Poetry preserves existing
-`tool.poetry.source` entries when it regenerates this file.
 
 ```bash
 poetry self update
 ```
+
+{{% note %}}
+`self update` uses the package sources configured in Poetry's own `pyproject.toml` file,
+which is located in the [configuration directory]({{< relref "configuration" >}}).
+To update Poetry from a custom package source, add a `tool.poetry.source` entry using
+the format described in [Package Sources]({{< relref "repositories/#package-sources" >}}).
+Sources configured in the current project's `pyproject.toml` do not affect `self update`.
+Poetry preserves existing `tool.poetry.source` entries when it regenerates this file.
+{{% /note %}}
 
 #### Options
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -955,7 +955,7 @@ The `self install` command ensures all additional packages specified are install
 runtime environment.
 
 {{% note %}}
-The `self install` command works similar to the [`install` command](#install).
+The `self install` command works similarly to the [`install` command](#install).
 However, it is different in that the packages managed are for Poetry's runtime environment.
 {{% /note %}}
 
@@ -1029,7 +1029,7 @@ The `self sync` command ensures all additional (and no other) packages specified
 are installed in the current runtime environment.
 
 {{% note %}}
-The `self sync` command works similar to the [`sync` command](#sync).
+The `self sync` command works similarly to the [`sync` command](#sync).
 However, it is different in that the packages managed are for Poetry's runtime environment.
 {{% /note %}}
 
@@ -1043,7 +1043,8 @@ poetry self sync
 
 ### self update
 
-The `self update` command updates Poetry version in its current runtime environment.
+The `self update` command updates the Poetry version and its dependencies
+in its current runtime environment.
 
 {{% note %}}
 The `self update` command works exactly like the [`update` command](#update).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -899,7 +899,8 @@ The `self` namespace groups subcommands to manage the Poetry installation itself
 
 {{% note %}}
 Use of these commands will create the required `pyproject.toml` and `poetry.lock` files in your
-[configuration directory]({{< relref "configuration" >}}).
+[configuration directory]({{< relref "configuration#config-directory" >}}). The `pyproject.toml`
+file is the system project used by `poetry self` commands.
 {{% /note %}}
 
 {{% warning %}}
@@ -972,6 +973,10 @@ poetry self install
 
 The `self lock` command reads this Poetry installation's system `pyproject.toml` file. The system
 dependencies are locked in the corresponding `poetry.lock` file.
+
+The system `pyproject.toml` file is stored as `pyproject.toml` in Poetry's
+[configuration directory]({{< relref "configuration#config-directory" >}}). Poetry creates it
+when a `self` command needs it, for example `self lock`, `self add`, or `self update`.
 
 ```bash
 poetry self lock
@@ -1048,6 +1053,13 @@ The `self update` command updates Poetry version in its current runtime environm
 The `self update` command works exactly like the [`update` command](#update). However,
 is different in that the packages managed are for Poetry's runtime environment.
 {{% /note %}}
+
+`self update` uses the package sources configured for Poetry's system project. To update Poetry
+from a custom package source, add a `[[tool.poetry.source]]` entry to the system `pyproject.toml`
+in Poetry's [configuration directory]({{< relref "configuration#config-directory" >}}) using the
+same format as [Package Sources]({{< relref "repositories/#package-sources" >}}). Sources configured
+in the current project's `pyproject.toml` do not affect `self update`. Poetry preserves existing
+`tool.poetry.source` entries when it regenerates this file.
 
 ```bash
 poetry self update


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10633

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

Summary:
- Document that `poetry self` commands use a system `pyproject.toml` in Poetry's configuration directory.
- Clarify that `poetry self update` reads package sources from that system project, not from the current project's `pyproject.toml`.
- Link the `[[tool.poetry.source]]` format to the package sources documentation.

Validation:
- `git diff --check`
- `rg -n "system project|configuration#config-directory|repositories/#package-sources|tool\.poetry\.source|current project.*self update|preserves existing" docs\cli.md`

Not run locally: documentation build, tests, or pre-commit.
