### PR TITLE
docs: clarify path dependency portability

### DIFF
--- a/docs/dependency-specification.md
+++ b/docs/dependency-specification.md
@@ -431,6 +431,13 @@ To install directory path dependencies in editable mode, use the `develop` keywo
 {{< /tab >}}
 {{< /tabs >}}
 
+{{% note %}}
+Path dependencies are intended for local development.
+When building a wheel or sdist, Poetry records directory path dependencies as `file://` requirements,
+which are not portable. Before distributing your project, publish each path dependency and replace
+the path with a version constraint.
+{{% /note %}}
+
 ## `url` dependencies
 
 `url` dependencies are libraries located on a remote archive.


### PR DESCRIPTION
# Pull Request Check List

Resolves: #6752

- [ ] Added **tests** for changed code. N/A — documentation-only change.
- [x] Updated **documentation** for changed code.

## Summary

Clarify that path dependencies are intended for local development and remain
non-portable in built distributions because Poetry records them as `file://`
requirements. Recommend publishing the dependency and replacing the path with a
version constraint before distribution.

## Validation

- `pre-commit run --files docs/dependency-specification.md`
- Built the documentation with the `python-poetry/website` build script.
- Built the static website with Hugo and verified the rendered note.
- Reproduced the behavior with Poetry by inspecting wheel and sdist metadata.
