### PR TITLE
Fix editable installs for project GUI scripts

### DIFF
--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -153,10 +153,10 @@ class EditableBuilder(Builder):
             )
             return []
 
-        scripts = entry_points.get("console_scripts", []) + entry_points.get(
-            "gui_scripts", []
-        )
-        for script in scripts:
+        scripts = [
+            (script, False) for script in entry_points.get("console_scripts", [])
+        ] + [(script, True) for script in entry_points.get("gui_scripts", [])]
+        for script, is_gui in scripts:
             name, script_with_extras = script.split(" = ")
             script_without_extras = script_with_extras.split("[")[0]
             try:
@@ -202,7 +202,12 @@ class EditableBuilder(Builder):
 
             if WINDOWS:
                 cmd_script = script_file.with_suffix(".cmd")
-                cmd = WINDOWS_CMD_TEMPLATE.format(python=self._env.python, script=name)
+                python = (
+                    self._env.python.with_name("pythonw.exe")
+                    if is_gui
+                    else self._env.python
+                )
+                cmd = WINDOWS_CMD_TEMPLATE.format(python=python, script=name)
                 self._debug(
                     f"  - Adding the <c2>{cmd_script.name}</c2> script wrapper to"
                     f" <b>{scripts_path}</b>"

--- a/src/poetry/masonry/builders/editable.py
+++ b/src/poetry/masonry/builders/editable.py
@@ -153,7 +153,9 @@ class EditableBuilder(Builder):
             )
             return []
 
-        scripts = entry_points.get("console_scripts", [])
+        scripts = entry_points.get("console_scripts", []) + entry_points.get(
+            "gui_scripts", []
+        )
         for script in scripts:
             name, script_with_extras = script.split(" = ")
             script_without_extras = script_with_extras.split("[")[0]

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -265,6 +265,40 @@ if __name__ == '__main__':
     assert tmp_venv._bin_dir.joinpath("fox").read_text(encoding="utf-8") == fox_script
 
 
+def test_builder_installs_project_gui_scripts(
+    tmp_path: Path, fixture_dir: FixtureDirGetter, mocker: MockerFixture
+) -> None:
+    project = tmp_path / "simple_project"
+    shutil.copytree(fixture_dir("simple_project"), project)
+    with project.joinpath("pyproject.toml").open("a", encoding="utf-8") as f:
+        f.write('\n[project.gui-scripts]\nfoo-gui = "foo:bar"\n')
+
+    poetry = Factory().create_poetry(project)
+    env_manager = EnvManager(poetry)
+    venv_path = tmp_path / "venv"
+    env_manager.build_venv(venv_path)
+    tmp_venv = VirtualEnv(venv_path)
+    mocker.patch("poetry.masonry.builders.editable.WINDOWS", True)
+
+    EditableBuilder(poetry, tmp_venv, NullIO()).build()
+
+    script_file = tmp_venv._bin_dir.joinpath("foo-gui")
+    cmd_script_file = script_file.with_suffix(".cmd")
+    assert script_file.exists()
+    assert cmd_script_file.exists()
+
+    dist_info = tmp_venv.site_packages.find(Path("simple_project-1.2.3.dist-info"))[0]
+    assert "[gui_scripts]\nfoo-gui=foo:bar\n" in dist_info.joinpath(
+        "entry_points.txt"
+    ).read_text(encoding="utf-8")
+
+    with dist_info.joinpath("RECORD").open(encoding="utf-8", newline="") as f:
+        record_entries = {row[0] for row in csv.reader(f)}
+
+    assert str(script_file) in record_entries
+    assert str(cmd_script_file) in record_entries
+
+
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(
     mocker: MockerFixture, extended_poetry: Poetry, tmp_path: Path
 ) -> None:

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -290,6 +290,11 @@ def test_builder_installs_project_gui_scripts(
     cmd_script_file = script_file.with_suffix(".cmd")
     assert script_file.exists()
     assert cmd_script_file.exists() is windows
+    if windows:
+        console_cmd = tmp_venv._bin_dir.joinpath("foo.cmd").read_text(encoding="utf-8")
+        gui_cmd = cmd_script_file.read_text(encoding="utf-8")
+        assert f'"{tmp_venv.python}"' in console_cmd
+        assert f'"{tmp_venv.python.with_name("pythonw.exe")}"' in gui_cmd
 
     dist_info = tmp_venv.site_packages.find(Path("simple_project-1.2.3.dist-info"))[0]
     assert "[gui_scripts]\nfoo-gui=foo:bar\n" in dist_info.joinpath(

--- a/tests/masonry/builders/test_editable_builder.py
+++ b/tests/masonry/builders/test_editable_builder.py
@@ -265,8 +265,12 @@ if __name__ == '__main__':
     assert tmp_venv._bin_dir.joinpath("fox").read_text(encoding="utf-8") == fox_script
 
 
+@pytest.mark.parametrize("windows", (True, False))
 def test_builder_installs_project_gui_scripts(
-    tmp_path: Path, fixture_dir: FixtureDirGetter, mocker: MockerFixture
+    tmp_path: Path,
+    fixture_dir: FixtureDirGetter,
+    mocker: MockerFixture,
+    windows: bool,
 ) -> None:
     project = tmp_path / "simple_project"
     shutil.copytree(fixture_dir("simple_project"), project)
@@ -278,14 +282,14 @@ def test_builder_installs_project_gui_scripts(
     venv_path = tmp_path / "venv"
     env_manager.build_venv(venv_path)
     tmp_venv = VirtualEnv(venv_path)
-    mocker.patch("poetry.masonry.builders.editable.WINDOWS", True)
+    mocker.patch("poetry.masonry.builders.editable.WINDOWS", windows)
 
     EditableBuilder(poetry, tmp_venv, NullIO()).build()
 
     script_file = tmp_venv._bin_dir.joinpath("foo-gui")
     cmd_script_file = script_file.with_suffix(".cmd")
     assert script_file.exists()
-    assert cmd_script_file.exists()
+    assert cmd_script_file.exists() is windows
 
     dist_info = tmp_venv.site_packages.find(Path("simple_project-1.2.3.dist-info"))[0]
     assert "[gui_scripts]\nfoo-gui=foo:bar\n" in dist_info.joinpath(
@@ -296,7 +300,7 @@ def test_builder_installs_project_gui_scripts(
         record_entries = {row[0] for row in csv.reader(f)}
 
     assert str(script_file) in record_entries
-    assert str(cmd_script_file) in record_entries
+    assert (str(cmd_script_file) in record_entries) is windows
 
 
 def test_builder_falls_back_on_setup_and_pip_for_packages_with_build_scripts(


### PR DESCRIPTION
Resolves: #10481

## Summary

- Install `gui_scripts` entry points during editable installs, alongside `console_scripts`.
- Add a regression for `[project.gui-scripts]`, including the Windows `.cmd` wrapper path.

## Validation

- `. .venv/bin/activate && pytest tests/masonry/builders/test_editable_builder.py -q` — passed
- `. .venv/bin/activate && ruff format --check src/poetry/masonry/builders/editable.py tests/masonry/builders/test_editable_builder.py` — passed
- `. .venv/bin/activate && ruff check src/poetry/masonry/builders/editable.py tests/masonry/builders/test_editable_builder.py` — passed
- `. .venv/bin/activate && mypy src/poetry/masonry/builders/editable.py tests/masonry/builders/test_editable_builder.py` — passed
- `git diff --check` — passed

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. Existing docs already say to run `poetry install` after adding GUI scripts.
