### PR TITLE
Skip plugin loading for version output

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -632,7 +632,9 @@ class Application(BaseApplication):
         if self._plugins_loaded:
             return
 
-        self._disable_plugins = io.input.has_parameter_option("--no-plugins")
+        self._disable_plugins = io.input.has_parameter_option(
+            "--no-plugins"
+        ) or io.input.has_parameter_option(["--version", "-V"], only_params=True)
 
         if not self._disable_plugins:
             from poetry.plugins.application_plugin import ApplicationPlugin

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -87,11 +87,14 @@ def test_application_version_does_not_load_plugins(
     assert tester.status_code == 0
 
 
-def test_application_subcommand_version_loads_plugins(mocker: MockerFixture) -> None:
+@pytest.mark.parametrize("command", ["run python -V", "run -- python -V"])
+def test_application_subcommand_version_loads_plugins(
+    command: str, mocker: MockerFixture
+) -> None:
     load_plugins = mocker.spy(PluginManager, "load_plugins")
     tester = ApplicationTester(Application())
 
-    tester.execute("run -- python -V")
+    tester.execute(command)
 
     load_plugins.assert_called_once()
 

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -14,6 +14,7 @@ from cleo.testers.application_tester import ApplicationTester
 from poetry.console.application import Application
 from poetry.console.commands.command import Command
 from poetry.plugins.application_plugin import ApplicationPlugin
+from poetry.plugins.plugin_manager import PluginManager
 from poetry.plugins.plugin_manager import ProjectPluginCache
 from poetry.repositories.cached_repository import CachedRepository
 from poetry.utils.authenticator import Authenticator
@@ -71,6 +72,28 @@ def test_application_with_plugins_disabled(with_add_command_plugin: None) -> Non
 
     assert re.search(r"\s+foo\s+Foo Command", tester.io.fetch_output()) is None
     assert tester.status_code == 0
+
+
+@pytest.mark.parametrize("version_option", ["--version", "-V"])
+def test_application_version_does_not_load_plugins(
+    version_option: str, mocker: MockerFixture
+) -> None:
+    load_plugins = mocker.spy(PluginManager, "load_plugins")
+    tester = ApplicationTester(Application())
+
+    tester.execute(version_option)
+
+    load_plugins.assert_not_called()
+    assert tester.status_code == 0
+
+
+def test_application_subcommand_version_loads_plugins(mocker: MockerFixture) -> None:
+    load_plugins = mocker.spy(PluginManager, "load_plugins")
+    tester = ApplicationTester(Application())
+
+    tester.execute("run -- python -V")
+
+    load_plugins.assert_called_once()
 
 
 def test_application_execute_plugin_command(with_add_command_plugin: None) -> None:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10625

- [x] Added **tests** for changed code.
- [x] Documentation is not required for this internal startup optimization.

## Summary

Skip application plugin discovery when Poetry is invoked with the global `--version` or `-V` flag. Plugins cannot change Poetry's version output, and loading their entry points adds avoidable startup latency.

The check lives in `_load_plugins()` alongside the existing `--no-plugins` fast path. It uses Cleo's parameter boundary handling so version arguments forwarded to subprocesses, such as `poetry run -- python -V`, continue to load Poetry plugins normally.

## Testing

- `.venv/bin/pytest tests/console/test_application.py -q` — 22 passed
- `PATH="/tmp/poetry-test-bin:$PATH" .venv/bin/pytest tests/console -q` — 958 passed, 6 skipped
- `PATH="/tmp/poetry-test-bin:$PATH" .venv/bin/pytest -q` — 3176 passed, 27 skipped
- `.venv/bin/mypy` — success across 374 source files
- `.venv/bin/pre-commit run --files src/poetry/console/application.py tests/console/test_application.py` — passed