### PR TITLE
fix(console): don't warn on missing path dep in excluded group

### DIFF
--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -582,7 +582,9 @@ class Application(BaseApplication):
         # so a warning that's irrelevant in this command's context doesn't
         # surface. Skipped when verbose/debug so the full picture is still
         # available on request.
-        to_suppress = set(command.suppressed_loggers) if level >= logging.WARNING else set()
+        to_suppress = (
+            set(command.suppressed_loggers) if level >= logging.WARNING else set()
+        )
 
         # Reset any logger a previous command in this process suppressed but
         # this one doesn't, so the suppression doesn't leak into commands

--- a/src/poetry/console/application.py
+++ b/src/poetry/console/application.py
@@ -7,6 +7,7 @@ from contextlib import suppress
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import cast
 
 from cleo._utils import find_similar_names
@@ -122,6 +123,15 @@ Since <info>Poetry (<b>2.0.0</>)</>, the <c1>shell</> command is not installed b
 
 
 class Application(BaseApplication):
+    # Logger names raised to ERROR by a previous command's suppressed_loggers
+    # (see register_command_loggers). A ClassVar because logging levels are
+    # process-global state on the named logger, shared across Application
+    # instances -- so the bookkeeping for "what did we previously suppress"
+    # has to be process-global too, or a fresh Application() (e.g. a new
+    # test, or another poetry.console.application.Application().run() call
+    # in the same process) won't know to reset it.
+    _suppressed_logger_names: ClassVar[set[str]] = set()
+
     def __init__(self) -> None:
         super().__init__("poetry", __version__)
 
@@ -567,6 +577,26 @@ class Application(BaseApplication):
                 _level = logging.INFO
 
             logger.setLevel(_level)
+
+        # Raise these loggers above WARNING for this command specifically,
+        # so a warning that's irrelevant in this command's context doesn't
+        # surface. Skipped when verbose/debug so the full picture is still
+        # available on request.
+        to_suppress = set(command.suppressed_loggers) if level >= logging.WARNING else set()
+
+        # Reset any logger a previous command in this process suppressed but
+        # this one doesn't, so the suppression doesn't leak into commands
+        # that never asked for it (logger levels are global process state).
+        # Mutated in place (rather than `self._suppressed_logger_names = ...`)
+        # so the update lands on the shared ClassVar instead of shadowing it
+        # with a same-named instance attribute.
+        for name in Application._suppressed_logger_names - to_suppress:
+            logging.getLogger(name).setLevel(level)
+
+        for name in to_suppress:
+            logging.getLogger(name).setLevel(logging.ERROR)
+
+        Application._suppressed_logger_names = to_suppress
 
     def configure_env(self, event: Event, event_name: str, _: EventDispatcher) -> None:
         from poetry.console.commands.env_command import EnvCommand

--- a/src/poetry/console/commands/command.py
+++ b/src/poetry/console/commands/command.py
@@ -15,6 +15,12 @@ if TYPE_CHECKING:
 
 class Command(BaseCommand):
     loggers: ClassVar[list[str]] = []
+    # Loggers whose warnings should be suppressed (raised to ERROR) for this
+    # command specifically, unless running verbose/debug. Used for warnings
+    # that fire regardless of context that doesn't apply to this command
+    # (e.g. a path-dependency existence warning from a group excluded by
+    # --without/--only, see poetry-core's PathDependency.__init__).
+    suppressed_loggers: ClassVar[list[str]] = []
 
     _poetry: Poetry | None = None
 

--- a/src/poetry/console/commands/install.py
+++ b/src/poetry/console/commands/install.py
@@ -83,6 +83,17 @@ you can set the "package-mode" to false in your pyproject.toml file.
         "poetry.inspection.info",
     ]
 
+    # poetry-core's PathDependency.__init__ eagerly warns if a path
+    # dependency's directory doesn't exist, regardless of --with/--without/
+    # --only group selection (the group-aware check happens later, in
+    # Installer, and is what actually determines whether a missing path is
+    # an error). Suppress the premature warning here so a path dependency in
+    # an excluded group (e.g. a dev-only local package not present in a
+    # Docker image) doesn't get flagged for a group that was never going to
+    # be installed. install.py -> chef.py -> installer.py still raises a
+    # real error for any missing path that *is* actually needed.
+    suppressed_loggers: ClassVar[list[str]] = ["poetry.core.packages.path_dependency"]
+
     @property
     def activated_groups(self) -> set[NormalizedName]:
         if self.option("only-root"):

--- a/tests/console/test_application.py
+++ b/tests/console/test_application.py
@@ -56,6 +56,65 @@ def with_add_command_plugin(mocker: MockerFixture) -> None:
     mock_metadata_entry_points(mocker, AddCommandPlugin)
 
 
+SUPPRESSIBLE_LOGGER_NAME = "tests.console.some_irrelevant_logger"
+
+
+class WarnCommand(Command):
+    name = "warn"
+
+    description = "A command that has a logger it wants suppressed by default."
+
+    suppressed_loggers: ClassVar[list[str]] = [SUPPRESSIBLE_LOGGER_NAME]
+
+    def handle(self) -> int:
+        return 0
+
+
+class AddWarnCommandPlugin(ApplicationPlugin):
+    commands: ClassVar[list[type[Command]]] = [WarnCommand]
+
+
+@pytest.fixture
+def with_add_warn_command_plugin(mocker: MockerFixture) -> None:
+    mock_metadata_entry_points(mocker, AddWarnCommandPlugin)
+
+
+@pytest.mark.parametrize(
+    ("options", "expected_suppressed"),
+    [
+        ("", True),
+        ("--verbose", False),
+        ("-vv", False),
+    ],
+)
+def test_application_suppressed_loggers_are_raised_above_warning(
+    with_add_warn_command_plugin: None,
+    options: str,
+    expected_suppressed: bool,
+) -> None:
+    """
+    A command's suppressed_loggers are raised above WARNING at default
+    verbosity, so a warning logged by that logger doesn't reach the user --
+    this is what InstallCommand uses to stop poetry-core's group-unaware
+    path-dependency warning from firing for a group that isn't part of the
+    current install/sync invocation (see issue #10461). Verbose/debug runs
+    leave it alone so the full picture is still available on request.
+    """
+    import logging
+
+    logger = logging.getLogger(SUPPRESSIBLE_LOGGER_NAME)
+
+    app = Application()
+    tester = ApplicationTester(app)
+    tester.execute(f"warn {options}".strip())
+
+    assert tester.status_code == 0
+    if expected_suppressed:
+        assert logger.getEffectiveLevel() > logging.WARNING
+    else:
+        assert logger.getEffectiveLevel() <= logging.WARNING
+
+
 def test_application_with_plugins(with_add_command_plugin: None) -> None:
     app = Application()
 


### PR DESCRIPTION
Resolves: #10461

## Problem

`PathDependency.__init__` (in poetry-core) unconditionally logs a warning if a path/directory/file dependency's target doesn't exist, at the point the full `pyproject.toml` is parsed — before this CLI has determined which `--with`/`--without`/`--only` groups are actually active for the current `install`/`sync` invocation. So a path dependency in an excluded group (e.g. a dev-only local package that's never copied into a Docker image) gets flagged even though it was never going to be installed.

The already-correct, group-aware validation in `Installer` (`installer.py:373`, `dep.validate(raise_error=not op.skipped)`) still runs afterward and is unaffected — a path dependency that IS actually needed and IS missing still fails install/sync with a real error, exactly as before.

## Fix

Added a `suppressed_loggers` mechanism to `Command` (parallel to the existing `loggers` list `register_command_loggers` already reads), letting a command raise specific loggers above WARNING for itself, unless run with `--verbose`/`-vv`/`--debug`. `InstallCommand` (and `SyncCommand`, which inherits from it) uses this to suppress `poetry.core.packages.path_dependency`'s premature warning.

While testing, found and fixed a related issue: logger levels are global process state, so an earlier version of this raised the level but never reset it for a later command in the same process that doesn't ask for suppression. `Application` now tracks which logger names it's currently suppressing and resets any a new command doesn't ask for — relevant for anything running more than one command per process, this repo's own test suite included.

Nothing changed in poetry-core; this is scoped entirely to how this CLI configures logging per command.

## Tests

- `tests/console/test_application.py`: new test covering default/`--verbose`/`-vv`.
- `tests/console/commands/test_install.py`: existing fixtures already cover the scenario. Ran the full suite deterministically and with randomized order (several times) specifically to rule out logger-state leakage across tests.

- [x] Added tests for changed code.
- [ ] Documentation: none needed, internal logging fix with no user-facing API change.

---
Note on process: I worked on this with AI assistance (Claude) to investigate the root cause, write the fix, and write/run the tests. I reviewed and understand the changes and I'm the one deciding what's in this PR.