### PR TITLE
fix(show): pick the env-compatible version for duplicated lock entries

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -154,11 +154,10 @@ lists all packages available."""
             return 1
 
         locked_repo = self.poetry.locker.locked_repository()
+        root = self.project_with_activated_groups_only()
 
         if package:
-            return self._display_single_package_information(package, locked_repo)
-
-        root = self.project_with_activated_groups_only()
+            return self._display_single_package_information(package, locked_repo, root)
 
         # Show tree view if requested
         if self.option("tree"):
@@ -173,19 +172,28 @@ lists all packages available."""
         return "poetry lock"
 
     def _display_single_package_information(
-        self, package: str, locked_repository: Repository
+        self, package: str, locked_repository: Repository, root: ProjectPackage
     ) -> int:
         locked_packages = locked_repository.packages
         canonicalized_package = canonicalize_name(package)
-        pkg = None
+        matches = [
+            locked for locked in locked_packages if locked.name == canonicalized_package
+        ]
 
-        for locked in locked_packages:
-            if locked.name == canonicalized_package:
-                pkg = locked
-                break
-
-        if not pkg:
+        if not matches:
             raise ValueError(f"Package {package} not found")
+
+        pkg = matches[0]
+        if len(matches) > 1:
+            # The lock file may contain several entries for the same name (e.g.
+            # platform- or marker-conditioned variants). Select the one that
+            # applies to the current environment, consistent with the
+            # all-packages view. Fall back to the first match if none of them
+            # apply, so the command still displays something.
+            required_locked_packages = self._required_locked_packages(
+                root, locked_packages
+            )
+            pkg = next((p for p in matches if p in required_locked_packages), pkg)
 
         required_by = reverse_deps(pkg, locked_repository)
 
@@ -258,19 +266,15 @@ lists all packages available."""
 
         return 0
 
-    def _display_packages_information(
-        self, locked_repository: Repository, root: ProjectPackage
-    ) -> int:
-        import shutil
-
+    def _required_locked_packages(
+        self, root: ProjectPackage, locked_packages: list[Package]
+    ) -> set[Package]:
+        """Return the locked packages required by the current environment."""
         from cleo.io.null_io import NullIO
 
         from poetry.puzzle.solver import Solver
-        from poetry.repositories.installed_repository import InstalledRepository
         from poetry.repositories.repository_pool import RepositoryPool
-        from poetry.utils.helpers import get_package_version_display_string
 
-        locked_packages = locked_repository.packages
         pool = RepositoryPool.from_packages(locked_packages, self.poetry.config)
         solver = Solver(
             root,
@@ -283,7 +287,18 @@ lists all packages available."""
         with solver.use_environment(self.env):
             ops = solver.solve().calculate_operations()
 
-        required_locked_packages = {op.package for op in ops if not op.skipped}
+        return {op.package for op in ops if not op.skipped}
+
+    def _display_packages_information(
+        self, locked_repository: Repository, root: ProjectPackage
+    ) -> int:
+        import shutil
+
+        from poetry.repositories.installed_repository import InstalledRepository
+        from poetry.utils.helpers import get_package_version_display_string
+
+        locked_packages = locked_repository.packages
+        required_locked_packages = self._required_locked_packages(root, locked_packages)
 
         show_latest = self.option("latest")
         show_all = self.option("all")

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1858,6 +1858,114 @@ cachy (!) 0.1.1 Cachy package
         assert tester.io.fetch_output() == expected
 
 
+@output_format_parametrize
+def test_show_single_package_selects_env_compatible_duplicate_8945(
+    output_format: str,
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+) -> None:
+    # https://github.com/python-poetry/poetry/issues/8945
+    # When the lock file has several marker-conditioned entries for the same
+    # package, `poetry show <package>` must report the version applicable to the
+    # current environment (darwin here), matching what `poetry show` reports.
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "0.1.0", "platform": "linux"})
+    )
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "0.1.1", "platform": "darwin"})
+    )
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "files": [],
+                },
+                {
+                    "name": "cachy",
+                    "version": "0.1.1",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "files": [],
+                },
+            ],
+            "metadata": {"content-hash": "123456789"},
+        }
+    )
+
+    tester.execute(f"cachy {output_format}")
+
+    if "json" in output_format:
+        result = json.loads(tester.io.fetch_output())
+        assert result["version"] == "0.1.1"
+    else:
+        output = tester.io.fetch_output()
+        assert "0.1.1" in output
+        assert "0.1.0" not in output
+
+
+def test_show_single_package_with_duplicate_falls_back_when_env_excluded_8945(
+    tester: CommandTester,
+    poetry: Poetry,
+    installed: Repository,
+    repo: DummyRepository,
+) -> None:
+    # https://github.com/python-poetry/poetry/issues/8945
+    # If none of the duplicate lock entries applies to the current environment,
+    # `poetry show <package>` should still display a version (the first match)
+    # rather than raising.
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "0.1.0", "platform": "linux"})
+    )
+    poetry.package.add_dependency(
+        Factory.create_dependency("cachy", {"version": "0.1.1", "platform": "win32"})
+    )
+
+    assert isinstance(poetry.locker, DummyLocker)
+    poetry.locker.mock_lock_data(
+        {
+            "package": [
+                {
+                    "name": "cachy",
+                    "version": "0.1.0",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "files": [],
+                },
+                {
+                    "name": "cachy",
+                    "version": "0.1.1",
+                    "description": "Cachy package",
+                    "optional": False,
+                    "platform": "*",
+                    "python-versions": "*",
+                    "files": [],
+                },
+            ],
+            "metadata": {"content-hash": "123456789"},
+        }
+    )
+
+    tester.execute("cachy")
+
+    output = tester.io.fetch_output()
+    assert "0.1.0" in output
+    assert "0.1.1" not in output
+
+
 def test_show_tree(
     tester: CommandTester, poetry: Poetry, installed: Repository
 ) -> None:

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -1915,7 +1915,9 @@ def test_show_single_package_selects_env_compatible_duplicate_8945(
         assert "0.1.0" not in output
 
 
+@output_format_parametrize
 def test_show_single_package_with_duplicate_falls_back_when_env_excluded_8945(
+    output_format: str,
     tester: CommandTester,
     poetry: Poetry,
     installed: Repository,
@@ -1959,11 +1961,15 @@ def test_show_single_package_with_duplicate_falls_back_when_env_excluded_8945(
         }
     )
 
-    tester.execute("cachy")
+    tester.execute(f"cachy {output_format}")
 
-    output = tester.io.fetch_output()
-    assert "0.1.0" in output
-    assert "0.1.1" not in output
+    if "json" in output_format:
+        result = json.loads(tester.io.fetch_output())
+        assert result["version"] == "0.1.0"
+    else:
+        output = tester.io.fetch_output()
+        assert "0.1.0" in output
+        assert "0.1.1" not in output
 
 
 def test_show_tree(


### PR DESCRIPTION
# Pull Request Check List

Resolves: #8945

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. <!-- N/A: bug fix, no documented behaviour or API change -->

## Problem

`poetry show <package>` reports the wrong version when the lock file contains multiple entries for the same package (e.g. marker-conditioned variants for different Python versions or platforms). `_display_single_package_information()` picks the first name-match and ignores environment markers:

```python
for locked in locked_packages:
    if locked.name == canonicalized_package:
        pkg = locked
        break
```

So `poetry show <pkg>` can print a different version than `poetry show` (all packages) does for the same environment — the two views disagree, and the single-package view is the wrong one.

## Fix

Make the single-package path select the environment-appropriate entry the same way the all-packages path already does. The solver-based environment resolution (`Solver(...).use_environment(self.env)` → `required_locked_packages`) is extracted into a shared helper `_required_locked_packages()` used by **both** paths, so they can no longer disagree.

To keep the common case free of any new cost, the solver is only consulted when a package actually has more than one lock entry; for the usual single-entry case, selection and output are byte-identical to before. If none of the duplicate entries applies to the current environment, it falls back to the first match (so `show` still displays something rather than erroring). The fix is marker-agnostic — it works for `python_version`, `sys_platform`, and any other environment markers, since it defers entirely to the solver's environment resolution.

## Note on a behaviour change

Because the single-package path now reuses the group-activated project root (needed so its selection matches the all-packages view), `poetry show <pkg>` now validates `--only`/`--with`/`--without` group names the same way `poetry show` already does: an undeclared group name now raises `GroupNotFoundError` instead of being silently ignored. Valid invocations and the plain `poetry show <pkg>` are unaffected. Happy to scope this out (only activate groups when duplicates are present) if you'd prefer to preserve the previous lenient behaviour for the single-package path.

## Test

Adds tests in `tests/console/commands/test_show.py` (mirroring `test_show_hides_incompatible_package_with_duplicate`): a package with two marker-conditioned lock entries is shown with the environment-appropriate version, in both text and JSON output, plus a fallback case for when no entry applies to the current environment.
