### PR TITLE
fix: sanitize default project name generated by init

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -128,7 +128,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         name = self.option("name")
         if not name:
-            name = project_path.name.lower()
+            name = self._sanitize_package_name(project_path.name)
 
             if is_interactive:
                 question = self.create_question(
@@ -513,6 +513,22 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
             )
 
         return author
+
+    @staticmethod
+    def _sanitize_package_name(name: str) -> str:
+        """Turn an arbitrary directory name into a valid default project name.
+
+        Project names may only contain ASCII letters, digits, periods,
+        underscores and hyphens (see
+        https://packaging.python.org/en/latest/specifications/name-normalization/#name-format).
+        Anything else - spaces in particular, since directory names commonly
+        contain them - is collapsed into a single hyphen so that ``poetry
+        init`` never proposes an invalid name by default.
+        """
+        name = re.sub(r"[^A-Za-z0-9._-]+", "-", name.lower())
+        name = re.sub(r"-{2,}", "-", name).strip("-_.")
+
+        return name or "project"
 
     @staticmethod
     def _validate_package(package: str | None) -> str | None:

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -105,6 +105,29 @@ def test_noninteractive(
     assert expected_build_system in toml_content
 
 
+def test_noninteractive_default_name_sanitizes_directory_with_spaces(
+    app: PoetryTestApplication,
+    mocker: MockerFixture,
+    poetry: Poetry,
+    repo: DummyRepository,
+    tmp_path: Path,
+) -> None:
+    command = app.find("init")
+    assert isinstance(command, InitCommand)
+    command._pool = poetry.pool
+
+    project_dir = tmp_path / "my project with spaces"
+    project_dir.mkdir()
+
+    mocker.patch("pathlib.Path.cwd", return_value=project_dir)
+
+    tester = CommandTester(command)
+    tester.execute(args="", interactive=False)
+
+    toml_content = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'name = "my-project-with-spaces"' in toml_content
+
+
 def test_interactive_with_dependencies(
     tester: CommandTester, repo: DummyRepository
 ) -> None:
@@ -1014,6 +1037,25 @@ def test_validate_package_valid(name: str | None) -> None:
 def test_validate_package_invalid(name: str) -> None:
     with pytest.raises(ValueError):
         assert InitCommand._validate_package(name)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("my project with spaces", "my-project-with-spaces"),
+        ("My Project With Spaces", "my-project-with-spaces"),
+        ("my-package", "my-package"),
+        ("my_package", "my_package"),
+        ("my.package", "my.package"),
+        ("  leading and trailing  ", "leading-and-trailing"),
+        ("under__score--mix..dot", "under__score-mix..dot"),
+        ("café project", "caf-project"),
+        ("!!!", "project"),
+        ("", "project"),
+    ],
+)
+def test_sanitize_package_name(name: str, expected: str) -> None:
+    assert InitCommand._sanitize_package_name(name) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves: #10974

`poetry init` derives its default package name from the current directory's basename, but only lowercases it. Directory names with spaces (or anything else outside the [PEP 503 name format](https://packaging.python.org/en/latest/specifications/name-normalization/#name-format): letters, digits, `.`, `_`, `-`) get written straight into `pyproject.toml`'s `[project.name]`, which produces an invalid distribution name, e.g.:

```
c:\temp\my project with spaces>poetry init -n
...
name = "my project with spaces"
```

This adds `InitCommand._sanitize_package_name()`, which collapses any run of disallowed characters into a single hyphen before the name is used as the default. Same repro now gives `name = "my-project-with-spaces"`.

Only the directory-derived default is touched - `--name` and interactively-typed names are unchanged, since that's a matter of validating user input rather than a wrong default.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (no user-facing docs describe this default-naming behavior)