### PR TITLE
feat: allow multiple authors in poetry init

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -11,10 +11,12 @@ from typing import ClassVar
 
 from cleo.helpers import option
 from packaging.utils import canonicalize_name
+from tomlkit import array
 from tomlkit import inline_table
 
 from poetry.console.commands.command import Command
 from poetry.console.commands.env_command import EnvCommand
+from poetry.core.utils.patterns import AUTHOR_REGEX
 from poetry.utils.dependency_specification import RequirementsParser
 from poetry.utils.env.python import Python
 
@@ -39,7 +41,13 @@ class InitCommand(Command):
     options: ClassVar[list[Option]] = [
         option("name", None, "Name of the package.", flag=False),
         option("description", None, "Description of the package.", flag=False),
-        option("author", None, "Author name of the package.", flag=False),
+        option(
+            "author",
+            None,
+            "Author name of the package.",
+            flag=False,
+            multiple=True,
+        ),
         option("python", None, "Compatible Python versions.", flag=False),
         option(
             "dependency",
@@ -148,21 +156,31 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if not description and is_interactive:
             description = self.ask(self.create_question("Description []: ", default=""))
 
-        author = self.option("author")
-        if not author and vcs_config.get("user.name"):
-            author = vcs_config["user.name"]
-            author_email = vcs_config.get("user.email")
-            if author_email:
-                author += f" <{author_email}>"
-
-        if is_interactive:
-            question = self.create_question(
-                f"Author [<comment>{author}</comment>, n to skip]: ", default=author
+        authors = [
+            author
+            for author in (
+                self._validate_author(author, "") for author in self.option("author")
             )
-            question.set_validator(lambda v: self._validate_author(v, author))
-            author = self.ask(question)
+            if author
+        ]
 
-        authors = [author] if author else []
+        if not authors:
+            author = None
+            if vcs_config.get("user.name"):
+                author = vcs_config["user.name"]
+                author_email = vcs_config.get("user.email")
+                if author_email:
+                    author += f" <{author_email}>"
+
+            if is_interactive:
+                question = self.create_question(
+                    f"Author [<comment>{author}</comment>, n to skip]: ",
+                    default=author,
+                )
+                question.set_validator(lambda v: self._validate_author(v, author))
+                author = self.ask(question)
+
+            authors = [author] if author else []
 
         license_name = self.option("license")
         if not license_name and is_interactive:
@@ -253,6 +271,11 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             layout_.create(project_path, with_pyproject=False)
 
         content = layout_.generate_project_content(project_path)
+        if len(authors) > 1:
+            content["project"]["authors"] = array().multiline(True)
+            for author in authors:
+                content["project"]["authors"].append(self._format_author(author))
+
         for section, item in content.items():
             pyproject.data.append(section, item)
 
@@ -498,7 +521,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
     @staticmethod
     def _validate_author(author: str, default: str) -> str | None:
         from poetry.core.utils.helpers import combine_unicode
-        from poetry.core.utils.patterns import AUTHOR_REGEX
 
         author = combine_unicode(author or default)
 
@@ -513,6 +535,19 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             )
 
         return author
+
+    @staticmethod
+    def _format_author(author: str) -> dict[str, str]:
+        m = AUTHOR_REGEX.match(author)
+        if m is None:
+            # This should not happen because author has been validated before.
+            raise ValueError(f"Invalid author: {author}")
+
+        formatted_author = {"name": m.group("name")}
+        if email := m.group("email"):
+            formatted_author["email"] = email
+
+        return formatted_author
 
     @staticmethod
     def _validate_package(package: str | None) -> str | None:

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -12,12 +12,12 @@ from typing import cast
 
 from cleo.helpers import option
 from packaging.utils import canonicalize_name
+from poetry.core.utils.patterns import AUTHOR_REGEX
 from tomlkit import array
 from tomlkit import inline_table
 
 from poetry.console.commands.command import Command
 from poetry.console.commands.env_command import EnvCommand
-from poetry.core.utils.patterns import AUTHOR_REGEX
 from poetry.utils.dependency_specification import RequirementsParser
 from poetry.utils.env.python import Python
 

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
+from typing import cast
 
 from cleo.helpers import option
 from packaging.utils import canonicalize_name
@@ -156,10 +157,11 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if not description and is_interactive:
             description = self.ask(self.create_question("Description []: ", default=""))
 
+        option_authors = cast("list[str]", self.option("author") or [])
         authors = [
             author
             for author in (
-                self._validate_author(author, "") for author in self.option("author")
+                self._validate_author(author, "") for author in option_authors
             )
             if author
         ]
@@ -177,7 +179,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     f"Author [<comment>{author}</comment>, n to skip]: ",
                     default=author,
                 )
-                question.set_validator(lambda v: self._validate_author(v, author))
+                question.set_validator(lambda v: self._validate_author(v, author or ""))
                 author = self.ask(question)
 
             authors = [author] if author else []

--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import cast
 
 from cleo.helpers import option
 from packaging.utils import canonicalize_name
@@ -157,18 +156,28 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
         if not description and is_interactive:
             description = self.ask(self.create_question("Description []: ", default=""))
 
-        option_authors = cast("list[str]", self.option("author") or [])
-        authors = [
+        raw_option_authors = self.option("author")
+        if raw_option_authors is None:
+            option_authors: list[str] = []
+        elif isinstance(raw_option_authors, str):
+            option_authors = [raw_option_authors]
+        else:
+            option_authors = list(raw_option_authors)
+
+        option_authors = [
             author
             for author in (
                 self._validate_author(author, "") for author in option_authors
             )
             if author
         ]
+        authors: list[str] = []
 
-        if not authors:
-            author = None
-            if vcs_config.get("user.name"):
+        if len(option_authors) > 1 or (option_authors and not is_interactive):
+            authors = option_authors
+        else:
+            author = option_authors[0] if option_authors else None
+            if not author and vcs_config.get("user.name"):
                 author = vcs_config["user.name"]
                 author_email = vcs_config.get("user.email")
                 if author_email:

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -972,6 +972,33 @@ dependencies = [
     )
 
 
+def test_init_non_interactive_with_multiple_authors(
+    tester: CommandTester, source_dir: Path
+) -> None:
+    tester.execute(
+        "--author 'Alice Example <alice@example.com>' "
+        "--author 'Bob Example <bob@example.com>' "
+        "--name 'my-package' "
+        "--python '>=3.12'",
+        interactive=False,
+    )
+
+    expected = """\
+[project]
+name = "my-package"
+version = "0.1.0"
+description = ""
+authors = [
+    {name = "Alice Example",email = "alice@example.com"},
+    {name = "Bob Example",email = "bob@example.com"},
+]
+requires-python = ">=3.12"
+dependencies = [
+]
+"""
+    assert expected in (source_dir / "pyproject.toml").read_text(encoding="utf-8")
+
+
 def test_init_existing_pyproject_with_build_system_fails(
     tester: CommandTester, source_dir: Path, init_basic_inputs: str
 ) -> None:


### PR DESCRIPTION
﻿## Summary

Allows `poetry init --author` to be passed multiple times, e.g.:

```bash
poetry init --author "Alice Example <alice@example.com>" --author "Bob Example <bob@example.com>"
```

## Why

Fixes #8864. The issue asks for a non-interactive way to provide multiple authors. A maintainer suggested supporting repeated `--author` flags, which keeps the CLI usable in scripts and avoids interactive prompts.

## Changes

- Marks the `init` command's `--author` option as repeatable
- Validates every provided author with the existing author validator
- Writes multiple authors to `[project].authors` while preserving the existing single-author interactive/default behavior
- Adds a regression test for repeated `--author`

## Validation

- `python -m pytest tests/console/commands/test_init.py::test_init_non_interactive_with_multiple_authors tests/console/commands/test_init.py::test_init_non_interactive_existing_pyproject_add_dependency -q -o addopts=''`
- `git diff --check`

## AI assistance disclosure

This PR was prepared with assistance from OpenAI Codex. The change was reviewed locally and validated with focused tests.
