### PR TITLE
refactor: fix confusing method name

### DIFF
--- a/src/poetry/repositories/http_repository.py
+++ b/src/poetry/repositories/http_repository.py
@@ -147,7 +147,7 @@ class HTTPRepository(CachedRepository):
         )
 
     @contextmanager
-    def _cached_or_downloaded_file(
+    def _downloaded_file(
         self, link: Link, *, raise_accepts_ranges: bool = False
     ) -> Iterator[Path]:
         self._log(f"Downloading: {link.url}", level="debug")
@@ -247,7 +247,7 @@ class HTTPRepository(CachedRepository):
                 return package_info
 
         try:
-            with self._cached_or_downloaded_file(
+            with self._downloaded_file(
                 link, raise_accepts_ranges=raise_accepts_ranges
             ) as filepath:
                 return PackageInfo.from_wheel(filepath)
@@ -266,7 +266,7 @@ class HTTPRepository(CachedRepository):
     def _get_info_from_sdist(self, link: Link) -> PackageInfo:
         from poetry.inspection.info import PackageInfo
 
-        with self._cached_or_downloaded_file(link) as filepath:
+        with self._downloaded_file(link) as filepath:
             return PackageInfo.from_sdist(filepath)
 
     def _get_info_from_metadata(self, link: Link) -> PackageInfo | None:
@@ -506,7 +506,7 @@ class HTTPRepository(CachedRepository):
         return data.asdict()
 
     def calculate_sha256(self, link: Link) -> str | None:
-        with self._cached_or_downloaded_file(link) as filepath:
+        with self._downloaded_file(link) as filepath:
             hash_name = get_highest_priority_hash_type(link.hashes, link.filename)
             known_hash = None
             with suppress(ValueError, AttributeError):

--- a/tests/repositories/fixtures/pypi.org/generate.py
+++ b/tests/repositories/fixtures/pypi.org/generate.py
@@ -306,7 +306,7 @@ class FileManager:
             dst.relative_to(FIXTURE_PATH_REPOSITORIES_PYPI),
         )
 
-        with self.pypi._cached_or_downloaded_file(link) as src:
+        with self.pypi._downloaded_file(link) as src:
             shutil.copy(src, dst)
 
         return ReleaseFileMetadata(dst)
@@ -322,7 +322,7 @@ class FileManager:
         )
 
         with (
-            self.pypi._cached_or_downloaded_file(link) as src,
+            self.pypi._downloaded_file(link) as src,
             zipfile.ZipFile(
                 dst, "w", compression=zipfile.ZIP_DEFLATED
             ) as stubbed_sdist,
@@ -371,7 +371,7 @@ class FileManager:
         )
 
         with (
-            self.pypi._cached_or_downloaded_file(link) as src,
+            self.pypi._downloaded_file(link) as src,
             GzipFile(dst.as_posix(), mode="wb", mtime=0) as gz,
             tarfile.TarFile(
                 dst, mode="w", fileobj=gz, format=tarfile.PAX_FORMAT

--- a/tests/repositories/test_legacy_repository.py
+++ b/tests/repositories/test_legacy_repository.py
@@ -654,7 +654,7 @@ def test_cached_or_downloaded_file_supports_trailing_slash(
     legacy_repository: LegacyRepository,
 ) -> None:
     repo = legacy_repository
-    with repo._cached_or_downloaded_file(
+    with repo._downloaded_file(
         Link("https://files.pythonhosted.org/pytest-3.5.0-py2.py3-none-any.whl/")
     ) as filepath:
         assert filepath.name == "pytest-3.5.0-py2.py3-none-any.whl"


### PR DESCRIPTION
Caching has been introduced in #7916 and removed in #7995.
