### PR TITLE
fix: reinstall editable dependencies when develop mode changes

### DIFF
--- a/src/poetry/puzzle/transaction.py
+++ b/src/poetry/puzzle/transaction.py
@@ -109,22 +109,30 @@ class Transaction:
                     pass
 
                 # We have to perform an update if the version or another
-                # attribute of the package has changed (source type, url, ref, ...).
-                elif result_package.version != installed_package.version or (
-                    (
-                        # This has to be done because installed packages cannot
-                        # have type "legacy". If a package with type "legacy"
-                        # is installed, the installed package has no source_type.
-                        # Thus, if installed_package has no source_type and
-                        # the result_package has source_type "legacy" (negation of
-                        # the following condition), update must not be performed.
-                        # This quirk has the side effect that when switching
-                        # from PyPI to legacy (or vice versa),
-                        # no update is performed.
-                        installed_package.source_type
-                        or result_package.source_type != "legacy"
+                # attribute of the package has changed
+                # (source type, url, ref, develop, ...).
+                elif (
+                    result_package.version != installed_package.version
+                    or (
+                        result_package.source_type in {"directory", "git"}
+                        and result_package.develop != installed_package.develop
                     )
-                    and not result_package.is_same_package_as(installed_package)
+                    or (
+                        (
+                            # This has to be done because installed packages cannot
+                            # have type "legacy". If a package with type "legacy"
+                            # is installed, the installed package has no source_type.
+                            # Thus, if installed_package has no source_type and
+                            # the result_package has source_type "legacy" (negation of
+                            # the following condition), update must not be performed.
+                            # This quirk has the side effect that when switching
+                            # from PyPI to legacy (or vice versa),
+                            # no update is performed.
+                            installed_package.source_type
+                            or result_package.source_type != "legacy"
+                        )
+                        and not result_package.is_same_package_as(installed_package)
+                    )
                 ):
                     operations.append(
                         Update(

--- a/src/poetry/repositories/installed_repository.py
+++ b/src/poetry/repositories/installed_repository.py
@@ -124,6 +124,7 @@ class InstalledRepository(Repository):
         source_reference = None
         source_resolved_reference = None
         source_subdirectory = None
+        develop = False
         if is_standard_package:
             if path.name.endswith(".dist-info"):
                 paths = cls.get_package_paths(env=env, name=dist_metadata["name"])
@@ -146,6 +147,7 @@ class InstalledRepository(Repository):
                         # TODO: handle multiple source directories?
                         if is_editable_package:
                             source_type = "directory"
+                            develop = True
                             path = paths.pop()
                             if path.name == "src":
                                 path = path.parent
@@ -170,6 +172,7 @@ class InstalledRepository(Repository):
             source_reference=source_reference,
             source_resolved_reference=source_resolved_reference,
             source_subdirectory=source_subdirectory,
+            develop=develop,
         )
 
         package.description = dist_metadata.get(  # type: ignore[attr-defined]

--- a/tests/puzzle/test_transaction.py
+++ b/tests/puzzle/test_transaction.py
@@ -253,6 +253,98 @@ def test_it_should_update_installed_packages_if_sources_are_different() -> None:
 
 
 @pytest.mark.parametrize(
+    ("source_type", "source_url"),
+    [
+        ("directory", "/path/to/package"),
+        ("git", "https://github.com/demo/demo.git"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("installed_develop", "result_develop"),
+    [(False, True), (True, False)],
+)
+def test_it_should_update_installed_editable_package_if_develop_changes(
+    source_type: str,
+    source_url: str,
+    installed_develop: bool,
+    result_develop: bool,
+) -> None:
+    installed_package = Package(
+        "a",
+        "1.0.0",
+        source_type=source_type,
+        source_url=source_url,
+        develop=installed_develop,
+    )
+    result_package = Package(
+        "a",
+        "1.0.0",
+        source_type=source_type,
+        source_url=source_url,
+        develop=result_develop,
+    )
+    transaction = Transaction(
+        [installed_package],
+        {result_package: get_transitive_info(1)},
+        installed_packages=[installed_package],
+    )
+
+    operations = transaction.calculate_operations(synchronize=True)
+
+    assert len(operations) == 1
+    operation = operations[0]
+    assert isinstance(operation, Update)
+    assert operation.initial_package.develop is installed_develop
+    assert operation.target_package.develop is result_develop
+
+
+@pytest.mark.parametrize(
+    ("source_type", "source_url"),
+    [
+        (None, None),
+        ("url", "https://example.org/package.whl"),
+        ("file", "/path/to/package.whl"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("installed_develop", "result_develop"),
+    [(False, True), (True, False)],
+)
+def test_it_should_ignore_develop_for_non_editable_package_types(
+    source_type: str | None,
+    source_url: str | None,
+    installed_develop: bool,
+    result_develop: bool,
+) -> None:
+    installed_package = Package(
+        "a",
+        "1.0.0",
+        source_type=source_type,
+        source_url=source_url,
+        develop=installed_develop,
+    )
+    result_package = Package(
+        "a",
+        "1.0.0",
+        source_type=source_type,
+        source_url=source_url,
+        develop=result_develop,
+    )
+    transaction = Transaction(
+        [installed_package],
+        {result_package: get_transitive_info(1)},
+        installed_packages=[installed_package],
+    )
+
+    operations = transaction.calculate_operations(synchronize=True)
+
+    assert len(operations) == 1
+    operation = operations[0]
+    assert operation.job_type == "install"
+    assert operation.skipped
+
+
+@pytest.mark.parametrize(
     ("groups", "expected"),
     [
         (set(), []),

--- a/tests/repositories/test_installed_repository.py
+++ b/tests/repositories/test_installed_repository.py
@@ -12,6 +12,10 @@ from typing import NamedTuple
 
 import pytest
 
+from poetry.core.packages.package import Package
+
+from poetry.installation.operations.update import Update
+from poetry.puzzle.transaction import Transaction
 from poetry.repositories.installed_repository import InstalledRepository
 from poetry.utils._compat import getencoding
 from poetry.utils.env import EnvManager
@@ -23,7 +27,6 @@ from tests.helpers import with_working_directory
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from poetry.core.packages.package import Package
     from pytest import LogCaptureFixture
     from pytest_mock.plugin import MockerFixture
 
@@ -285,6 +288,34 @@ def test_load_editable_package(
     assert editable.version.text == "2.3.4"
     assert editable.source_type == "directory"
     assert editable.source_url == editable_source_directory_path
+    assert editable.develop
+
+
+def test_legacy_editable_package_is_updated_to_non_editable(
+    repository: InstalledRepository, editable_source_directory_path: str
+) -> None:
+    installed_package = get_package_from_repository("editable", repository)
+    assert installed_package is not None
+    result_package = Package(
+        installed_package.name,
+        installed_package.version,
+        source_type="directory",
+        source_url=editable_source_directory_path,
+        develop=False,
+    )
+    transaction = Transaction(
+        [installed_package],
+        [result_package],
+        installed_packages=[installed_package],
+    )
+
+    operations = transaction.calculate_operations(synchronize=True)
+
+    assert len(operations) == 1
+    operation = operations[0]
+    assert isinstance(operation, Update)
+    assert operation.initial_package.develop
+    assert not operation.target_package.develop
 
 
 def test_load_editable_src_dir_package(
@@ -297,6 +328,7 @@ def test_load_editable_src_dir_package(
     assert editable.version.text == "2.3.4"
     assert editable.source_type == "directory"
     assert editable.source_url == editable_source_directory_path
+    assert editable.develop
 
 
 def test_load_editable_with_import_package(repository: InstalledRepository) -> None:
@@ -465,7 +497,7 @@ def test_system_site_packages_source_type(
     """
     venv_path = tmp_path / "venv"
     site_path = tmp_path / "site"
-    for dist_info in {"cleo-0.7.6.dist-info", "directory_pep_610-1.2.3.dist-info"}:
+    for dist_info in ("cleo-0.7.6.dist-info", "directory_pep_610-1.2.3.dist-info"):
         shutil.copytree(site_purelib / dist_info, site_path / dist_info)
     mocker.patch("poetry.utils.env.virtual_env.VirtualEnv.sys_path", [str(site_path)])
     mocker.patch(


### PR DESCRIPTION
Resolves: #7088

Addresses the editable/non-editable sync transition described in #10666.

## Summary

When a directory or Git dependency kept the same name, version, and source but
changed between editable and non-editable mode,
`Transaction.calculate_operations()` treated the installed and resolved
packages as unchanged. As a result, `poetry sync` did not reinstall the
dependency and left its previous install mode in place.

Treat a change to the package's `develop` flag as an update condition for the
directory and Git source types that support editable installs. Registry, URL,
and file packages continue to ignore this field. Legacy editable directory
installs discovered through a plain-text `.pth` file are also marked as
editable, so switching one of those installs to non-editable schedules the
required update.

This does not address the separate transitive dependency metadata problem
described in #10683, where a PEP 621 dependency loses `develop = true` while
the lock file is built.

## Validation

- Focused editable-state tests: 13 passed
- Transaction and installed-repository tests: 123 passed
- Puzzle and installed-repository tests: 394 passed
- Directory end-to-end installs in both directions verified the module path, `.pth`
  behavior, and PEP 610 editable metadata
- Ruff check, Ruff format check, and Mypy passed for the changed Python files
- `git diff --check` passed

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code — no user-facing command or
  configuration documentation changes are required.