### PR TITLE
docs: update http links to https in documentation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -163,7 +163,7 @@ poetry run pytest --cov=src/poetry --cov-report term
 {{% /note %}}
 
 When you contribute to Poetry, automated tools will be run to make sure your code is suitable to be merged. Besides
-pytest, you will need to make sure your code typechecks properly using [mypy](http://mypy-lang.org/):
+pytest, you will need to make sure your code typechecks properly using [mypy](https://mypy-lang.org/):
 
 ```bash
 poetry run mypy

--- a/docs/pyproject.md
+++ b/docs/pyproject.md
@@ -333,7 +333,7 @@ Which are:
 - `C` - python module import path
 - `D` - the entry point of the plugin (a function or class)
 
-Example (from [`poetry-plugin-export`](http://github.com/python-poetry/poetry-plugin-export)):
+Example (from [`poetry-plugin-export`](https://github.com/python-poetry/poetry-plugin-export)):
 
 ```toml
 [project.entry-points."poetry.application.plugin"]
@@ -945,7 +945,7 @@ Which are:
 - `C` - python module import path
 - `D` - the entry point of the plugin (a function or class)
 
-Example (from [`poetry-plugin-export`](http://github.com/python-poetry/poetry-plugin-export)):
+Example (from [`poetry-plugin-export`](https://github.com/python-poetry/poetry-plugin-export)):
 
 ```toml
 [tool.poetry.plugins."poetry.application.plugin"]


### PR DESCRIPTION
## Summary

Update insecure `http://` links to `https://` in documentation files:

- **docs/pyproject.md**: Two references to `poetry-plugin-export` used `http://github.com` → changed to `https://github.com`
- **docs/contributing.md**: `mypy-lang.org` link used `http://` → changed to `https://`

Both `github.com` and `mypy-lang.org` enforce HTTPS and redirect HTTP to HTTPS, so this change eliminates unnecessary redirects and aligns with security best practices.

## Type of change

- [x] Documentation