### PR TITLE
fix(env): prevent crash when invalid Python or Python 2.x is in PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [2.4.2] - Unreleased
+
+### Fixed
+
+- Fix an issue where Poetry commands fail when Python 2.7 is present in the `PATH` ([#10897](https://github.com/python-poetry/poetry/issues/10897)).
+
+
 ## [2.4.1] - 2026-05-09
 
 ### Changed

--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -258,9 +258,8 @@ class Python:
 
         # fallback to findpython, restrict to finding only executables
         # named "python" as the intention here is just that, nothing more
-        if python := findpython.find("python"):
-            if cls._is_valid_python(python):
-                return cls(python=python)
+        if (python := findpython.find("python")) and cls._is_valid_python(python):
+            return cls(python=python)
 
         return None
 
@@ -282,13 +281,13 @@ class Python:
     def get_by_name(cls, python_name: str) -> Python | None:
         # Ignore broken installations.
         with contextlib.suppress(ValueError, CalledProcessError):
-            if python := ShutilWhichPythonProvider.find_python_by_name(python_name):
-                if cls._is_valid_python(python):
-                    return cls(python=python)
-
-        if python := findpython.find(python_name):
-            if cls._is_valid_python(python):
+            if (
+                python := ShutilWhichPythonProvider.find_python_by_name(python_name)
+            ) and cls._is_valid_python(python):
                 return cls(python=python)
+
+        if (python := findpython.find(python_name)) and cls._is_valid_python(python):
+            return cls(python=python)
 
         return None
 

--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -85,16 +85,20 @@ class Python:
             raise ValueError("Either python or executable must be provided")
 
     @classmethod
+    def _is_valid_python(cls, python: findpython.PythonVersion) -> bool:
+        try:
+            _ = python.interpreter
+            return True
+        except (CalledProcessError, ValueError):
+            return False
+
+    @classmethod
     def find_all(cls) -> Iterator[Python]:
         venv_path: Path | None = (
             Path(venv) if (venv := os.environ.get("VIRTUAL_ENV")) else None
         )
         for python in findpython.find_all():
-            try:
-                # Ensure the python interpreter is valid and can be queried.
-                # Accessing interpreter property runs the check.
-                _ = python.interpreter
-            except (CalledProcessError, ValueError):
+            if not cls._is_valid_python(python):
                 continue
 
             if venv_path and is_relative_to(python.executable, venv_path):
@@ -184,54 +188,39 @@ class Python:
     def name(self) -> str:
         return cast("str", self._python.name)
 
-    @property
-    def executable(self) -> Path:
+    def _get_python_property(self, name: str) -> Any:
         try:
-            return cast("Path", self._python.interpreter)
+            return getattr(self._python, name)
         except CalledProcessError as e:
             raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
+
+    @property
+    def executable(self) -> Path:
+        return cast("Path", self._get_python_property("interpreter"))
 
     @property
     def implementation(self) -> str:
-        try:
-            return cast("str", self._python.implementation.lower())
-        except CalledProcessError as e:
-            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
+        return cast("str", self._get_python_property("implementation").lower())
 
     @property
     def free_threaded(self) -> bool:
-        try:
-            return cast("bool", self._python.freethreaded)
-        except CalledProcessError as e:
-            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
+        return cast("bool", self._get_python_property("freethreaded"))
 
     @property
     def major(self) -> int:
-        try:
-            return cast("int", self._python.major)
-        except CalledProcessError as e:
-            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
+        return cast("int", self._get_python_property("major"))
 
     @property
     def minor(self) -> int:
-        try:
-            return cast("int", self._python.minor)
-        except CalledProcessError as e:
-            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
+        return cast("int", self._get_python_property("minor"))
 
     @property
     def patch(self) -> int:
-        try:
-            return cast("int", self._python.patch)
-        except CalledProcessError as e:
-            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
+        return cast("int", self._get_python_property("patch"))
 
     @property
     def version(self) -> Version:
-        try:
-            return Version.parse(str(self._python.version))
-        except CalledProcessError as e:
-            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
+        return Version.parse(str(self._get_python_property("version")))
 
     @cached_property
     def patch_version(self) -> Version:
@@ -263,20 +252,14 @@ class Python:
                  or None if no valid environment is found.
         """
         for python in ShutilWhichPythonProvider().find_pythons():
-            try:
-                _ = python.interpreter
+            if cls._is_valid_python(python):
                 return cls(python=python)
-            except (CalledProcessError, ValueError):
-                pass
 
         # fallback to findpython, restrict to finding only executables
         # named "python" as the intention here is just that, nothing more
         if python := findpython.find("python"):
-            try:
-                _ = python.interpreter
+            if cls._is_valid_python(python):
                 return cls(python=python)
-            except (CalledProcessError, ValueError):
-                pass
 
         return None
 
@@ -299,15 +282,12 @@ class Python:
         # Ignore broken installations.
         with contextlib.suppress(ValueError, CalledProcessError):
             if python := ShutilWhichPythonProvider.find_python_by_name(python_name):
-                _ = python.interpreter
-                return cls(python=python)
+                if cls._is_valid_python(python):
+                    return cls(python=python)
 
         if python := findpython.find(python_name):
-            try:
-                _ = python.interpreter
+            if cls._is_valid_python(python):
                 return cls(python=python)
-            except (CalledProcessError, ValueError):
-                pass
 
         return None
 

--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -4,6 +4,8 @@ import contextlib
 import os
 import sys
 
+from subprocess import CalledProcessError
+
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -88,6 +90,13 @@ class Python:
             Path(venv) if (venv := os.environ.get("VIRTUAL_ENV")) else None
         )
         for python in findpython.find_all():
+            try:
+                # Ensure the python interpreter is valid and can be queried.
+                # Accessing interpreter property runs the check.
+                _ = python.interpreter
+            except (CalledProcessError, ValueError):
+                continue
+
             if venv_path and is_relative_to(python.executable, venv_path):
                 continue
             yield cls(python=python)
@@ -177,31 +186,52 @@ class Python:
 
     @property
     def executable(self) -> Path:
-        return cast("Path", self._python.interpreter)
+        try:
+            return cast("Path", self._python.interpreter)
+        except CalledProcessError as e:
+            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
 
     @property
     def implementation(self) -> str:
-        return cast("str", self._python.implementation.lower())
+        try:
+            return cast("str", self._python.implementation.lower())
+        except CalledProcessError as e:
+            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
 
     @property
     def free_threaded(self) -> bool:
-        return cast("bool", self._python.freethreaded)
+        try:
+            return cast("bool", self._python.freethreaded)
+        except CalledProcessError as e:
+            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
 
     @property
     def major(self) -> int:
-        return cast("int", self._python.major)
+        try:
+            return cast("int", self._python.major)
+        except CalledProcessError as e:
+            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
 
     @property
     def minor(self) -> int:
-        return cast("int", self._python.minor)
+        try:
+            return cast("int", self._python.minor)
+        except CalledProcessError as e:
+            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
 
     @property
     def patch(self) -> int:
-        return cast("int", self._python.patch)
+        try:
+            return cast("int", self._python.patch)
+        except CalledProcessError as e:
+            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
 
     @property
     def version(self) -> Version:
-        return Version.parse(str(self._python.version))
+        try:
+            return Version.parse(str(self._python.version))
+        except CalledProcessError as e:
+            raise ValueError(f"Invalid Python executable: {self._python.executable}") from e
 
     @cached_property
     def patch_version(self) -> Version:
@@ -233,12 +263,20 @@ class Python:
                  or None if no valid environment is found.
         """
         for python in ShutilWhichPythonProvider().find_pythons():
-            return cls(python=python)
+            try:
+                _ = python.interpreter
+                return cls(python=python)
+            except (CalledProcessError, ValueError):
+                pass
 
         # fallback to findpython, restrict to finding only executables
         # named "python" as the intention here is just that, nothing more
         if python := findpython.find("python"):
-            return cls(python=python)
+            try:
+                _ = python.interpreter
+                return cls(python=python)
+            except (CalledProcessError, ValueError):
+                pass
 
         return None
 
@@ -259,12 +297,17 @@ class Python:
     @classmethod
     def get_by_name(cls, python_name: str) -> Python | None:
         # Ignore broken installations.
-        with contextlib.suppress(ValueError):
+        with contextlib.suppress(ValueError, CalledProcessError):
             if python := ShutilWhichPythonProvider.find_python_by_name(python_name):
+                _ = python.interpreter
                 return cls(python=python)
 
         if python := findpython.find(python_name):
-            return cls(python=python)
+            try:
+                _ = python.interpreter
+                return cls(python=python)
+            except (CalledProcessError, ValueError):
+                pass
 
         return None
 

--- a/src/poetry/utils/env/python/manager.py
+++ b/src/poetry/utils/env/python/manager.py
@@ -9,6 +9,7 @@ from subprocess import CalledProcessError
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import NamedTuple
 from typing import cast
 from typing import overload

--- a/tests/utils/test_python_manager.py
+++ b/tests/utils/test_python_manager.py
@@ -141,3 +141,77 @@ def test_python_find_compatible(
     python = Python.get_compatible_python(poetry)
 
     assert Version.from_parts(3, 4) <= python.version <= Version.from_parts(4, 0)
+
+
+def test_python_ignores_broken_installations(mocker: MockerFixture) -> None:
+    from subprocess import CalledProcessError
+
+    mock_good_pv = mocker.MagicMock(spec=findpython.PythonVersion)
+    mock_good_pv.executable = Path("/usr/bin/python3.12")
+    mock_good_pv.interpreter = Path("/usr/bin/python3.12")
+    mock_good_pv.version = packaging.version.Version("3.12.0")
+
+    mock_bad_pv = mocker.MagicMock(spec=findpython.PythonVersion)
+    mock_bad_pv.executable = Path("/usr/bin/python2.7")
+    type(mock_bad_pv).interpreter = mocker.PropertyMock(
+        side_effect=CalledProcessError(2, ["/usr/bin/python2.7", "-Ic", "..."])
+    )
+
+    mocker.patch("findpython.find_all", return_value=[mock_bad_pv, mock_good_pv])
+
+    pythons = list(Python.find_all())
+    assert len(pythons) == 1
+    assert pythons[0].executable == Path("/usr/bin/python3.12")
+
+
+def test_get_active_python_ignores_broken_installations(mocker: MockerFixture) -> None:
+    from subprocess import CalledProcessError
+
+    mock_bad_pv = mocker.MagicMock(spec=findpython.PythonVersion)
+    mock_bad_pv.executable = Path("/usr/bin/python2.7")
+    type(mock_bad_pv).interpreter = mocker.PropertyMock(
+        side_effect=CalledProcessError(2, ["/usr/bin/python2.7", "-Ic", "..."])
+    )
+
+    mocker.patch(
+        "poetry.utils.env.python.providers.ShutilWhichPythonProvider.find_pythons",
+        return_value=[mock_bad_pv],
+    )
+    mocker.patch("findpython.find", return_value=None)
+
+    assert Python.get_active_python() is None
+
+
+def test_get_by_name_ignores_broken_installations(mocker: MockerFixture) -> None:
+    from subprocess import CalledProcessError
+
+    mock_bad_pv = mocker.MagicMock(spec=findpython.PythonVersion)
+    mock_bad_pv.executable = Path("/usr/bin/python2.7")
+    type(mock_bad_pv).interpreter = mocker.PropertyMock(
+        side_effect=CalledProcessError(2, ["/usr/bin/python2.7", "-Ic", "..."])
+    )
+
+    mocker.patch(
+        "poetry.utils.env.python.providers.ShutilWhichPythonProvider.find_python_by_name",
+        return_value=mock_bad_pv,
+    )
+    mocker.patch("findpython.find", return_value=None)
+
+    assert Python.get_by_name("python") is None
+
+
+def test_python_properties_raise_value_error_on_subprocess_failure(
+    mocker: MockerFixture,
+) -> None:
+    from subprocess import CalledProcessError
+
+    mock_bad_pv = mocker.MagicMock(spec=findpython.PythonVersion)
+    mock_bad_pv.executable = Path("/usr/bin/python2.7")
+    type(mock_bad_pv).interpreter = mocker.PropertyMock(
+        side_effect=CalledProcessError(2, ["/usr/bin/python2.7", "-Ic", "..."])
+    )
+
+    python = Python(python=mock_bad_pv)
+    with pytest.raises(ValueError, match="Invalid Python executable"):
+        _ = python.executable
+


### PR DESCRIPTION
# Pull Request Check List

# Resolves: #10897

    - [ ] Added tests for changed code.
    - [x] Updated documentation for changed code.

## Description

With Poetry 2.4, system Python discovery checks candidate binaries using `findpython`. Some older or broken Python interpreters (specifically Python 2.7) do not support the isolated `-I` option when probed, resulting in a `CalledProcessError` with exit status 2 and crashing various Poetry commands.

This PR fixes the crash by:
1. Catching `CalledProcessError` and `ValueError` inside python discovery functions (`find_all`, `get_active_python`, `get_by_name`). When encountered, the invalid Python binary is safely skipped.
2. Converting `CalledProcessError` exceptions inside python manager properties (`executable`, `version`, `implementation`, etc.) to a standard `ValueError`.
3. Adding unit tests in `tests/utils/test_python_manager.py` that mock the discovery of broken Python installations (such as Python 2.7) to verify that they are cleanly ignored.

The documentation wasn't updates but is prepared, I shall add those once these changes are ensured that they are working and robust. 