### PR TITLE
docs: fix inconsistent heading

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -301,7 +301,7 @@ The `config` command allows you to edit poetry config settings and repositories.
 poetry config --list
 ```
 
-### Usage
+Usage:
 
 ````bash
 poetry config [options] [setting-key] [setting-value1] ... [setting-valueN]


### PR DESCRIPTION
Headings in the CLI section are only for commands and sub commands.