### PR TITLE
Fix init default project name normalization

### DIFF
--- a/src/poetry/console/commands/init.py
+++ b/src/poetry/console/commands/init.py
@@ -128,7 +128,7 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         name = self.option("name")
         if not name:
-            name = project_path.name.lower()
+            name = canonicalize_name(re.sub(r"\s+", "-", project_path.name.strip()))
 
             if is_interactive:
                 question = self.create_question(

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -105,6 +105,30 @@ def test_noninteractive(
     assert expected_build_system in toml_content
 
 
+def test_noninteractive_normalizes_default_project_name(
+    app: PoetryTestApplication,
+    mocker: MockerFixture,
+    poetry: Poetry,
+    tmp_path: Path,
+) -> None:
+    command = app.find("init")
+    assert isinstance(command, InitCommand)
+    command._pool = poetry.pool
+
+    project_path = tmp_path / "my project with spaces"
+    project_path.mkdir()
+    mocker.patch("pathlib.Path.cwd", return_value=project_path)
+
+    tester = CommandTester(command)
+    tester.execute(
+        "--author 'Your Name <you@example.com>' --python '>=3.12'",
+        interactive=False,
+    )
+
+    toml_content = (project_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'name = "my-project-with-spaces"' in toml_content
+
+
 def test_interactive_with_dependencies(
     tester: CommandTester, repo: DummyRepository
 ) -> None:


### PR DESCRIPTION
﻿### Problem

`poetry init -n` infers the project name from the current directory when `--name` is not provided. If that directory contains spaces, Poetry writes an invalid package name such as `my project with spaces` even though project names must use only letters, digits, `.`, `_`, or `-`.

### Reproducer

```console
PS> mkdir "my project with spaces"; cd "my project with spaces"
PS> poetry init -n
PS> Select-String 'name =' pyproject.toml
name = "my project with spaces"  # invalid
```

Expected:

```toml
name = "my-project-with-spaces"
```

### Fix

Normalize whitespace to hyphens before canonicalizing the default name inferred from the current directory. Explicit `--name` values and the existing interactive flow remain unchanged.

Closes #10974

### Testing

```console
PS> .\.venv\Scripts\python -m pytest tests\console\commands\test_init.py::test_noninteractive_normalizes_default_project_name -q
# before fix: FAILED, wrote name = "my project with spaces"
# after fix: 1 passed in 9.18s

PS> .\.venv\Scripts\python -m pytest tests\console\commands\test_init.py -q
68 passed in 11.97s

PS> .\.venv\Scripts\python -m pre_commit run --files src\poetry\console\commands\init.py tests\console\commands\test_init.py
Passed

PS> .\.venv\Scripts\python -m mypy src\poetry\console\commands\init.py tests\console\commands\test_init.py
Success: no issues found in 2 source files
```
