### PR TITLE
Fix explicit-priority sources not checked by poetry show --outdated

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -656,12 +656,18 @@ lists all packages available."""
                     return provider.search_for_direct_origin_dependency(dep)
 
         allow_prereleases: bool | None = None
-        source: str | None = None
         for dep in requires:
             if dep.name == package.name:
                 allow_prereleases = dep.allows_prereleases()
-                source = dep.source_name
                 break
+
+        # Use the locked package's own source rather than guessing from the first
+        # matching dependency. A package may be declared with several constraints
+        # (different markers and/or sources); the one active in the current
+        # environment is the one that was locked, and its source is recorded
+        # unambiguously on the locked package as ``source_reference`` (empty for
+        # the default repository). Direct-origin packages are handled above.
+        source = None if package.is_direct_origin() else package.source_reference
 
         name = package.name
         selector = VersionSelector(self.poetry.pool)

--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -656,16 +656,18 @@ lists all packages available."""
                     return provider.search_for_direct_origin_dependency(dep)
 
         allow_prereleases: bool | None = None
+        source: str | None = None
         for dep in requires:
             if dep.name == package.name:
                 allow_prereleases = dep.allows_prereleases()
+                source = dep.source_name
                 break
 
         name = package.name
         selector = VersionSelector(self.poetry.pool)
 
         return selector.find_best_candidate(
-            name, f">={package.pretty_version}", allow_prereleases
+            name, f">={package.pretty_version}", allow_prereleases, source=source
         )
 
     def get_update_status(self, latest: Package, package: Package) -> str:

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -2651,6 +2651,111 @@ cachy 0.1.0 0.2.0 Cachy package
 
 
 @output_format_parametrize
+def test_show_outdated_multiple_constraints_uses_locked_source(
+    output_format: str,
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+) -> None:
+    # A package may be declared with several constraints (different markers and
+    # sources). The lookup for the latest version must use the source of the
+    # constraint active in the current environment -- i.e. the one that was
+    # locked -- not simply the first declared constraint. MockEnv reports
+    # sys_platform == "darwin", so the darwin constraint (sourced from
+    # "explicit-darwin") is the active one.
+    explicit_linux = DummyRepository(name="explicit-linux")
+    explicit_darwin = DummyRepository(name="explicit-darwin")
+    poetry.pool.add_repository(explicit_linux, priority=Priority.EXPLICIT)
+    poetry.pool.add_repository(explicit_darwin, priority=Priority.EXPLICIT)
+
+    # The linux constraint is declared first, so a naive first-match lookup
+    # would query the wrong ("explicit-linux") source.
+    poetry.package.add_dependency(
+        Factory.create_dependency(
+            "cachy",
+            {
+                "version": "^0.1.0",
+                "source": "explicit-linux",
+                "markers": "sys_platform == 'linux'",
+            },
+        )
+    )
+    poetry.package.add_dependency(
+        Factory.create_dependency(
+            "cachy",
+            {
+                "version": "^0.1.0",
+                "source": "explicit-darwin",
+                "markers": "sys_platform == 'darwin'",
+            },
+        )
+    )
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")  # newer, but on the WRONG source
+    cachy_020.description = "Cachy package"
+    cachy_030 = get_package("cachy", "0.3.0")  # newer, on the locked source
+    cachy_030.description = "Cachy package"
+
+    installed.add_package(cachy_010)
+
+    explicit_linux.add_package(cachy_010)
+    explicit_linux.add_package(cachy_020)
+    explicit_darwin.add_package(cachy_010)
+    explicit_darwin.add_package(cachy_030)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://foo.bar/explicit-darwin",
+                        "reference": "explicit-darwin",
+                    },
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": []},
+            },
+        }
+    )
+
+    tester.execute(f"--outdated {output_format}")
+
+    expected: str | list[dict[str, str]] = ""
+    if "json" in output_format:
+        expected = [
+            {
+                "name": "cachy",
+                "version": "0.1.0",
+                "latest_version": "0.3.0",
+                "description": "Cachy package",
+                "installed_status": "installed",
+            },
+        ]
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        expected = """\
+cachy 0.1.0 0.3.0 Cachy package
+"""
+        assert tester.io.fetch_output() == expected
+
+
+@output_format_parametrize
 def test_show_top_level(
     output_format: str,
     tester: CommandTester,

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -14,9 +14,11 @@ from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.dependency_group import DependencyGroup
 
 from poetry.factory import Factory
+from poetry.repositories.repository_pool import Priority
 from poetry.utils._compat import tomllib
 from tests.helpers import MOCK_DEFAULT_GIT_REVISION
 from tests.helpers import DummyLocker
+from tests.helpers import DummyRepository
 from tests.helpers import get_package
 
 
@@ -25,7 +27,6 @@ if TYPE_CHECKING:
 
     from poetry.poetry import Poetry
     from poetry.repositories import Repository
-    from tests.helpers import DummyRepository
     from tests.types import CommandTesterFactory
 
 
@@ -2570,6 +2571,82 @@ def test_url_dependency_is_not_outdated_by_repository_package(
         assert json.loads(tester.io.fetch_output()) == expected
     else:
         expected = ""
+        assert tester.io.fetch_output() == expected
+
+
+@output_format_parametrize
+def test_show_outdated_explicit_source(
+    output_format: str,
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+) -> None:
+    explicit_repo = DummyRepository(name="explicit")
+    poetry.pool.add_repository(explicit_repo, priority=Priority.EXPLICIT)
+
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "^0.1.0", "source": "explicit"})
+    )
+
+    cachy_010 = get_package("cachy", "0.1.0")
+    cachy_010.description = "Cachy package"
+    cachy_020 = get_package("cachy", "0.2.0")
+    cachy_020.description = "Cachy package"
+
+    installed.add_package(cachy_010)
+
+    # Only the explicit repository knows about cachy; it must still be
+    # consulted when checking for a newer version.
+    explicit_repo.add_package(cachy_010)
+    explicit_repo.add_package(cachy_020)
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "checksum": [],
+                    "source": {
+                        "type": "legacy",
+                        "url": "https://foo.bar/explicit",
+                        "reference": "explicit",
+                    },
+                },
+            ],
+            "metadata": {
+                "python-versions": "*",
+                "platform": "*",
+                "content-hash": "123456789",
+                "files": {"cachy": []},
+            },
+        }
+    )
+
+    tester.execute(f"--outdated {output_format}")
+
+    expected: str | list[dict[str, str]] = ""
+    if "json" in output_format:
+        expected = [
+            {
+                "name": "cachy",
+                "version": "0.1.0",
+                "latest_version": "0.2.0",
+                "description": "Cachy package",
+                "installed_status": "installed",
+            },
+        ]
+        assert json.loads(tester.io.fetch_output()) == expected
+    else:
+        expected = """\
+cachy 0.1.0 0.2.0 Cachy package
+"""
         assert tester.io.fetch_output() == expected
 
 


### PR DESCRIPTION
## Problem

When a dependency is pinned to a repository with `priority = "explicit"`, `poetry show --outdated` never reports it as outdated, even when a newer version exists in that repository.

## Root cause

`ShowCommand.find_latest_package` looks up each locked package's matching `Dependency` to read `allow_prereleases`, but discards the dependency's `source_name` before calling `VersionSelector.find_best_candidate`. Without a `source`, `RepositoryPool.find_packages` falls back to searching `self.repositories`, which intentionally excludes repositories with `Priority.EXPLICIT` (see the `repositories` property docstring in `repository_pool.py`). So a package that only exists in an explicit repository is silently skipped.

## Fix

Pass the dependency's `source_name` through to `find_best_candidate`, the same way `poetry init`/`poetry add` already do (`ConsoleCommand._find_best_version_for_package`). This lets `RepositoryPool.find_packages` resolve the specific named repository directly, bypassing the explicit-repo exclusion just for that lookup, exactly as intended for a dependency pinned to a source.

## Testing

Added `test_show_outdated_explicit_source` covering a dependency sourced from an explicit-priority repository. Confirmed it fails with the old code (`PackageNotFoundError`, since the explicit repo is never consulted) and passes with the fix.

Fixes #10425