### PR TITLE
docs: fix typo in InstalledRepository.get_package_paths docstring

### DIFF
--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -42,7 +42,7 @@ class InstalledRepository(Repository):
         """
         Process a .pth file within the site-packages directories, and return any valid
         paths. We skip executable .pth files as there is no reliable means to do this
-        without side-effects to current run-time. Mo check is made that the item refers
+        without side-effects to current run-time. No check is made that the item refers
         to a directory rather than a file, however, in order to maintain backwards
         compatibility, we allow non-existing paths to be discovered. The latter
         behaviour is different to how Python's site-specific hook configuration works.


### PR DESCRIPTION
## Summary
- Fixes a one-word typo in the docstring of `InstalledRepository.get_package_paths`: "Mo check is made" should read "No check is made".

## Test plan
- Docstring-only change, no behavior affected.