### PR TITLE
Require a path separator when detecting the active virtualenv

### DIFF
--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -517,7 +517,7 @@ class EnvManager:
             paths.append(p)
 
         p_venv = os.path.normcase(str(venv))
-        if any(p.startswith(p_venv) for p in paths):
+        if any(p == p_venv or p.startswith(p_venv + os.sep) for p in paths):
             # Running properly in the virtualenv, don't need to do anything
             return self.get_system_env()
 

--- a/tests/utils/env/test_env_manager.py
+++ b/tests/utils/env/test_env_manager.py
@@ -1367,6 +1367,48 @@ def test_create_venv_does_not_keep_inconsistent_envs_entry(
     assert envs["other"]["patch"] == "3.7.0"
 
 
+def test_create_venv_does_not_mistake_a_sibling_venv_for_the_target_venv(
+    manager: EnvManager,
+    poetry: Poetry,
+    config: Config,
+    mocker: MockerFixture,
+    config_virtualenvs_path: Path,
+    venv_name: str,
+    mocked_python_register: MockedPythonRegister,
+) -> None:
+    """Regression test for https://github.com/python-poetry/poetry/issues/10357.
+
+    A sibling virtualenv whose directory name merely *extends* the target
+    venv's name as a string (e.g. Poetry itself running from ``.venv-poetry``
+    while the project venv is ``.venv``) must not be mistaken for "already
+    running inside the target venv". Otherwise `create_venv()` wrongly
+    returns `get_system_env()` and the project gets installed into the
+    system/base Python instead of its own virtualenv.
+    """
+    if "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
+
+    poetry.package.python_versions = "^3.9"
+
+    mocker.patch(
+        "poetry.utils.env.EnvManager.build_venv", side_effect=lambda *args, **kwargs: ""
+    )
+
+    python = mocked_python_register("3.9.0")
+    venv = config_virtualenvs_path / f"{venv_name}-py3.9"
+
+    # A sibling interpreter whose resolved path merely *starts with* the
+    # target venv's path as a string (".venv-poetry" extends ".venv") while
+    # living in a completely separate directory, not inside it.
+    sibling_executable = Path(f"{venv}-poetry") / "bin" / "python3.9"
+    mocker.patch("sys.executable", str(sibling_executable))
+    mocker.patch("os.path.islink", return_value=False)
+
+    env = manager.create_venv(python=python)
+
+    assert env.path == venv
+
+
 def test_build_venv_does_not_change_loglevel(
     tmp_path: Path, manager: EnvManager, caplog: LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #10357

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. <!-- N/A: internal bug fix, no user-facing behaviour or documented API changes -->

## Problem

When Poetry is itself hosted in a virtualenv whose name is a textual prefix-superset of the project venv — for example Poetry runs from `.venv-poetry` while the project venv is `.venv` — `create_venv()` mistakes the two for the same environment and installs the project's dependencies into the base/system Python instead of the project venv.

After building the target venv, `create_venv()` walks `sys.executable`'s symlink chain to decide whether Poetry is already running inside it:

```python
p_venv = os.path.normcase(str(venv))
if any(p.startswith(p_venv) for p in paths):
    # Running properly in the virtualenv, don't need to do anything
    return self.get_system_env()
```

`str.startswith` has no path boundary, so `".../.venv-poetry/bin/python".startswith(".../.venv")` is `True`. Poetry wrongly concludes it is inside `.venv`, returns `get_system_env()`, and the install lands in the base Python.

## Fix

Require a path-separator boundary:

```python
if any(p == p_venv or p.startswith(p_venv + os.sep) for p in paths):
```

A real in-venv interpreter (`<venv>/bin/python`) still matches via `p_venv + os.sep`, while a sibling such as `.venv-poetry` no longer does. Both `p` and `p_venv` are already passed through `os.path.normcase`, so `os.sep` is the correct native boundary on POSIX and Windows.

A regression test covering the sibling-venv scenario is included.
