### PR TITLE
feat(show): add dependency group output

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1099,6 +1099,7 @@ required by
 * `--outdated (-o)`: Show the latest version but only for packages that are outdated.
 * `--all (-a)`: Show all packages (even those not compatible with current system).
 * `--top-level (-T)`: Only show explicitly defined packages.
+* `--with-groups`: Show dependency group names.
 * `--no-truncate`: Do not truncate the output based on the terminal width.
 * `--format (-f)`: Specify the output format (`json` or `text`). Default is `text`. `json` cannot be combined with the `--tree` option.
 

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -13,6 +13,7 @@ from packaging.utils import canonicalize_name
 
 from poetry.console.commands.env_command import EnvCommand
 from poetry.console.commands.group_command import GroupCommand
+from poetry.packages.transitive_package_info import group_sort_key
 from poetry.utils.constants import POETRY_SYSTEM_PROJECT_NAME
 
 
@@ -74,6 +75,7 @@ class ShowCommand(GroupCommand, EnvCommand):
             "Show all packages (even those not compatible with current system).",
         ),
         option("top-level", "T", "Show only top-level dependencies."),
+        option("with-groups", None, "Show dependency group names."),
         option(
             "no-truncate",
             None,
@@ -112,6 +114,13 @@ lists all packages available."""
                     " package.</error>"
                 )
                 return 1
+
+        if self.option("with-groups") and self.option("tree"):
+            self.line_error(
+                "<error>Error: Cannot use --tree and --with-groups at the same"
+                " time.</error>"
+            )
+            return 1
 
         if self.option("why"):
             if self.option("tree") and package is None:
@@ -289,16 +298,19 @@ lists all packages available."""
         show_all = self.option("all")
         show_top_level = self.option("top-level")
         show_why = self.option("why")
+        show_groups = self.option("with-groups")
         width = (
             sys.maxsize
             if self.option("no-truncate")
             else shutil.get_terminal_size().columns
         )
         name_length = version_length = latest_length = required_by_length = 0
+        groups_length = 0
         latest_packages = {}
         latest_statuses = {}
         installed_repo = InstalledRepository.load(self.env)
         requires = root.all_requires
+        package_groups = self._package_groups(root) if show_groups else {}
 
         # Computing widths
         for locked in locked_packages:
@@ -349,6 +361,14 @@ lists all packages available."""
                             required_by_length,
                             len(" from " + ",".join(required_by.keys())),
                         )
+
+                    if show_groups:
+                        groups_length = max(
+                            groups_length,
+                            len(
+                                self._format_groups(package_groups.get(locked.name, []))
+                            ),
+                        )
             else:
                 name_length = max(name_length, current_length)
                 version_length = max(
@@ -364,6 +384,12 @@ lists all packages available."""
                     required_by = reverse_deps(locked, locked_repository)
                     required_by_length = max(
                         required_by_length, len(" from " + ",".join(required_by.keys()))
+                    )
+
+                if show_groups:
+                    groups_length = max(
+                        groups_length,
+                        len(self._format_groups(package_groups.get(locked.name, []))),
                     )
 
         if self.option("format") == OutputFormats.JSON:
@@ -403,6 +429,11 @@ lists all packages available."""
                     if required_by:
                         package["required_by"] = list(required_by.keys())
 
+                if show_groups:
+                    package["groups"] = [
+                        str(group) for group in package_groups.get(locked.name, [])
+                    ]
+
                 package["description"] = locked.description
 
                 packages.append(package)
@@ -412,10 +443,21 @@ lists all packages available."""
             return 0
 
         write_version = name_length + version_length + 3 <= width
-        write_latest = name_length + version_length + latest_length + 3 <= width
+        write_groups = (
+            show_groups and name_length + version_length + groups_length + 3 <= width
+        )
+        group_column_length = groups_length if write_groups else 0
+        write_latest = (
+            name_length + version_length + group_column_length + latest_length + 3
+            <= width
+        )
 
         why_end_column = (
-            name_length + version_length + latest_length + required_by_length
+            name_length
+            + version_length
+            + group_column_length
+            + latest_length
+            + required_by_length
         )
         write_why = show_why and (why_end_column + 3) <= width
         write_description = (why_end_column + 24) <= width
@@ -460,6 +502,11 @@ lists all packages available."""
                     locked, root=self.poetry.file.path.parent
                 )
                 line += f" <b>{version:{version_length}}</b>"
+
+            if write_groups:
+                groups = self._format_groups(package_groups.get(locked.name, []))
+                line += f" {groups:{groups_length}}"
+
             if show_latest:
                 latest = latest_packages[locked.pretty_name]
                 update_status = latest_statuses[locked.pretty_name]
@@ -494,6 +541,9 @@ lists all packages available."""
                 if show_latest:
                     remaining -= latest_length
 
+                if write_groups:
+                    remaining -= groups_length
+
                 if len(locked.description) > remaining:
                     description = description[: remaining - 3] + "..."
 
@@ -502,6 +552,37 @@ lists all packages available."""
             self.line(line)
 
         return 0
+
+    def _package_groups(
+        self, root: ProjectPackage
+    ) -> dict[NormalizedName, list[NormalizedName]]:
+        active_groups = set(root._dependency_groups)
+        lock_data = self.poetry.locker.lock_data
+
+        if (
+            lock_data.get("metadata", {}).get("lock-version")
+            and self.poetry.locker.is_locked_groups_and_markers()
+        ):
+            return {
+                package.name: sorted(
+                    info.groups.intersection(active_groups), key=group_sort_key
+                )
+                for package, info in self.poetry.locker.locked_packages().items()
+            }
+
+        package_groups: dict[NormalizedName, set[NormalizedName]] = {}
+        for group_name, group in root._dependency_groups.items():
+            for dependency in group.dependencies_for_locking:
+                package_groups.setdefault(dependency.name, set()).add(group_name)
+
+        return {
+            package_name: sorted(groups, key=group_sort_key)
+            for package_name, groups in package_groups.items()
+        }
+
+    @staticmethod
+    def _format_groups(groups: list[NormalizedName]) -> str:
+        return ", ".join(groups) if groups else "-"
 
     def _display_packages_tree_information(
         self, locked_repository: Repository, root: ProjectPackage

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -310,7 +310,16 @@ lists all packages available."""
         latest_statuses = {}
         installed_repo = InstalledRepository.load(self.env)
         requires = root.all_requires
-        package_groups = self._package_groups(root) if show_groups else {}
+        package_groups: dict[NormalizedName, list[NormalizedName]] = {}
+        default_groups = ""
+        formatted_groups: dict[NormalizedName, str] = {}
+        if show_groups:
+            package_groups = self._package_groups(root)
+            default_groups = self._format_groups([])
+            formatted_groups = {
+                package_name: self._format_groups(groups)
+                for package_name, groups in package_groups.items()
+            }
 
         # Computing widths
         for locked in locked_packages:
@@ -365,9 +374,7 @@ lists all packages available."""
                     if show_groups:
                         groups_length = max(
                             groups_length,
-                            len(
-                                self._format_groups(package_groups.get(locked.name, []))
-                            ),
+                            len(formatted_groups.get(locked.name, default_groups)),
                         )
             else:
                 name_length = max(name_length, current_length)
@@ -389,7 +396,7 @@ lists all packages available."""
                 if show_groups:
                     groups_length = max(
                         groups_length,
-                        len(self._format_groups(package_groups.get(locked.name, []))),
+                        len(formatted_groups.get(locked.name, default_groups)),
                     )
 
         if self.option("format") == OutputFormats.JSON:
@@ -504,7 +511,7 @@ lists all packages available."""
                 line += f" <b>{version:{version_length}}</b>"
 
             if write_groups:
-                groups = self._format_groups(package_groups.get(locked.name, []))
+                groups = formatted_groups.get(locked.name, default_groups)
                 line += f" {groups:{groups_length}}"
 
             if show_latest:
@@ -556,7 +563,7 @@ lists all packages available."""
     def _package_groups(
         self, root: ProjectPackage
     ) -> dict[NormalizedName, list[NormalizedName]]:
-        active_groups = set(root._dependency_groups)
+        active_groups = root.dependency_group_names(include_optional=True)
         lock_data = self.poetry.locker.lock_data
 
         if (
@@ -571,7 +578,8 @@ lists all packages available."""
             }
 
         package_groups: dict[NormalizedName, set[NormalizedName]] = {}
-        for group_name, group in root._dependency_groups.items():
+        for group_name in root.dependency_group_names(include_optional=True):
+            group = root.dependency_group(group_name)
             for dependency in group.dependencies_for_locking:
                 package_groups.setdefault(dependency.name, set()).add(group_name)
 

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -413,6 +413,135 @@ def test_show_basic_with_group_options(
         assert tester.io.fetch_output() == expected
 
 
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        (
+            "--with-groups",
+            """\
+cachy  0.1.0 main Cachy package
+pytest 3.7.3 test Pytest package
+""",
+        ),
+        (
+            "--with time --with-groups",
+            """\
+cachy    0.1.0 main Cachy package
+pendulum 2.0.0 time Pendulum package
+pytest   3.7.3 test Pytest package
+""",
+        ),
+    ],
+)
+def test_show_with_groups(
+    options: str,
+    expected: str,
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+) -> None:
+    _configure_project_with_groups(poetry, installed)
+
+    tester.execute(options)
+
+    assert tester.io.fetch_output() == expected
+
+
+def test_show_with_groups_json(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+) -> None:
+    _configure_project_with_groups(poetry, installed)
+
+    tester.execute("--with time --without test --with-groups --format json")
+
+    assert json.loads(tester.io.fetch_output()) == [
+        {
+            "name": "cachy",
+            "version": "0.1.0",
+            "groups": ["main"],
+            "description": "Cachy package",
+            "installed_status": "installed",
+        },
+        {
+            "name": "pendulum",
+            "version": "2.0.0",
+            "groups": ["time"],
+            "description": "Pendulum package",
+            "installed_status": "installed",
+        },
+    ]
+
+
+def test_show_with_groups_uses_lock_groups_for_transitive_packages(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_010.add_dependency(Factory.create_dependency("msgpack", "^1.0.0"))
+
+    msgpack_100 = get_package("msgpack", "1.0.0")
+    msgpack_100.description = "Msgpack package"
+
+    installed.add_package(cachy_010)
+    installed.add_package(msgpack_100)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "python-versions": "*",
+                    "groups": ["main"],
+                    "files": [],
+                    "dependencies": {"msgpack": "^1.0.0"},
+                },
+                {
+                    "name": "msgpack",
+                    "version": "1.0.0",
+                    "description": "Msgpack package",
+                    "optional": False,
+                    "python-versions": "*",
+                    "groups": ["main"],
+                    "files": [],
+                },
+            ],
+            "metadata": {
+                "lock-version": "2.1",
+                "python-versions": "*",
+                "content-hash": "123456789",
+            },
+        }
+    )
+
+    tester.execute("--with-groups")
+
+    assert (
+        tester.io.fetch_output()
+        == """\
+cachy   0.1.0 main Cachy package
+msgpack 1.0.0 main Msgpack package
+"""
+    )
+
+
+def test_show_with_groups_cannot_be_combined_with_tree(
+    tester: CommandTester,
+) -> None:
+    tester.execute("--tree --with-groups")
+
+    assert tester.status_code == 1
+    assert (
+        tester.io.fetch_error()
+        == "Error: Cannot use --tree and --with-groups at the same time.\n"
+    )
+
+
 @output_format_parametrize
 def test_show_basic_with_installed_packages_single(
     output_format: str,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8164

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

This adds a `--with-groups` option to `poetry show` so users can see which dependency groups each listed package belongs to without opening `pyproject.toml` or inspecting the lock file manually.

For text output, the command prints a group column after the package version. For JSON output, it adds a `groups` list. When lock-file group metadata is available, the command uses it so transitive packages can also be annotated; otherwise it falls back to the active root dependency groups. `--tree --with-groups` returns a clear error because tree output does not have a tabular group column.

Local checks:

```bash
.\.venv\Scripts\python.exe -m pytest tests\console\commands\test_show.py -q
.\.venv\Scripts\python.exe -m ruff check src\poetry\console\commands\show.py tests\console\commands\test_show.py
.\.venv\Scripts\python.exe -m ruff format --check src\poetry\console\commands\show.py tests\console\commands\test_show.py
.\.venv\Scripts\python.exe -m mypy src\poetry\console\commands\show.py
git diff --check
```

Breaking changes: None.