### PR TITLE
release: bump version to 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [2.4.3] - 2026-09-05
+
+### Fixed
+
+- Fix an issue where Poetry could not extract sdists on Python 3.10.0-3.10.12 and 3.11.0-3.11.4 ([#11037](https://github.com/python-poetry/poetry/pull/11037)).
+
+
 ## [2.4.2] - 2026-08-29
 
 ### Fixed
@@ -7,6 +14,7 @@
 - Fix an issue where Poetry installs an artifact that is not listed in the lockfile when the package source does not provide a hash for this artifact ([#11030](https://github.com/python-poetry/poetry/pull/11030)).
 - Fix a path traversal vulnerability when downloading files from a compromised URL and/or package source ([#11029](https://github.com/python-poetry/poetry/pull/11029)).
 - Fix a path traversal vulnerability in sdist extraction on Python 3.10.0-3.10.12 and 3.11.0-3.11.4 that could allow malicious tarball files to write files outside the target directory ([#11027](https://github.com/python-poetry/poetry/pull/11027)).
+
 
 ## [2.4.1] - 2026-05-09
 
@@ -2764,7 +2772,8 @@ Initial release
 
 
 
-[Unreleased]: https://github.com/python-poetry/poetry/compare/2.4.2...main
+[Unreleased]: https://github.com/python-poetry/poetry/compare/2.4.3...main
+[2.4.3]: https://github.com/python-poetry/poetry/releases/tag/2.4.3
 [2.4.2]: https://github.com/python-poetry/poetry/releases/tag/2.4.2
 [2.4.1]: https://github.com/python-poetry/poetry/releases/tag/2.4.1
 [2.4.0]: https://github.com/python-poetry/poetry/releases/tag/2.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry"
-version = "2.4.2"
+version = "2.4.3"
 description = "Python dependency management and packaging made easy."
 requires-python = ">=3.10,<4.0"
 dependencies = [


### PR DESCRIPTION
### Fixed

- Fix an issue where Poetry could not extract sdists on Python 3.10.0-3.10.12 and 3.11.0-3.11.4 ([#11037](https://github.com/python-poetry/poetry/pull/11037)).