### PR TITLE
solver: fix KeyError due to orphan decisions - root cause

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1645,9 +1645,9 @@ develop = false
 
 [package.source]
 type = "git"
-url = "https://github.com/python-poetry/poetry-core.git"
-reference = "HEAD"
-resolved_reference = "5de24118d23a05a23af5d9eb1d8bd98850d09205"
+url = "https://github.com/radoering/poetry-core.git"
+reference = "fix-excluding-local-versions"
+resolved_reference = "97d3c24f2451c82b23a4c714bf8fcc50511d05a8"
 
 [[package]]
 name = "pre-commit"
@@ -2393,4 +2393,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "afaa5fde455af4891db15f45aeaab108a0e666284d10be763880d134f3ecf639"
+content-hash = "1590c7a79d60394233eac5049cc40416eda400abfa5f1f354f28ef8267b67442"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.5.0.dev0"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "poetry-core @ git+https://github.com/python-poetry/poetry-core.git",
+    "poetry-core @ git+https://github.com/radoering/poetry-core.git@fix-excluding-local-versions",
     "build (>=1.2.1,<2.0.0)",
     "cachecontrol[filecache] (>=0.14.0,<0.15.0)",
     "cleo (>=2.1.0,<3.0.0)",

--- a/src/poetry/puzzle/provider.py
+++ b/src/poetry/puzzle/provider.py
@@ -32,6 +32,7 @@ from poetry.packages import DependencyPackage
 from poetry.packages.direct_origin import DirectOrigin
 from poetry.packages.package_collection import PackageCollection
 from poetry.puzzle.exceptions import OverrideNeededError
+from poetry.repositories.exceptions import PackageNotFoundError
 from poetry.repositories.repository_pool import Priority
 
 
@@ -151,6 +152,9 @@ class Provider:
         self._source_root: Path | None = None
         self._direct_origin_packages: dict[str, Package] = {}
         self._locked: dict[NormalizedName, list[DependencyPackage]] = defaultdict(list)
+        self._local_variants: dict[
+            tuple[NormalizedName, str, str | None], list[Version]
+        ] = {}
         self._use_latest: Collection[NormalizedName] = []
         self._active_root_extras = (
             frozenset(active_root_extras) if active_root_extras is not None else None
@@ -439,6 +443,67 @@ class Provider:
             _dependencies.append(dep)
         return _dependencies
 
+    def _local_version_variants(
+        self, package: Package, dependency: Dependency
+    ) -> list[Version]:
+        """
+        The local variants of ``package``'s release that the same search offers,
+        e.g. ``2.12.1+cpu`` for ``2.12.1``.
+
+        The repositories are asked rather than the versions seen so far being
+        remembered: a locked package is handed to the solver without being
+        searched for at all, so its variants would still be unknown when its
+        incompatibilities are recorded. Querying with ``dependency``'s source
+        covers exactly the repositories this run draws candidates from, and the
+        answer does not depend on how far resolution has progressed.
+        """
+        key = (package.name, package.version.text, dependency.source_name)
+        if (variants := self._local_variants.get(key)) is None:
+            query = Dependency(package.name, f"=={package.version}")
+            if dependency.source_name:
+                query.source_name = dependency.source_name
+            try:
+                candidates = self._pool.find_packages(query)
+            except PackageNotFoundError:
+                candidates = []
+            variants = sorted({c.version for c in candidates if c.version.is_local()})
+            self._local_variants[key] = variants
+        return variants
+
+    def _identity_dependency(
+        self, package: Package, dependency: Dependency
+    ) -> Dependency:
+        """
+        The dependency used as the positive term of ``package``'s
+        incompatibilities, i.e. the term meaning "this very build".
+
+        ``Package.to_dependency()`` pins the version with ``==``, which per
+        PEP 440 also matches local variants of the same release: ``==2.12.1``
+        matches ``2.12.1+cpu``. That is right for a version specifier written by
+        a user, but wrong for a term that is supposed to denote one build -- it
+        lets the incompatibilities recorded for ``torch 2.12.1`` apply to a
+        ``torch 2.12.1+cpu`` build that does not have those dependencies at all.
+        So exclude the local variants of the same release explicitly.
+
+        (PEP 440 arbitrary equality, ``===2.12.1``, expresses this directly, but
+        cannot be used here: an arbitrary equality never merges with an adjacent
+        range, so the incompatibilities built during conflict resolution stop
+        shrinking and the solver fails to terminate.)
+        """
+        self_dependency = package.to_dependency()
+        version = package.version
+        if version.is_local() or package.is_direct_origin():
+            # `==2.12.1+cpu` already matches nothing but itself, and a direct
+            # origin has no sibling builds to be confused with.
+            return self_dependency
+
+        constraint: VersionConstraint = version
+        for variant in self._local_version_variants(package, dependency):
+            constraint = constraint.difference(variant)
+        if constraint != self_dependency.constraint:
+            self_dependency.constraint = constraint
+        return self_dependency
+
     def incompatibilities_for(
         self, dependency_package: DependencyPackage
     ) -> list[Incompatibility]:
@@ -479,16 +544,27 @@ class Provider:
                 ):
                     return [
                         Incompatibility(
-                            [Term(package.to_dependency(), True)],
+                            [
+                                Term(
+                                    self._identity_dependency(
+                                        package, dependency_package.dependency
+                                    ),
+                                    True,
+                                )
+                            ],
                             PythonCauseError(
                                 package.python_versions, str(self._python_constraint)
                             ),
                         )
                     ]
 
+        self_dependency = self._identity_dependency(
+            package, dependency_package.dependency
+        )
+
         return [
             Incompatibility(
-                [Term(package.to_dependency(), True), Term(dep, False)],
+                [Term(self_dependency, True), Term(dep, False)],
                 DependencyCauseError(),
             )
             for dep in self._get_dependencies_with_overrides(dependencies, package)

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -219,8 +219,28 @@ class Solver:
                                 continue
 
                             _package.add_dependency(dep)
+            elif info := results.get(package):
+                solved_packages[package] = info
             else:
-                solved_packages[package] = results[package]
+                # The solver decided this package, but the depth-first search
+                # above did not reach it from the project's dependencies, so
+                # nothing in the solution requires it.
+                #
+                # This happens when two builds share a base version and differ
+                # only by a local segment, e.g. `torch 2.12.1`, which requires
+                # `triton`, and a `torch 2.12.1+cpu` build, which does not.
+                # While backtracking, the solver records the incompatibilities
+                # of the `2.12.1` build and then settles on `2.12.1+cpu`. Since
+                # a local segment is ignored by `==`, `2.12.1+cpu` satisfies the
+                # term `torch (==2.12.1)`, so the discarded build's
+                # incompatibilities keep deriving its transitive dependencies,
+                # which are left behind as orphan decisions. They must not be
+                # carried into the solution.
+                self._provider.debug(
+                    f"<warning>Discarding orphan package {package.complete_name}"
+                    f" ({package.full_pretty_version}): not reachable from the"
+                    f" project's dependencies.</warning>"
+                )
 
         return solved_packages
 

--- a/src/poetry/puzzle/solver.py
+++ b/src/poetry/puzzle/solver.py
@@ -219,28 +219,8 @@ class Solver:
                                 continue
 
                             _package.add_dependency(dep)
-            elif info := results.get(package):
-                solved_packages[package] = info
             else:
-                # The solver decided this package, but the depth-first search
-                # above did not reach it from the project's dependencies, so
-                # nothing in the solution requires it.
-                #
-                # This happens when two builds share a base version and differ
-                # only by a local segment, e.g. `torch 2.12.1`, which requires
-                # `triton`, and a `torch 2.12.1+cpu` build, which does not.
-                # While backtracking, the solver records the incompatibilities
-                # of the `2.12.1` build and then settles on `2.12.1+cpu`. Since
-                # a local segment is ignored by `==`, `2.12.1+cpu` satisfies the
-                # term `torch (==2.12.1)`, so the discarded build's
-                # incompatibilities keep deriving its transitive dependencies,
-                # which are left behind as orphan decisions. They must not be
-                # carried into the solution.
-                self._provider.debug(
-                    f"<warning>Discarding orphan package {package.complete_name}"
-                    f" ({package.full_pretty_version}): not reachable from the"
-                    f" project's dependencies.</warning>"
-                )
+                solved_packages[package] = results[package]
 
         return solved_packages
 

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -132,16 +132,13 @@ def test_solver_local_version_variant_does_not_leak_dependencies(
     The explicit source serves two builds of the same base version: "2.12.1+cpu",
     which needs no "triton", and a plain "2.12.1" (the macOS wheel), whose
     metadata does. The "setuptools" conflict makes the solver record the
-    incompatibilities of both builds before it settles on "2.12.1+cpu" -- which
-    *satisfies* the term "torch (==2.12.1)", because a local version segment is
-    ignored by "==". The discarded build's incompatibilities therefore keep
-    deriving "triton", leaving it behind as a decision that no package in the
-    solution requires.
+    incompatibilities of both builds before it settles on "2.12.1+cpu".
 
-    The solver now drops such orphan decisions instead of raising a KeyError.
-    Note that this only treats the symptom: "triton" is still resolved and
-    completed for nothing, and the leak still causes false resolution failures
-    (see the xfail-ed tests below).
+    Because a local version segment is ignored by "==", "2.12.1+cpu" satisfies
+    the term "torch (==2.12.1)". Unless that term is narrowed to the build it
+    describes, the plain build's incompatibilities keep deriving "triton",
+    which is then left in the solution as a decision that nothing requires --
+    and which used to crash the aggregation step with a KeyError.
     """
 
     def torchcpu_build(version: str) -> Package:
@@ -194,12 +191,11 @@ def test_solver_local_version_variant_does_not_leak_dependencies(
     )
 
     # The assertion below isn't the point of this test, but pins down the
-    # resolution order the reproduction depends on. Which build is completed
-    # first matters: the bug only occurs because the plain 2.12.1 build is
-    # completed -- recording its triton incompatibility -- while a *different*
+    # resolution order the leak depends on: the plain 2.12.1 build has to be
+    # completed -- recording its `triton` incompatibility -- while a *different*
     # build satisfying the same "torch (==2.12.1)" term is what gets decided.
-    # If the solver ever settled on 2.12.1 instead, triton would be a genuine
-    # dependency and this test would silently stop covering the bug.
+    # If the solver ever stopped completing the plain build, or settled on it
+    # instead, this test would silently stop covering the bug.
     assert [
         (call.args[0].package.name, str(call.args[0].package.version))
         for call in complete_package_spy.mock_calls
@@ -213,22 +209,13 @@ def test_solver_local_version_variant_does_not_leak_dependencies(
         ("torch", "2.12.1"),
         # backtracking settles the setuptools conflict...
         ("setuptools", "81.0.0"),
-        # ...and 2.12.1+cpu is decided after all, inheriting the
-        # incompatibility recorded for 2.12.1 above, which derives...
+        # ...and 2.12.1+cpu is decided after all. The incompatibility recorded
+        # for 2.12.1 above does not apply to it, so nothing follows: no triton
+        # is ever completed, let alone left behind in the solution.
         ("torch", "2.12.1+cpu"),
-        # ...this orphan, which nothing in the solution actually requires.
-        ("triton", "3.7.1"),
     ]
 
 
-@pytest.mark.xfail(
-    reason=(
-        "The dependencies of a plain release leak onto its local variants,"
-        " because `==2.12.1` also matches `2.12.1+cpu`. Only the resulting"
-        " orphan decisions are handled, not the leak itself."
-    ),
-    strict=True,
-)
 def test_solver_local_version_variant_is_not_wrongly_excluded(
     package: ProjectPackage,
     repo: Repository,
@@ -242,23 +229,18 @@ def test_solver_local_version_variant_is_not_wrongly_excluded(
     ``test_solver_local_version_variant_does_not_leak_dependencies`` with one
     change: the "triton" that the plain 2.12.1 build requires exists in no
     repository. The "2.12.1+cpu" build needs no triton and satisfies
-    "torch (==2.12.1)", so the solver should settle on it and succeed.
+    "torch (==2.12.1)", so the solver must settle on it and succeed.
 
-    It does select it, but then the incompatibility recorded for the plain
-    build leaks onto it exactly as in the test above -- only here the leaked
-    requirement is unsatisfiable, so instead of an orphan decision it takes the
-    whole resolution down::
+    Before the incompatibility terms were narrowed, the solver did select
+    2.12.1+cpu, but the plain build's incompatibility then leaked onto it and,
+    because the leaked requirement was unsatisfiable, took the whole resolution
+    down instead of merely leaving an orphan behind:
 
         selecting torch (2.12.1+cpu)
         derived: triton (==3.7.1)
         fact: no versions of triton match 3.7.1
         conflict: torch (2.12.1) depends on triton (==3.7.1)
         ! thus: torch is forbidden
-
-    Unlike an orphan decision, this cannot be repaired when aggregating the
-    solved packages, because resolution has already failed by then. A fix has
-    to stop the incompatibilities recorded for one build from applying to a
-    sibling build of the same base version.
     """
 
     def torchcpu_build(version: str) -> Package:
@@ -304,14 +286,6 @@ def test_solver_local_version_variant_is_not_wrongly_excluded(
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "The dependencies of a plain release leak onto its local variants,"
-        " because `==2.12.1` also matches `2.12.1+cpu`. Only the resulting"
-        " orphan decisions are handled, not the leak itself."
-    ),
-    strict=True,
-)
 def test_solver_local_version_variant_is_not_wrongly_excluded_via_stale_lock(
     package: ProjectPackage,
     repo: Repository,

--- a/tests/puzzle/test_solver.py
+++ b/tests/puzzle/test_solver.py
@@ -118,6 +118,273 @@ def test_solver_install_single(
     check_solver_result(transaction, [{"job": "install", "package": package_a}])
 
 
+def test_solver_local_version_variant_does_not_leak_dependencies(
+    package: ProjectPackage,
+    repo: Repository,
+    pool: RepositoryPool,
+    io: NullIO,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression test for the "orphan decision" bug, modelled on the reported
+    `torch` / `torch+cpu` failure (`KeyError: Package('triton', '3.7.1')`).
+
+    The explicit source serves two builds of the same base version: "2.12.1+cpu",
+    which needs no "triton", and a plain "2.12.1" (the macOS wheel), whose
+    metadata does. The "setuptools" conflict makes the solver record the
+    incompatibilities of both builds before it settles on "2.12.1+cpu" -- which
+    *satisfies* the term "torch (==2.12.1)", because a local version segment is
+    ignored by "==". The discarded build's incompatibilities therefore keep
+    deriving "triton", leaving it behind as a decision that no package in the
+    solution requires.
+
+    The solver now drops such orphan decisions instead of raising a KeyError.
+    Note that this only treats the symptom: "triton" is still resolved and
+    completed for nothing, and the leak still causes false resolution failures
+    (see the xfail-ed tests below).
+    """
+
+    def torchcpu_build(version: str) -> Package:
+        return Package(
+            "torch", version, source_type="legacy", source_reference="torchcpu"
+        )
+
+    package.add_dependency(
+        Factory.create_dependency(
+            "torch", {"version": "==2.12.1", "source": "torchcpu"}
+        )
+    )
+    # Both torch builds cap setuptools at <82 while the project itself accepts
+    # any version and the lock prefers 83.0.0. Resolving that conflict is what
+    # makes the solver record the incompatibilities of both builds before it
+    # decides on one of them.
+    package.add_dependency(Factory.create_dependency("setuptools", "*"))
+
+    torchcpu = Repository("torchcpu")
+    pool.add_repository(torchcpu, priority=Priority.EXPLICIT)
+
+    torch_cpu = torchcpu_build("2.12.1+cpu")
+    torch_cpu.add_dependency(Factory.create_dependency("setuptools", "<82"))
+    torchcpu.add_package(torch_cpu)
+
+    # The same index also serves a plain 2.12.1 wheel, which does need triton.
+    torch_plain = torchcpu_build("2.12.1")
+    torch_plain.add_dependency(Factory.create_dependency("setuptools", "<82"))
+    torch_plain.add_dependency(Factory.create_dependency("triton", "==3.7.1"))
+    torchcpu.add_package(torch_plain)
+
+    repo.add_package(get_package("triton", "3.7.1"))
+    setuptools_81 = get_package("setuptools", "81.0.0")
+    repo.add_package(setuptools_81)
+    setuptools_83 = get_package("setuptools", "83.0.0")
+    repo.add_package(setuptools_83)
+
+    solver = Solver(package, pool, [], [setuptools_83], io)
+
+    complete_package_spy = mocker.spy(solver._provider, "complete_package")
+    transaction = solver.solve()
+
+    # Notably no triton: it is only required by the discarded plain build.
+    check_solver_result(
+        transaction,
+        [
+            {"job": "install", "package": setuptools_81},
+            {"job": "install", "package": torch_cpu},
+        ],
+    )
+
+    # The assertion below isn't the point of this test, but pins down the
+    # resolution order the reproduction depends on. Which build is completed
+    # first matters: the bug only occurs because the plain 2.12.1 build is
+    # completed -- recording its triton incompatibility -- while a *different*
+    # build satisfying the same "torch (==2.12.1)" term is what gets decided.
+    # If the solver ever settled on 2.12.1 instead, triton would be a genuine
+    # dependency and this test would silently stop covering the bug.
+    assert [
+        (call.args[0].package.name, str(call.args[0].package.version))
+        for call in complete_package_spy.mock_calls
+    ] == [
+        ("root", "1.0"),
+        # locked, so preferred and decided first
+        ("setuptools", "83.0.0"),
+        # the highest torch candidate, rejected over `setuptools (<82)`
+        ("torch", "2.12.1+cpu"),
+        # the next candidate; its `triton` incompatibility is recorded here
+        ("torch", "2.12.1"),
+        # backtracking settles the setuptools conflict...
+        ("setuptools", "81.0.0"),
+        # ...and 2.12.1+cpu is decided after all, inheriting the
+        # incompatibility recorded for 2.12.1 above, which derives...
+        ("torch", "2.12.1+cpu"),
+        # ...this orphan, which nothing in the solution actually requires.
+        ("triton", "3.7.1"),
+    ]
+
+
+@pytest.mark.xfail(
+    reason=(
+        "The dependencies of a plain release leak onto its local variants,"
+        " because `==2.12.1` also matches `2.12.1+cpu`. Only the resulting"
+        " orphan decisions are handled, not the leak itself."
+    ),
+    strict=True,
+)
+def test_solver_local_version_variant_is_not_wrongly_excluded(
+    package: ProjectPackage,
+    repo: Repository,
+    pool: RepositoryPool,
+    io: NullIO,
+) -> None:
+    """
+    The second symptom of the same leak: a *false* resolution failure.
+
+    This is the setup of
+    ``test_solver_local_version_variant_does_not_leak_dependencies`` with one
+    change: the "triton" that the plain 2.12.1 build requires exists in no
+    repository. The "2.12.1+cpu" build needs no triton and satisfies
+    "torch (==2.12.1)", so the solver should settle on it and succeed.
+
+    It does select it, but then the incompatibility recorded for the plain
+    build leaks onto it exactly as in the test above -- only here the leaked
+    requirement is unsatisfiable, so instead of an orphan decision it takes the
+    whole resolution down::
+
+        selecting torch (2.12.1+cpu)
+        derived: triton (==3.7.1)
+        fact: no versions of triton match 3.7.1
+        conflict: torch (2.12.1) depends on triton (==3.7.1)
+        ! thus: torch is forbidden
+
+    Unlike an orphan decision, this cannot be repaired when aggregating the
+    solved packages, because resolution has already failed by then. A fix has
+    to stop the incompatibilities recorded for one build from applying to a
+    sibling build of the same base version.
+    """
+
+    def torchcpu_build(version: str) -> Package:
+        return Package(
+            "torch", version, source_type="legacy", source_reference="torchcpu"
+        )
+
+    package.add_dependency(
+        Factory.create_dependency(
+            "torch", {"version": "==2.12.1", "source": "torchcpu"}
+        )
+    )
+    package.add_dependency(Factory.create_dependency("setuptools", "*"))
+
+    torchcpu = Repository("torchcpu")
+    pool.add_repository(torchcpu, priority=Priority.EXPLICIT)
+
+    torch_cpu = torchcpu_build("2.12.1+cpu")
+    torch_cpu.add_dependency(Factory.create_dependency("setuptools", "<82"))
+    torchcpu.add_package(torch_cpu)
+
+    torch_plain = torchcpu_build("2.12.1")
+    torch_plain.add_dependency(Factory.create_dependency("setuptools", "<82"))
+    torch_plain.add_dependency(Factory.create_dependency("triton", "==3.7.1"))
+    torchcpu.add_package(torch_plain)
+
+    # Note: no triton in any repository, so the plain build is not installable.
+    setuptools_81 = get_package("setuptools", "81.0.0")
+    repo.add_package(setuptools_81)
+    setuptools_83 = get_package("setuptools", "83.0.0")
+    repo.add_package(setuptools_83)
+
+    solver = Solver(package, pool, [], [setuptools_83], io)
+
+    transaction = solver.solve()
+
+    check_solver_result(
+        transaction,
+        [
+            {"job": "install", "package": setuptools_81},
+            {"job": "install", "package": torch_cpu},
+        ],
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "The dependencies of a plain release leak onto its local variants,"
+        " because `==2.12.1` also matches `2.12.1+cpu`. Only the resulting"
+        " orphan decisions are handled, not the leak itself."
+    ),
+    strict=True,
+)
+def test_solver_local_version_variant_is_not_wrongly_excluded_via_stale_lock(
+    package: ProjectPackage,
+    repo: Repository,
+    pool: RepositoryPool,
+    io: NullIO,
+) -> None:
+    """
+    A false resolution failure from the same leak, reached by a different
+    route: here it is a *cap* rather than a missing package that leaks.
+
+    The plain 2.12.1 build caps ``setuptools (<82)`` while the root asks for
+    ``>=83``; the 2.12.1+cpu build caps nothing and satisfies ``==2.12.1``, so
+    the answer is setuptools 83.0.0 with torch 2.12.1+cpu. Because the plain
+    build's requirement is attributed to the whole ``==2.12.1`` term, the
+    2.12.1+cpu build is excluded along with it and resolution fails::
+
+        conflict: torch (2.12.1) depends on setuptools (<82)
+        ! which is caused by "root depends on torch (==2.12.1)"
+        ! thus: setuptools is required
+
+    This needs the stale lock below to reproduce: the plain build's
+    incompatibility has to be recorded while 2.12.1+cpu is still a live
+    candidate, and the locked plain build is preferred and completed first.
+    Without the lock the solver reaches 2.12.1+cpu first and never records the
+    conflicting term.
+    """
+
+    def torchcpu_build(version: str) -> Package:
+        return Package(
+            "torch", version, source_type="legacy", source_reference="torchcpu"
+        )
+
+    package.add_dependency(
+        Factory.create_dependency(
+            "torch", {"version": "==2.12.1", "source": "torchcpu"}
+        )
+    )
+    package.add_dependency(Factory.create_dependency("setuptools", ">=83"))
+
+    torchcpu = Repository("torchcpu")
+    pool.add_repository(torchcpu, priority=Priority.EXPLICIT)
+
+    # The +cpu build caps nothing and needs no triton.
+    torch_cpu = torchcpu_build("2.12.1+cpu")
+    torchcpu.add_package(torch_cpu)
+
+    torch_plain = torchcpu_build("2.12.1")
+    torch_plain.add_dependency(Factory.create_dependency("setuptools", "<82"))
+    torch_plain.add_dependency(Factory.create_dependency("triton", "==3.7.1"))
+    torchcpu.add_package(torch_plain)
+
+    repo.add_package(get_package("triton", "3.7.1"))
+    repo.add_package(get_package("setuptools", "81.0.0"))
+    setuptools_83 = get_package("setuptools", "83.0.0")
+    repo.add_package(setuptools_83)
+
+    # A stale lock pinning the *plain* build, so it is preferred and completed
+    # before 2.12.1+cpu is ever considered.
+    locked = [torchcpu_build("2.12.1"), setuptools_83]
+
+    solver = Solver(package, pool, [], locked, io)
+
+    transaction = solver.solve()
+
+    check_solver_result(
+        transaction,
+        [
+            {"job": "install", "package": setuptools_83},
+            {"job": "install", "package": torch_cpu},
+        ],
+    )
+
+
 def test_solver_remove_if_no_longer_locked(
     package: ProjectPackage, pool: RepositoryPool, io: NullIO
 ) -> None:


### PR DESCRIPTION
Alternative to #11008 that fixes the root cause instead of the symptom - however too **slow** (and more **risky**).

To avoid orphan decisions we have to exclude local versions from the dependency constraint of the first term of the incompatibility. Since we have no means to express such a constraint, we determine all available local versions and build the difference of the public version with them.

This solution has a notable performance issue - it queries the index for all (local) versions of each chosen package version. Actually, we would need a constraint to exclude all local versions to build the term of the incompatibility (similar to arbitrary equality `===`). I gave this a quick try, but this resulted in a hanging resolver - either due to bugs in my arbitrary equality implementation or because the solver is not prepared for arbitrary equality - I did not investigate further.

# Pull Request Check List

Resolves: #10965

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
