### PR TITLE
fix: resolve Windows command wrappers before execution

### DIFF
--- a/src/poetry/utils/env/base_env.py
+++ b/src/poetry/utils/env/base_env.py
@@ -34,6 +34,12 @@ if TYPE_CHECKING:
     PythonVersion = tuple[int, int, int, str, int]
 
 
+# Executable suffixes to look for on Windows, in lookup order; `.exe` first so
+# that resolution of already-working executables is unchanged. Not read from
+# PATHEXT, so lookup cannot be influenced by the environment Poetry runs in.
+WINDOWS_BIN_SUFFIXES = (".exe", ".cmd")
+
+
 class MarkerEnv(TypedDict):
     implementation_name: str
     implementation_version: str
@@ -492,28 +498,26 @@ class Env(ABC):
         """
         Return path to the given executable.
         """
-        if self._is_windows and not bin.endswith(".exe"):
-            bin_path = self._bin_dir / (bin + ".exe")
+        if self._is_windows and not bin.endswith(WINDOWS_BIN_SUFFIXES):
+            candidates = [bin + suffix for suffix in WINDOWS_BIN_SUFFIXES]
         else:
-            bin_path = self._bin_dir / bin
+            candidates = [bin]
 
-        if not bin_path.exists():
+        directories = [self._bin_dir]
+        if self._is_windows:
             # On Windows, some executables can be in the base path
             # This is especially true when installing Python with
             # the official installer, where python.exe will be at
             # the root of the env path.
-            if self._is_windows:
-                if not bin.endswith(".exe"):
-                    bin_path = self._path / (bin + ".exe")
-                else:
-                    bin_path = self._path / bin
+            directories.append(self._path)
 
+        for candidate in candidates:
+            for directory in directories:
+                bin_path = directory / candidate
                 if bin_path.exists():
                     return str(bin_path)
 
-            return bin
-
-        return str(bin_path)
+        return bin
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Env):

--- a/tests/console/commands/test_run.py
+++ b/tests/console/commands/test_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 
 from typing import TYPE_CHECKING
@@ -165,6 +166,7 @@ def test_run_has_helpful_error_when_command_not_found(
 def test_run_console_scripts_of_editable_dependencies_on_windows(
     tmp_venv: VirtualEnv,
     command_tester_factory: CommandTesterFactory,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     On Windows, Poetry installs console scripts of editable dependencies by creating
@@ -182,7 +184,18 @@ def test_run_console_scripts_of_editable_dependencies_on_windows(
 
     This test validates that you can also run such a CMD script file via `poetry run`
     just by providing the script's name without the `.cmd` extension.
+
+    PATH is padded past the ~8191 character limit at which `cmd.exe` stops resolving
+    unqualified command names, so that this also covers python-poetry/poetry#10482.
+    Poetry must therefore resolve the script to a full path itself rather than leave
+    the lookup to the shell.
     """
+    # `VirtualEnv.execute` builds the subprocess PATH from `os.environ`, so padding
+    # it here is what ends up reaching `cmd.exe`.
+    padded_path = os.pathsep.join([os.environ["PATH"], *["C:\\NotAPath"] * 1000])
+    assert len(padded_path) > 8191, "PATH is too short to reproduce #10482"
+    monkeypatch.setenv("PATH", padded_path)
+
     tester = command_tester_factory("run", environment=tmp_venv)
 
     cmd_script_file = tmp_venv._bin_dir / "quix.cmd"

--- a/tests/utils/env/test_env.py
+++ b/tests/utils/env/test_env.py
@@ -526,6 +526,51 @@ def test_command_from_bin_preserves_relative_path(manager: EnvManager) -> None:
 
 
 @pytest.fixture
+def windows_env(tmp_path: Path) -> VirtualEnv:
+    """A ``VirtualEnv`` that resolves executables using Windows rules.
+
+    ``Env._is_windows`` and ``Env._bin_dir`` are derived from ``sys.platform`` in
+    ``Env.__init__``, so they are overridden here to exercise the Windows lookup
+    from any host platform.
+    """
+    path = tmp_path / "venv"
+    env = VirtualEnv(path, path)
+    env._is_windows = True
+    # `Env.__init__` may rewrite `_path` on Windows, so derive from it rather than
+    # from `path` to keep both directories consistent on every platform.
+    env._bin_dir = env._path / "Scripts"
+    env._bin_dir.mkdir(parents=True)
+    return env
+
+
+def test_bin_prefers_exe_over_cmd_on_windows(windows_env: VirtualEnv) -> None:
+    exe = windows_env._bin_dir / "mytool.exe"
+    exe.touch()
+    (windows_env._bin_dir / "mytool.cmd").touch()
+
+    assert windows_env._bin("mytool") == str(exe)
+
+
+def test_bin_finds_cmd_script_on_windows(windows_env: VirtualEnv) -> None:
+    # https://github.com/python-poetry/poetry/issues/10482
+    # Editable installs write a shebang script plus a `.cmd` wrapper, never a
+    # `.exe`, so resolution must not depend on `cmd.exe` searching PATH.
+    (windows_env._bin_dir / "pepscript").touch()
+    cmd_script = windows_env._bin_dir / "pepscript.cmd"
+    cmd_script.touch()
+
+    assert windows_env._bin("pepscript") == str(cmd_script)
+
+
+def test_bin_accepts_explicit_suffix_on_windows(windows_env: VirtualEnv) -> None:
+    cmd_script = windows_env._bin_dir / "pepscript.cmd"
+    cmd_script.touch()
+
+    # A suffix that is already present must not have another one appended.
+    assert windows_env._bin("pepscript.cmd") == str(cmd_script)
+
+
+@pytest.fixture
 def system_env_read_only(system_env: SystemEnv, mocker: MockerFixture) -> SystemEnv:
     original_is_dir_writable = is_dir_writable
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10482

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. No documentation change is needed for this internal command-resolution fix.

## What changed

On Windows, Poetry now resolves `.cmd` wrappers in a virtual environment before handing the command to the shell. Existing `.exe` lookup keeps its current priority, and explicit `.cmd` arguments are handled too.

The existing editable-dependency command test now uses a PATH longer than the reported `cmd.exe` limit. Unit tests cover `.exe` precedence, `.cmd` fallback, and explicit suffixes.

## Checks

- `pytest tests/utils/env/test_env.py tests/console/commands/test_run.py -p no:randomly` — 58 passed, 1 Windows-only test skipped locally
- `mypy` on the three changed files
- `ruff check --ignore FURB188` and `ruff format --check` on the three changed files
- `git diff --check`

The long-PATH end-to-end assertion is Windows-only and will be exercised by CI. The implementation and review were assisted by Claude Code and Codex; I reviewed the final diff and test results.
