### PR TITLE
Generate launchers for gui-scripts in editable installs

### DIFF
--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -153,8 +153,8 @@ class EditableBuilder(Builder):
             )
             return []
 
-        scripts = entry_points.get("console_scripts", []) + entry_points.get(
-            "gui_scripts", []
+        scripts = (entry_points.get("console_scripts") or []) + (
+            entry_points.get("gui_scripts") or []
         )
         for script in scripts:
             name, script_with_extras = script.split(" = ")

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -153,7 +153,9 @@ class EditableBuilder(Builder):
             )
             return []
 
-        scripts = entry_points.get("console_scripts", [])
+        scripts = entry_points.get("console_scripts", []) + entry_points.get(
+            "gui_scripts", []
+        )
         for script in scripts:
             name, script_with_extras = script.split(" = ")
             script_without_extras = script_with_extras.split("[")[0]

--- a/tests/fixtures/simple_project/pyproject.toml
+++ b/tests/fixtures/simple_project/pyproject.toml
@@ -20,6 +20,9 @@ foo = "foo:bar"
 baz = "bar:baz.boom.bim"
 fox = "fuz.foo:bar.baz"
 
+[project.gui-scripts]
+gui-foo = "foo:gui"
+
 [tool.poetry]
 classifiers = [
     "Topic :: Software Development :: Build Tools",

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -145,6 +145,10 @@ def test_builder_installs_proper_files_for_standard_packages(
     builder.build()
 
     assert tmp_venv._bin_dir.joinpath("foo").exists()
+    # GUI scripts are only available via PEP 621 [project.gui-scripts];
+    # the legacy [tool.poetry] schema does not support a gui-scripts table.
+    if project == "simple_project":
+        assert tmp_venv._bin_dir.joinpath("gui-foo").exists()
     pth_file = Path("simple_project.pth")
     assert tmp_venv.site_packages.exists(pth_file)
     assert (
@@ -176,10 +180,14 @@ def test_builder_installs_proper_files_for_standard_packages(
     )
 
     assert dist_info.joinpath("INSTALLER").read_text(encoding="utf-8") == "poetry"
+    expected_entry_points = (
+        "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\nfox=fuz.foo:bar.baz\n\n"
+    )
+    if project == "simple_project":
+        expected_entry_points += "[gui_scripts]\ngui-foo=foo:gui\n\n"
     assert (
         dist_info.joinpath("entry_points.txt").read_text(encoding="utf-8")
-        == "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\n"
-        "fox=fuz.foo:bar.baz\n\n"
+        == expected_entry_points
     )
     metadata = f"""\
 Metadata-Version: {expected_metadata_version()}
@@ -263,6 +271,23 @@ if __name__ == '__main__':
 """
 
     assert tmp_venv._bin_dir.joinpath("fox").read_text(encoding="utf-8") == fox_script
+
+    if project == "simple_project":
+        assert str(tmp_venv._bin_dir.joinpath("gui-foo")) in record_entries
+
+        gui_foo_script = f"""\
+#!{tmp_venv.python}
+import sys
+from foo import gui
+
+if __name__ == '__main__':
+    sys.exit(gui())
+"""
+
+        assert (
+            tmp_venv._bin_dir.joinpath("gui-foo").read_text(encoding="utf-8")
+            == gui_foo_script
+        )
 
 
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -204,10 +204,9 @@ def test_builder_installs_proper_files_for_standard_packages(
     )
 
     assert dist_info.joinpath("INSTALLER").read_text(encoding="utf-8") == "poetry"
-    assert (
-        dist_info.joinpath("entry_points.txt").read_text(encoding="utf-8")
-        == expected_entry_points_for(project)
-    )
+    assert dist_info.joinpath("entry_points.txt").read_text(
+        encoding="utf-8"
+    ) == expected_entry_points_for(project)
     metadata = f"""\
 Metadata-Version: {expected_metadata_version()}
 Name: simple-project

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -127,14 +127,18 @@ def expected_python_classifiers(min_version: str | None = None) -> str:
     )
 
 
-def expected_entry_points_for(project: str) -> str:
-    entry_points = (
-        "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\nfox=fuz.foo:bar.baz\n\n"
-    )
-    if project == "simple_project":
-        entry_points += "[gui_scripts]\ngui-foo=foo:gui\n\n"
+CONSOLE_ENTRY_POINTS = (
+    "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\nfox=fuz.foo:bar.baz\n\n"
+)
+GUI_ENTRY_POINTS = "[gui_scripts]\ngui-foo=foo:gui\n\n"
 
-    return entry_points
+
+def record_entries_for(dist_info: Path) -> set[str]:
+    with open(dist_info.joinpath("RECORD"), encoding="utf-8", newline="") as f:
+        records = list(csv.reader(f))
+
+    assert all(len(row) == 3 for row in records)
+    return {row[0] for row in records}
 
 
 def assert_gui_script_installed(tmp_venv: VirtualEnv, record_entries: set[str]) -> None:
@@ -155,9 +159,16 @@ if __name__ == '__main__':
     assert gui_foo.read_text(encoding="utf-8") == gui_foo_script
 
 
-@pytest.mark.parametrize("project", ("simple_project", "simple_project_legacy"))
+@pytest.mark.parametrize(
+    ("project", "expected_entry_points"),
+    [
+        ("simple_project", CONSOLE_ENTRY_POINTS + GUI_ENTRY_POINTS),
+        ("simple_project_legacy", CONSOLE_ENTRY_POINTS),
+    ],
+)
 def test_builder_installs_proper_files_for_standard_packages(
     project: str,
+    expected_entry_points: str,
     simple_poetry: Poetry,
     tmp_path: Path,
     fixture_dir: FixtureDirGetter,
@@ -204,9 +215,10 @@ def test_builder_installs_proper_files_for_standard_packages(
     )
 
     assert dist_info.joinpath("INSTALLER").read_text(encoding="utf-8") == "poetry"
-    assert dist_info.joinpath("entry_points.txt").read_text(
-        encoding="utf-8"
-    ) == expected_entry_points_for(project)
+    assert (
+        dist_info.joinpath("entry_points.txt").read_text(encoding="utf-8")
+        == expected_entry_points
+    )
     metadata = f"""\
 Metadata-Version: {expected_metadata_version()}
 Name: simple-project
@@ -237,12 +249,7 @@ My Package
         )
     assert dist_info.joinpath("METADATA").read_text(encoding="utf-8") == metadata
 
-    with open(dist_info.joinpath("RECORD"), encoding="utf-8", newline="") as f:
-        reader = csv.reader(f)
-        records = list(reader)
-
-    assert all(len(row) == 3 for row in records)
-    record_entries = {row[0] for row in records}
+    record_entries = record_entries_for(dist_info)
     pth_file = Path("simple_project.pth")
     assert tmp_venv.site_packages.exists(pth_file)
     assert str(tmp_venv.site_packages.find(pth_file)[0]) in record_entries
@@ -290,8 +297,15 @@ if __name__ == '__main__':
 
     assert tmp_venv._bin_dir.joinpath("fox").read_text(encoding="utf-8") == fox_script
 
-    if project == "simple_project":
-        assert_gui_script_installed(tmp_venv, record_entries)
+
+def test_builder_installs_gui_scripts(
+    simple_poetry: Poetry, tmp_venv: VirtualEnv
+) -> None:
+    builder = EditableBuilder(simple_poetry, tmp_venv, NullIO())
+    builder.build()
+
+    dist_info = tmp_venv.site_packages.find(Path("simple_project-1.2.3.dist-info"))[0]
+    assert_gui_script_installed(tmp_venv, record_entries_for(dist_info))
 
 
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -127,6 +127,34 @@ def expected_python_classifiers(min_version: str | None = None) -> str:
     )
 
 
+def expected_entry_points_for(project: str) -> str:
+    entry_points = (
+        "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\nfox=fuz.foo:bar.baz\n\n"
+    )
+    if project == "simple_project":
+        entry_points += "[gui_scripts]\ngui-foo=foo:gui\n\n"
+
+    return entry_points
+
+
+def assert_gui_script_installed(tmp_venv: VirtualEnv, record_entries: set[str]) -> None:
+    gui_foo = tmp_venv._bin_dir.joinpath("gui-foo")
+
+    assert gui_foo.exists()
+    assert str(gui_foo) in record_entries
+
+    gui_foo_script = f"""\
+#!{tmp_venv.python}
+import sys
+from foo import gui
+
+if __name__ == '__main__':
+    sys.exit(gui())
+"""
+
+    assert gui_foo.read_text(encoding="utf-8") == gui_foo_script
+
+
 @pytest.mark.parametrize("project", ("simple_project", "simple_project_legacy"))
 def test_builder_installs_proper_files_for_standard_packages(
     project: str,
@@ -145,10 +173,6 @@ def test_builder_installs_proper_files_for_standard_packages(
     builder.build()
 
     assert tmp_venv._bin_dir.joinpath("foo").exists()
-    # GUI scripts are only available via PEP 621 [project.gui-scripts];
-    # the legacy [tool.poetry] schema does not support a gui-scripts table.
-    if project == "simple_project":
-        assert tmp_venv._bin_dir.joinpath("gui-foo").exists()
     pth_file = Path("simple_project.pth")
     assert tmp_venv.site_packages.exists(pth_file)
     assert (
@@ -180,14 +204,9 @@ def test_builder_installs_proper_files_for_standard_packages(
     )
 
     assert dist_info.joinpath("INSTALLER").read_text(encoding="utf-8") == "poetry"
-    expected_entry_points = (
-        "[console_scripts]\nbaz=bar:baz.boom.bim\nfoo=foo:bar\nfox=fuz.foo:bar.baz\n\n"
-    )
-    if project == "simple_project":
-        expected_entry_points += "[gui_scripts]\ngui-foo=foo:gui\n\n"
     assert (
         dist_info.joinpath("entry_points.txt").read_text(encoding="utf-8")
-        == expected_entry_points
+        == expected_entry_points_for(project)
     )
     metadata = f"""\
 Metadata-Version: {expected_metadata_version()}
@@ -273,21 +292,7 @@ if __name__ == '__main__':
     assert tmp_venv._bin_dir.joinpath("fox").read_text(encoding="utf-8") == fox_script
 
     if project == "simple_project":
-        assert str(tmp_venv._bin_dir.joinpath("gui-foo")) in record_entries
-
-        gui_foo_script = f"""\
-#!{tmp_venv.python}
-import sys
-from foo import gui
-
-if __name__ == '__main__':
-    sys.exit(gui())
-"""
-
-        assert (
-            tmp_venv._bin_dir.joinpath("gui-foo").read_text(encoding="utf-8")
-            == gui_foo_script
-        )
+        assert_gui_script_installed(tmp_venv, record_entries)
 
 
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(


### PR DESCRIPTION
## Summary

Scripts declared in `[project.gui-scripts]` are not made available by `poetry install` (editable mode). This fixes #10481 (labelled `kind/bug` + `status/confirmed`).

`EditableBuilder._add_scripts()` only reads the `console_scripts` entry-point group:

```python
scripts = entry_points.get("console_scripts", [])
```

so GUI scripts are silently dropped from the venv's `bin`/`Scripts` directory.

### The editable-vs-wheel asymmetry

Wheel installs are unaffected: the wheel only records entry points in `entry_points.txt`, and **pip** generates the launchers for both `console_scripts` and `gui_scripts` at install time. Editable installs, by contrast, generate the launcher scripts themselves inside `EditableBuilder` — and that code path never iterated `gui_scripts`. The result is an inconsistency: a project's GUI scripts work after `pip install .` / building a wheel, but are missing after `poetry install`.

Note that the editable dist-info's `entry_points.txt` already lists the `[gui_scripts]` group correctly, because poetry-core's `convert_entry_points()` returns both groups (verified against poetry-core 2.4.1):

```python
elif group_name == "gui-scripts":
    group_name = "gui_scripts"
```

So the metadata is right; only the launcher generation is incomplete. (A prior attempt, #9549, was closed procedurally pending poetry-core support for the `gui_scripts` group — that support now exists.)

## The fix

One line — also iterate the `gui_scripts` group:

```python
scripts = entry_points.get("console_scripts", []) + entry_points.get("gui_scripts", [])
```

Editable mode writes an identical plain-Python script (plus a Windows `.cmd` wrapper) for every script, with no console-vs-gui distinction, so the rest of the loop (`split(" = ")`, the `ValueError` hint handling, the `.cmd` wrapper) applies to GUI scripts unchanged.

## Reproduction

A minimal project:

```toml
[project]
name = "mygui-pkg"
version = "0.1.0"

[project.scripts]
mycli = "mygui_pkg:cli"

[project.gui-scripts]
mygui = "mygui_pkg:gui"

[build-system]
requires = ["poetry-core>=2.0"]
build-backend = "poetry.core.masonry.api"
```

**Before** this change, after an editable install:
- `entry_points.txt` contains both `[console_scripts]` and `[gui_scripts]` blocks ✅
- `Scripts/mycli` (+ `mycli.cmd` on Windows) exists ✅
- `Scripts/mygui` is **missing** ❌

**After** this change, `Scripts/mygui` (+ `mygui.cmd`) is generated alongside `mycli`, with the same launcher content.

## Test

Extends `test_builder_installs_proper_files_for_standard_packages` in `tests/masonry/builders/test_editable_builder.py`:

- The `simple_project` fixture gains a `[project.gui-scripts]` entry (`gui-foo = "foo:gui"`).
- New assertions: `tmp_venv._bin_dir.joinpath("gui-foo").exists()`, the launcher file contents, and the `RECORD` entry.
- The existing `entry_points.txt` assertion is updated to include the `[gui_scripts]` block.

The GUI-specific assertions are gated on `project == "simple_project"` rather than also applied to `simple_project_legacy`, because the legacy `[tool.poetry]` schema in poetry-core (`poetry-schema.json`) does not define a `gui-scripts` table — `[tool.poetry.gui-scripts]` is rejected as an unexpected property. GUI scripts are a PEP 621–only feature, so the legacy fixture is intentionally left unchanged.

Verified: the new assertion fails on `main` (no launcher generated) and passes with the fix.

```
$ pytest tests/masonry/builders/test_editable_builder.py -k standard_packages
2 passed
```

`ruff check`, `ruff format --check`, and `mypy` all pass on the changed files.

## Coordination

I'm aware of other open PRs that touch `EditableBuilder._add_scripts()` / the same launcher path: #9802 (shebang spaces), #10946 (Windows UTF-8 script wrappers), and #10736 (file scripts). As of opening this PR none of them have merged, so this applies cleanly to `main`. If any of them merge first, I'm happy to rebase and re-apply the `gui_scripts` inclusion to the new launcher path — in particular #9802 hardcodes a `"console"` kind, and the intent here is simply that GUI scripts also get a generated launcher.

## AI assistance disclosure

This change was prepared with the help of Claude (Anthropic). A human reviewed the bug, the one-line fix, and the test; the reproduction and the failing-on-main / passing-with-fix behavior were verified by actually running the editable builder and the test suite, not assumed. I'm responsible for the contents of this PR and happy to make any adjustments maintainers request.
