### PR TITLE
docs(inspection): drop the stale extras param from to_package's docstring

### DIFF
--- a/src/poetry/inspection/info.py
+++ b/src/poetry/inspection/info.py
@@ -123,7 +123,6 @@ class PackageInfo:
 
         :param name: Name to use for the package, if not specified name from this
             instance is used.
-        :param extras: Extras to activate for this package.
         :param root_dir:  Optional root directory to use for the package. If set,
             dependency strings will be parsed relative to this directory.
         """


### PR DESCRIPTION
`PackageInfo.to_package(name=None, root_dir=None)`'s docstring documents a `:param extras:` entry — the parameter no longer exists (leftover from an older `to_package(..., extras, ...)` signature). The stale line is removed. Docs-only; no linked issue since this is a docstring correction.