### PR TITLE
feat(init): allow multiple `--author` flags for poetry init

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -39,7 +39,13 @@ class InitCommand(Command):
     options: ClassVar[list[Option]] = [
         option("name", None, "Name of the package.", flag=False),
         option("description", None, "Description of the package.", flag=False),
-        option("author", None, "Author name of the package.", flag=False),
+        option(
+            "author",
+            None,
+            "Author name of the package (repeatable for multiple authors).",
+            flag=False,
+            multiple=True,
+        ),
         option("python", None, "Compatible Python versions.", flag=False),
         option(
             "dependency",
@@ -148,21 +154,26 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if not description and is_interactive:
             description = self.ask(self.create_question("Description []: ", default=""))
 
-        author = self.option("author")
-        if not author and vcs_config.get("user.name"):
-            author = vcs_config["user.name"]
-            author_email = vcs_config.get("user.email")
-            if author_email:
-                author += f" <{author_email}>"
+        # --author can be repeated (multiple=True), so we get a tuple or empty tuple
+        authors = list(self.option("author"))
 
-        if is_interactive:
-            question = self.create_question(
-                f"Author [<comment>{author}</comment>, n to skip]: ", default=author
-            )
-            question.set_validator(lambda v: self._validate_author(v, author))
-            author = self.ask(question)
+        if not authors:
+            author = None
+            if vcs_config.get("user.name"):
+                author = vcs_config["user.name"]
+                author_email = vcs_config.get("user.email")
+                if author_email:
+                    author += f" <{author_email}>"
 
-        authors = [author] if author else []
+            if is_interactive:
+                question = self.create_question(
+                    f"Author [<comment>{author}</comment>, n to skip]: ", default=author
+                )
+                question.set_validator(lambda v: self._validate_author(v, author))
+                author = self.ask(question)
+
+            if author:
+                authors.append(author)
 
         license_name = self.option("license")
         if not license_name and is_interactive:
@@ -237,7 +248,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             name,
             version,
             description=description,
-            author=authors[0] if authors else None,
+            authors=authors or None,
             readme_format=readme_format,
             license=license_name,
             python=python,

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -65,7 +65,7 @@ class Layout:
         version: str = "0.1.0",
         description: str = "",
         readme_format: str = "md",
-        author: str | None = None,
+        authors: list[str] | None = None,
         license: str | None = None,
         python: str | None = None,
         dependencies: Mapping[str, str | Mapping[str, Any]] | None = None,
@@ -86,10 +86,10 @@ class Layout:
         self._dependencies = dependencies or {}
         self._dev_dependencies = dev_dependencies or {}
 
-        if not author:
-            author = "Your Name <you@example.com>"
+        if not authors:
+            authors = ["Your Name <you@example.com>"]
 
-        self._author = author
+        self._authors = authors
 
     @property
     def basedir(self) -> Path:
@@ -147,15 +147,16 @@ class Layout:
         project_content["name"] = self._project
         project_content["version"] = self._version
         project_content["description"] = self._description
-        m = AUTHOR_REGEX.match(self._author)
-        if m is None:
-            # This should not happen because author has been validated before.
-            raise ValueError(f"Invalid author: {self._author}")
-        else:
-            author = {"name": m.group("name")}
-            if email := m.group("email"):
-                author["email"] = email
-            project_content["authors"].append(author)
+        for raw_author in self._authors:
+            m = AUTHOR_REGEX.match(raw_author)
+            if m is None:
+                # This should not happen because author has been validated before.
+                raise ValueError(f"Invalid author: {raw_author}")
+            else:
+                author = {"name": m.group("name")}
+                if email := m.group("email"):
+                    author["email"] = email
+                project_content["authors"].append(author)
 
         if self._license:
             project_content["license"] = self._license

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1115,6 +1115,54 @@ def test_package_include(
     assert expected in tester.io.fetch_output()
 
 
+def test_init_command_allows_multiple_authors(
+    tester: CommandTester,
+) -> None:
+    inputs = [
+        "1.2.3",  # Version
+        "",  # Description
+        "n",  # Author (skip interactive)
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    tester.execute(
+        "--name my-package "
+        "--description 'Multi-author' "
+        "--author 'Alice <alice@example.com>' "
+        "--author 'Bob <bob@example.com>' "
+        "--python '>=3.8'",
+        inputs="\n".join(inputs),
+    )
+
+    output = tester.io.fetch_output()
+    assert '{name = "Alice",email = "alice@example.com"}' in output
+    assert '{name = "Bob",email = "bob@example.com"}' in output
+
+
+def test_init_command_single_author_still_works(
+    tester: CommandTester,
+) -> None:
+    inputs = [
+        "1.2.3",  # Version
+        "",  # Description
+        "n",  # Author (skip interactive)
+        "n",  # Interactive packages
+        "n",  # Interactive dev packages
+        "\n",  # Generate
+    ]
+
+    tester.execute(
+        "--name my-package "
+        "--author 'Charlie <charlie@example.com>'",
+        inputs="\n".join(inputs),
+    )
+
+    output = tester.io.fetch_output()
+    assert '{name = "Charlie",email = "charlie@example.com"}' in output
+
+
 @pytest.mark.parametrize(
     ["use_poetry_python", "python"],
     [


### PR DESCRIPTION
# Allow multiple \`--author\` flags for \`poetry init\`

Fixes [#8864](https://github.com/python-poetry/poetry/issues/8864)

## Problem

The \`--author\` flag on \`poetry init\` only accepted a single author. The \`pyproject.toml\` standard already supports \`authors\` as a list, but there was no way to set multiple authors from the CLI.

## Solution

Made \`--author\` repeatable (following the same pattern as \`--dependency\` and \`--dev-dependency\`):

```bash
poetry init --author "Alice <alice@example.com>" --author "Bob <bob@example.com>"
```

The interactive prompt still works for a single author when no CLI flags are provided.

## Changes

- **init.py**: Added \`multiple=True\` to the \`--author\` option, updated logic to collect authors into a list
- **layout.py**: Changed \`Layout.__init__\` from \`author: str | None\` to \`authors: list[str] | None\`, updated \`generate_project_template\` to iterate over all authors

## Backwards Compatibility

Fully backwards compatible. Single author usage is unchanged, and the default fallback (\`"Your Name <you@example.com>"\`) is preserved when no authors are provided.
