### PR TITLE
fix(init): validate Python version constraint in interactive prompt

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -181,6 +181,8 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
                     f"Compatible Python versions [<comment>{python}</comment>]: ",
                     default=python,
                 )
+                question.set_validator(self._validate_version_constraint)
+                question.set_max_attempts(3)
                 python = self.ask(question)
 
         if is_interactive:

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -1048,6 +1048,29 @@ def test_validate_version_constraint_rejects_invalid_inputs(invalid: str) -> Non
         InitCommand._validate_version_constraint(invalid)
 
 
+def test_python_version_constraint_validated_in_interactive_prompt(
+    tester: CommandTester,
+) -> None:
+    """Invalid Python version constraints should be rejected and re-prompted."""
+    inputs = [
+        "my-package",      # Package name
+        "1.2.3",           # Version
+        "",                # Description
+        "n",               # Author
+        "",                # License
+        "invalid-python",  # Python version -- INVALID, gets rejected
+        ">=3.8",           # Python version -- VALID on retry
+        "n",               # Interactive packages
+        "n",               # Interactive dev packages
+        "\n",              # Generate
+    ]
+    tester.execute(inputs="\n".join(inputs))
+    output = tester.io.fetch_output()
+
+    assert 'requires-python = ">=3.8"' in output
+    assert 'requires-python = "invalid-python"' not in output
+
+
 @pytest.mark.parametrize(
     "author",
     [


### PR DESCRIPTION
Resolves: #7043 (partially — applies same validation to Python version prompt that #10909 applied to dependency version prompt)

## Bug

The interactive Python version prompt in \`poetry init\` accepted arbitrary strings without validation, writing them verbatim into \`pyproject.toml\`. For example:

\`\`\`
Compatible Python versions [>=3.12]: invalid-python
\`\`\`

would produce \`requires-python = \"invalid-python\"\`, only failing at the next \`poetry lock\`.

PR #10909 added \`_validate_version_constraint\` to the dependency-version prompt but the Python-version prompt was not updated.

## Fix

Apply the same \`question.set_validator(self._validate_version_constraint)\` and \`question.set_max_attempts(3)\` to the **Compatible Python versions** question in \`_init_pyproject\`, consistent with the dependency-version and author validators in the same command.

## Verification

\`\`\`
pytest tests/console/commands/test_init.py \
    -k test_python_version_constraint_validated_in_interactive_prompt
\`\`\`

Before fix: invalid constraint accepted, test fails.
After fix: invalid constraint rejected, user re-prompted, test passes.

> AI-assisted development (GitHub Copilot / Claude); logic and test authored by contributor.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.