### PR TITLE
tests: deduplicate environment check output helper

### DIFF
--- a/tests/console/commands/env/helpers.py
+++ b/tests/console/commands/env/helpers.py
@@ -1,51 +1,8 @@
 from __future__ import annotations
 
-import os
-
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Any
-
-from poetry.core.constraints.version import Version
-
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-VERSION_3_7_1 = Version.parse("3.7.1")
 
 
 def build_venv(path: Path | str, **_: Any) -> None:
     Path(path).mkdir(parents=True, exist_ok=True)
-
-
-def check_output_wrapper(
-    version: Version = VERSION_3_7_1,
-) -> Callable[[list[str], Any, Any], str]:
-    def check_output(cmd: list[str], *args: Any, **kwargs: Any) -> str:
-        # cmd is a list, like ["python", "-c", "do stuff"]
-        python_cmd = cmd[-1]
-        if "print(json.dumps(env))" in python_cmd:
-            return (
-                f'{{"version_info": [{version.major}, {version.minor},'
-                f" {version.patch}]}}"
-            )
-
-        if "sys.version_info[:3]" in python_cmd:
-            return version.text
-
-        if "sys.version_info[:2]" in python_cmd:
-            return f"{version.major}.{version.minor}"
-
-        if "import sys; print(sys.executable)" in python_cmd:
-            executable = cmd[0]
-            basename = os.path.basename(executable)
-            return f"/usr/bin/{basename}"
-
-        if "print(sys.base_prefix)" in python_cmd:
-            return "/usr"
-
-        assert "import sys; print(sys.prefix)" in python_cmd
-        return "/prefix"
-
-    return check_output

--- a/tests/console/commands/env/test_remove.py
+++ b/tests/console/commands/env/test_remove.py
@@ -6,7 +6,7 @@ import pytest
 
 from poetry.core.constraints.version import Version
 
-from tests.console.commands.env.helpers import check_output_wrapper
+from tests.helpers import check_output_wrapper
 
 
 if TYPE_CHECKING:

--- a/tests/console/commands/env/test_use.py
+++ b/tests/console/commands/env/test_use.py
@@ -15,7 +15,7 @@ from poetry.toml.file import TOMLFile
 from poetry.utils.env import MockEnv
 from poetry.utils.env.python.exceptions import NoCompatiblePythonVersionFoundError
 from tests.console.commands.env.helpers import build_venv
-from tests.console.commands.env.helpers import check_output_wrapper
+from tests.helpers import check_output_wrapper
 
 
 if TYPE_CHECKING:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import keyring
 
+from poetry.core.constraints.version import Version
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.link import Link
 from poetry.core.vcs.git import ParsedUrl
@@ -26,6 +27,7 @@ from poetry.utils.password_manager import PoetryKeyring
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Iterator
     from collections.abc import Mapping
     from typing import Any
@@ -33,7 +35,6 @@ if TYPE_CHECKING:
     import responses
 
     from keyring.backend import KeyringBackend
-    from poetry.core.constraints.version import Version
     from poetry.core.packages.dependency import Dependency
     from pytest_mock import MockerFixture
     from requests import PreparedRequest
@@ -52,6 +53,36 @@ FIXTURE_PATH_REPOSITORIES_PYPI = FIXTURE_PATH_REPOSITORIES / "pypi.org"
 
 # Used as a mock for latest git revision.
 MOCK_DEFAULT_GIT_REVISION = "9cf87a285a2d3fbb0b9fa621997b3acc3631ed24"
+VERSION_3_7_1 = Version.parse("3.7.1")
+
+
+def check_output_wrapper(
+    version: Version = VERSION_3_7_1, base_prefix: str = "/usr"
+) -> Callable[[list[str], Any, Any], str]:
+    def check_output(cmd: list[str], *args: Any, **kwargs: Any) -> str:
+        python_cmd = cmd[-1]
+        if "print(json.dumps(env))" in python_cmd:
+            return (
+                f'{{"version_info": [{version.major}, {version.minor},'
+                f" {version.patch}]}}"
+            )
+
+        if "sys.version_info[:3]" in python_cmd:
+            return version.text
+
+        if "sys.version_info[:2]" in python_cmd:
+            return f"{version.major}.{version.minor}"
+
+        if "import sys; print(sys.executable)" in python_cmd:
+            return f"/usr/bin/{os.path.basename(cmd[0])}"
+
+        if "print(sys.base_prefix)" in python_cmd:
+            return base_prefix
+
+        assert "import sys; print(sys.prefix)" in python_cmd
+        return "/prefix"
+
+    return check_output
 
 
 def get_package(

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -25,10 +25,10 @@ from poetry.utils.env.python.exceptions import InvalidCurrentPythonVersionError
 from poetry.utils.env.python.exceptions import NoCompatiblePythonVersionFoundError
 from poetry.utils.env.python.exceptions import PythonVersionNotFoundError
 from poetry.utils.helpers import remove_directory
+from tests.helpers import check_output_wrapper as make_check_output
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from collections.abc import Iterator
     from unittest.mock import MagicMock
 
@@ -42,43 +42,9 @@ if TYPE_CHECKING:
     from tests.types import MockedPythonRegister
     from tests.types import ProjectFactory
 
-VERSION_3_7_1 = Version.parse("3.7.1")
-
 
 def build_venv(path: Path | str, **__: Any) -> None:
     os.mkdir(str(path))
-
-
-def check_output_wrapper(
-    version: Version = VERSION_3_7_1,
-) -> Callable[[list[str], Any, Any], str]:
-    def check_output(cmd: list[str], *args: Any, **kwargs: Any) -> str:
-        # cmd is a list, like ["python", "-c", "do stuff"]
-        python_cmd = cmd[-1]
-        if "print(json.dumps(env))" in python_cmd:
-            return (
-                f'{{"version_info": [{version.major}, {version.minor},'
-                f" {version.patch}]}}"
-            )
-
-        if "sys.version_info[:3]" in python_cmd:
-            return version.text
-
-        if "sys.version_info[:2]" in python_cmd:
-            return f"{version.major}.{version.minor}"
-
-        if "import sys; print(sys.executable)" in python_cmd:
-            executable = cmd[0]
-            basename = os.path.basename(executable)
-            return f"/usr/bin/{basename}"
-
-        if "print(sys.base_prefix)" in python_cmd:
-            return sys.base_prefix
-
-        assert "import sys; print(sys.prefix)" in python_cmd
-        return "/prefix"
-
-    return check_output
 
 
 @pytest.fixture
@@ -572,7 +538,7 @@ def test_deactivate_activated(
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        side_effect=make_check_output(base_prefix=sys.base_prefix),
     )
 
     manager.deactivate()
@@ -619,7 +585,7 @@ def test_get_prefers_explicitly_activated_virtualenvs_over_env_var(
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(),
+        side_effect=make_check_output(base_prefix=sys.base_prefix),
     )
 
     env = manager.get()
@@ -689,7 +655,9 @@ def test_remove_by_python_version(
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(Version.parse("3.6.6")),
+        side_effect=make_check_output(
+            Version.parse("3.6.6"), base_prefix=sys.base_prefix
+        ),
     )
 
     venv = manager.remove("3.6")
@@ -714,7 +682,9 @@ def test_remove_by_name(
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(Version.parse("3.6.6")),
+        side_effect=make_check_output(
+            Version.parse("3.6.6"), base_prefix=sys.base_prefix
+        ),
     )
 
     venv = manager.remove(f"{venv_name}-py3.6")
@@ -739,7 +709,9 @@ def test_remove_by_string_with_python_and_version(
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(Version.parse("3.6.6")),
+        side_effect=make_check_output(
+            Version.parse("3.6.6"), base_prefix=sys.base_prefix
+        ),
     )
 
     venv = manager.remove("python3.6")
@@ -764,7 +736,9 @@ def test_remove_by_full_path_to_python(
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(Version.parse("3.6.6")),
+        side_effect=make_check_output(
+            Version.parse("3.6.6"), base_prefix=sys.base_prefix
+        ),
     )
 
     expected_venv_path = tmp_path / f"{venv_name}-py3.6"
@@ -872,7 +846,9 @@ def test_remove_also_deactivates(
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(Version.parse("3.6.6")),
+        side_effect=make_check_output(
+            Version.parse("3.6.6"), base_prefix=sys.base_prefix
+        ),
     )
 
     envs_file = TOMLFile(tmp_path / "envs.toml")
@@ -916,7 +892,9 @@ def test_remove_keeps_dir_if_not_deleteable(
 
     mocker.patch(
         "subprocess.check_output",
-        side_effect=check_output_wrapper(Version.parse("3.6.6")),
+        side_effect=make_check_output(
+            Version.parse("3.6.6"), base_prefix=sys.base_prefix
+        ),
     )
 
     def err_on_rm_venv_only(path: Path, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
Relates-to: #3155

## Summary

- move the duplicated environment `check_output` mock into `tests.helpers`
- preserve the console tests' `/usr` base prefix and the environment manager tests' runtime `sys.base_prefix`
- import the shared helper directly from each affected test module

This removes 34 net lines while keeping the existing test behavior unchanged.

## Verification

- `pytest -n 0 tests/console/commands/env/test_use.py tests/console/commands/env/test_remove.py tests/utils/env/test_env_manager.py` (`68 passed`)
- `mypy tests/helpers.py tests/console/commands/env/helpers.py tests/console/commands/env/test_remove.py tests/console/commands/env/test_use.py tests/utils/env/test_env_manager.py`
- `pre-commit run --files tests/helpers.py tests/console/commands/env/helpers.py tests/console/commands/env/test_remove.py tests/console/commands/env/test_use.py tests/utils/env/test_env_manager.py`

The local Homebrew environment provides `python3` but no bare `python`, so the pytest run used a temporary PATH entry mapping `python` to `python3`. No repository files were changed for that local environment difference.

## Checklist

- [x] Updated and ran the affected tests.
- [ ] Updated documentation (not applicable; test-only cleanup).
