### PR TITLE
fix: respect Content-Disposition for URL dependencies

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -592,7 +592,10 @@ class Executor:
             cleanup_archive = True
         elif package.source_type == "url":
             assert package.source_url is not None
-            archive = self._download_link(operation, Link(package.source_url))
+            filename = package.files[0]["file"] if len(package.files) == 1 else None
+            archive = self._download_link(
+                operation, Link(package.source_url, filename=filename)
+            )
         else:
             archive = self._download(operation)
 

--- a/src/poetry/packages/direct_origin.py
+++ b/src/poetry/packages/direct_origin.py
@@ -87,9 +87,13 @@ class DirectOrigin:
     def get_package_from_directory(cls, directory: Path) -> Package:
         return PackageInfo.from_directory(path=directory).to_package(root_dir=directory)
 
-    def _download_file(self, url: str, dest: Path) -> None:
-        download_file(
-            url, dest, session=self._authenticator, max_retries=self._max_retries
+    def _download_file(self, url: str, dest: Path) -> Path:
+        return download_file(
+            url,
+            dest,
+            session=self._authenticator,
+            max_retries=self._max_retries,
+            use_content_disposition=True,
         )
 
     def get_package_from_url(self, url: str) -> Package:

--- a/src/poetry/utils/cache.py
+++ b/src/poetry/utils/cache.py
@@ -52,6 +52,7 @@ _HASHES = {
     "sha1": (hashlib.sha1, 4),
     "sha256": (hashlib.sha256, 8),
 }
+_REDIRECT_FILE = "redirect.json"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -264,14 +265,35 @@ class ArtifactCache:
                 # Check again if the archive exists (under the lock) to avoid
                 # duplicate downloads because it may have already been downloaded
                 # by another thread in the meantime
-                if not cached_archive.exists():
+                cached_archive = self._get_cached_archive(
+                    cache_dir, strict=True, filename=link.filename
+                )
+                if cached_archive is None:
+                    cached_archive = cache_dir / link.filename
                     cache_dir.mkdir(parents=True, exist_ok=True)
+                    downloaded_archive: Path | None = None
                     try:
                         downloaded_archive = download_func(link.url, cached_archive)
                         if downloaded_archive is not None:
+                            if downloaded_archive.parent != cache_dir:
+                                raise ValueError(
+                                    "Downloaded archive must be in the artifact cache "
+                                    "directory"
+                                )
+                            if downloaded_archive != cached_archive:
+                                self._write_redirect(
+                                    cache_dir,
+                                    original=cached_archive.name,
+                                    resolved=downloaded_archive.name,
+                                )
                             cached_archive = downloaded_archive
                     except BaseException:
                         cached_archive.unlink(missing_ok=True)
+                        if (
+                            downloaded_archive is not None
+                            and downloaded_archive.parent == cache_dir
+                        ):
+                            downloaded_archive.unlink(missing_ok=True)
                         raise
 
         return cached_archive
@@ -299,6 +321,9 @@ class ArtifactCache:
         archives = self._get_cached_archives(cache_dir)
         if not archives:
             return None
+
+        if strict:
+            filename = self._get_redirected_filename(cache_dir, filename)
 
         candidates: list[tuple[float | None, Path]] = []
 
@@ -332,6 +357,32 @@ class ArtifactCache:
             return None
 
         return min(candidates)[1]
+
+    def _get_redirected_filename(
+        self, cache_dir: Path, filename: str | None
+    ) -> str | None:
+        redirect_file = cache_dir / _REDIRECT_FILE
+        try:
+            redirect = json.loads(redirect_file.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return filename
+
+        if (
+            isinstance(redirect, dict)
+            and redirect.get("original") == filename
+            and isinstance(resolved := redirect.get("resolved"), str)
+            and Path(resolved).name == resolved
+        ):
+            return resolved
+
+        return filename
+
+    def _write_redirect(self, cache_dir: Path, *, original: str, resolved: str) -> None:
+        redirect_file = cache_dir / _REDIRECT_FILE
+        redirect_file.write_text(
+            json.dumps({"original": original, "resolved": resolved}),
+            encoding="utf-8",
+        )
 
     def _get_cached_archives(self, cache_dir: Path) -> list[Path]:
         archive_types = ["whl", "tar.gz", "tar.bz2", "bz2", "zip"]

--- a/src/poetry/utils/cache.py
+++ b/src/poetry/utils/cache.py
@@ -232,7 +232,7 @@ class ArtifactCache:
         *,
         strict: bool,
         env: Env | None = ...,
-        download_func: Callable[[str, Path], None],
+        download_func: Callable[[str, Path], Path | None],
     ) -> Path: ...
 
     @overload
@@ -251,7 +251,7 @@ class ArtifactCache:
         *,
         strict: bool,
         env: Env | None = None,
-        download_func: Callable[[str, Path], None] | None = None,
+        download_func: Callable[[str, Path], Path | None] | None = None,
     ) -> Path | None:
         cache_dir = self.get_cache_directory_for_link(link)
 
@@ -267,7 +267,9 @@ class ArtifactCache:
                 if not cached_archive.exists():
                     cache_dir.mkdir(parents=True, exist_ok=True)
                     try:
-                        download_func(link.url, cached_archive)
+                        downloaded_archive = download_func(link.url, cached_archive)
+                        if downloaded_archive is not None:
+                            cached_archive = downloaded_archive
                     except BaseException:
                         cached_archive.unlink(missing_ok=True)
                         raise

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -131,6 +131,10 @@ class HTTPRangeRequestSupportedError(Exception):
     """Raised when server unexpectedly supports byte ranges."""
 
 
+_MAX_REMOTE_FILENAME_LENGTH = 255
+_INVALID_REMOTE_FILENAME_CHARS = {"\x00", ":"}
+
+
 @overload
 def download_file(
     url: str,
@@ -213,7 +217,14 @@ def _filename_from_content_disposition(content_disposition: str, default: str) -
     # Content-Disposition is controlled by the remote server. Strip both POSIX and
     # Windows path components so it cannot write outside of the cache directory.
     filename = filename.replace("\\", "/").rsplit("/", 1)[-1]
-    return default if filename in {"", ".", ".."} else filename
+    if (
+        filename in {"", ".", ".."}
+        or len(filename) > _MAX_REMOTE_FILENAME_LENGTH
+        or any(char in filename for char in _INVALID_REMOTE_FILENAME_CHARS)
+    ):
+        return default
+
+    return filename
 
 
 class Downloader:

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -14,10 +14,12 @@ import zipfile
 from collections.abc import Mapping
 from contextlib import contextmanager
 from contextlib import suppress
+from email.message import Message
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
 from typing import overload
 
 from requests.exceptions import ChunkedEncodingError
@@ -129,6 +131,7 @@ class HTTPRangeRequestSupportedError(Exception):
     """Raised when server unexpectedly supports byte ranges."""
 
 
+@overload
 def download_file(
     url: str,
     dest: Path,
@@ -137,10 +140,42 @@ def download_file(
     chunk_size: int = 1024,
     raise_accepts_ranges: bool = False,
     max_retries: int = 0,
-) -> None:
+    use_content_disposition: Literal[False] = False,
+) -> None: ...
+
+
+@overload
+def download_file(
+    url: str,
+    dest: Path,
+    *,
+    session: Authenticator | Session | None = None,
+    chunk_size: int = 1024,
+    raise_accepts_ranges: bool = False,
+    max_retries: int = 0,
+    use_content_disposition: Literal[True],
+) -> Path: ...
+
+
+def download_file(
+    url: str,
+    dest: Path,
+    *,
+    session: Authenticator | Session | None = None,
+    chunk_size: int = 1024,
+    raise_accepts_ranges: bool = False,
+    max_retries: int = 0,
+    use_content_disposition: bool = False,
+) -> Path | None:
     from poetry.puzzle.provider import Indicator
 
-    downloader = Downloader(url, dest, session, max_retries=max_retries)
+    downloader = Downloader(
+        url,
+        dest,
+        session,
+        max_retries=max_retries,
+        use_content_disposition=use_content_disposition,
+    )
 
     if raise_accepts_ranges and downloader.accepts_ranges:
         raise HTTPRangeRequestSupportedError(f"URL {url} supports range requests.")
@@ -165,6 +200,21 @@ def download_file(
                     last_percent = percent
                     update_context(f"Downloading {url} {percent:3}%")
 
+    return downloader.destination if use_content_disposition else None
+
+
+def _filename_from_content_disposition(content_disposition: str, default: str) -> str:
+    message = Message()
+    message["Content-Disposition"] = content_disposition
+    filename = message.get_filename()
+    if not filename:
+        return default
+
+    # Content-Disposition is controlled by the remote server. Strip both POSIX and
+    # Windows path components so it cannot write outside of the cache directory.
+    filename = filename.replace("\\", "/").rsplit("/", 1)[-1]
+    return default if filename in {"", ".", ".."} else filename
+
 
 class Downloader:
     def __init__(
@@ -173,12 +223,23 @@ class Downloader:
         dest: Path,
         session: Authenticator | Session | None = None,
         max_retries: int = 0,
+        use_content_disposition: bool = False,
     ):
         self._dest = dest
         self._max_retries = max_retries
         self._session = session or get_default_authenticator()
         self._url = url
         self._response = self._get()
+        if use_content_disposition and (
+            content_disposition := self._response.headers.get("Content-Disposition")
+        ):
+            self._dest = dest.with_name(
+                _filename_from_content_disposition(content_disposition, dest.name)
+            )
+
+    @property
+    def destination(self) -> Path:
+        return self._dest
 
     @cached_property
     def accepts_ranges(self) -> bool:

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1078,6 +1078,33 @@ def test_executor_should_write_pep610_url_references_for_wheel_urls(
         assert dest.exists(), "cached file should not be deleted"
 
 
+def test_executor_uses_locked_filename_for_url_dependency(
+    executor: Executor,
+    fixture_dir: FixtureDirGetter,
+    mocker: MockerFixture,
+) -> None:
+    filename = "demo-0.1.0-py2.py3-none-any.whl"
+    package = Package(
+        "demo",
+        "0.1.0",
+        source_type="url",
+        source_url="https://files.example.org/content",
+    )
+    package.files = [{"file": filename, "hash": "sha256:unused"}]
+    download_link = mocker.patch.object(
+        executor,
+        "_download_link",
+        return_value=fixture_dir("distributions") / filename,
+    )
+    mocker.patch.object(executor._wheel_installer, "install")
+
+    executor._install(Install(package))
+
+    link = download_link.call_args.args[1]
+    assert link.url == package.source_url
+    assert link.filename == filename
+
+
 @pytest.mark.parametrize(
     (
         "is_sdist_cached",

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1099,7 +1099,7 @@ def test_executor_uses_locked_filename_for_url_dependency(
     executor: Executor,
     fixture_dir: FixtureDirGetter,
     mocker: MockerFixture,
-    files: list[dict[str, str]],
+    files: list[PackageFile],
     expected_filename: str | None,
 ) -> None:
     filename = "demo-0.1.0-py2.py3-none-any.whl"
@@ -1121,7 +1121,7 @@ def test_executor_uses_locked_filename_for_url_dependency(
 
     link = download_link.call_args.args[1]
     assert link.url == package.source_url
-    assert link.filename == expected_filename
+    assert link.filename == (expected_filename or "content")
 
 
 @pytest.mark.parametrize(

--- a/tests/installation/test_executor.py
+++ b/tests/installation/test_executor.py
@@ -1078,10 +1078,29 @@ def test_executor_should_write_pep610_url_references_for_wheel_urls(
         assert dest.exists(), "cached file should not be deleted"
 
 
+@pytest.mark.parametrize(
+    ("files", "expected_filename"),
+    [
+        ([], None),
+        (
+            [
+                {"file": "demo-0.1.0-py2.py3-none-any.whl", "hash": "sha256:unused"},
+                {"file": "demo-0.1.0.tar.gz", "hash": "sha256:unused"},
+            ],
+            None,
+        ),
+        (
+            [{"file": "demo-0.1.0-py2.py3-none-any.whl", "hash": "sha256:unused"}],
+            "demo-0.1.0-py2.py3-none-any.whl",
+        ),
+    ],
+)
 def test_executor_uses_locked_filename_for_url_dependency(
     executor: Executor,
     fixture_dir: FixtureDirGetter,
     mocker: MockerFixture,
+    files: list[dict[str, str]],
+    expected_filename: str | None,
 ) -> None:
     filename = "demo-0.1.0-py2.py3-none-any.whl"
     package = Package(
@@ -1090,7 +1109,7 @@ def test_executor_uses_locked_filename_for_url_dependency(
         source_type="url",
         source_url="https://files.example.org/content",
     )
-    package.files = [{"file": filename, "hash": "sha256:unused"}]
+    package.files = files
     download_link = mocker.patch.object(
         executor,
         "_download_link",
@@ -1102,7 +1121,7 @@ def test_executor_uses_locked_filename_for_url_dependency(
 
     link = download_link.call_args.args[1]
     assert link.url == package.source_url
-    assert link.filename == filename
+    assert link.filename == expected_filename
 
 
 @pytest.mark.parametrize(

--- a/tests/packages/test_direct_origin.py
+++ b/tests/packages/test_direct_origin.py
@@ -12,6 +12,8 @@ from poetry.utils.cache import ArtifactCache
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import responses
+
     from pytest_mock import MockerFixture
 
     from tests.types import FixtureDirGetter
@@ -46,6 +48,30 @@ def test_direct_origin_caches_url_dependency(tmp_path: Path) -> None:
         }
     ]
     assert artifact_cache.get_cached_archive_for_link(Link(url), strict=True)
+
+
+def test_direct_origin_uses_content_disposition_filename(
+    http: responses.RequestsMock,
+    fixture_dir: FixtureDirGetter,
+    tmp_path: Path,
+) -> None:
+    artifact_cache = ArtifactCache(cache_dir=tmp_path)
+    direct_origin = DirectOrigin(artifact_cache)
+    filename = "demo-0.1.0-py2.py3-none-any.whl"
+    url = "https://files.example.org/content"
+    http.get(
+        url,
+        body=(fixture_dir("distributions") / filename).read_bytes(),
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+    package = direct_origin.get_package_from_url(url)
+
+    assert package.name == "demo"
+    assert package.files[0]["file"] == filename
+    assert artifact_cache.get_cached_archive_for_link(
+        Link(url, filename=filename), strict=True
+    )
 
 
 def test_direct_origin_does_not_download_url_dependency_when_cached(

--- a/tests/packages/test_direct_origin.py
+++ b/tests/packages/test_direct_origin.py
@@ -66,9 +66,12 @@ def test_direct_origin_uses_content_disposition_filename(
     )
 
     package = direct_origin.get_package_from_url(url)
+    cached_package = direct_origin.get_package_from_url(url)
 
     assert package.name == "demo"
     assert package.files[0]["file"] == filename
+    assert cached_package.files == package.files
+    assert len(http.calls) == 1
     assert artifact_cache.get_cached_archive_for_link(
         Link(url, filename=filename), strict=True
     )

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -362,6 +362,51 @@ def test_get_cached_archive_for_link_no_race_condition(
         download_mock.assert_called_once()
 
 
+def test_get_cached_archive_for_link_uses_downloaded_filename(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    cache = ArtifactCache(cache_dir=tmp_path)
+    link = Link("https://example.org/content")
+    downloaded_filename = "demo-0.1.0.tar.gz"
+
+    def download(_: str, dest: Path) -> Path:
+        downloaded = dest.with_name(downloaded_filename)
+        downloaded.write_bytes(b"demo")
+        return downloaded
+
+    download_mock = mocker.Mock(side_effect=download)
+
+    first = cache.get_cached_archive_for_link(
+        link, strict=True, download_func=download_mock
+    )
+    second = cache.get_cached_archive_for_link(
+        link, strict=True, download_func=download_mock
+    )
+
+    expected = cache.get_cache_directory_for_link(link) / downloaded_filename
+    assert first == second == expected
+    download_mock.assert_called_once()
+
+
+def test_get_cached_archive_for_link_rejects_download_outside_cache(
+    tmp_path: Path,
+) -> None:
+    cache = ArtifactCache(cache_dir=tmp_path / "cache")
+    link = Link("https://example.org/content")
+    outside = tmp_path / "demo-0.1.0.tar.gz"
+
+    def download(_: str, __: Path) -> Path:
+        outside.write_bytes(b"demo")
+        return outside
+
+    with pytest.raises(
+        ValueError, match="Downloaded archive must be in the artifact cache directory"
+    ):
+        cache.get_cached_archive_for_link(link, strict=True, download_func=download)
+
+    assert outside.exists()
+
+
 def test_get_cached_archive_for_git() -> None:
     """Smoke test that checks that no assertion is raised."""
     cache = ArtifactCache(cache_dir=Path())

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -142,6 +142,44 @@ def test_download_file(
     assert http.calls[-1].request.headers["Accept-Encoding"] == "Identity"
 
 
+@pytest.mark.parametrize(
+    ("content_disposition", "expected_filename"),
+    [
+        ("attachment; filename=demo-0.1.0.tar.gz", "demo-0.1.0.tar.gz"),
+        (
+            "attachment; filename=../../demo-0.1.0.tar.gz",
+            "demo-0.1.0.tar.gz",
+        ),
+        (
+            "attachment; filename=..\\\\..\\\\demo-0.1.0.tar.gz",
+            "demo-0.1.0.tar.gz",
+        ),
+        (
+            "attachment; filename*=UTF-8''d%C3%A9mo-0.1.0.tar.gz",
+            "démo-0.1.0.tar.gz",
+        ),
+        ("attachment; filename=..", "content"),
+    ],
+)
+def test_download_file_uses_content_disposition_filename(
+    http: responses.RequestsMock,
+    tmp_path: Path,
+    content_disposition: str,
+    expected_filename: str,
+) -> None:
+    url = "https://foo.com/content"
+    http.get(
+        url,
+        body=b"demo",
+        headers={"Content-Disposition": content_disposition},
+    )
+
+    path = download_file(url, tmp_path / "content", use_content_disposition=True)
+
+    assert path == tmp_path / expected_filename
+    assert path.read_bytes() == b"demo"
+
+
 def test_downloader_with_invalid_content_length(
     http: responses.RequestsMock, tmp_path: Path
 ) -> None:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -158,7 +158,16 @@ def test_download_file(
             "attachment; filename*=UTF-8''d%C3%A9mo-0.1.0.tar.gz",
             "démo-0.1.0.tar.gz",
         ),
+        ("attachment; filename=", "content"),
+        (
+            "attachment; filename=plain.tar.gz; filename*=UTF-8''encoded.tar.gz",
+            "plain.tar.gz",
+        ),
         ("attachment; filename=..", "content"),
+        ("attachment; filename=demo:0.1.0.tar.gz", "content"),
+        ('attachment; filename="demo\x00.tar.gz"', "content"),
+        ("attachment; filename=" + "a" * 255, "a" * 255),
+        ("attachment; filename=" + "a" * 256, "content"),
     ],
 )
 def test_download_file_uses_content_disposition_filename(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #4472

## Summary

Direct URL dependencies may point to endpoints such as `/content` or `/master`, while the response provides the real archive name in `Content-Disposition`. Poetry previously cached those downloads under the URL path name, so package inspection or installation could not recognize the wheel or source archive.

This change:

- uses the response's `Content-Disposition` filename when resolving direct URL dependencies;
- sanitizes both POSIX and Windows path components before writing to the artifact cache;
- lets the cache retain the downloader's final path; and
- reuses the locked package filename during installation, so the original URL can remain unchanged.

## Testing

- Full test suite: 3180 passed, 27 skipped
- `mypy`
- `pre-commit run --files <changed files>`

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (Not required; no user-facing option or workflow changed.)