### PR TITLE
Cache Poetry JSON schema validation

### DIFF
--- a/src/poetry/json/__init__.py
+++ b/src/poetry/json/__init__.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 
+from functools import cache
 from importlib.resources import files
+from typing import TYPE_CHECKING
 from typing import Any
 
 import fastjsonschema
@@ -10,18 +12,21 @@ import fastjsonschema
 from fastjsonschema.exceptions import JsonSchemaValueException
 
 
-def validate_object(obj: dict[str, Any]) -> list[str]:
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@cache
+def _get_validator_and_properties() -> tuple[
+    Callable[[dict[str, Any]], dict[str, Any]], frozenset[str]
+]:
     schema = json.loads(
         (files(__package__) / "schemas" / "poetry.json").read_text(encoding="utf-8")
     )
 
-    validate = fastjsonschema.compile(schema)
-
-    errors = []
-    try:
-        validate(obj)
-    except JsonSchemaValueException as e:
-        errors = [e.message]
+    validator: Callable[[dict[str, Any]], dict[str, Any]] = fastjsonschema.compile(
+        schema
+    )
 
     core_schema = json.loads(
         (files("poetry.core") / "json" / "schemas" / "poetry-schema.json").read_text(
@@ -29,7 +34,19 @@ def validate_object(obj: dict[str, Any]) -> list[str]:
         )
     )
 
-    properties = schema["properties"].keys() | core_schema["properties"].keys()
+    properties = frozenset(schema["properties"]) | frozenset(core_schema["properties"])
+    return validator, properties
+
+
+def validate_object(obj: dict[str, Any]) -> list[str]:
+    validate, properties = _get_validator_and_properties()
+
+    errors = []
+    try:
+        validate(obj)
+    except JsonSchemaValueException as e:
+        errors = [e.message]
+
     additional_properties = obj.keys() - properties
     for key in additional_properties:
         errors.append(f"Additional properties are not allowed ('{key}' was unexpected)")


### PR DESCRIPTION
Companion to https://github.com/python-poetry/poetry-core/pull/965

As in the other - unlikely to make any difference to regular poetry users, but makes a dent in the unit test execution.  Locally I see it being less impactful than the poetry-core version, but still worth having.
