### PR TITLE
perf: caching

### DIFF
--- a/src/poetry/mixology/term.py
+++ b/src/poetry/mixology/term.py
@@ -8,6 +8,8 @@ from poetry.mixology.set_relation import SetRelation
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from poetry.core.constraints.version import VersionConstraint
     from poetry.core.packages.dependency import Dependency
 
@@ -23,8 +25,15 @@ class Term:
     def __init__(self, dependency: Dependency, is_positive: bool) -> None:
         self._dependency = dependency
         self._positive = is_positive
-        self.relation = functools.lru_cache(maxsize=None)(self._relation)
-        self.intersect = functools.lru_cache(maxsize=None)(self._intersect)
+
+    # The caches are created lazily because most terms never need them.
+    @functools.cached_property
+    def relation(self) -> Callable[[Term], str]:
+        return functools.lru_cache(maxsize=None)(self._relation)
+
+    @functools.cached_property
+    def intersect(self) -> Callable[[Term], Term | None]:
+        return functools.lru_cache(maxsize=None)(self._intersect)
 
     @property
     def inverse(self) -> Term:

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -76,7 +76,8 @@ class HTTPRepository(CachedRepository):
             pool_size=pool_size,
         )
         self._authenticator.add_repository(name, url)
-        self.get_page = functools.lru_cache(maxsize=None)(self._get_page)
+        self.get_page = functools.cache(self._get_page)
+        self._find_packages = functools.cache(self._find_packages_uncached)  # type: ignore[method-assign]
 
         self._lazy_wheel = config.get("solver.lazy-wheel", True)
         self._max_retries = config.get("requests.max-retries", 0)
@@ -178,7 +179,7 @@ class HTTPRepository(CachedRepository):
                 return True
         return False
 
-    def _find_packages(
+    def _find_packages_uncached(
         self, name: NormalizedName, constraint: VersionConstraint
     ) -> list[Package]:
         """


### PR DESCRIPTION
Two caching changes that improve performance for resolving large projects a bit:

- Apparently, `Term.relation` and `Term.intersection` is often not used and constructing the cache in `__init__` costs some time. The trick with the `cached_property` seems simple enough and effective. In case anyone is wondering if we should apply this trick in general: It only makes sense for classes if many instances of the class are created and the cached methods are not used in many instances. We do not create that many instances of other classes where instance methods are cached.
- `_find_packages` seems to be called with the same name and constraint multiple times, especially when resolving with overrides.