### PR TITLE
test: add coverage for poetry.toml.TOMLFile

### DIFF
--- a/tests/toml/test_file.py
+++ b/tests/toml/test_file.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tomlkit.toml_document import TOMLDocument
+
+from poetry.toml import TOMLError
+from poetry.toml import TOMLFile
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_path_returns_the_given_path(tmp_path: Path) -> None:
+    path = tmp_path / "pyproject.toml"
+
+    assert TOMLFile(path).path == path
+
+
+def test_exists_is_false_when_file_is_missing(tmp_path: Path) -> None:
+    path = tmp_path / "pyproject.toml"
+
+    assert TOMLFile(path).exists() is False
+
+
+def test_exists_is_true_when_file_is_present(tmp_path: Path) -> None:
+    path = tmp_path / "pyproject.toml"
+    path.write_text("", encoding="utf-8")
+
+    assert TOMLFile(path).exists() is True
+
+
+def test_read_returns_a_toml_document(tmp_path: Path) -> None:
+    path = tmp_path / "pyproject.toml"
+    path.write_text('[tool.poetry]\nname = "poetry"\n', encoding="utf-8")
+
+    content = TOMLFile(path).read()
+
+    assert isinstance(content, TOMLDocument)
+    assert content["tool"]["poetry"]["name"] == "poetry"
+
+
+def test_read_raises_toml_error_on_invalid_toml(tmp_path: Path) -> None:
+    path = tmp_path / "pyproject.toml"
+    path.write_text("<<<<<<<<<<<", encoding="utf-8")
+
+    with pytest.raises(TOMLError) as excval:
+        TOMLFile(path).read()
+
+    assert f"Invalid TOML file {path.as_posix()}" in str(excval.value)
+
+
+def test_str_returns_posix_path(tmp_path: Path) -> None:
+    path = tmp_path / "pyproject.toml"
+
+    assert str(TOMLFile(path)) == path.as_posix()


### PR DESCRIPTION
TOMLFile (the wrapper around tomlkit's TOMLFile that poetry uses for reading pyproject.toml) doesn't have its own test file. The only place it's exercised is tests/pyproject/test_pyproject_toml_file.py, and that only covers what happens when the TOML is invalid.

This fills in the rest: path, exists(), a normal successful read(), and __str__.

Ran pytest, mypy, and ruff locally, all green.

Relates-to: #3155

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (not applicable, test-only change)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
