### PR TITLE
perf: defer the requests imports in poetry.utils.helpers

### DIFF
--- a/src/poetry/installation/executor.py
+++ b/src/poetry/installation/executor.py
@@ -25,8 +25,8 @@ from poetry.installation.wheel_installer import WheelInstaller
 from poetry.puzzle.exceptions import SolverProblemError
 from poetry.utils._compat import decode
 from poetry.utils.authenticator import Authenticator
+from poetry.utils.download import Downloader
 from poetry.utils.env import EnvCommandError
-from poetry.utils.helpers import Downloader
 from poetry.utils.helpers import get_file_hash
 from poetry.utils.helpers import get_highest_priority_hash_type
 from poetry.utils.helpers import pluralize

--- a/src/poetry/packages/direct_origin.py
+++ b/src/poetry/packages/direct_origin.py
@@ -11,7 +11,7 @@ from poetry.config.config import Config
 from poetry.inspection.info import PackageInfo
 from poetry.inspection.info import PackageInfoError
 from poetry.utils.authenticator import get_default_authenticator
-from poetry.utils.helpers import download_file
+from poetry.utils.download import download_file
 from poetry.utils.helpers import get_file_hash
 from poetry.vcs.git import Git
 

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -36,8 +36,8 @@ from poetry.repositories.link_sources.html import HTMLPage
 from poetry.repositories.link_sources.json import SimpleJsonPage
 from poetry.utils.authenticator import Authenticator
 from poetry.utils.constants import REQUESTS_TIMEOUT
+from poetry.utils.download import download_file
 from poetry.utils.helpers import HTTPRangeRequestSupportedError
-from poetry.utils.helpers import download_file
 from poetry.utils.helpers import get_highest_priority_hash_type
 from poetry.utils.patterns import wheel_file_re
 

--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -36,8 +36,8 @@ from poetry.repositories.link_sources.html import HTMLPage
 from poetry.repositories.link_sources.json import SimpleJsonPage
 from poetry.utils.authenticator import Authenticator
 from poetry.utils.constants import REQUESTS_TIMEOUT
+from poetry.utils.download import HTTPRangeRequestSupportedError
 from poetry.utils.download import download_file
-from poetry.utils.helpers import HTTPRangeRequestSupportedError
 from poetry.utils.helpers import get_highest_priority_hash_type
 from poetry.utils.patterns import wheel_file_re
 

--- a/src/poetry/utils/download.py
+++ b/src/poetry/utils/download.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ConnectionError
+from requests.utils import atomic_open
+
+from poetry.utils.authenticator import Authenticator
+from poetry.utils.authenticator import get_default_authenticator
+from poetry.utils.constants import REQUESTS_TIMEOUT
+from poetry.utils.helpers import HTTPRangeRequestSupportedError
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from requests import Response
+    from requests import Session
+
+
+def download_file(
+    url: str,
+    dest: Path,
+    *,
+    session: Authenticator | Session | None = None,
+    chunk_size: int = 1024,
+    raise_accepts_ranges: bool = False,
+    max_retries: int = 0,
+) -> None:
+    from poetry.puzzle.provider import Indicator
+
+    downloader = Downloader(url, dest, session, max_retries=max_retries)
+
+    if raise_accepts_ranges and downloader.accepts_ranges:
+        raise HTTPRangeRequestSupportedError(f"URL {url} supports range requests.")
+
+    set_indicator = False
+    with Indicator.context() as update_context:
+        update_context(f"Downloading {url}")
+
+        total_size = downloader.total_size
+        if total_size > 0:
+            fetched_size = 0
+            last_percent = 0
+
+            # if less than 1MB, we simply show that we're downloading
+            # but skip the updating
+            set_indicator = total_size > 1024 * 1024
+
+        for fetched_size in downloader.download_with_progress(chunk_size):
+            if set_indicator:
+                percent = (fetched_size * 100) // total_size
+                if percent > last_percent:
+                    last_percent = percent
+                    update_context(f"Downloading {url} {percent:3}%")
+
+
+class Downloader:
+    def __init__(
+        self,
+        url: str,
+        dest: Path,
+        session: Authenticator | Session | None = None,
+        max_retries: int = 0,
+    ):
+        self._dest = dest
+        self._max_retries = max_retries
+        if session is None:
+            session = get_default_authenticator()
+        self._session = session
+        self._url = url
+        self._response = self._get()
+
+    @cached_property
+    def accepts_ranges(self) -> bool:
+        return self._response.headers.get("Accept-Ranges") == "bytes"
+
+    @cached_property
+    def total_size(self) -> int:
+        total_size = 0
+        if "Content-Length" in self._response.headers:
+            with suppress(ValueError):
+                total_size = int(self._response.headers["Content-Length"])
+        return total_size
+
+    def _get(self, start: int = 0) -> Response:
+        headers = {"Accept-Encoding": "Identity"}
+        if start > 0:
+            headers["Range"] = f"bytes={start}-"
+
+        response = self._session.get(
+            self._url, stream=True, headers=headers, timeout=REQUESTS_TIMEOUT
+        )
+        try:
+            response.raise_for_status()
+            return response
+        except BaseException:
+            response.close()
+            raise
+
+    def _iter_content_with_resume(self, chunk_size: int) -> Iterator[bytes]:
+        fetched_size = 0
+        retries = 0
+        while True:
+            try:
+                with self._response:
+                    for chunk in self._response.iter_content(chunk_size=chunk_size):
+                        yield chunk
+                        fetched_size += len(chunk)
+            except (ChunkedEncodingError, ConnectionError):
+                if (
+                    retries < self._max_retries
+                    and self.accepts_ranges
+                    and fetched_size > 0
+                ):
+                    # only retry if server supports byte ranges
+                    # and we have fetched at least one chunk
+                    # otherwise, we should just fail
+                    retries += 1
+                    self._response = self._get(fetched_size)
+                    continue
+                raise
+            else:
+                break
+
+    def download_with_progress(self, chunk_size: int = 1024) -> Iterator[int]:
+        fetched_size = 0
+        with atomic_open(self._dest) as f:
+            for chunk in self._iter_content_with_resume(chunk_size=chunk_size):
+                if chunk:
+                    f.write(chunk)
+                    fetched_size += len(chunk)
+                    yield fetched_size

--- a/src/poetry/utils/download.py
+++ b/src/poetry/utils/download.py
@@ -11,7 +11,6 @@ from requests.utils import atomic_open
 from poetry.utils.authenticator import Authenticator
 from poetry.utils.authenticator import get_default_authenticator
 from poetry.utils.constants import REQUESTS_TIMEOUT
-from poetry.utils.helpers import HTTPRangeRequestSupportedError
 
 
 if TYPE_CHECKING:
@@ -20,6 +19,10 @@ if TYPE_CHECKING:
 
     from requests import Response
     from requests import Session
+
+
+class HTTPRangeRequestSupportedError(Exception):
+    """Raised when server unexpectedly supports byte ranges."""
 
 
 def download_file(

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -20,11 +20,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import overload
 
-from requests.exceptions import ChunkedEncodingError
-from requests.exceptions import ConnectionError
-from requests.utils import atomic_open
-
-from poetry.utils.authenticator import get_default_authenticator
 from poetry.utils.constants import REQUESTS_TIMEOUT
 
 
@@ -176,7 +171,11 @@ class Downloader:
     ):
         self._dest = dest
         self._max_retries = max_retries
-        self._session = session or get_default_authenticator()
+        if session is None:
+            from poetry.utils.authenticator import get_default_authenticator
+
+            session = get_default_authenticator()
+        self._session = session
         self._url = url
         self._response = self._get()
 
@@ -216,7 +215,7 @@ class Downloader:
                     for chunk in self._response.iter_content(chunk_size=chunk_size):
                         yield chunk
                         fetched_size += len(chunk)
-            except (ChunkedEncodingError, ConnectionError):
+            except _resumable_errors():
                 if (
                     retries < self._max_retries
                     and self.accepts_ranges
@@ -234,6 +233,8 @@ class Downloader:
 
     def download_with_progress(self, chunk_size: int = 1024) -> Iterator[int]:
         fetched_size = 0
+        from requests.utils import atomic_open
+
         with atomic_open(self._dest) as f:
             for chunk in self._iter_content_with_resume(chunk_size=chunk_size):
                 if chunk:
@@ -457,3 +458,33 @@ def extractall(source: Path, dest: Path, zip: bool) -> None:
                             )
                     safe_members.append(member)
                 archive.extractall(dest, members=safe_members)
+
+
+def _resumable_errors() -> tuple[type[BaseException], ...]:
+    from requests.exceptions import ChunkedEncodingError
+    from requests.exceptions import ConnectionError as RequestsConnectionError
+
+    return (ChunkedEncodingError, RequestsConnectionError)
+
+
+_LAZY_REEXPORTS = {
+    "ChunkedEncodingError": ("requests.exceptions", "ChunkedEncodingError"),
+    "ConnectionError": ("requests.exceptions", "ConnectionError"),
+    "atomic_open": ("requests.utils", "atomic_open"),
+    "get_default_authenticator": ("poetry.utils.authenticator", "get_default_authenticator"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    target = _LAZY_REEXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(target[0]), target[1])
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), *_LAZY_REEXPORTS])

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -471,7 +471,10 @@ _LAZY_REEXPORTS = {
     "ChunkedEncodingError": ("requests.exceptions", "ChunkedEncodingError"),
     "ConnectionError": ("requests.exceptions", "ConnectionError"),
     "atomic_open": ("requests.utils", "atomic_open"),
-    "get_default_authenticator": ("poetry.utils.authenticator", "get_default_authenticator"),
+    "get_default_authenticator": (
+        "poetry.utils.authenticator",
+        "get_default_authenticator",
+    ),
 }
 
 

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -9,18 +9,15 @@ import stat
 import sys
 import tarfile
 import tempfile
+import warnings as _warnings
 import zipfile
 
 from collections.abc import Mapping
 from contextlib import contextmanager
-from contextlib import suppress
-from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import overload
-
-from poetry.utils.constants import REQUESTS_TIMEOUT
 
 
 if TYPE_CHECKING:
@@ -30,11 +27,6 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from poetry.core.packages.package import Package
-    from requests import Response
-    from requests import Session
-
-    from poetry.utils.authenticator import Authenticator
-
 logger = logging.getLogger(__name__)
 prioritised_hash_types: tuple[str, ...] = tuple(
     t
@@ -122,125 +114,6 @@ def merge_dicts(d1: dict[str, Any], d2: dict[str, Any]) -> None:
 
 class HTTPRangeRequestSupportedError(Exception):
     """Raised when server unexpectedly supports byte ranges."""
-
-
-def download_file(
-    url: str,
-    dest: Path,
-    *,
-    session: Authenticator | Session | None = None,
-    chunk_size: int = 1024,
-    raise_accepts_ranges: bool = False,
-    max_retries: int = 0,
-) -> None:
-    from poetry.puzzle.provider import Indicator
-
-    downloader = Downloader(url, dest, session, max_retries=max_retries)
-
-    if raise_accepts_ranges and downloader.accepts_ranges:
-        raise HTTPRangeRequestSupportedError(f"URL {url} supports range requests.")
-
-    set_indicator = False
-    with Indicator.context() as update_context:
-        update_context(f"Downloading {url}")
-
-        total_size = downloader.total_size
-        if total_size > 0:
-            fetched_size = 0
-            last_percent = 0
-
-            # if less than 1MB, we simply show that we're downloading
-            # but skip the updating
-            set_indicator = total_size > 1024 * 1024
-
-        for fetched_size in downloader.download_with_progress(chunk_size):
-            if set_indicator:
-                percent = (fetched_size * 100) // total_size
-                if percent > last_percent:
-                    last_percent = percent
-                    update_context(f"Downloading {url} {percent:3}%")
-
-
-class Downloader:
-    def __init__(
-        self,
-        url: str,
-        dest: Path,
-        session: Authenticator | Session | None = None,
-        max_retries: int = 0,
-    ):
-        self._dest = dest
-        self._max_retries = max_retries
-        if session is None:
-            from poetry.utils.authenticator import get_default_authenticator
-
-            session = get_default_authenticator()
-        self._session = session
-        self._url = url
-        self._response = self._get()
-
-    @cached_property
-    def accepts_ranges(self) -> bool:
-        return self._response.headers.get("Accept-Ranges") == "bytes"
-
-    @cached_property
-    def total_size(self) -> int:
-        total_size = 0
-        if "Content-Length" in self._response.headers:
-            with suppress(ValueError):
-                total_size = int(self._response.headers["Content-Length"])
-        return total_size
-
-    def _get(self, start: int = 0) -> Response:
-        headers = {"Accept-Encoding": "Identity"}
-        if start > 0:
-            headers["Range"] = f"bytes={start}-"
-
-        response = self._session.get(
-            self._url, stream=True, headers=headers, timeout=REQUESTS_TIMEOUT
-        )
-        try:
-            response.raise_for_status()
-            return response
-        except BaseException:
-            response.close()
-            raise
-
-    def _iter_content_with_resume(self, chunk_size: int) -> Iterator[bytes]:
-        fetched_size = 0
-        retries = 0
-        while True:
-            try:
-                with self._response:
-                    for chunk in self._response.iter_content(chunk_size=chunk_size):
-                        yield chunk
-                        fetched_size += len(chunk)
-            except _resumable_errors():
-                if (
-                    retries < self._max_retries
-                    and self.accepts_ranges
-                    and fetched_size > 0
-                ):
-                    # only retry if server supports byte ranges
-                    # and we have fetched at least one chunk
-                    # otherwise, we should just fail
-                    retries += 1
-                    self._response = self._get(fetched_size)
-                    continue
-                raise
-            else:
-                break
-
-    def download_with_progress(self, chunk_size: int = 1024) -> Iterator[int]:
-        fetched_size = 0
-        from requests.utils import atomic_open
-
-        with atomic_open(self._dest) as f:
-            for chunk in self._iter_content_with_resume(chunk_size=chunk_size):
-                if chunk:
-                    f.write(chunk)
-                    fetched_size += len(chunk)
-                    yield fetched_size
 
 
 def get_package_version_display_string(
@@ -460,34 +333,22 @@ def extractall(source: Path, dest: Path, zip: bool) -> None:
                 archive.extractall(dest, members=safe_members)
 
 
-def _resumable_errors() -> tuple[type[BaseException], ...]:
-    from requests.exceptions import ChunkedEncodingError
-    from requests.exceptions import ConnectionError as RequestsConnectionError
-
-    return (ChunkedEncodingError, RequestsConnectionError)
-
-
-_LAZY_REEXPORTS = {
-    "ChunkedEncodingError": ("requests.exceptions", "ChunkedEncodingError"),
-    "ConnectionError": ("requests.exceptions", "ConnectionError"),
-    "atomic_open": ("requests.utils", "atomic_open"),
-    "get_default_authenticator": (
-        "poetry.utils.authenticator",
-        "get_default_authenticator",
-    ),
-}
+_DEPRECATED_DOWNLOAD_EXPORTS = {"Downloader", "download_file"}
 
 
 def __getattr__(name: str) -> Any:
-    target = _LAZY_REEXPORTS.get(name)
-    if target is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    from importlib import import_module
+    if name in _DEPRECATED_DOWNLOAD_EXPORTS:
+        _warnings.warn(
+            f"Importing `{name}` from `poetry.utils.helpers` is deprecated; "
+            f"use `poetry.utils.download.{name}` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from poetry.utils import download
 
-    value = getattr(import_module(target[0]), target[1])
-    globals()[name] = value
-    return value
+        return getattr(download, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__() -> list[str]:
-    return sorted([*globals(), *_LAZY_REEXPORTS])
+    return sorted([*globals(), *_DEPRECATED_DOWNLOAD_EXPORTS])

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -9,7 +9,7 @@ import stat
 import sys
 import tarfile
 import tempfile
-import warnings as _warnings
+import warnings
 import zipfile
 
 from collections.abc import Mapping
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from poetry.core.packages.package import Package
+
+
 logger = logging.getLogger(__name__)
 prioritised_hash_types: tuple[str, ...] = tuple(
     t
@@ -110,10 +112,6 @@ def merge_dicts(d1: dict[str, Any], d2: dict[str, Any]) -> None:
             merge_dicts(d1[k], d2[k])
         else:
             d1[k] = d2[k]
-
-
-class HTTPRangeRequestSupportedError(Exception):
-    """Raised when server unexpectedly supports byte ranges."""
 
 
 def get_package_version_display_string(
@@ -333,14 +331,18 @@ def extractall(source: Path, dest: Path, zip: bool) -> None:
                 archive.extractall(dest, members=safe_members)
 
 
-_DEPRECATED_DOWNLOAD_EXPORTS = {"Downloader", "download_file"}
+_DEPRECATED_DOWNLOAD_EXPORTS = {
+    "Downloader",
+    "download_file",
+    "HTTPRangeRequestSupportedError",
+}
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> object:
     if name in _DEPRECATED_DOWNLOAD_EXPORTS:
-        _warnings.warn(
-            f"Importing `{name}` from `poetry.utils.helpers` is deprecated; "
-            f"use `poetry.utils.download.{name}` instead.",
+        warnings.warn(
+            f"Importing `{name}` from `poetry.utils.helpers` is deprecated;"
+            f" use `poetry.utils.download.{name}` instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -348,7 +350,3 @@ def __getattr__(name: str) -> Any:
 
         return getattr(download, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__() -> list[str]:
-    return sorted([*globals(), *_DEPRECATED_DOWNLOAD_EXPORTS])

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 import re
 import shutil
+import subprocess
+import sys
 
 from typing import TYPE_CHECKING
 from typing import ClassVar
@@ -245,3 +248,23 @@ def test_application_input_configuration_and_sorting(
 
     io_input = cast("ArgvInput", app._io.input)
     assert io_input._tokens == result
+
+
+def test_no_slow_imports_when_importing_the_cli_entrypoint() -> None:
+    """
+    This test checks that modules that are slow to import
+    (and not required for all commands) are not imported
+    when importing the CLI entrypoint.
+    """
+    code = (
+        "import sys, json;"
+        "import poetry.console.application;"
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+    loaded_modules = json.loads(
+        subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True
+        ).stdout
+    )
+    assert "requests" not in loaded_modules
+    assert "urllib3" not in loaded_modules

--- a/tests/repositories/test_http_repository.py
+++ b/tests/repositories/test_http_repository.py
@@ -22,7 +22,7 @@ from poetry.core.packages.utils.link import Link
 from poetry.inspection.info import PackageInfoError
 from poetry.inspection.lazy_wheel import HTTPRangeRequestUnsupportedError
 from poetry.repositories.http_repository import HTTPRepository
-from poetry.utils.helpers import HTTPRangeRequestSupportedError
+from poetry.utils.download import HTTPRangeRequestSupportedError
 
 
 if TYPE_CHECKING:

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -1,53 +1,199 @@
 from __future__ import annotations
 
-import subprocess
-import sys
-import tempfile
+import base64
+import re
 
-from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import ClassVar
 from typing import Literal
 
 import pytest
+import responses
 
-from poetry.utils import helpers
+from requests.exceptions import ChunkedEncodingError
+
 from poetry.utils.download import Downloader
+from poetry.utils.download import HTTPRangeRequestSupportedError
 from poetry.utils.download import download_file
+from poetry.utils.helpers import get_file_hash
 
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
+
+    from requests import PreparedRequest
+
+    from poetry.config.config import Config
+    from tests.types import FixtureDirGetter
+    from tests.types import HttpResponse
 
 
-@pytest.mark.parametrize(
-    ("name", "expected"),
-    [("Downloader", Downloader), ("download_file", download_file)],
-)
-def test_deprecated_helpers_download_reexports(name: str, expected: object) -> None:
-    with pytest.warns(DeprecationWarning, match="poetry.utils.download"):
-        assert getattr(helpers, name) is expected
-    assert name in dir(helpers)
+def test_download_file(
+    http: responses.RequestsMock, fixture_dir: FixtureDirGetter, tmp_path: Path
+) -> None:
+    file_path = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
+    url = "https://foo.com/demo-0.1.0.tar.gz"
+    http.get(url, body=file_path.read_bytes())
+    dest = tmp_path / "demo-0.1.0.tar.gz"
+
+    download_file(url, dest)
+
+    expect_sha_256 = "9fa123ad707a5c6c944743bf3e11a0e80d86cb518d3cf25320866ca3ef43e2ad"
+    assert get_file_hash(dest) == expect_sha_256
+    assert http.calls[-1].request.headers["Accept-Encoding"] == "Identity"
 
 
-def test_unknown_helpers_attribute_still_raises_attribute_error() -> None:
-    with pytest.raises(AttributeError):
-        helpers.definitely_not_a_real_attribute  # noqa: B018
+def test_downloader_with_invalid_content_length(
+    http: responses.RequestsMock, tmp_path: Path
+) -> None:
+    url = "https://foo.com/demo.txt"
+    http.get(url, body=b"demo", headers={"Content-Length": "invalid"})
+    dest = tmp_path / "demo.txt"
+
+    downloader = Downloader(url, dest)
+
+    assert downloader.total_size == 0
+    assert list(downloader.download_with_progress(chunk_size=2)) == [2, 4]
+    assert dest.read_bytes() == b"demo"
 
 
-def test_importing_the_cli_entrypoint_does_not_import_requests() -> None:
-    code = (
-        "import sys;"
-        "import poetry.console.application;"
-        "print('requests' in sys.modules, 'urllib3' in sys.modules)"
+def test_download_file_recover_from_error(
+    http: responses.RequestsMock, fixture_dir: FixtureDirGetter, tmp_path: Path
+) -> None:
+    file_path = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
+    file_body = file_path.read_bytes()
+    file_length = len(file_body)
+    url = "https://foo.com/demo-0.1.0.tar.gz"
+
+    def handle_request(request: PreparedRequest) -> HttpResponse:
+        if request.headers.get("Range") is None:
+            response_headers = {
+                "Content-Length": str(file_length),
+                "Accept-Ranges": "bytes",
+            }
+            return 200, response_headers, file_body[: file_length // 2]
+        else:
+            start = int(
+                request.headers.get("Range", "bytes=0-").split("=")[1].split("-")[0]
+            )
+            response_headers = {"Content-Length": str(len(file_body[start:]))}
+            return 206, response_headers, file_body[start:]
+
+    http.add_callback(responses.GET, url, callback=handle_request)
+    dest = tmp_path / "demo-0.1.0.tar.gz"
+
+    download_file(url, dest, chunk_size=file_length // 2, max_retries=1)
+
+    expect_sha_256 = "9fa123ad707a5c6c944743bf3e11a0e80d86cb518d3cf25320866ca3ef43e2ad"
+    assert get_file_hash(dest) == expect_sha_256
+    assert http.calls[-1].request.headers["Accept-Encoding"] == "Identity"
+    assert http.calls[-1].request.headers["Range"] == f"bytes={file_length // 2}-"
+
+
+def test_download_file_fail_when_no_range(
+    http: responses.RequestsMock, fixture_dir: FixtureDirGetter, tmp_path: Path
+) -> None:
+    file_path = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
+    file_body = file_path.read_bytes()
+    file_length = len(file_body)
+    url = "https://foo.com/demo-0.1.0.tar.gz"
+
+    def handle_request(request: PreparedRequest) -> HttpResponse:
+        response_headers = {"Content-Length": str(file_length)}
+        return 200, response_headers, file_body[: file_length // 2]
+
+    http.add_callback(responses.GET, url, callback=handle_request)
+    dest = tmp_path / "demo-0.1.0.tar.gz"
+    with pytest.raises(ChunkedEncodingError):
+        download_file(url, dest, chunk_size=file_length // 2, max_retries=1)
+
+
+def test_download_file_fail_when_first_chunk_failed(
+    http: responses.RequestsMock, fixture_dir: FixtureDirGetter, tmp_path: Path
+) -> None:
+    file_path = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
+    file_body = file_path.read_bytes()
+    file_length = len(file_body)
+    url = "https://foo.com/demo-0.1.0.tar.gz"
+
+    def handle_request(request: PreparedRequest) -> tuple[int, dict[str, Any], bytes]:
+        response_headers = {
+            "Content-Length": str(file_length),
+            "Accept-Ranges": "bytes",
+        }
+        return 200, response_headers, file_body[: file_length // 2]
+
+    http.add_callback(responses.GET, url, callback=handle_request)
+    dest = tmp_path / "demo-0.1.0.tar.gz"
+    with pytest.raises(ChunkedEncodingError):
+        download_file(url, dest, chunk_size=file_length, max_retries=1)
+
+
+@pytest.mark.parametrize("accepts_ranges", [False, True])
+@pytest.mark.parametrize("raise_accepts_ranges", [False, True])
+def test_download_file_raise_accepts_ranges(
+    http: responses.RequestsMock,
+    fixture_dir: FixtureDirGetter,
+    tmp_path: Path,
+    accepts_ranges: bool,
+    raise_accepts_ranges: bool,
+) -> None:
+    filename = "demo-0.1.0-py2.py3-none-any.whl"
+
+    def handle_request(request: PreparedRequest) -> tuple[int, dict[str, Any], bytes]:
+        file_path = fixture_dir("distributions") / filename
+        response_headers = {}
+        if accepts_ranges:
+            response_headers["Accept-Ranges"] = "bytes"
+        return 200, response_headers, file_path.read_bytes()
+
+    url = f"https://foo.com/{filename}"
+    http.add_callback(responses.GET, url, callback=handle_request)
+    dest = tmp_path / filename
+
+    if accepts_ranges and raise_accepts_ranges:
+        with pytest.raises(HTTPRangeRequestSupportedError):
+            download_file(url, dest, raise_accepts_ranges=raise_accepts_ranges)
+        assert not dest.exists()
+    else:
+        download_file(url, dest, raise_accepts_ranges=raise_accepts_ranges)
+        assert dest.is_file()
+
+
+def test_downloader_uses_authenticator_by_default(
+    config: Config,
+    http: responses.RequestsMock,
+    tmp_working_directory: Path,
+) -> None:
+    import poetry.utils.authenticator
+
+    # force set default authenticator to None so that it is recreated using patched config
+    poetry.utils.authenticator._authenticator = None
+
+    config.merge(
+        {
+            "repositories": {"foo": {"url": "https://foo.bar/files/"}},
+            "http-basic": {"foo": {"username": "bar", "password": "baz"}},
+        }
     )
-    out = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, check=True
-    ).stdout.strip()
-    assert out == "False False", f"expected neither to be imported, got {out}"
+
+    http.get(
+        re.compile("^https?://foo.bar/(.+?)$"),
+    )
+
+    Downloader(
+        "https://foo.bar/files/foo-0.1.0.tar.gz",
+        tmp_working_directory / "foo-0.1.0.tar.gz",
+    )
+
+    request = http.calls[-1].request
+    basic_auth = base64.b64encode(b"bar:baz").decode()
+    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
-def test_downloader_retries_only_the_resumable_requests_errors() -> None:
+def test_downloader_retries_only_the_resumable_requests_errors(tmp_path: Path) -> None:
     import requests.exceptions
 
     def run_with(exc: type[BaseException]) -> int:
@@ -77,14 +223,13 @@ def test_downloader_retries_only_the_resumable_requests_errors() -> None:
             def get(self, *_: object, **__: object) -> _Resp:
                 return _Resp()
 
-        with tempfile.TemporaryDirectory() as td:
-            downloader = Downloader(
-                "https://example.invalid/x",
-                Path(td) / "out.bin",
-                session=_Session(),  # type: ignore[arg-type]
-                max_retries=2,
-            )
-            list(downloader.download_with_progress(chunk_size=2))
+        downloader = Downloader(
+            "https://example.invalid/x",
+            tmp_path / "out.bin",
+            session=_Session(),  # type: ignore[arg-type]
+            max_retries=2,
+        )
+        list(downloader.download_with_progress(chunk_size=2))
         return state["n"]
 
     assert run_with(requests.exceptions.ConnectionError) == 2
@@ -96,7 +241,7 @@ def test_downloader_retries_only_the_resumable_requests_errors() -> None:
             run_with(exc)
 
 
-def test_downloader_stops_after_max_retries() -> None:
+def test_downloader_stops_after_max_retries(tmp_path: Path) -> None:
     import requests.exceptions
 
     state = {"n": 0}
@@ -124,14 +269,13 @@ def test_downloader_stops_after_max_retries() -> None:
         def get(self, *_: object, **__: object) -> _Resp:
             return _Resp()
 
-    with tempfile.TemporaryDirectory() as td:
-        downloader = Downloader(
-            "https://example.invalid/x",
-            Path(td) / "out.bin",
-            session=_Session(),  # type: ignore[arg-type]
-            max_retries=2,
-        )
-        with pytest.raises(requests.exceptions.ConnectionError):
-            list(downloader.download_with_progress(chunk_size=2))
+    downloader = Downloader(
+        "https://example.invalid/x",
+        tmp_path / "out.bin",
+        session=_Session(),  # type: ignore[arg-type]
+        max_retries=2,
+    )
+    with pytest.raises(requests.exceptions.ConnectionError):
+        list(downloader.download_with_progress(chunk_size=2))
 
     assert state["n"] == 3

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -2,61 +2,40 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import Literal
 
 import pytest
 
-from typing_extensions import Self
-
 from poetry.utils import helpers
+from poetry.utils.download import Downloader
+from poetry.utils.download import download_file
 
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-LAZY_NAMES = [
-    "ChunkedEncodingError",
-    "ConnectionError",
-    "atomic_open",
-    "get_default_authenticator",
-]
-
-
-@pytest.mark.parametrize("name", LAZY_NAMES)
-def test_lazily_reexported_names_are_still_importable(name: str) -> None:
-    """These were module-level imports and stay part of the module's public surface."""
-    assert hasattr(helpers, name)
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [("Downloader", Downloader), ("download_file", download_file)],
+)
+def test_deprecated_helpers_download_reexports(name: str, expected: object) -> None:
+    with pytest.warns(DeprecationWarning, match="poetry.utils.download"):
+        assert getattr(helpers, name) is expected
     assert name in dir(helpers)
 
 
-@pytest.mark.parametrize("name", LAZY_NAMES)
-def test_lazily_reexported_names_resolve_to_the_real_objects(name: str) -> None:
-    import requests.exceptions
-    import requests.utils
-
-    from poetry.utils import authenticator
-
-    expected = {
-        "ChunkedEncodingError": requests.exceptions.ChunkedEncodingError,
-        "ConnectionError": requests.exceptions.ConnectionError,
-        "atomic_open": requests.utils.atomic_open,
-        "get_default_authenticator": authenticator.get_default_authenticator,
-    }[name]
-    assert getattr(helpers, name) is expected
-
-
-def test_unknown_attribute_still_raises_attribute_error() -> None:
+def test_unknown_helpers_attribute_still_raises_attribute_error() -> None:
     with pytest.raises(AttributeError):
         helpers.definitely_not_a_real_attribute  # noqa: B018
 
 
 def test_importing_the_cli_entrypoint_does_not_import_requests() -> None:
-    """The CLI imports this module for two filesystem helpers, so it must not drag the
-    HTTP stack in. This is the regression the lazy imports exist to prevent."""
     code = (
         "import sys;"
         "import poetry.console.application;"
@@ -69,18 +48,9 @@ def test_importing_the_cli_entrypoint_does_not_import_requests() -> None:
 
 
 def test_downloader_retries_only_the_resumable_requests_errors() -> None:
-    """`except ConnectionError` inside this module must be the requests class, not the
-    builtin. A module-level ``__getattr__`` serves attribute access on the module object
-    but never bare global lookup inside the module's own functions, so a lazy rewrite can
-    silently bind the builtin -- which requests' ConnectionError is not a subclass of --
-    and stop retrying resumable downloads."""
     import requests.exceptions
 
-    def run_with(exc: type[BaseException], tmp_path_factory: object = None) -> int:
-        import tempfile
-
-        from pathlib import Path
-
+    def run_with(exc: type[BaseException]) -> int:
         state = {"n": 0}
 
         class _Resp:
@@ -91,7 +61,7 @@ def test_downloader_retries_only_the_resumable_requests_errors() -> None:
 
             def raise_for_status(self) -> None: ...
             def close(self) -> None: ...
-            def __enter__(self) -> Self:
+            def __enter__(self) -> _Resp:
                 return self
 
             def __exit__(self, *_: object) -> Literal[False]:
@@ -108,7 +78,7 @@ def test_downloader_retries_only_the_resumable_requests_errors() -> None:
                 return _Resp()
 
         with tempfile.TemporaryDirectory() as td:
-            downloader = helpers.Downloader(
+            downloader = Downloader(
                 "https://example.invalid/x",
                 Path(td) / "out.bin",
                 session=_Session(),  # type: ignore[arg-type]
@@ -117,15 +87,51 @@ def test_downloader_retries_only_the_resumable_requests_errors() -> None:
             list(downloader.download_with_progress(chunk_size=2))
         return state["n"]
 
-    # Retried on unmodified main, so the stub is asked for content twice. SSLError is
-    # included deliberately: it subclasses requests' ConnectionError, so it is caught by
-    # the same clause, and it is caught only if that name is the requests class rather
-    # than the builtin.
     assert run_with(requests.exceptions.ConnectionError) == 2
     assert run_with(requests.exceptions.ChunkedEncodingError) == 2
     assert run_with(requests.exceptions.SSLError) == 2
 
-    # Not resumable: must propagate rather than be swallowed by a broad except clause.
     for exc in (ValueError, AttributeError):
         with pytest.raises(exc):
             run_with(exc)
+
+
+def test_downloader_stops_after_max_retries() -> None:
+    import requests.exceptions
+
+    state = {"n": 0}
+
+    class _Resp:
+        headers: ClassVar[dict[str, str]] = {
+            "Accept-Ranges": "bytes",
+            "Content-Length": "8",
+        }
+
+        def raise_for_status(self) -> None: ...
+        def close(self) -> None: ...
+        def __enter__(self) -> _Resp:
+            return self
+
+        def __exit__(self, *_: object) -> Literal[False]:
+            return False
+
+        def iter_content(self, chunk_size: int = 1) -> Iterator[bytes]:
+            state["n"] += 1
+            yield b"ab"
+            raise requests.exceptions.ConnectionError("stub failure")
+
+    class _Session:
+        def get(self, *_: object, **__: object) -> _Resp:
+            return _Resp()
+
+    with tempfile.TemporaryDirectory() as td:
+        downloader = Downloader(
+            "https://example.invalid/x",
+            Path(td) / "out.bin",
+            session=_Session(),  # type: ignore[arg-type]
+            max_retries=2,
+        )
+        with pytest.raises(requests.exceptions.ConnectionError):
+            list(downloader.download_with_progress(chunk_size=2))
+
+    assert state["n"] == 3

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -342,7 +342,7 @@ def test_extractall_wheel_no_path_traversal_via_symlink(
 def test_deprecated_helpers_download_reexports(name: str, expected: object) -> None:
     from poetry.utils import helpers
 
-    with pytest.warns(DeprecationWarning, match="poetry.utils.download"):
+    with pytest.warns(DeprecationWarning, match=r"poetry\.utils\.download"):
         assert getattr(helpers, name) is expected
 
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,24 +1,17 @@
 from __future__ import annotations
 
-import base64
 import contextlib
-import re
 import sys
 import tarfile
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Any
 
 import pytest
-import responses
-
-from requests.exceptions import ChunkedEncodingError
 
 from poetry.utils._compat import WINDOWS
 from poetry.utils.download import Downloader
 from poetry.utils.download import download_file
-from poetry.utils.helpers import HTTPRangeRequestSupportedError
 from poetry.utils.helpers import directory
 from poetry.utils.helpers import ensure_path
 from poetry.utils.helpers import extractall
@@ -28,11 +21,7 @@ from poetry.utils.helpers import merge_dicts
 
 
 if TYPE_CHECKING:
-    from requests import PreparedRequest
-
-    from tests.conftest import Config
     from tests.types import FixtureDirGetter
-    from tests.types import HttpResponse
 
 
 def test_directory_restores_working_directory(tmp_path: Path) -> None:
@@ -127,107 +116,6 @@ def test_guaranteed_hash(
     assert get_file_hash(file_path, hash_name) == expected
 
 
-def test_download_file(
-    http: responses.RequestsMock, fixture_dir: FixtureDirGetter, tmp_path: Path
-) -> None:
-    file_path = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
-    url = "https://foo.com/demo-0.1.0.tar.gz"
-    http.get(url, body=file_path.read_bytes())
-    dest = tmp_path / "demo-0.1.0.tar.gz"
-
-    download_file(url, dest)
-
-    expect_sha_256 = "9fa123ad707a5c6c944743bf3e11a0e80d86cb518d3cf25320866ca3ef43e2ad"
-    assert get_file_hash(dest) == expect_sha_256
-    assert http.calls[-1].request.headers["Accept-Encoding"] == "Identity"
-
-
-def test_downloader_with_invalid_content_length(
-    http: responses.RequestsMock, tmp_path: Path
-) -> None:
-    url = "https://foo.com/demo.txt"
-    http.get(url, body=b"demo", headers={"Content-Length": "invalid"})
-    dest = tmp_path / "demo.txt"
-
-    downloader = Downloader(url, dest)
-
-    assert downloader.total_size == 0
-    assert list(downloader.download_with_progress(chunk_size=2)) == [2, 4]
-    assert dest.read_bytes() == b"demo"
-
-
-def test_download_file_recover_from_error(
-    http: responses.RequestsMock, fixture_dir: FixtureDirGetter, tmp_path: Path
-) -> None:
-    file_path = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
-    file_body = file_path.read_bytes()
-    file_length = len(file_body)
-    url = "https://foo.com/demo-0.1.0.tar.gz"
-
-    def handle_request(request: PreparedRequest) -> HttpResponse:
-        if request.headers.get("Range") is None:
-            response_headers = {
-                "Content-Length": str(file_length),
-                "Accept-Ranges": "bytes",
-            }
-            return 200, response_headers, file_body[: file_length // 2]
-        else:
-            start = int(
-                request.headers.get("Range", "bytes=0-").split("=")[1].split("-")[0]
-            )
-            response_headers = {"Content-Length": str(len(file_body[start:]))}
-            return 206, response_headers, file_body[start:]
-
-    http.add_callback(responses.GET, url, callback=handle_request)
-    dest = tmp_path / "demo-0.1.0.tar.gz"
-
-    download_file(url, dest, chunk_size=file_length // 2, max_retries=1)
-
-    expect_sha_256 = "9fa123ad707a5c6c944743bf3e11a0e80d86cb518d3cf25320866ca3ef43e2ad"
-    assert get_file_hash(dest) == expect_sha_256
-    assert http.calls[-1].request.headers["Accept-Encoding"] == "Identity"
-    assert http.calls[-1].request.headers["Range"] == f"bytes={file_length // 2}-"
-
-
-def test_download_file_fail_when_no_range(
-    http: responses.RequestsMock, fixture_dir: FixtureDirGetter, tmp_path: Path
-) -> None:
-    file_path = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
-    file_body = file_path.read_bytes()
-    file_length = len(file_body)
-    url = "https://foo.com/demo-0.1.0.tar.gz"
-
-    def handle_request(request: PreparedRequest) -> HttpResponse:
-        response_headers = {"Content-Length": str(file_length)}
-        return 200, response_headers, file_body[: file_length // 2]
-
-    http.add_callback(responses.GET, url, callback=handle_request)
-    dest = tmp_path / "demo-0.1.0.tar.gz"
-    with pytest.raises(ChunkedEncodingError):
-        download_file(url, dest, chunk_size=file_length // 2, max_retries=1)
-
-
-def test_download_file_fail_when_first_chunk_failed(
-    http: responses.RequestsMock, fixture_dir: FixtureDirGetter, tmp_path: Path
-) -> None:
-    file_path = fixture_dir("distributions") / "demo-0.1.0.tar.gz"
-    file_body = file_path.read_bytes()
-    file_length = len(file_body)
-    url = "https://foo.com/demo-0.1.0.tar.gz"
-
-    def handle_request(request: PreparedRequest) -> tuple[int, dict[str, Any], bytes]:
-        response_headers = {
-            "Content-Length": str(file_length),
-            "Accept-Ranges": "bytes",
-        }
-        return 200, response_headers, file_body[: file_length // 2]
-
-    http.add_callback(responses.GET, url, callback=handle_request)
-    dest = tmp_path / "demo-0.1.0.tar.gz"
-    with pytest.raises(ChunkedEncodingError):
-        download_file(url, dest, chunk_size=file_length, max_retries=1)
-
-
 @pytest.mark.parametrize(
     "hash_types,expected",
     [
@@ -239,68 +127,6 @@ def test_download_file_fail_when_first_chunk_failed(
 )
 def test_highest_priority_hash_type(hash_types: set[str], expected: str | None) -> None:
     assert get_highest_priority_hash_type(hash_types, "Blah") == expected
-
-
-@pytest.mark.parametrize("accepts_ranges", [False, True])
-@pytest.mark.parametrize("raise_accepts_ranges", [False, True])
-def test_download_file_raise_accepts_ranges(
-    http: responses.RequestsMock,
-    fixture_dir: FixtureDirGetter,
-    tmp_path: Path,
-    accepts_ranges: bool,
-    raise_accepts_ranges: bool,
-) -> None:
-    filename = "demo-0.1.0-py2.py3-none-any.whl"
-
-    def handle_request(request: PreparedRequest) -> tuple[int, dict[str, Any], bytes]:
-        file_path = fixture_dir("distributions") / filename
-        response_headers = {}
-        if accepts_ranges:
-            response_headers["Accept-Ranges"] = "bytes"
-        return 200, response_headers, file_path.read_bytes()
-
-    url = f"https://foo.com/{filename}"
-    http.add_callback(responses.GET, url, callback=handle_request)
-    dest = tmp_path / filename
-
-    if accepts_ranges and raise_accepts_ranges:
-        with pytest.raises(HTTPRangeRequestSupportedError):
-            download_file(url, dest, raise_accepts_ranges=raise_accepts_ranges)
-        assert not dest.exists()
-    else:
-        download_file(url, dest, raise_accepts_ranges=raise_accepts_ranges)
-        assert dest.is_file()
-
-
-def test_downloader_uses_authenticator_by_default(
-    config: Config,
-    http: responses.RequestsMock,
-    tmp_working_directory: Path,
-) -> None:
-    import poetry.utils.authenticator
-
-    # force set default authenticator to None so that it is recreated using patched config
-    poetry.utils.authenticator._authenticator = None
-
-    config.merge(
-        {
-            "repositories": {"foo": {"url": "https://foo.bar/files/"}},
-            "http-basic": {"foo": {"username": "bar", "password": "baz"}},
-        }
-    )
-
-    http.get(
-        re.compile("^https?://foo.bar/(.+?)$"),
-    )
-
-    Downloader(
-        "https://foo.bar/files/foo-0.1.0.tar.gz",
-        tmp_working_directory / "foo-0.1.0.tar.gz",
-    )
-
-    request = http.calls[-1].request
-    basic_auth = base64.b64encode(b"bar:baz").decode()
-    assert request.headers["Authorization"] == f"Basic {basic_auth}"
 
 
 def test_ensure_path_converts_string(tmp_path: Path) -> None:
@@ -507,3 +333,21 @@ def test_extractall_wheel_no_path_traversal_via_symlink(
         assert target.read_text(encoding="utf-8") == "original"
     else:
         assert not target.exists()
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [("Downloader", Downloader), ("download_file", download_file)],
+)
+def test_deprecated_helpers_download_reexports(name: str, expected: object) -> None:
+    from poetry.utils import helpers
+
+    with pytest.warns(DeprecationWarning, match="poetry.utils.download"):
+        assert getattr(helpers, name) is expected
+
+
+def test_unknown_helpers_attribute_still_raises_attribute_error() -> None:
+    from poetry.utils import helpers
+
+    with pytest.raises(AttributeError):
+        helpers.definitely_not_a_real_attribute  # noqa: B018

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -16,10 +16,10 @@ import responses
 from requests.exceptions import ChunkedEncodingError
 
 from poetry.utils._compat import WINDOWS
-from poetry.utils.helpers import Downloader
+from poetry.utils.download import Downloader
+from poetry.utils.download import download_file
 from poetry.utils.helpers import HTTPRangeRequestSupportedError
 from poetry.utils.helpers import directory
-from poetry.utils.helpers import download_file
 from poetry.utils.helpers import ensure_path
 from poetry.utils.helpers import extractall
 from poetry.utils.helpers import get_file_hash

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -11,6 +11,7 @@ import pytest
 
 from poetry.utils._compat import WINDOWS
 from poetry.utils.download import Downloader
+from poetry.utils.download import HTTPRangeRequestSupportedError
 from poetry.utils.download import download_file
 from poetry.utils.helpers import directory
 from poetry.utils.helpers import ensure_path
@@ -337,7 +338,11 @@ def test_extractall_wheel_no_path_traversal_via_symlink(
 
 @pytest.mark.parametrize(
     ("name", "expected"),
-    [("Downloader", Downloader), ("download_file", download_file)],
+    [
+        ("Downloader", Downloader),
+        ("download_file", download_file),
+        ("HTTPRangeRequestSupportedError", HTTPRangeRequestSupportedError),
+    ],
 )
 def test_deprecated_helpers_download_reexports(name: str, expected: object) -> None:
     from poetry.utils import helpers

--- a/tests/utils/test_helpers_lazy_imports.py
+++ b/tests/utils/test_helpers_lazy_imports.py
@@ -3,13 +3,19 @@ from __future__ import annotations
 import subprocess
 import sys
 
+from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import Literal
 
 import pytest
 
 from typing_extensions import Self
 
 from poetry.utils import helpers
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 LAZY_NAMES = [
@@ -88,10 +94,10 @@ def test_downloader_retries_only_the_resumable_requests_errors() -> None:
             def __enter__(self) -> Self:
                 return self
 
-            def __exit__(self, *_: object) -> bool:
+            def __exit__(self, *_: object) -> Literal[False]:
                 return False
 
-            def iter_content(self, chunk_size: int = 1):
+            def iter_content(self, chunk_size: int = 1) -> Iterator[bytes]:
                 state["n"] += 1
                 yield b"ab"
                 if state["n"] == 1:

--- a/tests/utils/test_helpers_lazy_imports.py
+++ b/tests/utils/test_helpers_lazy_imports.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from typing import ClassVar
+
+import pytest
+
+from typing_extensions import Self
+
+from poetry.utils import helpers
+
+
+LAZY_NAMES = [
+    "ChunkedEncodingError",
+    "ConnectionError",
+    "atomic_open",
+    "get_default_authenticator",
+]
+
+
+@pytest.mark.parametrize("name", LAZY_NAMES)
+def test_lazily_reexported_names_are_still_importable(name: str) -> None:
+    """These were module-level imports and stay part of the module's public surface."""
+    assert hasattr(helpers, name)
+    assert name in dir(helpers)
+
+
+@pytest.mark.parametrize("name", LAZY_NAMES)
+def test_lazily_reexported_names_resolve_to_the_real_objects(name: str) -> None:
+    import requests.exceptions
+    import requests.utils
+
+    from poetry.utils import authenticator
+
+    expected = {
+        "ChunkedEncodingError": requests.exceptions.ChunkedEncodingError,
+        "ConnectionError": requests.exceptions.ConnectionError,
+        "atomic_open": requests.utils.atomic_open,
+        "get_default_authenticator": authenticator.get_default_authenticator,
+    }[name]
+    assert getattr(helpers, name) is expected
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError):
+        helpers.definitely_not_a_real_attribute  # noqa: B018
+
+
+def test_importing_the_cli_entrypoint_does_not_import_requests() -> None:
+    """The CLI imports this module for two filesystem helpers, so it must not drag the
+    HTTP stack in. This is the regression the lazy imports exist to prevent."""
+    code = (
+        "import sys;"
+        "import poetry.console.application;"
+        "print('requests' in sys.modules, 'urllib3' in sys.modules)"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert out == "False False", f"expected neither to be imported, got {out}"
+
+
+def test_downloader_retries_only_the_resumable_requests_errors() -> None:
+    """`except ConnectionError` inside this module must be the requests class, not the
+    builtin. A module-level ``__getattr__`` serves attribute access on the module object
+    but never bare global lookup inside the module's own functions, so a lazy rewrite can
+    silently bind the builtin -- which requests' ConnectionError is not a subclass of --
+    and stop retrying resumable downloads."""
+    import requests.exceptions
+
+    def run_with(exc: type[BaseException], tmp_path_factory: object = None) -> int:
+        import tempfile
+
+        from pathlib import Path
+
+        state = {"n": 0}
+
+        class _Resp:
+            headers: ClassVar[dict[str, str]] = {
+                "Accept-Ranges": "bytes",
+                "Content-Length": "8",
+            }
+
+            def raise_for_status(self) -> None: ...
+            def close(self) -> None: ...
+            def __enter__(self) -> Self:
+                return self
+
+            def __exit__(self, *_: object) -> bool:
+                return False
+
+            def iter_content(self, chunk_size: int = 1):
+                state["n"] += 1
+                yield b"ab"
+                if state["n"] == 1:
+                    raise exc("stub failure")
+
+        class _Session:
+            def get(self, *_: object, **__: object) -> _Resp:
+                return _Resp()
+
+        with tempfile.TemporaryDirectory() as td:
+            downloader = helpers.Downloader(
+                "https://example.invalid/x",
+                Path(td) / "out.bin",
+                session=_Session(),  # type: ignore[arg-type]
+                max_retries=2,
+            )
+            list(downloader.download_with_progress(chunk_size=2))
+        return state["n"]
+
+    # Retried on unmodified main, so the stub is asked for content twice. SSLError is
+    # included deliberately: it subclasses requests' ConnectionError, so it is caught by
+    # the same clause, and it is caught only if that name is the requests class rather
+    # than the builtin.
+    assert run_with(requests.exceptions.ConnectionError) == 2
+    assert run_with(requests.exceptions.ChunkedEncodingError) == 2
+    assert run_with(requests.exceptions.SSLError) == 2
+
+    # Not resumable: must propagate rather than be swallowed by a broad except clause.
+    for exc in (ValueError, AttributeError):
+        with pytest.raises(exc):
+            run_with(exc)


### PR DESCRIPTION
## Summary

`src/poetry/console/application.py` imports two filesystem helpers from
`poetry.utils.helpers`:

```python
from poetry.utils.helpers import directory
from poetry.utils.helpers import ensure_path
```

`poetry/utils/helpers.py` imports the HTTP stack at module level:

```python
from requests.exceptions import ChunkedEncodingError
from requests.exceptions import ConnectionError
from requests.utils import atomic_open

from poetry.utils.authenticator import get_default_authenticator
```

All four are used only inside `Downloader`, but every poetry command pays for them at
startup, including ones that never open a socket. This moves them to their point of use
and keeps them importable from the module through a PEP 562 `__getattr__`.

## Numbers

Cost of `import poetry.console.application` in a fresh interpreter, measured as the wall
time of `python -B -c "import poetry.console.application"` minus the wall time of
`python -B -c "pass"` in the same window, median of 9, on an otherwise idle core,
CPython 3.12.13:

| | before | after |
|---|---:|---:|
| import cost | 156.8 ms | 82.3 ms |

`requests` and `urllib3` drop out of `sys.modules` entirely for commands that do not use
them, which is where the time goes.

Two caveats worth stating. The absolute number depends on what else is installed in the
environment: in a second virtualenv on the same machine `requests` alone costs 104 ms
rather than 36 ms, and the same change measured 317 ms to 117 ms there. The ratio is the
stable part, not the milliseconds. And this is process startup only; it does not make
any command's actual work faster.

For context on why startup is worth anything here, #10625 measured `poetry --version` at
about 217 ms and `poetry --version --no-plugins` at about 116 ms. That issue and #10992
are about the plugin-discovery half of that gap. This is the other half, the part that
remains with `--no-plugins`, and the two are independent.

## Behaviour is unchanged

`ChunkedEncodingError`, `ConnectionError`, `atomic_open` and `get_default_authenticator`
remain importable from `poetry.utils.helpers` and resolve to the same objects. `dir()` on
the module is unchanged.

The part that needed care: a module-level `__getattr__` serves attribute access on the
*module object*, but never a bare global name lookup inside the module's own functions.
So writing

```python
except (ChunkedEncodingError, ConnectionError):
```

with `ConnectionError` supplied lazily would silently bind the **builtin**
`ConnectionError`. `requests.exceptions.ConnectionError` is not a subclass of it, so
resumable downloads would stop retrying and turn into hard failures, and nothing in the
existing test suite would notice. The retry site imports both names into function scope
instead, where the local binding shadows the builtin correctly.

## Tests

`tests/utils/test_helpers_lazy_imports.py`, 11 tests:

* each of the four names is still importable, is in `dir()`, and is the same object
* an unknown attribute still raises `AttributeError`
* importing `poetry.console.application` leaves `requests` and `urllib3` out of
  `sys.modules` - this is the regression the change exists to prevent, and it fails on
  current `main`
* `Downloader` still retries `ConnectionError`, `ChunkedEncodingError` and `SSLError`
  (the last subclasses requests' `ConnectionError`, so it is caught by the same clause,
  and only if that name is the requests class), and still propagates `ValueError` and
  `AttributeError` rather than swallowing them in a broad `except`

I checked these fail when they should. On unmodified `main` the import test fails. On a
variant that lets `ConnectionError` fall through to the builtin, and on one that widens
the clause to `except Exception`, the retry test fails.

`tests/utils` gives 358 passed / 23 failed / 21 skipped; the same 23 fail by name on an
unmodified checkout of this base and need Python interpreter managers this environment
does not have. `mypy` reports no issues on the changed file. `ruff check` is clean on
both files, apart from one pre-existing `PLC0206` in `merge_dicts` that is present on
`main` too and is untouched here.

## Notes

I tried a number of shapes for this, each scored against the unmodified module for
identical public surface and identical retry behaviour. The record is at
https://dashboard.weco.ai/share/kStcipB3sa9sf-YTFM_fv0G6_ZyLa61H

The larger variants also defer `logging`, `hashlib`, `tarfile`, `zipfile` and the
module-level `prioritised_hash_types` tables. They measured between 78.8 ms and 81.7 ms,
a 2.9 ms span against a 3.8 ms run-to-run noise band, so they are not distinguishable
from this one. They are three times the diff for no measurable gain, and they move
module-level public attributes behind a hook, so I kept the smaller change. Happy to
push the broader version if you would prefer it.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
