### PR TITLE
fix(env): fallback to host Python version when target Python embedded wheel is missing

### DIFF
--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import re
 import subprocess
@@ -23,6 +24,9 @@ from poetry.utils.env.exceptions import EnvCommandError
 from poetry.utils.env.site_packages import SitePackages
 from poetry.utils.helpers import get_real_windows_path
 from poetry.utils.helpers import is_dir_writable
+
+
+logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -162,12 +166,24 @@ class Env(ABC):
         self._find_pip_executable()
 
     def get_embedded_wheel(self, distribution: str) -> Path:
-        wheel = get_embed_wheel(
-            distribution, f"{self.version_info[0]}.{self.version_info[1]}"
-        )
-        if wheel is None:
-            raise RuntimeError(f"embedded {distribution} wheel not found")
-        return wheel.path
+        target_version = f"{self.version_info[0]}.{self.version_info[1]}"
+        host_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
+
+        candidates = [target_version]
+        if host_version != target_version:
+            candidates.append(host_version)
+
+        for version in candidates:
+            wheel = get_embed_wheel(distribution, version)
+            if wheel is not None:
+                if version != target_version:
+                    logger.debug(
+                        f"Embedded {distribution} wheel not found for simulated version {target_version}. "
+                        f"Fell back to host Python version {host_version}."
+                    )
+                return wheel.path
+
+        raise RuntimeError(f"embedded {distribution} wheel not found")
 
     @property
     def pip_embedded(self) -> Path:


### PR DESCRIPTION
### Motivation

When running Poetry's test suite with modern versions of `virtualenv` (specifically `v21.5.0` or newer), the test suite fails on tests executing package operations within mock environments (issue faced here: https://github.com/NixOS/nixpkgs/issues/544083). 
This happens because:
1. `MockEnv` defaults to simulating a Python `3.7.0` environment (unless overridden).
2. Modern versions of `virtualenv` have dropped support for older Python versions (Python 3.7 support dropped in `v20.27.1`, and Python 3.8 support dropped in `v21.5.0`), removing their respective embedded seed wheels (`pip`, `setuptools`).
3. When Poetry attempts to retrieve the embedded pip wheel using `get_embed_wheel("pip", "3.7")` inside `get_embedded_wheel`, it returns `None`, raising a fatal `RuntimeError: embedded pip wheel not found`.
Since modern Python packaging wheels are universal (`py3-none-any.whl`), a wheel bundled for a newer version of Python is fully compatible and functional on older/mocked versions.

### Solution

This PR implements a fallback inside `get_embedded_wheel()` to query the host running Python's version (e.g. `sys.version_info`) if the mock/target environment's Python version wheel is not found in the `virtualenv` database.

This keeps Poetry's test suite highly compatible and prevents test regressions when building or testing Poetry on modern linux distributions and package repositories (such as NixOS/Nixpkgs) where Python 3.14 and virtualenv 21.6+ are the defaults.