### PR TITLE
docs: fix a duplicated word and the stale minimum Python version

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -140,7 +140,7 @@ start a [Discussion][Discussions].
 Poetry is developed using Poetry. Refer to the [documentation] to install Poetry in your local environment.
 
 {{% note %}}
-Poetry's development toolchain requires Python 3.9 or newer.
+Poetry's development toolchain requires Python 3.10 or newer.
 {{% /note %}}
 
 You should first fork the Poetry repository and then clone it locally, so that you can make pull requests against the

--- a/src/poetry/utils/env/env_manager.py
+++ b/src/poetry/utils/env/env_manager.py
@@ -568,7 +568,7 @@ class EnvManager:
 
         cli_result = virtualenv.cli_run(args, setup_logging=False)
 
-        # Exclude the venv folder from from macOS Time Machine backups
+        # Exclude the venv folder from macOS Time Machine backups
         # TODO: Add backup-ignore markers for other platforms too
         if sys.platform == "darwin":
             import xattr


### PR DESCRIPTION
- `src/poetry/utils/env/env_manager.py`: comment read "Exclude the venv folder **from from** macOS Time Machine backups".
- `docs/contributing.md`: claimed the development toolchain requires Python 3.9+, but `pyproject.toml` requires ">=3.10" — following the doc, a 3.9 contributor's `poetry install` fails. Now says 3.10.