### PR TITLE
Fix Windows script wrappers for UTF-8 paths

### DIFF
--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -36,9 +36,11 @@ if __name__ == '__main__':
     sys.exit({callable_}())
 """
 
-WINDOWS_CMD_TEMPLATE = """\
-@echo off\r\n"{python}" "%~dp0\\{script}" %*\r\n
-"""
+# The .cmd wrapper is written as UTF-8. Switch cmd.exe to UTF-8 before it
+# parses paths so non-ASCII virtualenv locations are handled correctly.
+WINDOWS_CMD_TEMPLATE = (
+    '@echo off\r\nchcp 65001 >nul\r\n"{python}" "%~dp0\\{script}" %*\r\n'
+)
 
 
 class EditableBuilder(Builder):
@@ -206,7 +208,7 @@ class EditableBuilder(Builder):
                     f" <b>{scripts_path}</b>"
                 )
 
-                with cmd_script.open("w", encoding="utf-8") as f:
+                with cmd_script.open("w", encoding="utf-8", newline="") as f:
                     f.write(decode(cmd))
 
                 added.append(cmd_script)

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -265,6 +265,30 @@ if __name__ == '__main__':
     assert tmp_venv._bin_dir.joinpath("fox").read_text(encoding="utf-8") == fox_script
 
 
+def test_builder_windows_cmd_wrapper_uses_utf8_code_page_for_non_ascii_paths(
+    simple_poetry: Poetry, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class WindowsScriptEnv(MockEnv):
+        @property
+        def python(self) -> Path:
+            return Path(
+                r"C:\Users\jmoni\OneDrive\Área de Trabalho\example\.venv\Scripts\python.exe"
+            )
+
+    env = WindowsScriptEnv(path=tmp_path / "Área de Trabalho" / ".venv")
+    python = env.python
+
+    monkeypatch.setattr("poetry.masonry.builders.editable.WINDOWS", True)
+
+    builder = EditableBuilder(simple_poetry, env, NullIO())
+    builder._add_scripts()
+
+    assert (
+        env.script_dirs[0].joinpath("foo.cmd").read_bytes()
+        == (f'@echo off\r\nchcp 65001 >nul\r\n"{python}" "%~dp0\\foo" %*\r\n').encode()
+    )
+
+
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(
     mocker: MockerFixture, extended_poetry: Poetry, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
# Pull Request Check List

Fixes #10193

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (Not applicable; behavior-only bug fix.)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

## Summary

Editable installs on Windows write `.cmd` script wrappers as UTF-8. When those wrappers are launched from a non-UTF-8 console code page, non-ASCII paths can be mojibake before `cmd.exe` invokes Python.

This changes the generated `.cmd` wrapper to switch `cmd.exe` to UTF-8 before the command containing the Python/script paths is parsed, and adds a regression test covering a Windows-style path containing `Área de Trabalho`.
