### PR TITLE
fix(solver): preserve extra marker scope across overrides

### DIFF
--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -40,10 +40,11 @@ def _effective_marker(dependency: Dependency) -> BaseMarker:
     The marker describing when a dependency actually applies: its own marker
     intersected with the marker of the package that required it (a dependency is
     only reached when its requiring package applies).
+
+    Extras in the transitive marker belong to the root marker world. Extras in
+    the dependency's own marker are local to its requiring package.
     """
-    return dependency.transitive_marker.without_extras().intersect(
-        dependency.marker.without_extras()
-    )
+    return dependency.transitive_marker.intersect(dependency.marker.without_extras())
 
 
 class Preference(IntEnum):
@@ -497,70 +498,16 @@ class VersionSolver:
         # False)]``; the negative term is the requirement, and its marker says
         # when it applies.
         requirements: dict[str, list[Dependency]] = collections.defaultdict(list)
-        root_edges: list[Dependency] = []
-        dependency_edges: dict[str, list[tuple[Dependency, Dependency]]] = (
-            collections.defaultdict(list)
-        )
         for incompat in incompatibility.external_incompatibilities:
             if not isinstance(incompat.cause, DependencyCauseError):
                 continue
-            positive_terms = [term for term in incompat.terms if term.is_positive()]
-            negative_terms = [term for term in incompat.terms if not term.is_positive()]
-            if len(positive_terms) != 1 or len(negative_terms) != 1:
-                continue
-            depender = positive_terms[0].dependency
-            dependency = negative_terms[0].dependency
-            requirements[dependency.name].append(dependency)
-            if depender.is_root:
-                root_edges.append(dependency)
-            else:
-                dependency_edges[depender.complete_name].append((depender, dependency))
+            for term in incompat.terms:
+                if not term.is_positive():
+                    requirements[term.dependency.name].append(term.dependency)
 
         # The markers of the current run: any marker at the top level, or one side
         # of an earlier split when nested.
         current_markers = self._provider._overrides_marker_intersection
-
-        # Walk dependency causes from the root to recover the marker world for each
-        # requirement. An ``extra`` marker on a non-root edge is local to its
-        # depending package, so evaluate it against that package's active features
-        # instead of leaking it into the root marker world.
-        package_markers: dict[str, BaseMarker] = {}
-        requirement_markers: dict[int, BaseMarker] = {}
-        pending: collections.deque[str] = collections.deque()
-        queued: set[str] = set()
-
-        def add_requirement_marker(dependency: Dependency, marker: BaseMarker) -> None:
-            previous = requirement_markers.get(id(dependency))
-            requirement_marker = marker if previous is None else previous.union(marker)
-            if previous != requirement_marker:
-                requirement_markers[id(dependency)] = requirement_marker
-
-            complete_name = dependency.complete_name
-            previous = package_markers.get(complete_name)
-            package_marker = marker if previous is None else previous.union(marker)
-            if previous == package_marker:
-                return
-
-            package_markers[complete_name] = package_marker
-            if complete_name not in queued:
-                pending.append(complete_name)
-                queued.add(complete_name)
-
-        for dependency in root_edges:
-            add_requirement_marker(
-                dependency, current_markers.intersect(dependency.marker)
-            )
-
-        while pending:
-            complete_name = pending.popleft()
-            queued.remove(complete_name)
-            depender_marker = package_markers[complete_name]
-            for depender, dependency in dependency_edges.get(complete_name, []):
-                edge_marker = dependency.marker.apply({"extra": set(depender.extras)})
-                add_requirement_marker(
-                    dependency, depender_marker.intersect(edge_marker)
-                )
-
         for deps in requirements.values():
             for dep1, dep2 in itertools.combinations(deps, 2):
                 # Compatible versions are not a real conflict.
@@ -568,12 +515,8 @@ class VersionSolver:
                     continue
 
                 # Where each requirement applies within the current run.
-                world1 = requirement_markers.get(
-                    id(dep1), _effective_marker(dep1).intersect(current_markers)
-                )
-                world2 = requirement_markers.get(
-                    id(dep2), _effective_marker(dep2).intersect(current_markers)
-                )
+                world1 = _effective_marker(dep1).intersect(current_markers)
+                world2 = _effective_marker(dep2).intersect(current_markers)
 
                 # Act only if both requirements apply somewhere in this run but
                 # never together. Splitting on ``world1`` then separates them. Both

--- a/src/poetry/mixology/version_solver.py
+++ b/src/poetry/mixology/version_solver.py
@@ -497,16 +497,70 @@ class VersionSolver:
         # False)]``; the negative term is the requirement, and its marker says
         # when it applies.
         requirements: dict[str, list[Dependency]] = collections.defaultdict(list)
+        root_edges: list[Dependency] = []
+        dependency_edges: dict[str, list[tuple[Dependency, Dependency]]] = (
+            collections.defaultdict(list)
+        )
         for incompat in incompatibility.external_incompatibilities:
             if not isinstance(incompat.cause, DependencyCauseError):
                 continue
-            for term in incompat.terms:
-                if not term.is_positive():
-                    requirements[term.dependency.name].append(term.dependency)
+            positive_terms = [term for term in incompat.terms if term.is_positive()]
+            negative_terms = [term for term in incompat.terms if not term.is_positive()]
+            if len(positive_terms) != 1 or len(negative_terms) != 1:
+                continue
+            depender = positive_terms[0].dependency
+            dependency = negative_terms[0].dependency
+            requirements[dependency.name].append(dependency)
+            if depender.is_root:
+                root_edges.append(dependency)
+            else:
+                dependency_edges[depender.complete_name].append((depender, dependency))
 
         # The markers of the current run: any marker at the top level, or one side
         # of an earlier split when nested.
         current_markers = self._provider._overrides_marker_intersection
+
+        # Walk dependency causes from the root to recover the marker world for each
+        # requirement. An ``extra`` marker on a non-root edge is local to its
+        # depending package, so evaluate it against that package's active features
+        # instead of leaking it into the root marker world.
+        package_markers: dict[str, BaseMarker] = {}
+        requirement_markers: dict[int, BaseMarker] = {}
+        pending: collections.deque[str] = collections.deque()
+        queued: set[str] = set()
+
+        def add_requirement_marker(dependency: Dependency, marker: BaseMarker) -> None:
+            previous = requirement_markers.get(id(dependency))
+            requirement_marker = marker if previous is None else previous.union(marker)
+            if previous != requirement_marker:
+                requirement_markers[id(dependency)] = requirement_marker
+
+            complete_name = dependency.complete_name
+            previous = package_markers.get(complete_name)
+            package_marker = marker if previous is None else previous.union(marker)
+            if previous == package_marker:
+                return
+
+            package_markers[complete_name] = package_marker
+            if complete_name not in queued:
+                pending.append(complete_name)
+                queued.add(complete_name)
+
+        for dependency in root_edges:
+            add_requirement_marker(
+                dependency, current_markers.intersect(dependency.marker)
+            )
+
+        while pending:
+            complete_name = pending.popleft()
+            queued.remove(complete_name)
+            depender_marker = package_markers[complete_name]
+            for depender, dependency in dependency_edges.get(complete_name, []):
+                edge_marker = dependency.marker.apply({"extra": set(depender.extras)})
+                add_requirement_marker(
+                    dependency, depender_marker.intersect(edge_marker)
+                )
+
         for deps in requirements.values():
             for dep1, dep2 in itertools.combinations(deps, 2):
                 # Compatible versions are not a real conflict.
@@ -514,8 +568,12 @@ class VersionSolver:
                     continue
 
                 # Where each requirement applies within the current run.
-                world1 = _effective_marker(dep1).intersect(current_markers)
-                world2 = _effective_marker(dep2).intersect(current_markers)
+                world1 = requirement_markers.get(
+                    id(dep1), _effective_marker(dep1).intersect(current_markers)
+                )
+                world2 = requirement_markers.get(
+                    id(dep2), _effective_marker(dep2).intersect(current_markers)
+                )
 
                 # Act only if both requirements apply somewhere in this run but
                 # never together. Splitting on ``world1`` then separates them. Both

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -809,19 +809,18 @@ class Provider:
         # Modifying dependencies as needed
         clean_dependencies = []
         for dep in dependencies:
-            if not dependency.transitive_marker.without_extras().is_any():
-                transitive_marker_intersection = (
-                    dependency.transitive_marker.without_extras().intersect(
-                        dep.marker.without_extras()
-                    )
-                )
-                if transitive_marker_intersection.is_empty():
-                    # The dependency is not needed, since the markers specified
-                    # for the current package selection are not compatible with
-                    # the markers for the current dependency, so we skip it
-                    continue
+            transitive_marker = (
+                dep.marker
+                if package.is_root()
+                else dependency.transitive_marker.intersect(dep.marker.without_extras())
+            )
+            if transitive_marker.is_empty():
+                # The dependency is not needed, since the markers specified
+                # for the current package selection are not compatible with
+                # the markers for the current dependency, so we skip it
+                continue
 
-                dep.transitive_marker = transitive_marker_intersection
+            dep.transitive_marker = transitive_marker
 
             if not dependency.python_constraint.is_any():
                 python_constraint_intersection = dep.python_constraint.intersect(

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -596,11 +596,21 @@ class Provider:
             if dep.name in self.UNSAFE_PACKAGES:
                 continue
 
+            dependency_marker = dep.marker
+            if package.is_root() and dep.in_extras:
+                dependency_marker = dependency_marker.intersect(
+                    parse_marker(
+                        " or ".join(f'extra == "{extra}"' for extra in dep.in_extras)
+                    )
+                )
+
             # When this run is restricted to a set of markers (see MARKER_SPLIT),
             # skip any dependency that cannot apply within that set; otherwise its
             # requirements would leak into a run where it never applies (see
             # #5506).
-            if self._overrides_marker_intersection.intersect(dep.marker).is_empty():
+            if self._overrides_marker_intersection.intersect(
+                dependency_marker
+            ).is_empty():
                 continue
 
             if self._env:
@@ -630,11 +640,7 @@ class Provider:
                 # without an existing lock file because the root package is used
                 # once for solving and a second time for re-resolving for installation.
                 dep = dep.clone()
-                dep.marker = dep.marker.intersect(
-                    parse_marker(
-                        " or ".join(f'extra == "{extra}"' for extra in dep.in_extras)
-                    )
-                )
+                dep.marker = dependency_marker
 
             _dependencies.append(dep)
 
@@ -749,6 +755,21 @@ class Provider:
                     dependencies.append(deps[0])
                 self.debug(msg)
                 continue
+
+            if package.is_root():
+                marker = next(
+                    (
+                        dep.marker
+                        for dep in deps
+                        if dep.marker.without_extras() != dep.marker
+                    ),
+                    None,
+                )
+                if marker is not None:
+                    # Root extras are global lock markers. Carry their branch in
+                    # the synthetic marker split instead of a package override,
+                    # whose extras are deliberately local and removed on merge.
+                    raise OverrideNeededError(*self.marker_split_overrides(marker))
 
             # At this point, we raise an exception that will
             # tell the solver to make new resolutions with specific overrides.

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -18,6 +18,7 @@ from poetry.mixology.failure import SolveFailureError
 from poetry.packages.transitive_package_info import TransitivePackageInfo
 from poetry.puzzle.exceptions import OverrideNeededError
 from poetry.puzzle.exceptions import SolverProblemError
+from poetry.puzzle.provider import MARKER_SPLIT
 from poetry.puzzle.provider import Indicator
 from poetry.puzzle.provider import Provider
 
@@ -465,7 +466,7 @@ def merge_override_packages(
             for dep in deps.values():
                 marker = (
                     dep.marker
-                    if override_package.is_root()
+                    if override_package.name == MARKER_SPLIT
                     else dep.marker.without_extras()
                 )
                 override_marker = override_marker.intersect(marker)

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -461,9 +461,14 @@ def merge_override_packages(
     ] = {}
     for override, o_packages in override_packages:
         override_marker: BaseMarker = AnyMarker()
-        for deps in override.values():
+        for override_package, deps in override.items():
             for dep in deps.values():
-                override_marker = override_marker.intersect(dep.marker.without_extras())
+                marker = (
+                    dep.marker
+                    if override_package.is_root()
+                    else dep.marker.without_extras()
+                )
+                override_marker = override_marker.intersect(marker)
         override_marker = simplify_marker(override_marker, python_constraint)
         for package, info in o_packages.items():
             for group, marker in info.markers.items():

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -5446,12 +5446,12 @@ def test_solver_resolves_conflicting_dependency_in_root_extras(
     )
 
 
-def test_solver_resolves_conflicting_dependency_in_transitive_extras(
+def _configure_transitive_extra_conflict(
     package: ProjectPackage,
-    pool: RepositoryPool,
     repo: Repository,
-    io: NullIO,
-) -> None:
+    *,
+    disjoint_root_extras: bool,
+) -> tuple[Package, Package]:
     package_a = get_package("A", "1.0")
     package_c1 = get_package("C", "1.0")
     package_c2 = get_package("C", "2.0")
@@ -5474,20 +5474,24 @@ def test_solver_resolves_conflicting_dependency_in_transitive_extras(
     package_d.add_dependency(get_dependency("A", {"version": "*", "extras": ["one"]}))
     package_e.add_dependency(get_dependency("A", {"version": "*", "extras": ["two"]}))
 
-    dep_d = get_dependency(
-        "D", {"version": "*", "markers": "extra != 'y'"}, optional=True
-    )
-    dep_d._in_extras = [canonicalize_name("x")]
-    dep_e = get_dependency(
-        "E", {"version": "*", "markers": "extra != 'x'"}, optional=True
-    )
-    dep_e._in_extras = [canonicalize_name("y")]
-    package.extras = {
-        canonicalize_name("x"): [dep_d],
-        canonicalize_name("y"): [dep_e],
-    }
-    package.add_dependency(dep_d)
-    package.add_dependency(dep_e)
+    if disjoint_root_extras:
+        dep_d = get_dependency(
+            "D", {"version": "*", "markers": "extra != 'y'"}, optional=True
+        )
+        dep_d._in_extras = [canonicalize_name("x")]
+        dep_e = get_dependency(
+            "E", {"version": "*", "markers": "extra != 'x'"}, optional=True
+        )
+        dep_e._in_extras = [canonicalize_name("y")]
+        package.extras = {
+            canonicalize_name("x"): [dep_d],
+            canonicalize_name("y"): [dep_e],
+        }
+        package.add_dependency(dep_d)
+        package.add_dependency(dep_e)
+    else:
+        package.add_dependency(get_dependency("D", "*"))
+        package.add_dependency(get_dependency("E", "*"))
 
     for dependency_package in (
         package_a,
@@ -5497,6 +5501,19 @@ def test_solver_resolves_conflicting_dependency_in_transitive_extras(
         package_e,
     ):
         repo.add_package(dependency_package)
+
+    return package_c1, package_c2
+
+
+def test_solver_resolves_conflicting_dependency_in_transitive_extras(
+    package: ProjectPackage,
+    pool: RepositoryPool,
+    repo: Repository,
+    io: NullIO,
+) -> None:
+    package_c1, package_c2 = _configure_transitive_extra_conflict(
+        package, repo, disjoint_root_extras=True
+    )
 
     transaction = Solver(package, pool, [], [], io).solve()
     solved_packages = transaction.get_solved_packages()
@@ -5515,38 +5532,7 @@ def test_solver_does_not_split_conflicting_transitive_extras_without_root_marker
     repo: Repository,
     io: NullIO,
 ) -> None:
-    package_a = get_package("A", "1.0")
-    package_c1 = get_package("C", "1.0")
-    package_c2 = get_package("C", "2.0")
-    package_d = get_package("D", "1.0")
-    package_e = get_package("E", "1.0")
-
-    dep_c1 = get_dependency("C", "1.0", optional=True)
-    dep_c1._in_extras = [canonicalize_name("one")]
-    dep_c1.marker = parse_marker("extra == 'one'")
-    dep_c2 = get_dependency("C", "2.0", optional=True)
-    dep_c2._in_extras = [canonicalize_name("two")]
-    dep_c2.marker = parse_marker("extra == 'two'")
-    package_a.extras = {
-        canonicalize_name("one"): [dep_c1],
-        canonicalize_name("two"): [dep_c2],
-    }
-    package_a.add_dependency(dep_c1)
-    package_a.add_dependency(dep_c2)
-
-    package_d.add_dependency(get_dependency("A", {"version": "*", "extras": ["one"]}))
-    package_e.add_dependency(get_dependency("A", {"version": "*", "extras": ["two"]}))
-    package.add_dependency(get_dependency("D", "*"))
-    package.add_dependency(get_dependency("E", "*"))
-
-    for dependency_package in (
-        package_a,
-        package_c1,
-        package_c2,
-        package_d,
-        package_e,
-    ):
-        repo.add_package(dependency_package)
+    _configure_transitive_extra_conflict(package, repo, disjoint_root_extras=False)
 
     with pytest.raises(SolverProblemError):
         Solver(package, pool, [], [], io).solve()

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -5439,10 +5439,53 @@ def test_solver_resolves_conflicting_dependency_in_root_extras(
     )
     solved_packages = transaction.get_solved_packages()
     assert solved_packages[package_a1].markers[MAIN_GROUP] == parse_marker(
-        "extra != 'bar' and extra == 'foo'"
+        "extra == 'foo' and extra != 'bar'"
     )
     assert solved_packages[package_a2].markers[MAIN_GROUP] == parse_marker(
-        "extra != 'foo' and extra == 'bar'"
+        "extra == 'bar' and extra != 'foo'"
+    )
+
+
+def test_solver_keeps_overlapping_root_extra_versions_disjoint(
+    package: ProjectPackage,
+    pool: RepositoryPool,
+    repo: Repository,
+    io: NullIO,
+) -> None:
+    package_a1 = get_package("A", "1.0")
+    package_a2 = get_package("A", "2.0")
+    package_b = get_package("B", "1.0")
+    package_b.add_dependency(get_dependency("A", "*"))
+
+    dep_a_networks = get_dependency("A", "1.0", optional=True)
+    dep_a_networks._in_extras = [canonicalize_name("networks")]
+    dep_b_sbml = get_dependency("B", "*", optional=True)
+    dep_b_sbml._in_extras = [canonicalize_name("sbml")]
+    dep_a_all = get_dependency("A", "1.0", optional=True)
+    dep_a_all._in_extras = [canonicalize_name("all")]
+    dep_b_all = get_dependency("B", "*", optional=True)
+    dep_b_all._in_extras = [canonicalize_name("all")]
+
+    package.extras = {
+        canonicalize_name("networks"): [dep_a_networks],
+        canonicalize_name("sbml"): [dep_b_sbml],
+        canonicalize_name("all"): [dep_a_all, dep_b_all],
+    }
+    for dependency in (dep_a_networks, dep_b_sbml, dep_a_all, dep_b_all):
+        package.add_dependency(dependency)
+
+    repo.add_package(package_a1)
+    repo.add_package(package_a2)
+    repo.add_package(package_b)
+
+    transaction = Solver(package, pool, [], [], io).solve()
+    solved_packages = transaction.get_solved_packages()
+
+    assert solved_packages[package_a1].markers[MAIN_GROUP] == parse_marker(
+        "extra == 'networks' or extra == 'all'"
+    )
+    assert solved_packages[package_a2].markers[MAIN_GROUP] == parse_marker(
+        "extra != 'networks' and extra != 'all' and extra == 'sbml'"
     )
 
 

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -5442,8 +5442,114 @@ def test_solver_resolves_conflicting_dependency_in_root_extras(
         "extra == 'foo' and extra != 'bar'"
     )
     assert solved_packages[package_a2].markers[MAIN_GROUP] == parse_marker(
-        "extra == 'bar' and extra != 'foo'"
+        "extra != 'foo' and extra == 'bar'"
     )
+
+
+def test_solver_resolves_conflicting_dependency_in_transitive_extras(
+    package: ProjectPackage,
+    pool: RepositoryPool,
+    repo: Repository,
+    io: NullIO,
+) -> None:
+    package_a = get_package("A", "1.0")
+    package_c1 = get_package("C", "1.0")
+    package_c2 = get_package("C", "2.0")
+    package_d = get_package("D", "1.0")
+    package_e = get_package("E", "1.0")
+
+    dep_c1 = get_dependency("C", "1.0", optional=True)
+    dep_c1._in_extras = [canonicalize_name("one")]
+    dep_c1.marker = parse_marker("extra == 'one'")
+    dep_c2 = get_dependency("C", "2.0", optional=True)
+    dep_c2._in_extras = [canonicalize_name("two")]
+    dep_c2.marker = parse_marker("extra == 'two'")
+    package_a.extras = {
+        canonicalize_name("one"): [dep_c1],
+        canonicalize_name("two"): [dep_c2],
+    }
+    package_a.add_dependency(dep_c1)
+    package_a.add_dependency(dep_c2)
+
+    package_d.add_dependency(get_dependency("A", {"version": "*", "extras": ["one"]}))
+    package_e.add_dependency(get_dependency("A", {"version": "*", "extras": ["two"]}))
+
+    dep_d = get_dependency(
+        "D", {"version": "*", "markers": "extra != 'y'"}, optional=True
+    )
+    dep_d._in_extras = [canonicalize_name("x")]
+    dep_e = get_dependency(
+        "E", {"version": "*", "markers": "extra != 'x'"}, optional=True
+    )
+    dep_e._in_extras = [canonicalize_name("y")]
+    package.extras = {
+        canonicalize_name("x"): [dep_d],
+        canonicalize_name("y"): [dep_e],
+    }
+    package.add_dependency(dep_d)
+    package.add_dependency(dep_e)
+
+    for dependency_package in (
+        package_a,
+        package_c1,
+        package_c2,
+        package_d,
+        package_e,
+    ):
+        repo.add_package(dependency_package)
+
+    transaction = Solver(package, pool, [], [], io).solve()
+    solved_packages = transaction.get_solved_packages()
+
+    assert solved_packages[package_c1].markers[MAIN_GROUP] == parse_marker(
+        "extra == 'x' and extra != 'y'"
+    )
+    assert solved_packages[package_c2].markers[MAIN_GROUP] == parse_marker(
+        "extra != 'x' and extra == 'y'"
+    )
+
+
+def test_solver_does_not_split_conflicting_transitive_extras_without_root_markers(
+    package: ProjectPackage,
+    pool: RepositoryPool,
+    repo: Repository,
+    io: NullIO,
+) -> None:
+    package_a = get_package("A", "1.0")
+    package_c1 = get_package("C", "1.0")
+    package_c2 = get_package("C", "2.0")
+    package_d = get_package("D", "1.0")
+    package_e = get_package("E", "1.0")
+
+    dep_c1 = get_dependency("C", "1.0", optional=True)
+    dep_c1._in_extras = [canonicalize_name("one")]
+    dep_c1.marker = parse_marker("extra == 'one'")
+    dep_c2 = get_dependency("C", "2.0", optional=True)
+    dep_c2._in_extras = [canonicalize_name("two")]
+    dep_c2.marker = parse_marker("extra == 'two'")
+    package_a.extras = {
+        canonicalize_name("one"): [dep_c1],
+        canonicalize_name("two"): [dep_c2],
+    }
+    package_a.add_dependency(dep_c1)
+    package_a.add_dependency(dep_c2)
+
+    package_d.add_dependency(get_dependency("A", {"version": "*", "extras": ["one"]}))
+    package_e.add_dependency(get_dependency("A", {"version": "*", "extras": ["two"]}))
+    package.add_dependency(get_dependency("D", "*"))
+    package.add_dependency(get_dependency("E", "*"))
+
+    for dependency_package in (
+        package_a,
+        package_c1,
+        package_c2,
+        package_d,
+        package_e,
+    ):
+        repo.add_package(dependency_package)
+
+    with pytest.raises(SolverProblemError):
+        Solver(package, pool, [], [], io).solve()
 
 
 def test_solver_keeps_overlapping_root_extra_versions_disjoint(
@@ -5485,7 +5591,7 @@ def test_solver_keeps_overlapping_root_extra_versions_disjoint(
         "extra == 'networks' or extra == 'all'"
     )
     assert solved_packages[package_a2].markers[MAIN_GROUP] == parse_marker(
-        "extra != 'networks' and extra != 'all' and extra == 'sbml'"
+        "extra == 'sbml' and extra != 'networks' and extra != 'all'"
     )
 
 

--- a/tests/puzzle/test_solver_internals.py
+++ b/tests/puzzle/test_solver_internals.py
@@ -14,6 +14,7 @@ from poetry.core.version.markers import parse_marker
 
 from poetry.factory import Factory
 from poetry.packages.transitive_package_info import TransitivePackageInfo
+from poetry.puzzle.provider import MARKER_SPLIT
 from poetry.puzzle.solver import PackageNode
 from poetry.puzzle.solver import Solver
 from poetry.puzzle.solver import depth_first_search
@@ -484,6 +485,29 @@ def test_merge_override_packages_dependency_extras() -> None:
             ' or sys_platform == "linux" and python_version >= "3.9"'
         )
     }
+
+
+def test_merge_override_packages_marker_split_extras() -> None:
+    marker_split = Package(MARKER_SPLIT, "0")
+    a1 = Package("a", "1")
+    a2 = Package("a", "2")
+
+    packages = merge_override_packages(
+        [
+            (
+                {marker_split: {MARKER_SPLIT: dep(MARKER_SPLIT, 'extra == "foo"')}},
+                {a1: TransitivePackageInfo(0, {MAIN_GROUP}, {MAIN_GROUP: AnyMarker()})},
+            ),
+            (
+                {marker_split: {MARKER_SPLIT: dep(MARKER_SPLIT, 'extra != "foo"')}},
+                {a2: TransitivePackageInfo(0, {MAIN_GROUP}, {MAIN_GROUP: AnyMarker()})},
+            ),
+        ],
+        parse_constraint("*"),
+    )
+
+    assert tm(packages[a1]) == {"main": 'extra == "foo"'}
+    assert tm(packages[a2]) == {"main": 'extra != "foo"'}
 
 
 @pytest.mark.parametrize(

--- a/tests/puzzle/test_solver_internals.py
+++ b/tests/puzzle/test_solver_internals.py
@@ -446,14 +446,15 @@ def test_merge_override_packages_restricted(package: ProjectPackage) -> None:
     }
 
 
-def test_merge_override_packages_extras(package: ProjectPackage) -> None:
-    """Extras from overrides should not be visible in the resulting marker."""
+def test_merge_override_packages_dependency_extras() -> None:
+    """Extras from non-root overrides should not reach the resulting marker."""
     a = Package("a", "1")
+    owner = Package("owner", "1")
 
     packages = merge_override_packages(
         [
             (
-                {package: {"a": dep("b", 'python_version < "3.9" and extra == "foo"')}},
+                {owner: {"a": dep("b", 'python_version < "3.9" and extra == "foo"')}},
                 {
                     a: TransitivePackageInfo(
                         0,
@@ -463,11 +464,7 @@ def test_merge_override_packages_extras(package: ProjectPackage) -> None:
                 },
             ),
             (
-                {
-                    package: {
-                        "a": dep("b", 'python_version >= "3.9" and extra == "foo"')
-                    }
-                },
+                {owner: {"a": dep("b", 'python_version >= "3.9" and extra == "foo"')}},
                 {
                     a: TransitivePackageInfo(
                         0,

--- a/tests/puzzle/test_solver_internals.py
+++ b/tests/puzzle/test_solver_internals.py
@@ -14,7 +14,6 @@ from poetry.core.version.markers import parse_marker
 
 from poetry.factory import Factory
 from poetry.packages.transitive_package_info import TransitivePackageInfo
-from poetry.puzzle.provider import MARKER_SPLIT
 from poetry.puzzle.solver import PackageNode
 from poetry.puzzle.solver import Solver
 from poetry.puzzle.solver import depth_first_search
@@ -447,15 +446,14 @@ def test_merge_override_packages_restricted(package: ProjectPackage) -> None:
     }
 
 
-def test_merge_override_packages_dependency_extras() -> None:
-    """Extras from non-root overrides should not reach the resulting marker."""
+def test_merge_override_packages_extras(package: ProjectPackage) -> None:
+    """Extras from overrides should not be visible in the resulting marker."""
     a = Package("a", "1")
-    owner = Package("owner", "1")
 
     packages = merge_override_packages(
         [
             (
-                {owner: {"a": dep("b", 'python_version < "3.9" and extra == "foo"')}},
+                {package: {"a": dep("b", 'python_version < "3.9" and extra == "foo"')}},
                 {
                     a: TransitivePackageInfo(
                         0,
@@ -465,7 +463,11 @@ def test_merge_override_packages_dependency_extras() -> None:
                 },
             ),
             (
-                {owner: {"a": dep("b", 'python_version >= "3.9" and extra == "foo"')}},
+                {
+                    package: {
+                        "a": dep("b", 'python_version >= "3.9" and extra == "foo"')
+                    }
+                },
                 {
                     a: TransitivePackageInfo(
                         0,
@@ -485,29 +487,6 @@ def test_merge_override_packages_dependency_extras() -> None:
             ' or sys_platform == "linux" and python_version >= "3.9"'
         )
     }
-
-
-def test_merge_override_packages_marker_split_extras() -> None:
-    marker_split = Package(MARKER_SPLIT, "0")
-    a1 = Package("a", "1")
-    a2 = Package("a", "2")
-
-    packages = merge_override_packages(
-        [
-            (
-                {marker_split: {MARKER_SPLIT: dep(MARKER_SPLIT, 'extra == "foo"')}},
-                {a1: TransitivePackageInfo(0, {MAIN_GROUP}, {MAIN_GROUP: AnyMarker()})},
-            ),
-            (
-                {marker_split: {MARKER_SPLIT: dep(MARKER_SPLIT, 'extra != "foo"')}},
-                {a2: TransitivePackageInfo(0, {MAIN_GROUP}, {MAIN_GROUP: AnyMarker()})},
-            ),
-        ],
-        parse_constraint("*"),
-    )
-
-    assert tm(packages[a1]) == {"main": 'extra == "foo"'}
-    assert tm(packages[a2]) == {"main": 'extra != "foo"'}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- preserve root-extra marker worlds while dependencies are completed
- keep extras on transitive dependency edges local to their requiring package
- reuse the existing marker-split conflict recovery instead of reconstructing dependency causes after a failure

## Problem

When incompatible versions are selected through different root extras, Poetry can merge solver results with overlapping lock markers. The same root marker context must survive when those versions are reached through extras of a transitive package.

The distinction is marker scope: a root extra is a global install condition, while an extra belonging to a dependency package is only meaningful while resolving that package.

## Change

Root dependencies initialize their transitive marker from the effective root marker, including implicit membership in a root extra. For every non-root edge, the parent's transitive marker is propagated while extras are removed from the edge's own marker. This preserves the root marker world without treating package-local extras as global conditions.

The transitive marker is assigned explicitly even when it is unconstrained. Leaving it unset would make the accessor fall back to the dependency's own marker and could reintroduce a package-local extra.

Root duplicate requirements containing extra markers use the existing synthetic marker-split override. Compatibility-mode merging preserves extras only for that synthetic override; ordinary package override extras are still removed.

## Tests

- exact #10971 lock regeneration and install dry run
- root-extra conflict regression
- transitive-extra conflict regression
- negative regression where both transitive-extra paths are simultaneously active
- `tests/puzzle`: 361 passed
- `tests/mixology`: 46 passed
- lock/install/update command tests: 113 passed
- mypy and pre-commit passed
- full serial suite: 3185 passed, with 8 local Windows/environment failures unrelated to solver markers

Resolves: #10971

- [x] Added tests for changed code.

## AI assistance

I used OpenAI Codex to help reproduce the issue, analyze marker propagation, draft the implementation and regression tests, and run local validation. I reviewed the simplified marker-scope design and validation results before approving this update and remain responsible for the submitted change.
