### PR TITLE
test: cover single-page repository responses

### DIFF
--- a/tests/repositories/test_single_page_repository.py
+++ b/tests/repositories/test_single_page_repository.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 from poetry.core.packages.dependency import Dependency
 
 from poetry.repositories.exceptions import PackageNotFoundError
@@ -13,6 +15,8 @@ from poetry.repositories.single_page_repository import SinglePageRepository
 
 
 if TYPE_CHECKING:
+    import responses
+
     from packaging.utils import NormalizedName
 
 
@@ -77,3 +81,24 @@ def test_single_page_repository_get_page_with_relative_links() -> None:
     for link in page.links:
         path = Path(link.path)
         assert path.parent == base_path
+
+
+def test_get_page_fetches_repository_url(http: responses.RequestsMock) -> None:
+    url = "https://single-page.example.org/packages.html"
+    http.get(url, body='<a href="demo-1.2.3.tar.gz">demo</a>')
+    repo = SinglePageRepository("single-page", url=url, disable_cache=True)
+
+    page = repo.get_page("ignored")
+
+    assert [link.filename for link in page.links] == ["demo-1.2.3.tar.gz"]
+
+
+def test_get_page_raises_if_repository_is_missing(
+    http: responses.RequestsMock,
+) -> None:
+    url = "https://single-page.example.org/packages.html"
+    http.get(url, status=404)
+    repo = SinglePageRepository("single-page", url=url, disable_cache=True)
+
+    with pytest.raises(PackageNotFoundError, match=r"Package \[demo\] not found\."):
+        repo.get_page("demo")


### PR DESCRIPTION
# Pull Request Check List

Relates-to: #3155

`SinglePageRepository` tests previously used a subclass that overrides `_get_page`, so the production implementation was not exercised.

This PR adds coverage for:

- fetching and parsing the repository's single page;
- raising `PackageNotFoundError` when the page returns a 404 response.

No production code or user-facing behavior is changed.

## Testing

- `python -m pytest tests/repositories/test_single_page_repository.py --cov=poetry.repositories.single_page_repository --cov-report=term-missing -q` — 5 passed, 100% coverage
- `python -m pytest tests/repositories --no-cov -q` — 337 passed
- `python -m pytest --no-cov -q` — 3175 passed, 27 skipped
- `pre-commit run --files tests/repositories/test_single_page_repository.py` — passed
- `mypy tests/repositories/test_single_page_repository.py` — passed

## AI assistance

OpenAI Codex assisted with identifying the coverage gap, drafting the tests, and running validation. The contributor reviewed the complete diff and test results.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. Not applicable: this is a test-only change.
