### PR TITLE
docs: clarify env use precedence over active virtualenvs

### DIFF
--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -14,9 +14,23 @@ menu:
 Poetry makes project environment isolation one of its core features.
 
 What this means is that it will always work isolated from your global Python installation.
-To achieve this, it will first check if it's currently running inside a virtual environment.
-If it is, it will use it directly without creating a new one. But if it's not, it will use
-one that it has already created or create a brand new one for you.
+To achieve this, Poetry chooses a project virtual environment in this order:
+
+1. If you previously ran [`poetry env use`](#switching-between-environments) for this
+   project, Poetry uses that **explicitly selected** environment (stored for the project
+   in Poetry's virtualenvs cache, typically as an `envs.toml` entry). This selection
+   takes precedence even if your shell currently has another virtual environment
+   activated (`VIRTUAL_ENV`).
+2. Otherwise, if Poetry is already running inside a virtual environment, it uses that
+   environment directly without creating a new one.
+3. Otherwise, it reuses an environment it previously created for the project, or creates
+   a new one.
+
+This matters if you manage virtual environments yourself (for example with `direnv` or
+`python -m venv`) and also run `poetry env use`: after that point, Poetry will prefer
+its remembered environment over the one your shell has activated. Use
+`poetry env use system` to clear the explicit selection and return to the default
+behavior above.
 
 By default, Poetry will try to use the Python version used during Poetry's installation
 to create the virtual environment for the current project.
@@ -75,6 +89,14 @@ special `system` Python version to retrieve the default behavior:
 ```bash
 poetry env use system
 ```
+
+{{% note %}}
+`poetry env use` records the chosen environment for the **current project** in Poetry's
+virtualenvs cache (commonly an `envs.toml` file under the directory controlled by the
+[`virtualenvs.path`]({{< relref "configuration" >}}) setting). That record can outlive a
+Poetry reinstall and will keep overriding an externally activated venv until you run
+`poetry env use system` (or remove the project's entry).
+{{% /note %}}
 
 ## Activating the environment
 

--- a/docs/managing-environments.md
+++ b/docs/managing-environments.md
@@ -26,11 +26,10 @@ To achieve this, Poetry chooses a project virtual environment in this order:
 3. Otherwise, it reuses an environment it previously created for the project, or creates
    a new one.
 
-This matters if you manage virtual environments yourself (for example with `direnv` or
-`python -m venv`) and also run `poetry env use`: after that point, Poetry will prefer
-its remembered environment over the one your shell has activated. Use
-`poetry env use system` to clear the explicit selection and return to the default
-behavior above.
+If you bring your own virtualenv tooling (for example `direnv` or `python -m venv`),
+prefer relying on step 2 above and avoid `poetry env use`, or clear an earlier
+selection with `poetry env use system` when you want the shell-activated environment
+to win again.
 
 By default, Poetry will try to use the Python version used during Poetry's installation
 to create the virtual environment for the current project.
@@ -91,11 +90,16 @@ poetry env use system
 ```
 
 {{% note %}}
-`poetry env use` records the chosen environment for the **current project** in Poetry's
-virtualenvs cache (commonly an `envs.toml` file under the directory controlled by the
-[`virtualenvs.path`]({{< relref "configuration" >}}) setting). That record can outlive a
-Poetry reinstall and will keep overriding an externally activated venv until you run
-`poetry env use system` (or remove the project's entry).
+`poetry env use` stores that project selection in an `envs.toml` file under Poetry's
+virtualenvs directory. Print the directory with:
+
+```bash
+poetry config virtualenvs.path
+```
+
+The file is typically `envs.toml` in that directory. It can remain after a Poetry
+reinstall; remove the project's entry there, or run `poetry env use system`, to clear
+the explicit selection. Precedence details are in the list at the top of this page.
 {{% /note %}}
 
 ## Activating the environment


### PR DESCRIPTION
Document that an explicit `poetry env use` selection (via envs.toml) wins over a shell-activated VIRTUAL_ENV, and how to reset with `poetry env use system`.

# Pull Request Check List

Resolves: #8247 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
