### PR TITLE
fix(env): fail on incompatible Python without venv creation

### DIFF
--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -378,18 +378,27 @@ class EnvManager:
         if not env.is_sane():
             force = True
 
-        if env.is_venv() and not force:
+        supported_python = self._poetry.package.python_constraint
+        create_venv = self._poetry.config.get("virtualenvs.create")
+
+        if (env.is_venv() and not force) or not create_venv:
             # Already inside a virtualenv.
             current_python = Version.parse(
                 ".".join(str(c) for c in env.version_info[:3])
             )
-            if not self._poetry.package.python_constraint.allows(current_python):
+            if not supported_python.allows(current_python):
                 raise InvalidCurrentPythonVersionError(
-                    self._poetry.package.python_versions, str(current_python)
+                    self._poetry.package.python_versions,
+                    str(current_python),
+                    note=(
+                        'Please change python executable via the "env use" command.'
+                        if create_venv
+                        else "Poetry cannot switch to a compatible Python version because"
+                        " virtualenv creation is disabled."
+                    ),
                 )
             return env
 
-        create_venv = self._poetry.config.get("virtualenvs.create")
         in_project_venv = self.use_in_project_venv()
         venv_prompt = self._poetry.config.get("virtualenvs.prompt")
 
@@ -406,19 +415,6 @@ class EnvManager:
         )
         if not name:
             name = self._poetry.package.name
-
-        supported_python = self._poetry.package.python_constraint
-        if create_venv is False:
-            current_python = Version.parse(
-                ".".join(str(c) for c in env.version_info[:3])
-            )
-            if not supported_python.allows(current_python):
-                raise InvalidCurrentPythonVersionError(
-                    self._poetry.package.python_versions,
-                    str(current_python),
-                    "Poetry cannot switch to a compatible Python version because "
-                    "virtualenv creation is disabled.",
-                )
 
         if not supported_python.allows(python.patch_version):
             # The currently activated or chosen Python version

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -408,6 +408,18 @@ class EnvManager:
             name = self._poetry.package.name
 
         supported_python = self._poetry.package.python_constraint
+        if create_venv is False:
+            current_python = Version.parse(
+                ".".join(str(c) for c in env.version_info[:3])
+            )
+            if not supported_python.allows(current_python):
+                raise InvalidCurrentPythonVersionError(
+                    self._poetry.package.python_versions,
+                    str(current_python),
+                    "Poetry cannot switch to a compatible Python version because "
+                    "virtualenv creation is disabled.",
+                )
+
         if not supported_python.allows(python.patch_version):
             # The currently activated or chosen Python version
             # is not compatible with the Python constraint specified

--- a/src/poetry/utils/env/python/exceptions.py
+++ b/src/poetry/utils/env/python/exceptions.py
@@ -31,11 +31,13 @@ class NoCompatiblePythonVersionFoundError(PythonVersionError):
 
 
 class InvalidCurrentPythonVersionError(PythonVersionError):
-    def __init__(self, expected: str, given: str) -> None:
+    def __init__(self, expected: str, given: str, note: str | None = None) -> None:
         message = (
             f"Current Python version ({given}) "
             f"is not allowed by the project ({expected}).\n"
             'Please change python executable via the "env use" command.'
         )
+        if note is not None:
+            message = f"{message}\n{note}"
 
         super().__init__(message)

--- a/src/poetry/utils/env/python/exceptions.py
+++ b/src/poetry/utils/env/python/exceptions.py
@@ -34,8 +34,7 @@ class InvalidCurrentPythonVersionError(PythonVersionError):
     def __init__(self, expected: str, given: str, note: str | None = None) -> None:
         message = (
             f"Current Python version ({given}) "
-            f"is not allowed by the project ({expected}).\n"
-            'Please change python executable via the "env use" command.'
+            f"is not allowed by the project ({expected})."
         )
         if note is not None:
             message = f"{message}\n{note}"

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -21,6 +21,7 @@ from poetry.utils.env import GET_PYTHON_VERSION_ONELINER
 from poetry.utils.env import EnvManager
 from poetry.utils.env import IncorrectEnvError
 from poetry.utils.env.env_manager import EnvsFile
+from poetry.utils.env.mock_env import MockEnv
 from poetry.utils.env.python.exceptions import InvalidCurrentPythonVersionError
 from poetry.utils.env.python.exceptions import NoCompatiblePythonVersionFoundError
 from poetry.utils.env.python.exceptions import PythonVersionNotFoundError
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from unittest.mock import MagicMock
 
+    from _pytest.monkeypatch import MonkeyPatch
     from cleo.io.buffered_io import BufferedIO
     from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
@@ -1067,6 +1069,50 @@ def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
 
     assert str(e.value) == expected_message
     assert m.call_count == 0
+
+
+@pytest.mark.parametrize("use_poetry_python", [True, False])
+def test_create_venv_fails_if_current_python_is_not_supported_without_creating_venv(
+    manager: EnvManager,
+    poetry: Poetry,
+    config: Config,
+    mocker: MockerFixture,
+    mocked_python_register: MockedPythonRegister,
+    monkeypatch: MonkeyPatch,
+    use_poetry_python: bool,
+) -> None:
+    config.config["virtualenvs"]["create"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = use_poetry_python
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+    poetry.package.python_versions = "^3.10"
+
+    current_python = mocked_python_register("3.9.0")
+    compatible_python = mocked_python_register("3.10.0")
+    mocker.patch.object(manager, "get", return_value=MockEnv(version_info=(3, 9, 0)))
+    mocker.patch(
+        "poetry.utils.env.env_manager.Python.get_preferred_python",
+        return_value=current_python if use_poetry_python else compatible_python,
+    )
+    get_compatible_python = mocker.patch(
+        "poetry.utils.env.env_manager.Python.get_compatible_python",
+        return_value=compatible_python,
+    )
+    build_venv = mocker.patch("poetry.utils.env.EnvManager.build_venv")
+
+    with pytest.raises(InvalidCurrentPythonVersionError) as e:
+        manager.create_venv()
+
+    expected_message = (
+        "Current Python version (3.9.0) is not allowed by the project (^3.10).\n"
+        'Please change python executable via the "env use" command.\n'
+        "Poetry cannot switch to a compatible Python version because virtualenv "
+        "creation is disabled."
+    )
+
+    assert str(e.value) == expected_message
+    get_compatible_python.assert_not_called()
+    build_venv.assert_not_called()
 
 
 @pytest.mark.parametrize("use_poetry_python", [True, False])

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -21,7 +21,6 @@ from poetry.utils.env import GET_PYTHON_VERSION_ONELINER
 from poetry.utils.env import EnvManager
 from poetry.utils.env import IncorrectEnvError
 from poetry.utils.env.env_manager import EnvsFile
-from poetry.utils.env.mock_env import MockEnv
 from poetry.utils.env.python.exceptions import InvalidCurrentPythonVersionError
 from poetry.utils.env.python.exceptions import NoCompatiblePythonVersionFoundError
 from poetry.utils.env.python.exceptions import PythonVersionNotFoundError
@@ -33,7 +32,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from unittest.mock import MagicMock
 
-    from _pytest.monkeypatch import MonkeyPatch
     from cleo.io.buffered_io import BufferedIO
     from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
@@ -1072,50 +1070,6 @@ def test_create_venv_fails_if_no_compatible_python_version_could_be_found(
 
 
 @pytest.mark.parametrize("use_poetry_python", [True, False])
-def test_create_venv_fails_if_current_python_is_not_supported_without_creating_venv(
-    manager: EnvManager,
-    poetry: Poetry,
-    config: Config,
-    mocker: MockerFixture,
-    mocked_python_register: MockedPythonRegister,
-    monkeypatch: MonkeyPatch,
-    use_poetry_python: bool,
-) -> None:
-    config.config["virtualenvs"]["create"] = False
-    config.config["virtualenvs"]["use-poetry-python"] = use_poetry_python
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-
-    poetry.package.python_versions = "^3.10"
-
-    current_python = mocked_python_register("3.9.0")
-    compatible_python = mocked_python_register("3.10.0")
-    mocker.patch.object(manager, "get", return_value=MockEnv(version_info=(3, 9, 0)))
-    mocker.patch(
-        "poetry.utils.env.env_manager.Python.get_preferred_python",
-        return_value=current_python if use_poetry_python else compatible_python,
-    )
-    get_compatible_python = mocker.patch(
-        "poetry.utils.env.env_manager.Python.get_compatible_python",
-        return_value=compatible_python,
-    )
-    build_venv = mocker.patch("poetry.utils.env.EnvManager.build_venv")
-
-    with pytest.raises(InvalidCurrentPythonVersionError) as e:
-        manager.create_venv()
-
-    expected_message = (
-        "Current Python version (3.9.0) is not allowed by the project (^3.10).\n"
-        'Please change python executable via the "env use" command.\n'
-        "Poetry cannot switch to a compatible Python version because virtualenv "
-        "creation is disabled."
-    )
-
-    assert str(e.value) == expected_message
-    get_compatible_python.assert_not_called()
-    build_venv.assert_not_called()
-
-
-@pytest.mark.parametrize("use_poetry_python", [True, False])
 def test_create_venv_does_not_try_to_find_compatible_versions_with_executable(
     manager: EnvManager,
     poetry: Poetry,
@@ -1244,11 +1198,44 @@ def test_create_venv_fails_if_current_python_version_is_not_supported(
 
     expected_message = (
         f"Current Python version ({current_version}) is not allowed by the project"
-        f' ({package_version}).\nPlease change python executable via the "env use"'
-        " command."
+        f" ({package_version}).\n"
+        f'Please change python executable via the "env use" command.'
     )
 
-    assert expected_message == str(e.value)
+    assert str(e.value) == expected_message
+
+
+@pytest.mark.parametrize("use_poetry_python", [True, False])
+def test_create_venv_fails_if_current_python_version_is_not_supported_no_venv_creation(
+    manager: EnvManager,
+    poetry: Poetry,
+    config: Config,
+    use_poetry_python: bool,
+) -> None:
+    config.config["virtualenvs"]["create"] = False
+    config.config["virtualenvs"]["use-poetry-python"] = use_poetry_python
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
+
+    current_version = Version.parse(".".join(str(c) for c in sys.version_info[:3]))
+    assert current_version.minor is not None
+    next_version = ".".join(
+        str(c) for c in (current_version.major, current_version.minor + 1, 0)
+    )
+    package_version = "~" + next_version
+    poetry.package.python_versions = package_version
+
+    with pytest.raises(InvalidCurrentPythonVersionError) as e:
+        manager.create_venv()
+
+    expected_message = (
+        f"Current Python version ({current_version}) is not allowed by the project"
+        f" ({package_version}).\n"
+        "Poetry cannot switch to a compatible Python version"
+        " because virtualenv creation is disabled."
+    )
+
+    assert str(e.value) == expected_message
 
 
 def test_create_venv_project_name_empty_sets_correct_prompt(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10226

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

When virtualenv creation is disabled, Poetry currently still tries to select a
compatible Python after detecting that the preferred/current Python does not
satisfy the project's constraint. Because no venv will be created, the command
then falls back to the system environment and can continue with the incompatible
Python despite logging that a compatible interpreter was selected.

This change turns that incompatibility into `InvalidCurrentPythonVersionError`
before compatible-interpreter discovery when `virtualenvs.create` is false. The
existing fallback behavior is preserved when Poetry can create a venv, and
explicit Python requests continue to raise `NoCompatiblePythonVersionFoundError`.

No breaking changes.

Validation:
- `.\.venv\Scripts\python.exe -m pytest tests\utils\env\test_env_manager.py -q`
- `.\.venv\Scripts\python.exe -m ruff check src\poetry\utils\env\env_manager.py tests\utils\env\test_env_manager.py`
- `.\.venv\Scripts\python.exe -m mypy src\poetry\utils\env\env_manager.py tests\utils\env\test_env_manager.py`
