### PR TITLE
Require version in [project] table in non-package mode

### DIFF
--- a/src/poetry/factory.py
+++ b/src/poetry/factory.py
@@ -372,12 +372,28 @@ class Factory(BaseFactory):
 
         dependencies = {canonicalize_name(d) for d in dependencies}
 
-        project_name = toml_data.get("project", {}).get("name") or poetry_config.get(
-            "name"
-        )
+        project = toml_data.get("project", {})
+        project_name = project.get("name") or poetry_config.get("name")
         if project_name is not None and canonicalize_name(project_name) in dependencies:
             results["errors"].append(
                 f"Project name ({project_name}) is same as one of its dependencies"
+            )
+
+        # PEP 621 requires a "version" in the [project] table unless it is listed
+        # in [project.dynamic]. In package mode this is already enforced (a
+        # version is always required), but in non-package mode the requirement
+        # was not checked, so a [project] table with a name but no version was
+        # silently accepted even though it is invalid per PEP 621.
+        if (
+            poetry_config.get("package-mode", True) is False
+            and project.get("name") is not None
+            and "version" not in project
+            and "version" not in project.get("dynamic", [])
+        ):
+            results["errors"].append(
+                "The [project] table requires a 'version' key when a 'name' key is"
+                " present. Either define 'version' statically or list it in the"
+                " 'dynamic' array."
             )
 
         return results

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -440,6 +440,48 @@ def test_validate_fails(fixture_dir: FixtureDirGetter) -> None:
     assert Factory.validate(pyproject) == {"errors": expected, "warnings": []}
 
 
+_PROJECT_VERSION_ERROR = (
+    "The [project] table requires a 'version' key when a 'name' key is present."
+    " Either define 'version' statically or list it in the 'dynamic' array."
+)
+
+
+@pytest.mark.parametrize(
+    ("project", "expected_errors"),
+    [
+        # non-package mode: name but no version and not dynamic -> error
+        ({"name": "foo"}, [_PROJECT_VERSION_ERROR]),
+        # non-package mode: static version -> valid
+        ({"name": "foo", "version": "1.0"}, []),
+        # non-package mode: version declared as dynamic -> valid
+        ({"name": "foo", "dynamic": ["version"]}, []),
+    ],
+)
+def test_validate_non_package_mode_requires_project_version(
+    project: dict[str, Any], expected_errors: list[str]
+) -> None:
+    toml_data: dict[str, Any] = {
+        "project": project,
+        "tool": {"poetry": {"package-mode": False}},
+    }
+
+    assert Factory.validate(toml_data) == {"errors": expected_errors, "warnings": []}
+
+
+def test_validate_package_mode_missing_version_not_duplicated() -> None:
+    # In package mode a missing version is already reported by the core schema
+    # validation, so the additional PEP 621 check must not fire (no duplicate).
+    toml_data: dict[str, Any] = {
+        "project": {"name": "foo"},
+        "tool": {"poetry": {}},
+    }
+
+    errors = Factory.validate(toml_data)["errors"]
+
+    assert _PROJECT_VERSION_ERROR not in errors
+    assert any("required in package mode" in error for error in errors)
+
+
 def test_create_poetry_fails_on_invalid_configuration(
     fixture_dir: FixtureDirGetter,
 ) -> None:


### PR DESCRIPTION
Closes #10032

## Bug

A `pyproject.toml` using the PEP 621 `[project]` table with a `name` but no `version`, in non-package mode, was silently accepted:

```toml
[project]
name = "test"
requires-python = ">=3.10"
dependencies = ["mkdocs"]

[tool.poetry]
package-mode = false
```

`poetry check` reported `All set!` (and `poetry lock` / `sync` proceeded) even though PEP 621 requires a `version` in the `[project]` table unless it is listed in `[project.dynamic]`.

## Root cause

`Factory.validate()` relies on the core schema validation to enforce the `version` requirement, but that check only fires in package mode (`Either [project.version] or [tool.poetry.version] is required in package mode.`). In non-package mode the requirement was never checked, so a `[project]` table with a name but no version passed validation.

## Fix

Add a targeted check in `Factory.validate()` that, in non-package mode, flags a `[project]` table which declares a `name` but has neither a static `version` nor `version` listed in `dynamic`.

The check is gated on non-package mode so that package mode continues to emit only the existing core message (no duplicate error). Valid cases remain valid:

- `version` declared statically -> OK
- `version` listed in `[project.dynamic]` -> OK
- legacy `[tool.poetry]`-only projects (no `[project]` table) -> unaffected

## Testing

- Added `test_validate_non_package_mode_requires_project_version` (parametrized: missing version -> error; static version -> OK; dynamic version -> OK) and `test_validate_package_mode_missing_version_not_duplicated` (ensures no duplicate error in package mode). The missing-version case fails on `main` and passes with this change.
- `pytest tests/test_factory.py tests/console/commands/test_check.py tests/json/test_schema.py` -> 66 passed.
- `ruff check`, `ruff format --check`, and `mypy` pass on the changed files.