### PR TITLE
fix(solver): resolve extra dependencies missing from a reused package's requires

### DIFF
--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -509,13 +509,14 @@ class Provider:
     ) -> DependencyPackage:
         package = dependency_package.package
         dependency = dependency_package.dependency
+        is_direct_origin = package.is_direct_origin()
 
         if package.is_root():
             dependency_package = dependency_package.clone()
             package = dependency_package.package
             dependency = dependency_package.dependency
             requires = package.all_requires
-        elif package.is_direct_origin():
+        elif is_direct_origin:
             requires = package.requires
         else:
             if (
@@ -555,20 +556,23 @@ class Provider:
         optional_dependencies = set()
         _dependencies = []
 
-        # Dependencies backing an extra (eg. "psycopg" for "postgresql") that aren't
-        # found in `requires` below fall back to these, keyed by name. This can
-        # happen for a package reused from the lock file: its `requires` may have
-        # been pruned down to whatever extras were active in an earlier resolution,
-        # while `package.extras` always keeps the complete, unpruned mapping.
-        # An extra can list several same-named dependencies with different markers
-        # (eg. a platform-restricted variant per `sys_platform`), so this keeps a
-        # list per name rather than a single entry.
-        extra_dependency_by_name: dict[str, list[Dependency]] = defaultdict(list)
-
         if dependency.extras:
             # Find all the optional dependencies that are wanted - taking care to allow
             # for self-referential extras.
             stack = sorted(dependency.extras)
+
+            # For direct origin dependencies from the lock file,
+            # only used extra dependencies are found in `requires`.
+            # If the package locked for a direct origin dependency is reused,
+            # its `requires` have been pruned down to whatever extras were active
+            # in an earlier resolution. This is an issue in subsequent resolutions
+            # if an additional extra is requested via changes in the pyproject.toml.
+            # (Dependencies from repositories are looked up again
+            # so that this is not issue for them.)
+            if is_direct_origin:
+                requires = requires.copy()
+                requires_extras = {extra for dep in requires for extra in dep.in_extras}
+
             while stack:
                 extra = stack.pop()
                 if extra in found_extras:
@@ -581,9 +585,8 @@ class Provider:
                         stack += sorted(extra_dependency.extras)
                     else:
                         optional_dependencies.add(extra_dependency.name)
-                        extra_dependency_by_name[extra_dependency.name].append(
-                            extra_dependency
-                        )
+                        if is_direct_origin and extra not in requires_extras:
+                            requires.append(extra_dependency)
 
             # If some extras/features were required, we need to add a special dependency
             # representing the base package to the current package.
@@ -601,8 +604,6 @@ class Provider:
                 new_dependency.source_name = dependency.source_name
 
             _dependencies.append(new_dependency)
-
-        names_in_requires = {dep.name for dep in requires}
 
         for dep in requires:
             if not self._python_constraint.allows_any(dep.python_constraint):
@@ -652,17 +653,6 @@ class Provider:
                 )
 
             _dependencies.append(dep)
-
-        # An activated extra's dependency may be entirely absent from `requires`
-        # above (see the comment on extra_dependency_by_name): add it directly so
-        # activating the extra actually pulls in what it needs. Only do this for
-        # names that don't appear in `requires` at all - if a same-named dependency
-        # is there but got filtered out (eg. a marker like python_version=='3.8'
-        # that doesn't match the current environment), that exclusion is
-        # deliberate and must be respected, not overridden.
-        for name in optional_dependencies:
-            if name not in names_in_requires:
-                _dependencies.extend(extra_dependency_by_name[name])
 
         if self._load_deferred:
             # Retrieving constraints for deferred dependencies

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -555,6 +555,13 @@ class Provider:
         optional_dependencies = set()
         _dependencies = []
 
+        # Dependencies backing an extra (eg. "psycopg" for "postgresql") that aren't
+        # found in `requires` below fall back to these, keyed by name. This can
+        # happen for a package reused from the lock file: its `requires` may have
+        # been pruned down to whatever extras were active in an earlier resolution,
+        # while `package.extras` always keeps the complete, unpruned mapping.
+        extra_dependency_by_name: dict[str, Dependency] = {}
+
         if dependency.extras:
             # Find all the optional dependencies that are wanted - taking care to allow
             # for self-referential extras.
@@ -571,6 +578,9 @@ class Provider:
                         stack += sorted(extra_dependency.extras)
                     else:
                         optional_dependencies.add(extra_dependency.name)
+                        extra_dependency_by_name.setdefault(
+                            extra_dependency.name, extra_dependency
+                        )
 
             # If some extras/features were required, we need to add a special dependency
             # representing the base package to the current package.
@@ -588,6 +598,8 @@ class Provider:
                 new_dependency.source_name = dependency.source_name
 
             _dependencies.append(new_dependency)
+
+        names_in_requires = {dep.name for dep in requires}
 
         for dep in requires:
             if not self._python_constraint.allows_any(dep.python_constraint):
@@ -637,6 +649,17 @@ class Provider:
                 )
 
             _dependencies.append(dep)
+
+        # An activated extra's dependency may be entirely absent from `requires`
+        # above (see the comment on extra_dependency_by_name): add it directly so
+        # activating the extra actually pulls in what it needs. Only do this for
+        # names that don't appear in `requires` at all - if a same-named dependency
+        # is there but got filtered out (eg. a marker like python_version=='3.8'
+        # that doesn't match the current environment), that exclusion is
+        # deliberate and must be respected, not overridden.
+        for name in optional_dependencies:
+            if name not in names_in_requires and name in extra_dependency_by_name:
+                _dependencies.append(extra_dependency_by_name[name])
 
         if self._load_deferred:
             # Retrieving constraints for deferred dependencies

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -560,7 +560,10 @@ class Provider:
         # happen for a package reused from the lock file: its `requires` may have
         # been pruned down to whatever extras were active in an earlier resolution,
         # while `package.extras` always keeps the complete, unpruned mapping.
-        extra_dependency_by_name: dict[str, Dependency] = {}
+        # An extra can list several same-named dependencies with different markers
+        # (eg. a platform-restricted variant per `sys_platform`), so this keeps a
+        # list per name rather than a single entry.
+        extra_dependency_by_name: dict[str, list[Dependency]] = defaultdict(list)
 
         if dependency.extras:
             # Find all the optional dependencies that are wanted - taking care to allow
@@ -578,8 +581,8 @@ class Provider:
                         stack += sorted(extra_dependency.extras)
                     else:
                         optional_dependencies.add(extra_dependency.name)
-                        extra_dependency_by_name.setdefault(
-                            extra_dependency.name, extra_dependency
+                        extra_dependency_by_name[extra_dependency.name].append(
+                            extra_dependency
                         )
 
             # If some extras/features were required, we need to add a special dependency
@@ -658,8 +661,8 @@ class Provider:
         # that doesn't match the current environment), that exclusion is
         # deliberate and must be respected, not overridden.
         for name in optional_dependencies:
-            if name not in names_in_requires and name in extra_dependency_by_name:
-                _dependencies.append(extra_dependency_by_name[name])
+            if name not in names_in_requires:
+                _dependencies.extend(extra_dependency_by_name[name])
 
         if self._load_deferred:
             # Retrieving constraints for deferred dependencies

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -19,7 +19,6 @@ from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.packages.url_dependency import URLDependency
 from poetry.core.packages.vcs_dependency import VCSDependency
-from poetry.core.version.markers import parse_marker
 
 from poetry.factory import Factory
 from poetry.inspection.info import PackageInfo
@@ -887,7 +886,7 @@ def test_complete_package_with_extras_preserves_source_name(
 
 
 def test_complete_package_resolves_extra_dependency_missing_from_requires(
-    provider: Provider, repository: Repository
+    root: ProjectPackage, repository: Repository, pool: RepositoryPool
 ) -> None:
     """
     A locked package's `requires` may have been pruned down to whatever extras
@@ -896,13 +895,16 @@ def test_complete_package_resolves_extra_dependency_missing_from_requires(
     dependency isn't in `requires` must still resolve it from `extras`
     (regression test for #10314).
     """
-    package_a = Package("A", "1.0")
+    package_a = Package("A", "1.0", source_type="url", source_url=SOME_URL)
     package_b = Package("B", "1.0")
     dep = get_dependency("B", "^1.0", optional=True)
     # dep is only present in `extras`, not added via package_a.add_dependency(dep)
     package_a.extras = {canonicalize_name("foo"): [dep]}
     repository.add_package(package_a)
     repository.add_package(package_b)
+
+    locked_package = Package("A", "1.0", source_type="url", source_url=SOME_URL)
+    provider = Provider(root, pool, NullIO(), locked=[locked_package])
 
     dependency = Dependency("A", "1.0", extras=["foo"])
 
@@ -915,7 +917,7 @@ def test_complete_package_resolves_extra_dependency_missing_from_requires(
 
 
 def test_complete_package_respects_marker_exclusion_over_missing_requires(
-    pool: RepositoryPool, repository: Repository
+    root: ProjectPackage, repository: Repository, pool: RepositoryPool
 ) -> None:
     """
     A dependency present in `requires` but excluded by a marker mismatch must
@@ -924,12 +926,13 @@ def test_complete_package_respects_marker_exclusion_over_missing_requires(
     """
     root = ProjectPackage("root", "1.2.3")
     root.python_versions = "^3.9"
-    provider = Provider(root, pool, NullIO())
+    locked_package = Package("A", "1.0", source_type="url", source_url=SOME_URL)
+    provider = Provider(root, pool, NullIO(), locked=[locked_package])
 
-    package_a = Package("A", "1.0")
+    package_a = Package("A", "1.0", source_type="url", source_url=SOME_URL)
     package_b = Package("B", "1.0")
     dep = get_dependency("B", "^1.0", optional=True)
-    dep.marker = parse_marker("python_version == '2.7'")
+    dep.marker = "python_version == '2.7'"
     package_a.add_dependency(dep)
     package_a.extras = {canonicalize_name("foo"): [dep]}
     repository.add_package(package_a)

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -924,7 +924,6 @@ def test_complete_package_respects_marker_exclusion_over_missing_requires(
     stay excluded, even though it's also absent from the filtered result (same
     as a genuinely-missing-from-requires dependency would be).
     """
-    root = ProjectPackage("root", "1.2.3")
     root.python_versions = "^3.9"
     locked_package = Package("A", "1.0", source_type="url", source_url=SOME_URL)
     provider = Provider(root, pool, NullIO(), locked=[locked_package])

--- a/tests/puzzle/test_provider.py
+++ b/tests/puzzle/test_provider.py
@@ -19,6 +19,7 @@ from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.packages.url_dependency import URLDependency
 from poetry.core.packages.vcs_dependency import VCSDependency
+from poetry.core.version.markers import parse_marker
 
 from poetry.factory import Factory
 from poetry.inspection.info import PackageInfo
@@ -883,6 +884,65 @@ def test_complete_package_with_extras_preserves_source_name(
     assert requires[0].source_name == source_name
     assert requires[1].name == "b"
     assert requires[1].source_name is None
+
+
+def test_complete_package_resolves_extra_dependency_missing_from_requires(
+    provider: Provider, repository: Repository
+) -> None:
+    """
+    A locked package's `requires` may have been pruned down to whatever extras
+    were active in an earlier resolution (see locker._get_locked_package()),
+    while `extras` always keeps the complete mapping. Activating an extra whose
+    dependency isn't in `requires` must still resolve it from `extras`
+    (regression test for #10314).
+    """
+    package_a = Package("A", "1.0")
+    package_b = Package("B", "1.0")
+    dep = get_dependency("B", "^1.0", optional=True)
+    # dep is only present in `extras`, not added via package_a.add_dependency(dep)
+    package_a.extras = {canonicalize_name("foo"): [dep]}
+    repository.add_package(package_a)
+    repository.add_package(package_b)
+
+    dependency = Dependency("A", "1.0", extras=["foo"])
+
+    complete_package = provider.complete_package(
+        DependencyPackage(dependency, package_a)
+    )
+
+    requires = complete_package.package.all_requires
+    assert {r.name for r in requires} == {"a", "b"}
+
+
+def test_complete_package_respects_marker_exclusion_over_missing_requires(
+    pool: RepositoryPool, repository: Repository
+) -> None:
+    """
+    A dependency present in `requires` but excluded by a marker mismatch must
+    stay excluded, even though it's also absent from the filtered result (same
+    as a genuinely-missing-from-requires dependency would be).
+    """
+    root = ProjectPackage("root", "1.2.3")
+    root.python_versions = "^3.9"
+    provider = Provider(root, pool, NullIO())
+
+    package_a = Package("A", "1.0")
+    package_b = Package("B", "1.0")
+    dep = get_dependency("B", "^1.0", optional=True)
+    dep.marker = parse_marker("python_version == '2.7'")
+    package_a.add_dependency(dep)
+    package_a.extras = {canonicalize_name("foo"): [dep]}
+    repository.add_package(package_a)
+    repository.add_package(package_b)
+
+    dependency = Dependency("A", "1.0", extras=["foo"])
+
+    complete_package = provider.complete_package(
+        DependencyPackage(dependency, package_a)
+    )
+
+    requires = complete_package.package.all_requires
+    assert "b" not in {r.name for r in requires}
 
 
 @pytest.mark.parametrize("with_extra", [False, True])

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -5547,7 +5547,7 @@ def test_solver_resolves_duplicate_extra_dependencies_missing_from_requires(
         Factory.create_dependency("A", {"version": "*", "extras": ["foo"]})
     )
 
-    package_a = get_package("A", "1.0")
+    package_a = Package("A", "1.0", source_type="url", source_url="https://example.org")
     package_b1 = get_package("B", "1.0")
     package_b2 = get_package("B", "2.0")
 
@@ -5557,11 +5557,10 @@ def test_solver_resolves_duplicate_extra_dependencies_missing_from_requires(
     dep2.marker = parse_marker("sys_platform == 'linux' and extra == 'foo'")
     package_a.extras = {canonicalize_name("foo"): [dep1, dep2]}
 
-    repo.add_package(package_a)
     repo.add_package(package_b1)
     repo.add_package(package_b2)
 
-    solver = Solver(package, pool, [], [], io)
+    solver = Solver(package, pool, [], [package_a], io)
     transaction = solver.solve()
 
     check_solver_result(

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -5530,6 +5530,52 @@ def test_solver_resolves_duplicate_dependencies_with_restricted_extras(
     )
 
 
+def test_solver_resolves_duplicate_extra_dependencies_missing_from_requires(
+    package: ProjectPackage,
+    pool: RepositoryPool,
+    repo: Repository,
+    io: NullIO,
+) -> None:
+    """
+    Same shape as test_solver_resolves_duplicate_dependencies_with_restricted_extras,
+    but neither same-named dependency is added to package_a's own `requires`
+    (only `extras`), simulating a package reused from the lock file whose
+    `requires` was pruned down to whatever extras were active during an
+    earlier resolution (regression test for #10314).
+    """
+    package.add_dependency(
+        Factory.create_dependency("A", {"version": "*", "extras": ["foo"]})
+    )
+
+    package_a = get_package("A", "1.0")
+    package_b1 = get_package("B", "1.0")
+    package_b2 = get_package("B", "2.0")
+
+    dep1 = get_dependency("B", "^1.0", optional=True)
+    dep1.marker = parse_marker("sys_platform == 'win32' and extra == 'foo'")
+    dep2 = get_dependency("B", "^2.0", optional=True)
+    dep2.marker = parse_marker("sys_platform == 'linux' and extra == 'foo'")
+    package_a.extras = {canonicalize_name("foo"): [dep1, dep2]}
+
+    repo.add_package(package_a)
+    repo.add_package(package_b1)
+    repo.add_package(package_b2)
+
+    solver = Solver(package, pool, [], [], io)
+    transaction = solver.solve()
+
+    check_solver_result(
+        transaction,
+        (
+            [
+                {"job": "install", "package": package_b1},
+                {"job": "install", "package": package_b2},
+                {"job": "install", "package": package_a},
+            ]
+        ),
+    )
+
+
 def test_solver_resolves_optional_dependencies_and_group_with_extras(
     package: ProjectPackage,
     pool: RepositoryPool,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10314

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code. (not applicable — internal solver behavior, no user-facing docs to update)

## What

Editing `pyproject.toml` to add an extra to a VCS dependency (eg. changing `sqlalchemy @ git+...` to `sqlalchemy[postgresql] @ git+...`) and running `poetry lock` silently drops the extra's own dependencies (eg. `psycopg`), unless the same change is instead made via `poetry add`.

## Why

`Provider.complete_package()` looks up a package's optional/in-extras dependencies by matching names found in `package.extras` against `Dependency` objects present in `package.requires`. That works for a freshly-inspected package, but a package reused from the lock file (`Locker._get_locked_package()`) may have a `requires` list pruned down to whatever extras were active during an earlier resolution, while `package.extras` always keeps the full mapping. When the matching `Dependency` object isn't in `requires` anymore, the name is still recognized as needed but nothing gets added to satisfy it.

The fix falls back to the `Dependency` objects in `package.extras` for names that are entirely absent from `requires`. Names that are present but excluded for another reason (eg. a marker that doesn't match the current environment) are left alone, since that exclusion is deliberate — a second regression test covers this to make sure the fallback doesn't override legitimate marker-based exclusions.

## Verification

- Reproduced the bug against a real `poetry` installed from source, using an actual git clone of SQLAlchemy as the VCS dependency.
- Confirmed the fix resolves the reported case, and that removing the extra / re-locking with no changes both still behave correctly (stable, no regressions).
- Added two targeted regression tests in `tests/puzzle/test_provider.py`.
- Full test suite: 1104 passed; the only failures are 3 pre-existing ones unrelated to this change (confirmed identical on unmodified `main`: an LFS test needing network access, and a Python 3.14/embedded-pip environment issue).
- `ruff check`, `ruff format --check`, and `mypy` all clean on the changed files.

---
Disclosure: this PR was prepared with the assistance of Claude Code (Anthropic). The investigation, root-cause diagnosis, fix, and verification steps described above were done and checked by me.