### PR TITLE
feat(show): show wanted version for outdated packages

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1011,7 +1011,7 @@ poetry self show
 * `--addons`: List only add-on packages installed.
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
-* `--outdated (-o)`: Show the latest version but only for packages that are outdated.
+* `--outdated (-o)`: Show the latest and constraint-compatible versions for outdated packages.
 * `--format (-f)`: Specify the output format (`json` or `text`). Default is `text`. `json` cannot be combined with the `--tree` option.
 
 ### self show plugins
@@ -1096,7 +1096,7 @@ required by
 * `--only`: The only dependency groups to include.
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
-* `--outdated (-o)`: Show the latest version but only for packages that are outdated.
+* `--outdated (-o)`: Show the latest and constraint-compatible versions for outdated packages.
 * `--all (-a)`: Show all packages (even those not compatible with current system).
 * `--top-level (-T)`: Only show explicitly defined packages.
 * `--no-truncate`: Do not truncate the output based on the terminal width.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1012,7 +1012,7 @@ poetry self show
 * `--addons`: List only add-on packages installed.
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
-* `--outdated (-o)`: Show the latest version but only for packages that are outdated.
+* `--outdated (-o)`: Show the latest and constraint-compatible versions for outdated packages.
 * `--format (-f)`: Specify the output format (`json` or `text`). Default is `text`. `json` cannot be combined with the `--tree` option.
 
 ### self show plugins
@@ -1107,7 +1107,7 @@ required by
 * `--only`: The only dependency groups to include.
 * `--tree`: List the dependencies as a tree.
 * `--latest (-l)`: Show the latest version.
-* `--outdated (-o)`: Show the latest version but only for packages that are outdated.
+* `--outdated (-o)`: Show the latest and constraint-compatible versions for outdated packages.
 * `--all (-a)`: Show all packages (even those not compatible with current system).
 * `--top-level (-T)`: Only show explicitly defined packages.
 * `--no-truncate`: Do not truncate the output based on the terminal width.

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -4,6 +4,7 @@ import json
 import sys
 
 from enum import Enum
+from functools import cached_property
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.repositories.repository import Repository
+    from poetry.version.version_selector import VersionSelector
 
 
 def reverse_deps(pkg: Package, repo: Repository) -> dict[str, str]:
@@ -66,7 +68,7 @@ class ShowCommand(GroupCommand, EnvCommand):
         option(
             "outdated",
             "o",
-            "Show the latest version but only for packages that are outdated.",
+            "Show the latest and constraint-compatible versions for outdated packages.",
         ),
         option(
             "all",
@@ -286,6 +288,7 @@ lists all packages available."""
         required_locked_packages = {op.package for op in ops if not op.skipped}
 
         show_latest = self.option("latest")
+        show_outdated = self.option("outdated")
         show_all = self.option("all")
         show_top_level = self.option("top-level")
         show_why = self.option("why")
@@ -294,9 +297,11 @@ lists all packages available."""
             if self.option("no-truncate")
             else shutil.get_terminal_size().columns
         )
-        name_length = version_length = latest_length = required_by_length = 0
-        latest_packages = {}
-        latest_statuses = {}
+        name_length = version_length = wanted_length = latest_length = 0
+        required_by_length = 0
+        latest_packages: dict[str, Package] = {}
+        wanted_packages: dict[str, Package] = {}
+        latest_statuses: dict[str, str] = {}
         installed_repo = InstalledRepository.load(self.env)
         requires = root.all_requires
 
@@ -320,11 +325,15 @@ lists all packages available."""
                     latest = locked
 
                 latest_packages[locked.pretty_name] = latest
+                if show_outdated:
+                    wanted = self.find_wanted_package(locked, root, latest)
+                    wanted_packages[locked.pretty_name] = wanted
+
                 update_status = latest_statuses[locked.pretty_name] = (
                     self.get_update_status(latest, locked)
                 )
 
-                if not self.option("outdated") or update_status != "up-to-date":
+                if not show_outdated or update_status != "up-to-date":
                     name_length = max(name_length, current_length)
                     version_length = max(
                         version_length,
@@ -334,6 +343,15 @@ lists all packages available."""
                             )
                         ),
                     )
+                    if show_outdated:
+                        wanted_length = max(
+                            wanted_length,
+                            len(
+                                get_package_version_display_string(
+                                    wanted, root=self.poetry.file.path.parent
+                                )
+                            ),
+                        )
                     latest_length = max(
                         latest_length,
                         len(
@@ -375,7 +393,7 @@ lists all packages available."""
 
                 if (
                     show_latest
-                    and self.option("outdated")
+                    and show_outdated
                     and latest_statuses[locked.pretty_name] == "up-to-date"
                 ):
                     continue
@@ -394,6 +412,11 @@ lists all packages available."""
 
                 if show_latest:
                     latest = latest_packages[locked.pretty_name]
+                    if show_outdated:
+                        wanted = wanted_packages[locked.pretty_name]
+                        package["wanted_version"] = get_package_version_display_string(
+                            wanted, root=self.poetry.file.path.parent
+                        )
                     package["latest_version"] = get_package_version_display_string(
                         latest, root=self.poetry.file.path.parent
                     )
@@ -412,10 +435,23 @@ lists all packages available."""
             return 0
 
         write_version = name_length + version_length + 3 <= width
-        write_latest = name_length + version_length + latest_length + 3 <= width
+        write_wanted = (
+            show_outdated
+            and name_length + version_length + wanted_length + latest_length + 4
+            <= width
+        )
+        wanted_column_length = wanted_length if write_wanted else 0
+        write_latest = (
+            name_length + version_length + wanted_column_length + latest_length + 3
+            <= width
+        )
 
         why_end_column = (
-            name_length + version_length + latest_length + required_by_length
+            name_length
+            + version_length
+            + wanted_column_length
+            + latest_length
+            + required_by_length
         )
         write_why = show_why and (why_end_column + 3) <= width
         write_description = (why_end_column + 24) <= width
@@ -446,7 +482,7 @@ lists all packages available."""
 
             if (
                 show_latest
-                and self.option("outdated")
+                and show_outdated
                 and latest_statuses[locked.pretty_name] == "up-to-date"
             ):
                 continue
@@ -460,6 +496,12 @@ lists all packages available."""
                     locked, root=self.poetry.file.path.parent
                 )
                 line += f" <b>{version:{version_length}}</b>"
+            if write_wanted:
+                wanted = wanted_packages[locked.pretty_name]
+                version = get_package_version_display_string(
+                    wanted, root=self.poetry.file.path.parent
+                )
+                line += f" <fg=green>{version:{wanted_length}}</>"
             if show_latest:
                 latest = latest_packages[locked.pretty_name]
                 update_status = latest_statuses[locked.pretty_name]
@@ -493,6 +535,9 @@ lists all packages available."""
 
                 if show_latest:
                     remaining -= latest_length
+
+                if write_wanted:
+                    remaining -= wanted_length
 
                 if len(locked.description) > remaining:
                     description = description[: remaining - 3] + "..."
@@ -639,13 +684,18 @@ lists all packages available."""
             io.output.formatter.set_style(color, style)
             io.error_output.formatter.set_style(color, style)
 
+    @cached_property
+    def _version_selector(self) -> VersionSelector:
+        from poetry.version.version_selector import VersionSelector
+
+        return VersionSelector(self.poetry.pool)
+
     def find_latest_package(
         self, package: Package, root: ProjectPackage
     ) -> Package | None:
         from cleo.io.null_io import NullIO
 
         from poetry.puzzle.provider import Provider
-        from poetry.version.version_selector import VersionSelector
 
         # find the latest version allowed in this pool
         requires = root.all_requires
@@ -662,11 +712,36 @@ lists all packages available."""
                 break
 
         name = package.name
-        selector = VersionSelector(self.poetry.pool)
-
-        return selector.find_best_candidate(
+        return self._version_selector.find_best_candidate(
             name, f">={package.pretty_version}", allow_prereleases
         )
+
+    def find_wanted_package(
+        self, package: Package, root: ProjectPackage, latest: Package
+    ) -> Package:
+        if package.is_direct_origin():
+            return latest
+
+        wanted = package
+        has_root_dependency = False
+        for dep in root.all_requires:
+            if dep.name != package.name or dep.is_direct_origin():
+                continue
+
+            has_root_dependency = True
+            candidate = self._version_selector.find_best_candidate(
+                package.name,
+                dep.pretty_constraint,
+                dep.allows_prereleases(),
+                dep.source_name,
+            )
+            if candidate is not None and wanted.version < candidate.version:
+                wanted = candidate
+
+        if not has_root_dependency:
+            return latest
+
+        return wanted
 
     def get_update_status(self, latest: Package, package: Package) -> str:
         from poetry.core.constraints.version import parse_constraint

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -4,6 +4,7 @@ import json
 import sys
 
 from enum import Enum
+from functools import cached_property
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.project_package import ProjectPackage
 
     from poetry.repositories.repository import Repository
+    from poetry.version.version_selector import VersionSelector
 
 
 def reverse_deps(pkg: Package, repo: Repository) -> dict[str, str]:
@@ -66,7 +68,7 @@ class ShowCommand(GroupCommand, EnvCommand):
         option(
             "outdated",
             "o",
-            "Show the latest version but only for packages that are outdated.",
+            "Show the latest and constraint-compatible versions for outdated packages.",
         ),
         option(
             "all",
@@ -286,6 +288,7 @@ lists all packages available."""
         required_locked_packages = {op.package for op in ops if not op.skipped}
 
         show_latest = self.option("latest")
+        show_outdated = self.option("outdated")
         show_all = self.option("all")
         show_top_level = self.option("top-level")
         show_why = self.option("why")
@@ -294,9 +297,11 @@ lists all packages available."""
             if self.option("no-truncate")
             else shutil.get_terminal_size().columns
         )
-        name_length = version_length = latest_length = required_by_length = 0
-        latest_packages = {}
-        latest_statuses = {}
+        name_length = version_length = wanted_length = latest_length = 0
+        required_by_length = 0
+        latest_packages: dict[str, Package] = {}
+        wanted_packages: dict[str, Package] = {}
+        latest_statuses: dict[str, str] = {}
         installed_repo = InstalledRepository.load(self.env)
         requires = root.all_requires
 
@@ -320,11 +325,15 @@ lists all packages available."""
                     latest = locked
 
                 latest_packages[locked.pretty_name] = latest
+                if show_outdated:
+                    wanted = self.find_wanted_package(locked, root, latest)
+                    wanted_packages[locked.pretty_name] = wanted
+
                 update_status = latest_statuses[locked.pretty_name] = (
                     self.get_update_status(latest, locked)
                 )
 
-                if not self.option("outdated") or update_status != "up-to-date":
+                if not show_outdated or update_status != "up-to-date":
                     name_length = max(name_length, current_length)
                     version_length = max(
                         version_length,
@@ -334,6 +343,15 @@ lists all packages available."""
                             )
                         ),
                     )
+                    if show_outdated:
+                        wanted_length = max(
+                            wanted_length,
+                            len(
+                                get_package_version_display_string(
+                                    wanted, root=self.poetry.file.path.parent
+                                )
+                            ),
+                        )
                     latest_length = max(
                         latest_length,
                         len(
@@ -375,7 +393,7 @@ lists all packages available."""
 
                 if (
                     show_latest
-                    and self.option("outdated")
+                    and show_outdated
                     and latest_statuses[locked.pretty_name] == "up-to-date"
                 ):
                     continue
@@ -394,6 +412,11 @@ lists all packages available."""
 
                 if show_latest:
                     latest = latest_packages[locked.pretty_name]
+                    if show_outdated:
+                        wanted = wanted_packages[locked.pretty_name]
+                        package["wanted_version"] = get_package_version_display_string(
+                            wanted, root=self.poetry.file.path.parent
+                        )
                     package["latest_version"] = get_package_version_display_string(
                         latest, root=self.poetry.file.path.parent
                     )
@@ -412,10 +435,23 @@ lists all packages available."""
             return 0
 
         write_version = name_length + version_length + 3 <= width
-        write_latest = name_length + version_length + latest_length + 3 <= width
+        write_wanted = (
+            show_outdated
+            and name_length + version_length + wanted_length + latest_length + 4
+            <= width
+        )
+        wanted_column_length = wanted_length if write_wanted else 0
+        write_latest = (
+            name_length + version_length + wanted_column_length + latest_length + 3
+            <= width
+        )
 
         why_end_column = (
-            name_length + version_length + latest_length + required_by_length
+            name_length
+            + version_length
+            + wanted_column_length
+            + latest_length
+            + required_by_length
         )
         write_why = show_why and (why_end_column + 3) <= width
         write_description = (why_end_column + 24) <= width
@@ -446,7 +482,7 @@ lists all packages available."""
 
             if (
                 show_latest
-                and self.option("outdated")
+                and show_outdated
                 and latest_statuses[locked.pretty_name] == "up-to-date"
             ):
                 continue
@@ -460,6 +496,12 @@ lists all packages available."""
                     locked, root=self.poetry.file.path.parent
                 )
                 line += f" <b>{version:{version_length}}</b>"
+            if write_wanted:
+                wanted = wanted_packages[locked.pretty_name]
+                version = get_package_version_display_string(
+                    wanted, root=self.poetry.file.path.parent
+                )
+                line += f" <fg=green>{version:{wanted_length}}</>"
             if show_latest:
                 latest = latest_packages[locked.pretty_name]
                 update_status = latest_statuses[locked.pretty_name]
@@ -493,6 +535,9 @@ lists all packages available."""
 
                 if show_latest:
                     remaining -= latest_length
+
+                if write_wanted:
+                    remaining -= wanted_length
 
                 if len(locked.description) > remaining:
                     description = description[: remaining - 3] + "..."
@@ -639,13 +684,18 @@ lists all packages available."""
             io.output.formatter.set_style(color, style)
             io.error_output.formatter.set_style(color, style)
 
+    @cached_property
+    def _version_selector(self) -> VersionSelector:
+        from poetry.version.version_selector import VersionSelector
+
+        return VersionSelector(self.poetry.pool)
+
     def find_latest_package(
         self, package: Package, root: ProjectPackage
     ) -> Package | None:
         from cleo.io.null_io import NullIO
 
         from poetry.puzzle.provider import Provider
-        from poetry.version.version_selector import VersionSelector
 
         # find the latest version allowed in this pool
         requires = root.all_requires
@@ -670,11 +720,45 @@ lists all packages available."""
         source = None if package.is_direct_origin() else package.source_reference
 
         name = package.name
-        selector = VersionSelector(self.poetry.pool)
-
-        return selector.find_best_candidate(
-            name, f">={package.pretty_version}", allow_prereleases, source=source
+        return self._version_selector.find_best_candidate(
+            name,
+            f">={package.pretty_version}",
+            allow_prereleases,
+            source=source,
         )
+
+    def find_wanted_package(
+        self, package: Package, root: ProjectPackage, latest: Package
+    ) -> Package:
+        if package.is_direct_origin():
+            return latest
+
+        wanted = package
+        has_root_dependency = False
+        source = package.source_reference
+        for dep in root.all_requires:
+            if (
+                dep.name != package.name
+                or dep.is_direct_origin()
+                or dep.source_name != source
+                or not self.env.is_valid_for_marker(dep.marker)
+            ):
+                continue
+
+            has_root_dependency = True
+            candidate = self._version_selector.find_best_candidate(
+                package.name,
+                dep.pretty_constraint,
+                dep.allows_prereleases(),
+                source=source,
+            )
+            if candidate is not None and wanted.version < candidate.version:
+                wanted = candidate
+
+        if not has_root_dependency:
+            return latest
+
+        return wanted
 
     def get_update_status(self, latest: Package, package: Package) -> str:
         from poetry.core.constraints.version import parse_constraint

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -885,6 +885,7 @@ def test_show_outdated(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -893,7 +894,156 @@ def test_show_outdated(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0 0.2.0 Cachy package
+cachy 0.1.0 0.1.0 0.2.0 Cachy package
+"""
+        assert tester.io.fetch_output() == expected
+
+
+@output_format_parametrize
+def test_show_outdated_wanted_version_respects_dependency_constraint(
+    output_format: str,
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("cachy", ">=0.1.0,<0.3.0"))
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+    cachy_030 = get_package("cachy", "0.3.0")
+    cachy_030.description = "Cachy package"
+
+    installed.add_package(cachy_010)
+
+    repo.add_package(cachy_010)
+    repo.add_package(cachy_020)
+    repo.add_package(cachy_030)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": []},
+            },
+        }
+    )
+
+    tester.execute(f"--outdated {output_format}")
+
+    expected: str | list[dict[str, str]] = ""
+    if "json" in output_format:
+        expected = [
+            {
+                "name": "cachy",
+                "version": "0.1.0",
+                "wanted_version": "0.2.0",
+                "latest_version": "0.3.0",
+                "description": "Cachy package",
+                "installed_status": "installed",
+            },
+        ]
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        expected = """\
+cachy 0.1.0 0.2.0 0.3.0 Cachy package
+"""
+        assert tester.io.fetch_output() == expected
+
+
+@output_format_parametrize
+def test_show_outdated_wanted_version_uses_latest_for_transitive_dependency(
+    output_format: str,
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+
+    pendulum_200 = get_package("pendulum", "2.0.0")
+    pendulum_200.description = "Pendulum package"
+    pendulum_200.add_dependency(Factory.create_dependency("cachy", ">=0.1.0"))
+
+    installed.add_package(cachy_010)
+    installed.add_package(pendulum_200)
+
+    repo.add_package(cachy_010)
+    repo.add_package(cachy_020)
+    repo.add_package(pendulum_200)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "description": "Pendulum package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"cachy": ">=0.1.0"},
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": [], "pendulum": []},
+            },
+        }
+    )
+
+    tester.execute(f"--outdated {output_format}")
+
+    expected: str | list[dict[str, str]] = ""
+    if "json" in output_format:
+        expected = [
+            {
+                "name": "cachy",
+                "version": "0.1.0",
+                "wanted_version": "0.2.0",
+                "latest_version": "0.2.0",
+                "description": "Cachy package",
+                "installed_status": "installed",
+            },
+        ]
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        expected = """\
+cachy 0.1.0 0.2.0 0.2.0 Cachy package
 """
         assert tester.io.fetch_output() == expected
 
@@ -1017,6 +1167,7 @@ def test_show_outdated_has_prerelease_but_not_allowed(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1025,7 +1176,7 @@ def test_show_outdated_has_prerelease_but_not_allowed(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0 0.2.0 Cachy package
+cachy 0.1.0 0.1.0 0.2.0 Cachy package
 """
         assert tester.io.fetch_output() == expected
 
@@ -1105,6 +1256,7 @@ def test_show_outdated_has_prerelease_and_allowed(
             {
                 "name": "cachy",
                 "version": "0.1.0.dev1",
+                "wanted_version": "0.3.0.dev123",
                 "latest_version": "0.3.0.dev123",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1113,7 +1265,7 @@ def test_show_outdated_has_prerelease_and_allowed(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0.dev1 0.3.0.dev123 Cachy package
+cachy 0.1.0.dev1 0.3.0.dev123 0.3.0.dev123 Cachy package
 """
         assert tester.io.fetch_output() == expected
 
@@ -1187,6 +1339,7 @@ def test_show_outdated_formatting(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1194,6 +1347,7 @@ def test_show_outdated_formatting(
             {
                 "name": "pendulum",
                 "version": "2.0.0",
+                "wanted_version": "2.0.1",
                 "latest_version": "2.0.1",
                 "description": "Pendulum package",
                 "installed_status": "installed",
@@ -1202,10 +1356,82 @@ def test_show_outdated_formatting(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy    0.1.0 0.2.0 Cachy package
-pendulum 2.0.0 2.0.1 Pendulum package
+cachy    0.1.0 0.1.0 0.2.0 Cachy package
+pendulum 2.0.0 2.0.1 2.0.1 Pendulum package
 """
         assert tester.io.fetch_output() == expected
+
+
+def test_show_outdated_hides_wanted_column_when_terminal_is_narrow(
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
+    poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+
+    pendulum_200 = get_package("pendulum", "2.0.0")
+    pendulum_200.description = "Pendulum package"
+    pendulum_201 = get_package("pendulum", "2.0.1")
+    pendulum_201.description = "Pendulum package"
+
+    installed.add_package(cachy_010)
+    installed.add_package(pendulum_200)
+
+    repo.add_package(cachy_010)
+    repo.add_package(cachy_020)
+    repo.add_package(pendulum_200)
+    repo.add_package(pendulum_201)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "description": "Pendulum package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": [], "pendulum": []},
+            },
+        }
+    )
+
+    monkeypatch.setenv("COLUMNS", "21")
+    monkeypatch.setenv("LINES", "24")
+
+    tester.execute("--outdated")
+
+    expected = """\
+cachy    0.1.0 0.2.0
+pendulum 2.0.0 2.0.1
+"""
+    assert tester.io.fetch_output() == expected
 
 
 @pytest.mark.parametrize(
@@ -1327,6 +1553,7 @@ def test_show_outdated_local_dependencies(
             {
                 "name": "cachy",
                 "version": "0.2.0",
+                "wanted_version": "0.3.0",
                 "latest_version": "0.3.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1334,6 +1561,7 @@ def test_show_outdated_local_dependencies(
             {
                 "name": "project-with-setup",
                 "version": "0.1.1 ../project_with_setup",
+                "wanted_version": "0.1.2 ../project_with_setup",
                 "latest_version": "0.1.2 ../project_with_setup",
                 "description": "Demo project.",
                 "installed_status": "installed",
@@ -1448,6 +1676,7 @@ def test_show_outdated_git_dev_dependency(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1455,6 +1684,7 @@ def test_show_outdated_git_dev_dependency(
             {
                 "name": "demo",
                 "version": "0.1.1 9cf87a2",
+                "wanted_version": "0.1.2 9cf87a2",
                 "latest_version": "0.1.2 9cf87a2",
                 "description": "Demo package",
                 "installed_status": "installed",
@@ -1463,8 +1693,8 @@ def test_show_outdated_git_dev_dependency(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0         0.2.0         Cachy package
-demo  0.1.1 9cf87a2 0.1.2 9cf87a2 Demo package
+cachy 0.1.0         0.1.0         0.2.0         Cachy package
+demo  0.1.1 9cf87a2 0.1.2 9cf87a2 0.1.2 9cf87a2 Demo package
 """
         assert tester.io.fetch_output() == expected
 
@@ -1565,6 +1795,7 @@ def test_show_outdated_no_dev_git_dev_dependency(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1573,7 +1804,7 @@ def test_show_outdated_no_dev_git_dev_dependency(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0 0.2.0 Cachy package
+cachy 0.1.0 0.1.0 0.2.0 Cachy package
 """
         assert tester.io.fetch_output() == expected
 

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -886,6 +886,7 @@ def test_show_outdated(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -894,7 +895,156 @@ def test_show_outdated(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0 0.2.0 Cachy package
+cachy 0.1.0 0.1.0 0.2.0 Cachy package
+"""
+        assert tester.io.fetch_output() == expected
+
+
+@output_format_parametrize
+def test_show_outdated_wanted_version_respects_dependency_constraint(
+    output_format: str,
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("cachy", ">=0.1.0,<0.3.0"))
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+    cachy_030 = get_package("cachy", "0.3.0")
+    cachy_030.description = "Cachy package"
+
+    installed.add_package(cachy_010)
+
+    repo.add_package(cachy_010)
+    repo.add_package(cachy_020)
+    repo.add_package(cachy_030)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": []},
+            },
+        }
+    )
+
+    tester.execute(f"--outdated {output_format}")
+
+    expected: str | list[dict[str, str]] = ""
+    if "json" in output_format:
+        expected = [
+            {
+                "name": "cachy",
+                "version": "0.1.0",
+                "wanted_version": "0.2.0",
+                "latest_version": "0.3.0",
+                "description": "Cachy package",
+                "installed_status": "installed",
+            },
+        ]
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        expected = """\
+cachy 0.1.0 0.2.0 0.3.0 Cachy package
+"""
+        assert tester.io.fetch_output() == expected
+
+
+@output_format_parametrize
+def test_show_outdated_wanted_version_uses_latest_for_transitive_dependency(
+    output_format: str,
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+
+    pendulum_200 = get_package("pendulum", "2.0.0")
+    pendulum_200.description = "Pendulum package"
+    pendulum_200.add_dependency(Factory.create_dependency("cachy", ">=0.1.0"))
+
+    installed.add_package(cachy_010)
+    installed.add_package(pendulum_200)
+
+    repo.add_package(cachy_010)
+    repo.add_package(cachy_020)
+    repo.add_package(pendulum_200)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "description": "Pendulum package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {"cachy": ">=0.1.0"},
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": [], "pendulum": []},
+            },
+        }
+    )
+
+    tester.execute(f"--outdated {output_format}")
+
+    expected: str | list[dict[str, str]] = ""
+    if "json" in output_format:
+        expected = [
+            {
+                "name": "cachy",
+                "version": "0.1.0",
+                "wanted_version": "0.2.0",
+                "latest_version": "0.2.0",
+                "description": "Cachy package",
+                "installed_status": "installed",
+            },
+        ]
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        expected = """\
+cachy 0.1.0 0.2.0 0.2.0 Cachy package
 """
         assert tester.io.fetch_output() == expected
 
@@ -1018,6 +1168,7 @@ def test_show_outdated_has_prerelease_but_not_allowed(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1026,7 +1177,7 @@ def test_show_outdated_has_prerelease_but_not_allowed(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0 0.2.0 Cachy package
+cachy 0.1.0 0.1.0 0.2.0 Cachy package
 """
         assert tester.io.fetch_output() == expected
 
@@ -1106,6 +1257,7 @@ def test_show_outdated_has_prerelease_and_allowed(
             {
                 "name": "cachy",
                 "version": "0.1.0.dev1",
+                "wanted_version": "0.3.0.dev123",
                 "latest_version": "0.3.0.dev123",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1114,7 +1266,7 @@ def test_show_outdated_has_prerelease_and_allowed(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0.dev1 0.3.0.dev123 Cachy package
+cachy 0.1.0.dev1 0.3.0.dev123 0.3.0.dev123 Cachy package
 """
         assert tester.io.fetch_output() == expected
 
@@ -1188,6 +1340,7 @@ def test_show_outdated_formatting(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1195,6 +1348,7 @@ def test_show_outdated_formatting(
             {
                 "name": "pendulum",
                 "version": "2.0.0",
+                "wanted_version": "2.0.1",
                 "latest_version": "2.0.1",
                 "description": "Pendulum package",
                 "installed_status": "installed",
@@ -1203,10 +1357,82 @@ def test_show_outdated_formatting(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy    0.1.0 0.2.0 Cachy package
-pendulum 2.0.0 2.0.1 Pendulum package
+cachy    0.1.0 0.1.0 0.2.0 Cachy package
+pendulum 2.0.0 2.0.1 2.0.1 Pendulum package
 """
         assert tester.io.fetch_output() == expected
+
+
+def test_show_outdated_hides_wanted_column_when_terminal_is_narrow(
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    poetry.package.add_dependency(Factory.create_dependency("cachy", "^0.1.0"))
+    poetry.package.add_dependency(Factory.create_dependency("pendulum", "^2.0.0"))
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+
+    pendulum_200 = get_package("pendulum", "2.0.0")
+    pendulum_200.description = "Pendulum package"
+    pendulum_201 = get_package("pendulum", "2.0.1")
+    pendulum_201.description = "Pendulum package"
+
+    installed.add_package(cachy_010)
+    installed.add_package(pendulum_200)
+
+    repo.add_package(cachy_010)
+    repo.add_package(cachy_020)
+    repo.add_package(pendulum_200)
+    repo.add_package(pendulum_201)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "pendulum",
+                    "version": "2.0.0",
+                    "description": "Pendulum package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": [], "pendulum": []},
+            },
+        }
+    )
+
+    monkeypatch.setenv("COLUMNS", "21")
+    monkeypatch.setenv("LINES", "24")
+
+    tester.execute("--outdated")
+
+    expected = """\
+cachy    0.1.0 0.2.0
+pendulum 2.0.0 2.0.1
+"""
+    assert tester.io.fetch_output() == expected
 
 
 @pytest.mark.parametrize(
@@ -1328,6 +1554,7 @@ def test_show_outdated_local_dependencies(
             {
                 "name": "cachy",
                 "version": "0.2.0",
+                "wanted_version": "0.3.0",
                 "latest_version": "0.3.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1335,6 +1562,7 @@ def test_show_outdated_local_dependencies(
             {
                 "name": "project-with-setup",
                 "version": "0.1.1 ../project_with_setup",
+                "wanted_version": "0.1.2 ../project_with_setup",
                 "latest_version": "0.1.2 ../project_with_setup",
                 "description": "Demo project.",
                 "installed_status": "installed",
@@ -1449,6 +1677,7 @@ def test_show_outdated_git_dev_dependency(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1456,6 +1685,7 @@ def test_show_outdated_git_dev_dependency(
             {
                 "name": "demo",
                 "version": "0.1.1 9cf87a2",
+                "wanted_version": "0.1.2 9cf87a2",
                 "latest_version": "0.1.2 9cf87a2",
                 "description": "Demo package",
                 "installed_status": "installed",
@@ -1464,8 +1694,8 @@ def test_show_outdated_git_dev_dependency(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0         0.2.0         Cachy package
-demo  0.1.1 9cf87a2 0.1.2 9cf87a2 Demo package
+cachy 0.1.0         0.1.0         0.2.0         Cachy package
+demo  0.1.1 9cf87a2 0.1.2 9cf87a2 0.1.2 9cf87a2 Demo package
 """
         assert tester.io.fetch_output() == expected
 
@@ -1566,6 +1796,7 @@ def test_show_outdated_no_dev_git_dev_dependency(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.2.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -1574,7 +1805,7 @@ def test_show_outdated_no_dev_git_dev_dependency(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0 0.2.0 Cachy package
+cachy 0.1.0 0.1.0 0.2.0 Cachy package
 """
         assert tester.io.fetch_output() == expected
 
@@ -2586,13 +2817,17 @@ def test_show_outdated_explicit_source(
     poetry.pool.add_repository(explicit_repo, priority=Priority.EXPLICIT)
 
     poetry.package.add_dependency(
-        Factory.create_dependency("cachy", {"version": "^0.1.0", "source": "explicit"})
+        Factory.create_dependency(
+            "cachy", {"version": ">=0.1.0,<0.3.0", "source": "explicit"}
+        )
     )
 
     cachy_010 = get_package("cachy", "0.1.0")
     cachy_010.description = "Cachy package"
     cachy_020 = get_package("cachy", "0.2.0")
     cachy_020.description = "Cachy package"
+    cachy_030 = get_package("cachy", "0.3.0")
+    cachy_030.description = "Cachy package"
 
     installed.add_package(cachy_010)
 
@@ -2600,6 +2835,7 @@ def test_show_outdated_explicit_source(
     # consulted when checking for a newer version.
     explicit_repo.add_package(cachy_010)
     explicit_repo.add_package(cachy_020)
+    explicit_repo.add_package(cachy_030)
 
     assert isinstance(poetry.locker, DummyLocker)
     poetry.locker.mock_lock_data(
@@ -2637,7 +2873,8 @@ def test_show_outdated_explicit_source(
             {
                 "name": "cachy",
                 "version": "0.1.0",
-                "latest_version": "0.2.0",
+                "wanted_version": "0.2.0",
+                "latest_version": "0.3.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
             },
@@ -2645,7 +2882,7 @@ def test_show_outdated_explicit_source(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0 0.2.0 Cachy package
+cachy 0.1.0 0.2.0 0.3.0 Cachy package
 """
         assert tester.io.fetch_output() == expected
 
@@ -2675,7 +2912,7 @@ def test_show_outdated_multiple_constraints_uses_locked_source(
         Factory.create_dependency(
             "cachy",
             {
-                "version": "^0.1.0",
+                "version": ">=0.1.0,<0.3.0",
                 "source": "explicit-linux",
                 "markers": "sys_platform == 'linux'",
             },
@@ -2685,7 +2922,7 @@ def test_show_outdated_multiple_constraints_uses_locked_source(
         Factory.create_dependency(
             "cachy",
             {
-                "version": "^0.1.0",
+                "version": ">=0.1.0,<0.2.0",
                 "source": "explicit-darwin",
                 "markers": "sys_platform == 'darwin'",
             },
@@ -2704,6 +2941,7 @@ def test_show_outdated_multiple_constraints_uses_locked_source(
     explicit_linux.add_package(cachy_010)
     explicit_linux.add_package(cachy_020)
     explicit_darwin.add_package(cachy_010)
+    explicit_darwin.add_package(cachy_020)
     explicit_darwin.add_package(cachy_030)
 
     assert isinstance(poetry.locker, DummyLocker)
@@ -2742,6 +2980,7 @@ def test_show_outdated_multiple_constraints_uses_locked_source(
             {
                 "name": "cachy",
                 "version": "0.1.0",
+                "wanted_version": "0.1.0",
                 "latest_version": "0.3.0",
                 "description": "Cachy package",
                 "installed_status": "installed",
@@ -2750,7 +2989,7 @@ def test_show_outdated_multiple_constraints_uses_locked_source(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = """\
-cachy 0.1.0 0.3.0 Cachy package
+cachy 0.1.0 0.1.0 0.3.0 Cachy package
 """
         assert tester.io.fetch_output() == expected
 


### PR DESCRIPTION
## What

Adds a wanted version to poetry show --outdated text output and JSON output.

## Why

Closes #9495. poetry show --outdated currently reports the installed version and the latest version, but it does not show the highest version that still satisfies the project's dependency constraint. This makes it harder to tell whether a dependency can be updated with the current constraint or needs a constraint change.

## How

When --outdated is used, the command resolves a constraint-compatible candidate from the active root dependency constraints and displays it between the installed and latest versions. Candidate selection honors the current environment marker and the locked package's repository source, including explicit-priority and multiple-source dependencies. Direct-origin dependencies keep their existing display behavior, and transitive dependencies without a root constraint use the latest version.

The command reuses one cached VersionSelector for latest and wanted lookups. On narrow terminals, the wanted column is omitted before the existing latest column.

## Testing

- .\.venv\Scripts\python.exe -m pytest tests\console\commands\test_show.py -q — 90 passed
- .\.venv\Scripts\python.exe -m ruff check src\poetry\console\commands\show.py tests\console\commands\test_show.py
- .\.venv\Scripts\python.exe -m ruff format --check src\poetry\console\commands\show.py tests\console\commands\test_show.py
- .\.venv\Scripts\python.exe -m mypy src\poetry\console\commands\show.py tests\console\commands\test_show.py
- git diff --check
- GitHub Actions: full Python 3.10–3.14 matrix passed on Ubuntu, Windows, and macOS

Coverage includes root constraint caps, transitive dependencies, prereleases, direct origins, narrow terminals, explicit-priority repositories, and multiple marker/source declarations.

## Breaking changes

None. The JSON output gains a wanted_version field for --outdated results.