### PR TITLE
docs(cli): document how to configure a custom source for "self update"

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1053,6 +1053,19 @@ is different in that the packages managed are for Poetry's runtime environment.
 poetry self update
 ```
 
+#### Custom sources for self update
+
+Unlike the regular `update` command, `self update` does **not** use the `[[tool.poetry.source]]` entries in your project's `pyproject.toml`. Instead, it manages Poetry's own runtime environment using a separate `pyproject.toml` located at Poetry's configuration directory (usually `~/.config/pypoetry/pyproject.toml` on Linux/macOS or `%APPDATA%\pypoetry\pyproject.toml` on Windows).
+
+To use a private PyPI mirror or an internal index when updating Poetry itself, add your source to that file using `poetry self add` with a source specification, or edit the file directly. For example:
+
+```bash
+# Add a custom source to Poetry's own environment
+poetry self add --source my-mirror poetry
+```
+
+Alternatively, you can edit `~/.config/pypoetry/pyproject.toml` to add `[[tool.poetry.source]]` entries, just like in a regular project.
+
 #### Options
 
 * `--preview`: Allow the installation of pre-release versions.


### PR DESCRIPTION
## Summary

Addresses #10633.

Users in corporate or air-gapped environments cannot reach PyPI directly, so `poetry self update` fails without a way to specify a custom index. The documentation did not explain where or how to configure one.

## What was missing

`self update` manages Poetry's own runtime environment using a **separate** `pyproject.toml` in Poetry's config directory (e.g. `~/.config/pypoetry/pyproject.toml`), not the project's `pyproject.toml`. This is non-obvious and caused confusion.

## Change

Added a **"Custom sources for self update"** subsection under `### self update` that:

1. Explains that `self update` uses a separate `pyproject.toml` at Poetry's config directory.
2. Shows how to add a private source via `poetry self add --source`.
3. Mentions that the file can be edited directly like any other `pyproject.toml`.

## Test plan

- [ ] Render docs locally and verify the subsection appears correctly under `self update`