### PR TITLE
test: accept compatible extension wheel tags

### DIFF
--- a/tests/installation/test_chef.py
+++ b/tests/installation/test_chef.py
@@ -11,6 +11,7 @@ from zipfile import ZipFile
 import pytest
 
 from build import ProjectBuilder
+from packaging.utils import parse_wheel_filename
 from poetry.core.packages.utils.link import Link
 
 from poetry.factory import Factory
@@ -96,7 +97,10 @@ def test_prepare_directory_with_extensions(
     wheel = chef.prepare(archive)
 
     assert wheel.parent.parent == Path(tempfile.gettempdir())
-    assert wheel.name == f"extended-0.1-{env.supported_tags[0]}.whl"
+    name, version, _, tags = parse_wheel_filename(wheel.name)
+    assert name == "extended"
+    assert str(version) == "0.1"
+    assert not tags.isdisjoint(env.supported_tags)
 
     # cleanup generated tmp dir artifact
     os.unlink(wheel)


### PR DESCRIPTION
Resolves: #11013

## Summary

- Parse the generated extension wheel filename instead of assuming the build backend selects the first supported tag.
- Keep assertions for the distribution name and version, and verify that the generated wheel has at least one tag supported by the environment.

## Tests

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (Not applicable; test-only change.)

Ran: `poetry run pytest -q -p no:randomly -n 0 tests/installation/test_chef.py`

Ran: `poetry run pre-commit run --files tests/installation/test_chef.py`

Ran: `poetry run mypy tests/installation/test_chef.py`