### PR TITLE
fix(show): respect active extras when showing a group's dependency tree

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -17,6 +17,8 @@ from poetry.utils.constants import POETRY_SYSTEM_PROJECT_NAME
 
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from cleo.io.inputs.argument import Argument
     from cleo.io.inputs.option import Option
     from cleo.io.io import IO
@@ -509,10 +511,12 @@ lists all packages available."""
         packages = locked_repository.packages
 
         for p in packages:
-            for require in root.all_requires:
-                if p.name == require.name:
-                    self.display_package_tree(self.io, p, packages)
-                    break
+            requires = [r for r in root.all_requires if r.name == p.name]
+            if requires:
+                active_extras = {extra for r in requires for extra in r.extras}
+                self.display_package_tree(
+                    self.io, p, packages, active_extras=active_extras
+                )
 
         return 0
 
@@ -522,6 +526,7 @@ lists all packages available."""
         package: Package,
         installed_packages: list[Package],
         why_package: Package | None = None,
+        active_extras: Collection[NormalizedName] | None = None,
     ) -> None:
         io.write(f"<c1>{package.pretty_name}</c1>")
         description = ""
@@ -534,6 +539,13 @@ lists all packages available."""
             dependencies = [p for p in package.requires if p.name == why_package.name]
         else:
             dependencies = package.requires
+            if active_extras is not None:
+                dependencies = [
+                    d
+                    for d in dependencies
+                    if not d.in_extras
+                    or any(extra in active_extras for extra in d.in_extras)
+                ]
             dependencies = sorted(
                 dependencies,
                 key=lambda x: x.name,
@@ -563,6 +575,7 @@ lists all packages available."""
                 packages_in_tree,
                 tree_bar,
                 level + 1,
+                active_extras=dependency.extras if active_extras is not None else None,
             )
 
     def _display_tree(
@@ -573,6 +586,7 @@ lists all packages available."""
         packages_in_tree: set[NormalizedName],
         previous_tree_bar: str = "├",
         level: int = 1,
+        active_extras: Collection[NormalizedName] | None = None,
     ) -> None:
         previous_tree_bar = previous_tree_bar.replace("├", "│")
 
@@ -582,6 +596,14 @@ lists all packages available."""
                 dependencies = package.requires
 
                 break
+
+        if active_extras is not None:
+            dependencies = [
+                d
+                for d in dependencies
+                if not d.in_extras
+                or any(extra in active_extras for extra in d.in_extras)
+            ]
 
         dependencies = sorted(
             dependencies,
@@ -618,6 +640,9 @@ lists all packages available."""
                         packages_in_tree,
                         tree_bar,
                         level + 1,
+                        active_extras=(
+                            dependency.extras if active_extras is not None else None
+                        ),
                     )
                 finally:
                     packages_in_tree.discard(dependency.name)

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1978,6 +1978,104 @@ cachy 0.2.0
     assert tester.io.fetch_output() == expected
 
 
+def test_show_tree_only_group_respects_active_extras(
+    tester: CommandTester, poetry: Poetry, installed: Repository
+) -> None:
+    # The same package is required by two groups, but only group "a" activates
+    # the "foo" extra. The tree for group "b" must not show the extra's
+    # dependencies, while the tree for group "a" must.
+    poetry.package.add_dependency(
+        Factory.create_dependency(
+            "cachy", {"version": "^0.2.0", "extras": ["foo"]}, groups=["a"]
+        )
+    )
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", "^0.2.0", groups=["b"])
+    )
+
+    cachy2 = get_package("cachy", "0.2.0")
+    cachy2.add_dependency(Factory.create_dependency("msgpack-python", ">=0.5 <0.6"))
+    cachy2.add_dependency(
+        Factory.create_dependency(
+            "email-validator", {"version": ">=2.0", "markers": 'extra == "foo"'}
+        )
+    )
+    installed.add_package(cachy2)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.2.0",
+                    "description": "",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "dependencies": {
+                        "msgpack-python": ">=0.5 <0.6",
+                        "email-validator": {
+                            "version": ">=2.0",
+                            "markers": 'extra == "foo"',
+                        },
+                    },
+                },
+                {
+                    "name": "msgpack-python",
+                    "version": "0.5.1",
+                    "description": "",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+                {
+                    "name": "email-validator",
+                    "version": "2.0.0",
+                    "description": "",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {
+                    "cachy": [],
+                    "msgpack-python": [],
+                    "email-validator": [],
+                },
+            },
+        }
+    )
+
+    tester.execute("--tree --only b")
+
+    assert (
+        tester.io.fetch_output()
+        == """\
+cachy 0.2.0
+└── msgpack-python >=0.5 <0.6
+"""
+    )
+
+    tester.execute("--tree --only a")
+
+    assert (
+        tester.io.fetch_output()
+        == """\
+cachy 0.2.0
+├── email-validator >=2.0
+└── msgpack-python >=0.5 <0.6
+"""
+    )
+
+
 def test_show_tree_why_package(
     tester: CommandTester, poetry: Poetry, installed: Repository
 ) -> None:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10416

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Problem

`poetry show --tree --only <group>` can show another group's dependencies. If a package is required by two groups with different extras, one group's tree lists the other's extra deps. `show --only b` correctly omits `email-validator`; `--tree --only b` shows it.

## Fix

The flat output already respects active groups and their extras; the tree didn't. It walked each package's full `requires`, including deps gated behind extras the group never turned on. The tree now filters with the same rule the solver uses (a dep shows only if it isn't extra-gated, or one of its gating extras is active), carrying active extras down each edge. `display_package_tree`/`_display_tree` take a new `active_extras` arg defaulting to `None`, so plain `show <pkg> --tree` is unchanged.

## Tested

`test_show_tree_only_group_respects_active_extras`: same package in two groups, one with an extra, asserts the extra's dep is absent without it and present with it (reverting fails the first check). Full `test_show.py` passes; mypy and ruff clean. Scope: extras only, non-extra environment markers stay unfiltered (pre-existing).