### PR TITLE
Delay parsing requests timeout environment variable

### DIFF
--- a/src/poetry/publishing/uploader.py
+++ b/src/poetry/publishing/uploader.py
@@ -23,7 +23,7 @@ from requests_toolbelt.multipart import MultipartEncoderMonitor
 
 from poetry.__version__ import __version__
 from poetry.publishing.hash_manager import HashManager
-from poetry.utils.constants import REQUESTS_TIMEOUT
+from poetry.utils.constants import get_requests_timeout
 from poetry.utils.patterns import wheel_file_re
 
 
@@ -239,7 +239,7 @@ class Uploader:
                         data=monitor,
                         allow_redirects=False,
                         headers={"Content-Type": monitor.content_type},
-                        timeout=REQUESTS_TIMEOUT,
+                        timeout=get_requests_timeout(),
                     )
                 if resp is None or 200 <= resp.status_code < 300:
                     bar.set_format(
@@ -308,7 +308,7 @@ class Uploader:
             data=encoder,
             allow_redirects=False,
             headers={"Content-Type": encoder.content_type},
-            timeout=REQUESTS_TIMEOUT,
+            timeout=get_requests_timeout(),
         )
 
         resp.raise_for_status()

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -35,6 +35,7 @@ from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.link_sources.html import HTMLPage
 from poetry.repositories.link_sources.json import SimpleJsonPage
 from poetry.utils.authenticator import Authenticator
+from poetry.utils.constants import get_requests_timeout
 from poetry.utils.helpers import HTTPRangeRequestSupportedError
 from poetry.utils.helpers import download_file
 from poetry.utils.helpers import get_highest_priority_hash_type
@@ -538,7 +539,10 @@ class HTTPRepository(CachedRepository):
         url = self._url + endpoint
         try:
             response: requests.Response = self.session.get(
-                url, raise_for_status=False, headers=headers
+                url,
+                raise_for_status=False,
+                timeout=get_requests_timeout(),
+                headers=headers,
             )
             if response.status_code in (401, 403):
                 self._log(

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -35,7 +35,6 @@ from poetry.repositories.exceptions import RepositoryError
 from poetry.repositories.link_sources.html import HTMLPage
 from poetry.repositories.link_sources.json import SimpleJsonPage
 from poetry.utils.authenticator import Authenticator
-from poetry.utils.constants import REQUESTS_TIMEOUT
 from poetry.utils.helpers import HTTPRangeRequestSupportedError
 from poetry.utils.helpers import download_file
 from poetry.utils.helpers import get_highest_priority_hash_type
@@ -539,7 +538,7 @@ class HTTPRepository(CachedRepository):
         url = self._url + endpoint
         try:
             response: requests.Response = self.session.get(
-                url, raise_for_status=False, timeout=REQUESTS_TIMEOUT, headers=headers
+                url, raise_for_status=False, headers=headers
             )
             if response.status_code in (401, 403):
                 self._log(

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -206,6 +206,7 @@ class PyPiRepository(HTTPRepository):
             json_response = self.session.get(
                 self._base_url + endpoint,
                 raise_for_status=False,
+                timeout=get_requests_timeout(),
                 headers=headers,
             )
         except requests.exceptions.TooManyRedirects:
@@ -215,6 +216,7 @@ class PyPiRepository(HTTPRepository):
             json_response = self.session.get(
                 self._base_url + endpoint,
                 raise_for_status=False,
+                timeout=get_requests_timeout(),
                 headers=headers,
             )
 

--- a/src/poetry/repositories/pypi_repository.py
+++ b/src/poetry/repositories/pypi_repository.py
@@ -20,7 +20,7 @@ from poetry.repositories.exceptions import PackageNotFoundError
 from poetry.repositories.http_repository import HTTPRepository
 from poetry.repositories.link_sources.json import SimpleJsonPage
 from poetry.repositories.parsers.pypi_search_parser import SearchResultParser
-from poetry.utils.constants import REQUESTS_TIMEOUT
+from poetry.utils.constants import get_requests_timeout
 
 
 cache_control_logger.setLevel(logging.ERROR)
@@ -61,7 +61,9 @@ class PyPiRepository(HTTPRepository):
         results = []
 
         response = requests.get(
-            self._base_url + "search", params={"q": query}, timeout=REQUESTS_TIMEOUT
+            self._base_url + "search",
+            params={"q": query},
+            timeout=get_requests_timeout(),
         )
         parser = SearchResultParser()
         parser.feed(response.text)
@@ -204,7 +206,6 @@ class PyPiRepository(HTTPRepository):
             json_response = self.session.get(
                 self._base_url + endpoint,
                 raise_for_status=False,
-                timeout=REQUESTS_TIMEOUT,
                 headers=headers,
             )
         except requests.exceptions.TooManyRedirects:
@@ -214,7 +215,6 @@ class PyPiRepository(HTTPRepository):
             json_response = self.session.get(
                 self._base_url + endpoint,
                 raise_for_status=False,
-                timeout=REQUESTS_TIMEOUT,
                 headers=headers,
             )
 

--- a/src/poetry/utils/authenticator.py
+++ b/src/poetry/utils/authenticator.py
@@ -25,9 +25,9 @@ from poetry.config.config import Config
 from poetry.console.exceptions import ConsoleMessage
 from poetry.console.exceptions import PoetryRuntimeError
 from poetry.exceptions import PoetryError
-from poetry.utils.constants import REQUESTS_TIMEOUT
 from poetry.utils.constants import RETRY_AFTER_HEADER
 from poetry.utils.constants import STATUS_FORCELIST
+from poetry.utils.constants import get_requests_timeout
 from poetry.utils.password_manager import HTTPAuthCredential
 from poetry.utils.password_manager import PasswordManager
 
@@ -226,8 +226,9 @@ class Authenticator:
         )
 
         # Send the request.
+        timeout = kwargs["timeout"] if "timeout" in kwargs else get_requests_timeout()
         send_kwargs = {
-            "timeout": kwargs.get("timeout", REQUESTS_TIMEOUT),
+            "timeout": timeout,
             "allow_redirects": kwargs.get("allow_redirects", True),
         }
         send_kwargs.update(settings)

--- a/src/poetry/utils/constants.py
+++ b/src/poetry/utils/constants.py
@@ -2,12 +2,25 @@ from __future__ import annotations
 
 import os
 
+from poetry.config.config import int_normalizer
+
 
 # Name of Poetry's own system project used by `poetry self` commands.
 POETRY_SYSTEM_PROJECT_NAME = "poetry-instance"
 
 # Timeout for HTTP requests using the requests library.
-REQUESTS_TIMEOUT = int(os.getenv("POETRY_REQUESTS_TIMEOUT", 15))
+REQUESTS_TIMEOUT = 15
+
+
+def get_requests_timeout() -> int:
+    try:
+        return int_normalizer(
+            os.getenv("POETRY_REQUESTS_TIMEOUT", str(REQUESTS_TIMEOUT))
+        )
+    except ValueError as e:
+        raise ValueError(
+            "POETRY_REQUESTS_TIMEOUT must be an integer number of seconds"
+        ) from e
 
 RETRY_AFTER_HEADER = "retry-after"
 

--- a/src/poetry/utils/constants.py
+++ b/src/poetry/utils/constants.py
@@ -10,17 +10,34 @@ POETRY_SYSTEM_PROJECT_NAME = "poetry-instance"
 
 # Timeout for HTTP requests using the requests library.
 REQUESTS_TIMEOUT = 15
+_REQUESTS_TIMEOUT_CACHE_UNSET = object()
+_REQUESTS_TIMEOUT_CACHE_INVALID = object()
+_requests_timeout_cache: int | object = _REQUESTS_TIMEOUT_CACHE_UNSET
 
 
 def get_requests_timeout() -> int:
-    try:
-        return int_normalizer(
-            os.getenv("POETRY_REQUESTS_TIMEOUT", str(REQUESTS_TIMEOUT))
-        )
-    except ValueError as e:
-        raise ValueError(
-            "POETRY_REQUESTS_TIMEOUT must be an integer number of seconds"
-        ) from e
+    global _requests_timeout_cache
+
+    if _requests_timeout_cache is _REQUESTS_TIMEOUT_CACHE_UNSET:
+        try:
+            _requests_timeout_cache = int_normalizer(
+                os.getenv("POETRY_REQUESTS_TIMEOUT", str(REQUESTS_TIMEOUT))
+            )
+        except ValueError:
+            _requests_timeout_cache = _REQUESTS_TIMEOUT_CACHE_INVALID
+
+    if _requests_timeout_cache is _REQUESTS_TIMEOUT_CACHE_INVALID:
+        raise ValueError("POETRY_REQUESTS_TIMEOUT must be an integer number of seconds")
+
+    assert isinstance(_requests_timeout_cache, int)
+    return _requests_timeout_cache
+
+
+def _reset_requests_timeout_cache() -> None:
+    global _requests_timeout_cache
+
+    _requests_timeout_cache = _REQUESTS_TIMEOUT_CACHE_UNSET
+
 
 RETRY_AFTER_HEADER = "retry-after"
 

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -25,7 +25,7 @@ from requests.exceptions import ConnectionError
 from requests.utils import atomic_open
 
 from poetry.utils.authenticator import get_default_authenticator
-from poetry.utils.constants import REQUESTS_TIMEOUT
+from poetry.utils.constants import get_requests_timeout
 
 
 if TYPE_CHECKING:
@@ -198,7 +198,7 @@ class Downloader:
             headers["Range"] = f"bytes={start}-"
 
         response = self._session.get(
-            self._url, stream=True, headers=headers, timeout=REQUESTS_TIMEOUT
+            self._url, stream=True, headers=headers, timeout=get_requests_timeout()
         )
         try:
             response.raise_for_status()

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import os
 import re
 import shutil
+import subprocess
+import sys
 
 from typing import TYPE_CHECKING
 from typing import ClassVar
@@ -61,6 +64,27 @@ def test_application_with_plugins(with_add_command_plugin: None) -> None:
 
     assert re.search(r"\s+foo\s+Foo Command", tester.io.fetch_output()) is not None
     assert tester.status_code == 0
+
+
+def test_application_version_ignores_invalid_requests_timeout(
+    project_root: Path,
+) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root / "src")
+    env["POETRY_REQUESTS_TIMEOUT"] = "abc"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "poetry", "--version"],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.startswith("Poetry (version ")
+    assert "ValueError" not in result.stderr
 
 
 def test_application_with_plugins_disabled(with_add_command_plugin: None) -> None:

--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from poetry.utils.constants import REQUESTS_TIMEOUT
+from poetry.utils.constants import get_requests_timeout
+
+
+def test_get_requests_timeout_defaults_to_constant(environ: None) -> None:
+    assert get_requests_timeout() == REQUESTS_TIMEOUT
+
+
+def test_get_requests_timeout_from_environment(environ: None) -> None:
+    os.environ["POETRY_REQUESTS_TIMEOUT"] = "60"
+
+    assert get_requests_timeout() == 60
+
+
+def test_get_requests_timeout_reports_invalid_environment_value(
+    environ: None,
+) -> None:
+    os.environ["POETRY_REQUESTS_TIMEOUT"] = "abc"
+
+    with pytest.raises(ValueError, match="POETRY_REQUESTS_TIMEOUT"):
+        get_requests_timeout()

--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -2,10 +2,24 @@ from __future__ import annotations
 
 import os
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from poetry.utils.constants import REQUESTS_TIMEOUT
+from poetry.utils.constants import _reset_requests_timeout_cache
 from poetry.utils.constants import get_requests_timeout
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def requests_timeout_cache() -> Iterator[None]:
+    _reset_requests_timeout_cache()
+    yield
+    _reset_requests_timeout_cache()
 
 
 def test_get_requests_timeout_defaults_to_constant(environ: None) -> None:
@@ -22,6 +36,28 @@ def test_get_requests_timeout_reports_invalid_environment_value(
     environ: None,
 ) -> None:
     os.environ["POETRY_REQUESTS_TIMEOUT"] = "abc"
+
+    with pytest.raises(ValueError, match="POETRY_REQUESTS_TIMEOUT"):
+        get_requests_timeout()
+
+
+def test_get_requests_timeout_caches_environment_value(environ: None) -> None:
+    os.environ["POETRY_REQUESTS_TIMEOUT"] = "60"
+
+    assert get_requests_timeout() == 60
+
+    os.environ["POETRY_REQUESTS_TIMEOUT"] = "90"
+
+    assert get_requests_timeout() == 60
+
+
+def test_get_requests_timeout_caches_invalid_environment_value(environ: None) -> None:
+    os.environ["POETRY_REQUESTS_TIMEOUT"] = "abc"
+
+    with pytest.raises(ValueError, match="POETRY_REQUESTS_TIMEOUT"):
+        get_requests_timeout()
+
+    os.environ["POETRY_REQUESTS_TIMEOUT"] = "60"
 
     with pytest.raises(ValueError, match="POETRY_REQUESTS_TIMEOUT"):
         get_requests_timeout()


### PR DESCRIPTION
## Summary
- Delay parsing `POETRY_REQUESTS_TIMEOUT` until an HTTP request actually needs the timeout value.
- Keep the default timeout constant import-safe and parse the environment value through Poetry's integer normalizer helper.
- Add regression coverage for `python -m poetry --version` with an invalid timeout environment value.

Fixes #10969

## Validation
- `POETRY_REQUESTS_TIMEOUT=abc .\.venv\Scripts\python.exe -m poetry --version` -> `Poetry (version 2.5.0.dev0)`
- `.\.venv\Scripts\python.exe -m pytest -n 0 --basetemp=.pytest-tmp tests\utils\test_constants.py tests\console\test_application.py::test_application_version_ignores_invalid_requests_timeout` -> 4 passed
- `.\.venv\Scripts\python.exe -m pytest -n 0 --basetemp=.pytest-tmp tests\utils\test_authenticator.py tests\repositories\test_http_repository.py tests\repositories\test_pypi_repository.py tests\publishing` -> 173 passed
- `uvx ruff check src\poetry\utils\constants.py src\poetry\utils\authenticator.py src\poetry\utils\helpers.py src\poetry\repositories\http_repository.py src\poetry\repositories\pypi_repository.py src\poetry\publishing\uploader.py tests\console\test_application.py tests\utils\test_constants.py` -> passed

## Notes
- Full `pytest --basetemp=.pytest-tmp` on this Windows/Python 3.13.13 environment reached 3183 passed / 11 skipped, with 10 existing environment-sensitive failures unrelated to this change. The failures involved Windows path URI expectations, active Python discovery preferring Anaconda Python, and missing embedded pip wheels from the locally resolved virtualenv package.