### PR TITLE
docs: clarify update group lock scope

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1329,6 +1329,13 @@ You can do this using the `add` command.
 * `--sync`: Synchronize the environment with the locked packages and the specified groups.
 
 {{% note %}}
+The group options determine which dependency groups are installed or synchronized in the
+environment. They do not limit resolution of the lock file: `poetry.lock` keeps one consistent
+solution for all declared groups, so packages that belong to an excluded group can still change.
+To restrict which packages Poetry updates, pass their names to the command.
+{{% /note %}}
+
+{{% note %}}
 When `--only` is specified, `--with` and `--without` options are ignored.
 {{% /note %}}
 


### PR DESCRIPTION
## Summary

Clarify that the dependency-group options on `poetry update` select the groups applied to the environment, while `poetry.lock` still records one consistent resolution for every declared group.

This also points users who need a narrower lock-file update to the existing package-name arguments.

## Context

A user interpreted `poetry update --without dev` as freezing dev-group records in the lock file: https://github.com/orgs/python-poetry/discussions/10513

The documented note follows the current command flow: group selection is passed separately from the package update whitelist, and an update without package arguments makes all locked packages eligible before environment operations are filtered.

## Validation

- `git diff --check`
- Documentation-only change; no runtime behavior changed

- [ ] Added **tests** for changed code (not applicable: documentation only).
- [x] Updated **documentation** for changed code.