### PR TITLE
fix(show): report stale lock files clearly

### DIFF
--- a/src/poetry/console/commands/show.py
+++ b/src/poetry/console/commands/show.py
@@ -265,6 +265,7 @@ lists all packages available."""
 
         from cleo.io.null_io import NullIO
 
+        from poetry.puzzle.exceptions import SolverProblemError
         from poetry.puzzle.solver import Solver
         from poetry.repositories.installed_repository import InstalledRepository
         from poetry.repositories.repository_pool import RepositoryPool
@@ -280,8 +281,18 @@ lists all packages available."""
             io=NullIO(),
         )
         solver.provider.load_deferred(False)
-        with solver.use_environment(self.env):
-            ops = solver.solve().calculate_operations()
+        try:
+            with solver.use_environment(self.env):
+                ops = solver.solve().calculate_operations()
+        except SolverProblemError:
+            if not self.poetry.locker.is_fresh():
+                self.line_error(
+                    "<error>Error: pyproject.toml changed significantly since"
+                    " poetry.lock was last generated."
+                    f" Run `{self._lock_create_command()}` to fix the lock file.</error>"
+                )
+                return 1
+            raise
 
         required_locked_packages = {op.package for op in ops if not op.skipped}
 

--- a/tests/console/commands/test_show.py
+++ b/tests/console/commands/test_show.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from poetry.poetry import Poetry
     from poetry.repositories import Repository
     from tests.types import CommandTesterFactory
+    from tests.types import SetProjectContext
 
 
 @pytest.fixture
@@ -2433,6 +2434,24 @@ def test_show_errors_without_lock_file(tester: CommandTester, poetry: Poetry) ->
     tester.execute()
 
     expected = "Error: poetry.lock not found. Run `poetry lock` to create it.\n"
+    assert tester.io.fetch_error() == expected
+    assert tester.status_code == 1
+
+
+def test_show_errors_with_outdated_lock_file(
+    command_tester_factory: CommandTesterFactory,
+    set_project_context: SetProjectContext,
+) -> None:
+    with set_project_context("outdated_lock", in_place=False) as cwd:
+        poetry = Factory().create_poetry(cwd)
+        tester = command_tester_factory("show", poetry=poetry)
+
+        tester.execute()
+
+    expected = (
+        "Error: pyproject.toml changed significantly since poetry.lock was last "
+        "generated. Run `poetry lock` to fix the lock file.\n"
+    )
     assert tester.io.fetch_error() == expected
     assert tester.status_code == 1
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #9485

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. Not applicable; this corrects an existing CLI error path.

## Summary

When `poetry show` tries to solve against a stale lock file, the solver can currently emit a misleading dependency-resolution failure such as:

```text
Because test depends on basedmypy (2.4.0) which does not match any versions, version solving failed.
```

This change detects that specific combination—a stale lock followed by `SolverProblemError`—and reports Poetry's canonical recovery guidance instead:

```text
Error: pyproject.toml changed significantly since poetry.lock was last generated. Run `poetry lock` to fix the lock file.
```

Fresh-lock solver failures and successful stale-lock `show` paths remain unchanged.

## Validation

- Real CLI reproduction against the existing `outdated_lock` fixture.
- Regular and self `show` suites: 90 passed.
- Ruff, mypy, all changed-file pre-commit hooks, and Git whitespace checks passed.

AI assistance is disclosed in the commit trailer.
